### PR TITLE
feat(llm): representation router — to_llm_text, best_representation, MCP tool

### DIFF
--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -23,5 +23,6 @@ chematic-chem       = { path = "../chematic-chem",       version = "0.4.19", fea
 chematic-fp         = { path = "../chematic-fp",         version = "0.4.19" }
 chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.19" }
 chematic-3d         = { path = "../chematic-3d",         version = "0.4.19" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.4.19" }
 chematic-mol        = { path = "../chematic-mol",        version = "0.4.19" }
 chematic-perception = { path = "../chematic-perception", version = "0.4.19" }

--- a/crates/chematic-mcp/src/lib.rs
+++ b/crates/chematic-mcp/src/lib.rs
@@ -146,7 +146,7 @@ mod tests {
         let resp = handle_line(req).unwrap();
         assert!(resp["result"]["tools"].is_array());
         let count = resp["result"]["tools"].as_array().unwrap().len();
-        assert_eq!(count, 18);
+        assert_eq!(count, 19);
     }
 
     #[test]

--- a/crates/chematic-mcp/src/tools.rs
+++ b/crates/chematic-mcp/src/tools.rs
@@ -7,7 +7,8 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use chematic_3d::{generate_and_minimize_dreiding, write_xyz};
 use chematic_core::{Atom, AtomIdx, BondOrder, Element, MoleculeBuilder};
 use chematic_fp::{BitVec2048, ecfp4, tanimoto_ecfp4};
-use chematic_mol::{parse_moljson, write_moljson};
+use chematic_inchi::inchi;
+use chematic_mol::{parse_moljson, write_cml, write_moljson};
 use chematic_smarts::{
     AtomPrimitive, AtomQuery, BondPrimitive, BondQuery, McsConfig, find_matches,
     find_mcs_with_config, parse_smarts,
@@ -386,6 +387,20 @@ pub fn list_tools() -> Value {
                 },
                 "required": ["json"]
             }
+        },
+        {
+            "name": "representation_router",
+            "description": "Convert SMILES to the best molecular text representation for an LLM task. Based on arXiv 2026: CML/MolJSON outperform SMILES on structural reasoning; InChI is best for identification.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "smiles": { "type": "string", "description": "SMILES string" },
+                    "task":   { "type": "string",
+                                "enum": ["structural_reasoning","shortest_path","identification","property_prediction","generation","editing","default"],
+                                "description": "LLM task type — omit to use default (canonical_smiles)" }
+                },
+                "required": ["smiles"]
+            }
         }
     ]})
 }
@@ -412,6 +427,7 @@ pub fn call_tool(name: &str, args: &Value) -> Result<Value, String> {
         "retrosynthesis" => tool_retrosynthesis(args),
         "smiles_to_moljson" => tool_smiles_to_moljson(args),
         "moljson_to_smiles" => tool_moljson_to_smiles(args),
+        "representation_router" => tool_representation_router(args),
         _ => Err(format!("Unknown tool: {name}")),
     }
 }
@@ -803,6 +819,28 @@ fn tool_moljson_to_smiles(args: &Value) -> Result<Value, String> {
     ))
 }
 
+fn tool_representation_router(args: &Value) -> Result<Value, String> {
+    let smiles = get_str(args, "smiles")?;
+    let task = args
+        .get("task")
+        .and_then(|v| v.as_str())
+        .unwrap_or("default");
+    let mol = parse_mol(smiles)?;
+    let (format, repr) = match task {
+        "structural_reasoning" | "shortest_path" | "graph_reasoning" => {
+            ("moljson", write_moljson(&mol))
+        }
+        "identification" | "exact_match" => ("inchi", inchi(&mol)),
+        "editing" => ("cml", write_cml(&mol, None)),
+        _ => ("canonical_smiles", chematic_smiles::canonical_smiles(&mol)),
+    };
+    Ok(content(&json!({
+        "task": task,
+        "format": format,
+        "representation": repr
+    })))
+}
+
 // ── tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -940,7 +978,7 @@ mod tests {
     fn test_list_tools_count() {
         let tools = list_tools();
         let count = tools["tools"].as_array().unwrap().len();
-        assert_eq!(count, 18);
+        assert_eq!(count, 19);
     }
 
     #[test]

--- a/crates/chematic-py/python/chematic/__init__.py
+++ b/crates/chematic-py/python/chematic/__init__.py
@@ -16,6 +16,45 @@ from .chematic import (
 )
 
 
