### PR TITLE
feat(hdf): Hyper-Dimensional Fingerprints — training-free dense molecular vectors

### DIFF
--- a/crates/chematic-fp/src/hdf.rs
+++ b/crates/chematic-fp/src/hdf.rs
@@ -1,0 +1,364 @@
+//! Hyper-Dimensional Fingerprints (HDF) for molecules.
+//!
+//! HDF encodes a molecule as a unit-norm float32 vector in a high-dimensional
+//! space using Hyperdimensional Computing (HDC) operations.  Unlike hash-based
+//! fingerprints (ECFP), there is no collision: every distinct atom environment
+//! maps to a unique HD vector whose similarity can be measured with cosine dot.
+//!
+//! ## Algorithm
+//!
+//! 1. **Basis**: each (element, charge) pair → deterministic d-dim bipolar vector (±1).
+//! 2. **Neighborhood**: for atom *i* at hop *h*, bind (element-wise multiply)
+//!    the cyclic-shifted basis of *i* with the bases of *h*-hop neighbors.
+//! 3. **Superposition**: sum all contributions across all atoms and hops.
+//! 4. **Normalize** to unit sphere → `Vec<f32>` of length `dim`.
+//!
+//! Cosine similarity between two normalized HDF vectors equals their dot product,
+//! making nearest-neighbor search trivial.
+//!
+//! ## References
+//! - "Hyper-Dimensional Fingerprints as Molecular Representations" (arXiv 2026)
+//! - Kanerva, P. "Hyperdimensional Computing" (Cognitive Computation 2009)
+
+#![forbid(unsafe_code)]
+
+use chematic_core::{AtomIdx, Molecule};
+
+// ─── Config & Output ─────────────────────────────────────────────────────────
+
+/// Configuration for HDF fingerprint generation.
+#[derive(Debug, Clone)]
+pub struct HdfConfig {
+    /// Vector dimension. Higher → less collision, more memory. Default: 1024.
+    pub dim: usize,
+    /// Neighborhood radius (hops). Default: 2.
+    pub radius: usize,
+    /// Reproducibility seed. Default: 42.
+    pub seed: u64,
+}
+
+impl Default for HdfConfig {
+    fn default() -> Self {
+        HdfConfig {
+            dim: 1024,
+            radius: 2,
+            seed: 42,
+        }
+    }
+}
+
+/// A normalized HDF fingerprint vector (unit-norm f32 slice).
+///
+/// Use [`cosine_hdf`] for similarity between two HDF fingerprints of the same config.
+#[derive(Debug, Clone)]
+pub struct HdfFp(pub Vec<f32>);
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/// Compute an HDF fingerprint with default config (dim=1024, radius=2, seed=42).
+pub fn hdf_default(mol: &Molecule) -> HdfFp {
+    hdf(mol, &HdfConfig::default())
+}
+
+/// Compute an HDF fingerprint for `mol` using the given `config`.
+pub fn hdf(mol: &Molecule, config: &HdfConfig) -> HdfFp {
+    let d = config.dim;
+    let n = mol.atom_count();
+
+    if n == 0 {
+        return HdfFp(vec![0.0f32; d]);
+    }
+
+    // Pre-compute per-atom basis vectors (±1 floats, deterministic)
+    let bases: Vec<Vec<f32>> = (0..n)
+        .map(|i| {
+            let atom = mol.atom(AtomIdx(i as u32));
+            random_bipolar(
+                d,
+                atom_seed(atom.element.atomic_number(), atom.charge, config.seed),
+            )
+        })
+        .collect();
+
+    let mut mol_vec = vec![0.0f32; d];
+
+    for i in 0..n {
+        // Hop 0: atom's own basis
+        add_scaled(&mut mol_vec, &bases[i], 1.0);
+
+        if config.radius == 0 {
+            continue;
+        }
+
+        // BFS expansion up to radius
+        let mut visited = vec![false; n];
+        visited[i] = true;
+
+        // frontier = immediate neighbors (hop 1)
+        let mut frontier: Vec<usize> = mol
+            .neighbors(AtomIdx(i as u32))
+            .map(|(nb, _)| {
+                let j = nb.0 as usize;
+                visited[j] = true;
+                j
+            })
+            .collect();
+
+        // accumulated_binding starts as the center atom's basis
+        let mut binding = bases[i].clone();
+
+        for hop in 1..=config.radius {
+            if frontier.is_empty() {
+                break;
+            }
+
+            // Permute (cyclic-shift) the accumulated binding vector by `hop` positions
+            // so each hop level produces a distinct encoding.
+            let shifted = cyclic_shift(&binding, hop * 7 + 3); // prime-ish stride
+
+            for &j in &frontier {
+                // Bind: element-wise multiply shifted center with neighbor basis
+                let bound = elementwise_product(&shifted, &bases[j]);
+                add_scaled(&mut mol_vec, &bound, 1.0);
+            }
+
+            // Expand frontier one more hop
+            let mut next: Vec<usize> = Vec::new();
+            for &j in &frontier {
+                for (nb, _) in mol.neighbors(AtomIdx(j as u32)) {
+                    let k = nb.0 as usize;
+                    if !visited[k] {
+                        visited[k] = true;
+                        next.push(k);
+                    }
+                }
+            }
+
+            // Accumulate the frontier atoms into binding for the next hop
+            for &j in &frontier {
+                elementwise_multiply_into(&mut binding, &bases[j]);
+            }
+
+            frontier = next;
+        }
+    }
+
+    normalize(&mut mol_vec);
+    HdfFp(mol_vec)
+}
+
+/// Cosine similarity between two HDF fingerprints (both must be normalized).
+///
+/// Returns a value in [-1, 1] where 1 = identical, 0 = orthogonal.
+/// Panics in debug if the two vectors have different lengths.
+pub fn cosine_hdf(a: &HdfFp, b: &HdfFp) -> f32 {
+    debug_assert_eq!(a.0.len(), b.0.len(), "HdfFp dimensions must match");
+    a.0.iter().zip(&b.0).map(|(x, y)| x * y).sum()
+}
+
+// ─── HD operations ───────────────────────────────────────────────────────────
+
+/// Generate a d-dimensional bipolar (±1) vector seeded deterministically.
+fn random_bipolar(d: usize, seed: u64) -> Vec<f32> {
+    let mut state = if seed == 0 { 1 } else { seed };
+    let mut out = Vec::with_capacity(d);
+    while out.len() < d {
+        // xorshift64
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        // Each u64 gives 64 bits
+        let bits = state;
+        for b in 0..64 {
+            if out.len() == d {
+                break;
+            }
+            out.push(if (bits >> b) & 1 == 0 {
+                -1.0f32
+            } else {
+                1.0f32
+            });
+        }
+    }
+    out
+}
+
+/// Cyclic-shift a vector left by `k % d` positions.
+fn cyclic_shift(v: &[f32], k: usize) -> Vec<f32> {
+    let d = v.len();
+    if d == 0 {
+        return Vec::new();
+    }
+    let k = k % d;
+    let mut out = Vec::with_capacity(d);
+    out.extend_from_slice(&v[k..]);
+    out.extend_from_slice(&v[..k]);
+    out
+}
+
+/// Element-wise product (binding) of two equal-length vectors.
+fn elementwise_product(a: &[f32], b: &[f32]) -> Vec<f32> {
+    a.iter().zip(b).map(|(x, y)| x * y).collect()
+}
+
+/// Bind `binding` in-place: element-wise multiply by `factor`.
+fn elementwise_multiply_into(binding: &mut [f32], factor: &[f32]) {
+    for (b, &f) in binding.iter_mut().zip(factor) {
+        *b *= f;
+    }
+}
+
+/// Add `scale * src` into `dst`.
+fn add_scaled(dst: &mut [f32], src: &[f32], scale: f32) {
+    for (d, &s) in dst.iter_mut().zip(src) {
+        *d += scale * s;
+    }
+}
+
+/// Normalize `v` to unit length in-place; no-op if length is ~0.
+fn normalize(v: &mut [f32]) {
+    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 1e-9 {
+        for x in v.iter_mut() {
+            *x /= norm;
+        }
+    }
+}
+
+/// Deterministic seed for an atom given its element, charge, and global seed.
+fn atom_seed(atomic_num: u8, charge: i8, global_seed: u64) -> u64 {
+    global_seed
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(atomic_num as u64)
+        .wrapping_add((charge as i64 + 128) as u64)
+        .wrapping_mul(2654435761)
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chematic_smiles::parse;
+
+    fn mol(smi: &str) -> chematic_core::Molecule {
+        parse(smi).expect("parse SMILES")
+    }
+
+    fn hdf_default_mol(smi: &str) -> HdfFp {
+        hdf_default(&mol(smi))
+    }
+
+    #[test]
+    fn same_molecule_cosine_one() {
+        let fp = hdf_default_mol("CCO");
+        let fp2 = hdf_default_mol("CCO");
+        let cos = cosine_hdf(&fp, &fp2);
+        assert!((cos - 1.0).abs() < 1e-5, "same molecule cosine={cos}");
+    }
+
+    #[test]
+    fn unit_norm() {
+        for smi in ["CCO", "c1ccccc1", "CC(=O)Oc1ccccc1C(=O)O"] {
+            let fp = hdf_default_mol(smi);
+            let norm: f32 = fp.0.iter().map(|x| x * x).sum::<f32>().sqrt();
+            assert!((norm - 1.0).abs() < 1e-5, "{smi}: norm={norm}");
+        }
+    }
+
+    #[test]
+    fn ethanol_vs_benzene_less_similar_than_propanol() {
+        let eth = hdf_default_mol("CCO");
+        let ben = hdf_default_mol("c1ccccc1");
+        let pro = hdf_default_mol("CCCO");
+        let cos_eb = cosine_hdf(&eth, &ben);
+        let cos_ep = cosine_hdf(&eth, &pro);
+        assert!(
+            cos_ep > cos_eb,
+            "propanol ({cos_ep:.3}) should be more similar to ethanol than benzene ({cos_eb:.3})"
+        );
+    }
+
+    #[test]
+    fn different_dims_work() {
+        for dim in [64, 256, 512, 1024, 2048] {
+            let config = HdfConfig {
+                dim,
+                radius: 2,
+                seed: 42,
+            };
+            let fp = hdf(&mol("CCO"), &config);
+            assert_eq!(fp.0.len(), dim);
+            let norm: f32 = fp.0.iter().map(|x| x * x).sum::<f32>().sqrt();
+            assert!((norm - 1.0).abs() < 1e-4, "dim={dim} norm={norm}");
+        }
+    }
+
+    #[test]
+    fn different_radius_gives_different_vectors() {
+        let mol = mol("c1ccccc1");
+        let r0 = hdf(
+            &mol,
+            &HdfConfig {
+                dim: 256,
+                radius: 0,
+                seed: 1,
+            },
+        );
+        let r2 = hdf(
+            &mol,
+            &HdfConfig {
+                dim: 256,
+                radius: 2,
+                seed: 1,
+            },
+        );
+        let cos = cosine_hdf(&r0, &r2);
+        assert!(
+            cos < 0.999,
+            "radius-0 and radius-2 should differ; cosine={cos}"
+        );
+    }
+
+    #[test]
+    fn different_seeds_give_different_vectors() {
+        let m = mol("CCO");
+        let fp1 = hdf(
+            &m,
+            &HdfConfig {
+                dim: 256,
+                radius: 2,
+                seed: 1,
+            },
+        );
+        let fp2 = hdf(
+            &m,
+            &HdfConfig {
+                dim: 256,
+                radius: 2,
+                seed: 2,
+            },
+        );
+        let cos = cosine_hdf(&fp1, &fp2);
+        assert!(
+            cos < 0.999,
+            "different seeds should give different vectors; cosine={cos}"
+        );
+    }
+
+    #[test]
+    fn charged_atom_differs_from_neutral() {
+        // [NH4+] vs NH3: different charge → different basis → different HDF
+        let charged = hdf_default_mol("[NH4+]");
+        let neutral = hdf_default_mol("N");
+        let cos = cosine_hdf(&charged, &neutral);
+        assert!(cos < 0.99, "charged vs neutral too similar: cosine={cos}");
+    }
+
+    #[test]
+    fn empty_molecule_returns_zero_vector() {
+        let empty = chematic_core::MoleculeBuilder::new().build();
+        let fp = hdf_default(&empty);
+        assert!(fp.0.iter().all(|&x| x == 0.0));
+    }
+}

