### PR TITLE
docs: sync metrics, fix nav, soften AI use-case claim

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,6 +1,6 @@
 # Benchmark
 
-Measured environment: Python 3.12, Apple M-series, chematic v0.4.23, RDKit 2024.09.
+Measured environment: Python 3.12, Apple M-series, chematic v0.4.23, RDKit 2026.03.3.
 
 ---
 
@@ -11,7 +11,7 @@ Measured environment: Python 3.12, Apple M-series, chematic v0.4.23, RDKit 2024.
 | Import time | **~35 ms** | ~400 ms (11×) |
 | SMILES parse — 5,000 mol | **~5 ms** | ~50 ms (10×) |
 | ECFP4 batch — 10,000 mol | **36 ms** | ~500 ms (14×) |
-| Descriptor accuracy vs RDKit | **100%** on 5,000-mol corpus | baseline |
+| Descriptor accuracy vs RDKit | MW/HBA/HBD **100%** · TPSA **98.1%** · LogP **96.5%** (4,999-mol) | baseline |
 | Install | `pip install chematic` | conda or cmake |
 | C/C++ dependencies | **Zero** | Required |
 | WASM binary size | **504 KB** | ~30 MB |
@@ -117,7 +117,7 @@ python scripts/benchmark_vs_rdkit.py --rdkit
 
 ## 4. Descriptor Accuracy vs RDKit
 
-Tested on a 5,000-molecule ChEMBL-like SMILES corpus (`scripts/bench5k.py`).
+Tested on a 4,999-molecule ChEMBL-derived SMILES corpus (`scripts/bench5k.py`). See [Validation](validation.md) for full per-metric breakdown and known limitations.
 
 | Descriptor | Agreement | Tolerance |
 |-----------|-----------|-----------|
@@ -125,11 +125,12 @@ Tested on a 5,000-molecule ChEMBL-like SMILES corpus (`scripts/bench5k.py`).
 | Heavy atom count | 100% | exact |
 | H-bond donors (HBD) | 100% | exact |
 | H-bond acceptors (HBA) | 100% | exact |
-| TPSA | 100% | ±0.1 Å² |
-| LogP (Crippen) | 100% | ±0.3 |
+| TPSA | 98.1% | ±0.1 Å² |
+| LogP (Crippen) | 96.5% | ±0.3 |
 | Aromatic ring count | 100% | exact |
 
-All metrics reached 100% agreement with `rdkit.Chem.Descriptors` on the 5,000-molecule corpus as of v0.4.14.
+MW, HBA, HBD, and ARC reach 100% agreement on the 4,999-molecule ChEMBL corpus (RDKit 2026.03.3).
+TPSA and LogP gaps are documented in [Known Limitations](validation.md).
 
 ### How to reproduce
 
@@ -148,7 +149,7 @@ python scripts/bench5k.py path/to/SMILES.csv --detail
 | C/C++ compiler | Not required | Required (Boost) |
 | Docker image size delta | ~4 MB | ~200 MB+ |
 | GitHub Actions | Single pip line | Separate conda setup step |
-| JavaScript / WASM | `npm install @kent-tokyo/chematic` (~550 KB) | No official package |
+| JavaScript / WASM | `npm install @kent-tokyo/chematic` (504 KB) | No official package |
 | Browser deployment | Yes | No |
 
 ---
@@ -162,7 +163,7 @@ python scripts/bench5k.py path/to/SMILES.csv --detail
 | MCP server (AI agent integration) | 15 tools | Not available |
 | LSH approximate nearest-neighbour index | Built-in | Not available |
 | IUPAC name generation | Built-in (offline) | Not available |
-| Browser / WASM deployment | Yes (~550 KB) | No |
+| Browser / WASM deployment | Yes (504 KB) | No |
 | ECFP4 batch speed | 5–14× faster | Baseline |
 | SMARTS atom map `:N` | Yes | Yes |
 | Retrosynthesis (template-based) | 60 retro-SMIRKS built-in | External tool |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # chematic
 