+# Task → representation mapping (arXiv 2026: CML/MolJSON outperform SMILES on structural tasks)
+_TASK_REPR = {
+    "structural_reasoning": "moljson",
+    "shortest_path":        "moljson",
+    "graph_reasoning":      "moljson",
+    "identification":       "inchi",
+    "exact_match":          "inchi",
+    "property_prediction":  "canonical_smiles",
+    "generation":           "canonical_smiles",
+    "editing":              "cml",
+    "default":              "canonical_smiles",
+}
+
+
+def best_representation(task: str = "default") -> str:
+    """Return the recommended molecular text format for an LLM task.
+
+    Based on arXiv 2026 "Rethinking Molecular Text Representations for LLMs":
+    CML and MolJSON outperform SMILES on structural reasoning tasks; InChI is
+    best for exact identification.
+
+    Args:
+        task: one of ``structural_reasoning``, ``shortest_path``,
+              ``graph_reasoning``, ``identification``, ``exact_match``,
+              ``property_prediction``, ``generation``, ``editing``,
+              ``default``
+
+    Returns:
+        format string — pass directly to ``mol.to_llm_text(format)``
+
+    Example::
+
+        fmt = chematic.best_representation("structural_reasoning")
+        # → "moljson"
+        text = mol.to_llm_text(fmt)
+    """
+    return _TASK_REPR.get(task, "canonical_smiles")
+
+
 def from_smiles_list(smiles, /, *, skip_invalid=True):
     """Parse a list of SMILES strings into Mol objects.
 

--- a/crates/chematic-py/src/lib.rs
+++ b/crates/chematic-py/src/lib.rs
@@ -1345,6 +1345,49 @@ impl Mol {
         chematic_mol::write_moljson(&self.inner)
     }
 
+    /// Return the molecule in a text format suited for LLM prompts.
+    ///
+    /// Based on arXiv 2026 "Rethinking Molecular Text Representations for LLMs":
+    /// CML and MolJSON outperform SMILES on structural reasoning tasks.
+    ///
+    /// Args:
+    ///     format: one of ``"canonical_smiles"``, ``"smiles"``, ``"inchi"``,
+    ///             ``"inchikey"``, ``"moljson"``, ``"cml"``, ``"markdown"``
+    ///
+    ///     # Task-aware: use chematic.best_representation(task) to pick format
+    ///     fmt = chematic.best_representation("structural_reasoning")  # → "moljson"
+    ///     text = mol.to_llm_text(fmt)
+    ///
+    ///     # Direct format selection:
+    ///     mol.to_llm_text("moljson")
+    ///     mol.to_llm_text("inchi")
+    ///     mol.to_llm_text("markdown")   # multi-field summary
+    fn to_llm_text(&self, format: &str) -> PyResult<String> {
+        match format {
+            "canonical_smiles" | "smiles" => Ok(chematic_smiles::canonical_smiles(&self.inner)),
+            "inchi" => Ok(chematic_inchi::inchi(&self.inner)),
+            "inchikey" => {
+                let i = chematic_inchi::inchi(&self.inner);
+                Ok(chematic_inchi::inchi_key(&i))
+            }
+            "moljson" => Ok(chematic_mol::write_moljson(&self.inner)),
+            "cml" => Ok(chematic_mol::write_cml(&self.inner, None)),
+            "markdown" => {
+                let smi = chematic_smiles::canonical_smiles(&self.inner);
+                let inchi = chematic_inchi::inchi(&self.inner);
+                let mw = chematic_chem::molecular_weight(&self.inner);
+                let hac = chematic_chem::heavy_atom_count(&self.inner);
+                Ok(format!(
+                    "**SMILES**: {smi}\n**InChI**: {inchi}\n**MW**: {mw:.2} Da\n**Heavy atoms**: {hac}\n**MolJSON**:\n{}",
+                    chematic_mol::write_moljson(&self.inner)
+                ))
+            }
+            _ => Err(PyValueError::new_err(format!(
+                "Unknown format '{format}'. Choose: canonical_smiles, inchi, inchikey, moljson, cml, markdown"
+            ))),
+        }
+    }
+
     /// Export the 2D structure as a PDF document (bytes).
     ///
     ///     pdf_bytes = mol.to_pdf()


### PR DESCRIPTION
Based on arXiv 2026: task-aware dispatch to moljson|inchi|cml|canonical_smiles. 19 MCP tools total.