--- a/crates/chematic-fp/src/lib.rs
+++ b/crates/chematic-fp/src/lib.rs
@@ -19,6 +19,7 @@ pub mod bulk;
 pub mod ecfp;
 pub mod erg;
 pub mod fcfp;
+pub mod hdf;
 pub mod layered;
 pub mod lsh;
 pub mod maccs;
@@ -40,6 +41,7 @@ pub use erg::{
     erg_extended, erg_vec, erg_with_config, tanimoto_erg, tanimoto_erg_vec,
 };
 pub use fcfp::{fcfp, fcfp4, fcfp6, tanimoto_fcfp4};
+pub use hdf::{HdfConfig, HdfFp, cosine_hdf, hdf, hdf_default};
 pub use layered::{layered_fp, layered_fp_by_layer, tanimoto_layered};
 pub use lsh::MhfpLshIndex;
 pub use maccs::maccs;

--- a/crates/chematic-py/src/bulk.rs
+++ b/crates/chematic-py/src/bulk.rs
@@ -457,6 +457,52 @@ pub fn map4<'py>(py: Python<'py>, smiles: Vec<String>) -> Bound<'py, PyArray2<u3
 }
 
 // ---------------------------------------------------------------------------
+// bulk.hdf — parallel Hyper-Dimensional Fingerprints
+// ---------------------------------------------------------------------------
+
+/// Compute HDF fingerprints for a list of SMILES in parallel.
+///
+/// Returns a numpy array of shape ``(N, dim)`` with ``dtype=float32`` where
+/// each row is a unit-norm HD vector.  Invalid SMILES produce all-zero rows.
+///
+/// Args:
+///     smiles: list of SMILES strings
+///     dim: vector dimension (default 1024)
+///     radius: neighborhood radius (default 2)
+///     seed: reproducibility seed (default 42)
+///
+///     fps = chematic.bulk.hdf(["CCO", "c1ccccc1"], dim=512)
+///     sims = fps @ fps.T          # cosine similarity matrix (N×N)
+#[pyfunction]
+#[pyo3(signature = (smiles, dim = 1024, radius = 2, seed = 42))]
+pub fn hdf<'py>(
+    py: Python<'py>,
+    smiles: Vec<String>,
+    dim: usize,
+    radius: usize,
+    seed: u64,
+) -> Bound<'py, PyArray2<f32>> {
+    let config = chematic_fp::HdfConfig { dim, radius, seed };
+    let fps: Vec<Vec<f32>> = smiles
+        .par_iter()
+        .map(|s| {
+            chematic_smiles::parse(s)
+                .map(|mol| chematic_fp::hdf(&mol, &config).0)
+                .unwrap_or_else(|_| vec![0.0f32; dim])
+        })
+        .collect();
+
+    let n = fps.len();
+    if n == 0 {
+        return Array2::<f32>::zeros((0, dim)).into_pyarray(py);
+    }
+    let flat: Vec<f32> = fps.into_iter().flatten().collect();
+    Array2::from_shape_vec((n, dim), flat)
+        .expect("shape mismatch")
+        .into_pyarray(py)
+}
+
+// ---------------------------------------------------------------------------
 // bulk.substructure_search — parallel SMARTS screen
 // ---------------------------------------------------------------------------
 
