### PR TITLE
fix(ci): add permissions: contents: read to validation workflow

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -15,6 +15,8 @@ jobs:
   rdkit-parity:
     name: RDKit Parity Benchmark
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Resolves code scanning alert #8 (actions/missing-workflow-permissions). Adds `permissions: contents: read` to the rdkit-parity job — minimum required for checkout.