### PR TITLE
chore(actions): bump actions/setup-python from 5 to 6

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -49,7 +49,7 @@ jobs:
         run: wasm-pack build --target web --release -d ../../demo/pkg/
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -38,7 +38,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - uses: PyO3/maturin-action@v1
@@ -57,7 +57,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - uses: PyO3/maturin-action@v1


### PR DESCRIPTION
Resolves dependabot PR #24 (conflict があったため手動適用).

`actions/setup-python@v5` → `v6` を以下のファイルに適用:
- `.github/workflows/pages.yml`
- `.github/workflows/publish-pypi.yml` (macos / windows ジョブ)

Closes #24