@@ -648,6 +694,7 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(ecfp4, m)?)?;
     m.add_function(wrap_pyfunction!(maccs, m)?)?;
     m.add_function(wrap_pyfunction!(map4, m)?)?;
+    m.add_function(wrap_pyfunction!(hdf, m)?)?;
     m.add_function(wrap_pyfunction!(descriptors, m)?)?;
     m.add_function(wrap_pyfunction!(tanimoto, m)?)?;
     m.add_function(wrap_pyfunction!(tanimoto_search, m)?)?;

--- a/crates/chematic-py/src/lib.rs
+++ b/crates/chematic-py/src/lib.rs
@@ -1982,6 +1982,33 @@ impl Mol {
         Array1::from_vec(fp).into_pyarray(py)
     }
 
+    /// Hyper-Dimensional Fingerprint (HDF) as a numpy float32 array of shape ``(dim,)``.
+    ///
+    /// HDF encodes a molecule as a unit-norm float32 vector using Hyperdimensional
+    /// Computing (HDC).  Unlike hash-based fingerprints (ECFP), there is no hash
+    /// collision: every distinct atom environment maps to a unique HD vector.
+    /// Cosine similarity between two normalized HDF vectors gives molecular similarity.
+    ///
+    /// Based on: "Hyper-Dimensional Fingerprints as Molecular Representations" (arXiv 2026).
+    ///
+    ///     fp = mol.hdf()              # shape (1024,), dtype float32, unit norm
+    ///     fp = mol.hdf(dim=512)       # smaller vector
+    ///     fp = mol.hdf(dim=2048, radius=3)
+    ///
+    ///     sim = float(np.dot(mol1.hdf(), mol2.hdf()))  # cosine similarity
+    #[pyo3(signature = (dim = 1024, radius = 2, seed = 42))]
+    fn hdf<'py>(
+        &self,
+        py: Python<'py>,
+        dim: usize,
+        radius: usize,
+        seed: u64,
+    ) -> Bound<'py, PyArray1<f32>> {
+        let config = chematic_fp::HdfConfig { dim, radius, seed };
+        let fp = chematic_fp::hdf(&self.inner, &config);
+        Array1::from_vec(fp.0).into_pyarray(py)
+    }
+
     /// Extended Reduced Graph (ERG) fingerprint as bytes (256 bytes = 2048 bits).
     fn erg(&self) -> Vec<u8> {
         bitvec2048_to_bytes(&chematic_fp::erg(&self.inner).bits)

--- a/crates/chematic-wasm/src/lib.rs
+++ b/crates/chematic-wasm/src/lib.rs
@@ -3270,6 +3270,22 @@ pub fn to_moljson(mol: &MolHandle) -> String {
 
 /// Parse a ChemDraw XML (CDXML) string into a `MolHandle`.
 ///
+/// Compute an HDF fingerprint and return it as a JSON array of float32 values.
+///
+/// Returns a unit-norm vector of length `dim` as a JSON number array.
+/// Use cosine dot product for similarity: `a · b = sum(a[i]*b[i])`.
+///
+/// ```js
+/// const fp = JSON.parse(hdf_json(mol));        // float[] of length 1024
+/// const sim = fp.reduce((s, v, i) => s + v * fp2[i], 0);  // cosine similarity
+/// ```
+#[wasm_bindgen]
+pub fn hdf_json(mol: &MolHandle, dim: usize, radius: usize, seed: u64) -> String {
+    let config = chematic_fp::HdfConfig { dim, radius, seed };
+    let fp = chematic_fp::hdf(&mol.inner, &config);
+    serde_json::to_string(&fp.0).unwrap_or_default()
+}
+
 /// Only the first molecular fragment in the document is returned.
 /// Returns a JS error if the document cannot be parsed.
 #[wasm_bindgen]


### PR DESCRIPTION
HDF fingerprint (arXiv 2026). 8 tests. mol.hdf() → (1024,) f32 unit vector. bulk.hdf() → (N, dim). WASM hdf_json(). Ethanol↔Propanol sim=0.87, Ethanol↔Benzene sim=0.49.