-**Pure-Rust cheminformatics for Python** — no C/C++ dependencies, WASM-native, 70+ descriptors.
+**Pure-Rust cheminformatics for Python** — no C/C++ dependencies, WASM-native, 190+ descriptors.
 
 [![CI](https://github.com/kent-tokyo/chematic/actions/workflows/ci.yml/badge.svg)](https://github.com/kent-tokyo/chematic/actions)
 [![PyPI](https://img.shields.io/pypi/v/chematic)](https://pypi.org/project/chematic/)
@@ -21,7 +21,7 @@ print(mol.admet())                   # BBB, Caco-2, hERG, CYP3A4 in one call
 |---|---|---|
 | Install | `pip install chematic` | conda or complex build |
 | C/C++ deps | **Zero** | Required |
-| WASM | **Yes** (~550 KB) | No (30–50 MB) |
+| WASM | **Yes** (504 KB) | No (30–50 MB) |
 | pKa prediction | **Built-in** | External tool |
 | ADMET profile | **Built-in** | External tool |
 | Pure Python wheel | **Yes** | No |
@@ -29,7 +29,7 @@ print(mol.admet())                   # BBB, Caco-2, hERG, CYP3A4 in one call
 ## Features
 
 - **SMILES / SDF / MOL / InChI** parsing and writing
-- **70+ molecular descriptors** (MW, LogP, TPSA, QED, SA Score, pKa, ADMET …)
+- **190+ molecular descriptors** (MW, LogP, TPSA, QED, SA Score, pKa, ADMET …)
 - **Fingerprints**: ECFP4/6, FCFP4/6, MACCS, AtomPair, Torsion, Layered
 - **SMARTS** substructure search with full recursive SMARTS support
 - **Reactions**: SMIRKS application, reaction SMARTS matching, MDL RXN I/O

--- a/docs/rdkit-comparison.md
+++ b/docs/rdkit-comparison.md
@@ -45,7 +45,7 @@ chematic compiles to `wasm32-unknown-unknown` natively — no Emscripten, no cma
 
 ## 2. Performance
 
-All measurements: Python 3.12, Apple M-series, chematic v0.4.22, RDKit 2024.09.
+All measurements: Python 3.12, Apple M-series, chematic v0.4.22, RDKit 2026.03.3.
 
 ### Import time (cold process)
 
@@ -197,5 +197,5 @@ RDKit users while adding batch-first and browser-native capabilities.
 
 ---
 
-*Benchmark data: Apple M-series, Python 3.12, chematic v0.4.22, RDKit 2024.09.*  
+*Benchmark data: Apple M-series, Python 3.12, chematic v0.4.22, RDKit 2026.03.3.*  
 *Reproduce all benchmarks: see [benchmark details](benchmark.md).*

--- a/docs/rdkit_cheatsheet.md
+++ b/docs/rdkit_cheatsheet.md
@@ -289,7 +289,7 @@ df = pd.DataFrame(chematic.bulk.descriptors(smiles_list))
 
 - **pKa prediction** — built-in, no external tools
 - **ADMET profile** — BBB, Caco-2, hERG, CYP3A4 in a single call
-- **WASM support** — runs in the browser (~550 KB bundle)
+- **WASM support** — runs in the browser (504 KB bundle)
 - **MCP server** — direct integration with AI agents
 - **Pure Rust** — no conda, works in Docker / serverless / CI without extra setup
 - **Atropisomer detection** — `mol.atropisomers()` detects biaryl and allene axes

--- a/docs/use-cases/ai-drug-discovery.md
+++ b/docs/use-cases/ai-drug-discovery.md
@@ -1,4 +1,4 @@
-# Use case: AI-assisted drug discovery with Claude Desktop + MCP
+# Use case: AI-assisted molecular analysis with MCP
 
 ## Problem
 

--- a/docs/use-cases/python-notebook.md
+++ b/docs/use-cases/python-notebook.md
@@ -53,7 +53,7 @@ df = pd.DataFrame({
 print(f"Loaded {len(df)} molecules")
 ```
 
-## 2. Compute 70+ descriptors in parallel
+## 2. Compute 190+ descriptors in parallel
 
 ```python
 desc_df = pd.DataFrame(chematic.bulk.descriptors(df["smiles"].tolist()))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: chematic
-site_description: Pure-Rust cheminformatics for Python — SMILES, fingerprints, 70+ descriptors, pKa, ADMET
+site_description: Pure-Rust cheminformatics for Python — SMILES, fingerprints, 190+ descriptors, pKa, ADMET
 site_url: https://kent-tokyo.github.io/chematic/
 repo_url: https://github.com/kent-tokyo/chematic
 repo_name: kent-tokyo/chematic
@@ -51,18 +51,22 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - Use Cases:
-    - AI Drug Discovery (MCP): use-cases/ai-drug-discovery.md
-    - Batch Analysis: use-cases/batch-analysis.md
-    - Browser App (WASM): use-cases/browser-app.md
-    - Python Notebook: use-cases/python-notebook.md
-    - Rust Server: use-cases/rust-server.md
   - Getting Started:
     - Installation: getting_started/installation.md
     - Quick Start: getting_started/quickstart.md
+  - Use Cases:
+    - Python Notebook: use-cases/python-notebook.md
+    - Batch Analysis: use-cases/batch-analysis.md
+    - Browser App (WASM): use-cases/browser-app.md
+    - AI-Assisted Molecular Analysis (MCP): use-cases/ai-drug-discovery.md
+    - Rust Server: use-cases/rust-server.md
   - Cookbook (EN): cookbook.md
   - Cookbook (日本語): cookbook_ja.md
   - Benchmark: benchmark.md
+  - Reliability:
+    - Validation vs RDKit: validation.md
+    - Detailed RDKit Comparison: rdkit-comparison.md
+    - RDKit Issue Lessons: rdkit_issue_lessons.md
   - RDKit Migration Guide: rdkit_cheatsheet.md
   - API Reference:
     - chematic: api/chematic.md


### PR DESCRIPTION
## Summary

数値の不整合とナビゲーション漏れを 7 ファイルの最小変更で解消。

## 変更内容

| ファイル | 変更 |
|---|---|
| `mkdocs.yml` | site_description `70+` → `190+`; **Reliability** セクション追加 (validation / rdkit-comparison / rdkit_issue_lessons); Getting Started を Use Cases より前に移動 |
| `docs/index.md` | `70+` → `190+` (2 箇所); `~550 KB` → `504 KB` |
| `docs/benchmark.md` | RDKit `2024.09` → `2026.03.3`; corpus `5,000` → `4,999`; TPSA `100%` → `98.1%`, LogP `100%` → `96.5%`（validation.md と整合）; 550 KB → 504 KB |
| `docs/rdkit-comparison.md` | RDKit `2024.09` → `2026.03.3` |
| `docs/rdkit_cheatsheet.md` | `~550 KB` → `504 KB` |
| `docs/use-cases/python-notebook.md` | `70+` → `190+` descriptors |
| `docs/use-cases/ai-drug-discovery.md` | タイトル "drug discovery" → "molecular analysis" |

## Test plan

- [ ] `grep -rn "70+ desc" docs/ mkdocs.yml` → 0 件
- [ ] `grep -rn "2024.09" docs/` → 0 件
- [ ] `grep -rn "550 KB" docs/ mkdocs.yml` → 0 件
- [ ] mkdocs nav に Reliability セクションが表示される
- [ ] benchmark.md の TPSA/LogP 値が validation.md と一致している