### PR TITLE
feat(py): rdkit_compat Sprints 1-4 + AromaticityAlgorithm::RdkitLike (v0.4.24)

### DIFF
--- a/crates/chematic-mol/src/lib.rs
+++ b/crates/chematic-mol/src/lib.rs
@@ -44,7 +44,7 @@ pub use ket::{KetError, parse_ket, parse_ket_3d, write_ket, write_ket_3d};
 pub use mol2_tripos::{Mol2Error, parse_mol2, write_mol2};
 pub use mol2000::{
     MolMetadata, parse_mol, parse_mol_with_coords, parse_sdf_with_coords, write_mol,
-    write_mol_with_coords, write_sdf, write_sdf_with_charges,
+    write_mol_with_coords, write_sdf, write_sdf_record, write_sdf_with_charges,
 };
 pub use mol3000::{parse_mol_v3000, parse_mol_v3000_with_coords, write_mol_v3000};
 pub use moljson::{MolJsonError, parse_moljson, write_moljson};

--- a/crates/chematic-mol/src/mol2000.rs
+++ b/crates/chematic-mol/src/mol2000.rs
@@ -465,6 +465,27 @@ pub fn write_sdf_with_charges(
     out
 }
 
+/// Serialise a single molecule to one SDF record with arbitrary SD data fields.
+///
+/// Keys starting with `_` are treated as internal/computed properties and are
+/// omitted from the SD block (e.g. `_Name` is written into the MOL header, not
+/// as an SD field).  The record is terminated with `$$$$`.
+pub fn write_sdf_record(
+    mol: &Molecule,
+    meta: &MolMetadata,
+    coords: &[(f64, f64)],
+    props: &std::collections::HashMap<String, String>,
+) -> String {
+    let mut out = write_mol_with_coords(mol, meta, coords);
+    for (k, v) in props {
+        if !k.starts_with('_') {
+            out.push_str(&format!("> <{k}>\n{v}\n\n"));
+        }
+    }
+    out.push_str("$$$$\n");
+    out
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -741,5 +762,46 @@ many_bonds
     0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
 ";
         assert!(matches!(parse_mol(bad), Err(MolParseError::UnexpectedEnd)));
+    }
+
+    #[test]
+    fn test_write_sdf_record_props_roundtrip() {
+        use crate::sdf::SdfRecordReader;
+        use std::collections::HashMap;
+
+        let (mol, meta) = parse_mol(ETHANOL_MOL).expect("parse");
+        let coords = vec![(0.0, 0.0), (1.5, 0.0), (3.0, 0.0)];
+        let mut props = HashMap::new();
+        props.insert("Activity".to_string(), "7.2".to_string());
+        props.insert("Source".to_string(), "test".to_string());
+        props.insert("_Name".to_string(), "ethanol".to_string()); // internal, should be omitted
+
+        let sdf = write_sdf_record(&mol, &meta, &coords, &props);
+
+        // _Name must NOT appear as an SD field
+        assert!(
+            !sdf.contains("> <_Name>"),
+            "internal prop leaked to SD block"
+        );
+        // Other props must appear
+        assert!(sdf.contains("> <Activity>\n7.2"), "Activity missing");
+        assert!(sdf.contains("> <Source>\ntest"), "Source missing");
+        assert!(sdf.ends_with("$$$$\n"), "missing delimiter");
+
+        // Parse back and verify
+        let rec = SdfRecordReader::new(&sdf)
+            .next()
+            .expect("should have record")
+            .expect("should parse");
+        assert_eq!(rec.mol.atom_count(), mol.atom_count());
+        assert_eq!(
+            rec.properties.get("Activity").map(|s| s.as_str()),
+            Some("7.2")
+        );
+        assert_eq!(
+            rec.properties.get("Source").map(|s| s.as_str()),
+            Some("test")
+        );
+        assert!(!rec.properties.contains_key("_Name"));
     }
 }

--- a/crates/chematic-mol/src/sdf.rs
+++ b/crates/chematic-mol/src/sdf.rs
@@ -478,4 +478,24 @@ $$$$
             .collect();
         assert_eq!(records.len(), 1);
     }
+
+    #[test]
+    fn test_sdf_file_reader_malformed_record_yields_err() {
+        use std::io::{BufReader, Cursor};
+
+        // 3-record SDF: valid, malformed (bad atom count line), valid
+        let malformed = "broken\n  prog\n\n  NOTNUM  0  0 V2000\nM  END\n";
+        let sdf = format!("{MOL_A}$$$$\n{malformed}$$$$\n{MOL_B}$$$$\n");
+        let cursor = Cursor::new(sdf.into_bytes());
+        let results: Vec<_> = SdfFileReader::new(BufReader::new(cursor)).collect();
+
+        // Three items: Ok, Err, Ok
+        assert_eq!(results.len(), 3);
+        assert!(results[0].is_ok(), "first record should be ok");
+        assert!(
+            results[1].is_err(),
+            "second record should be err (malformed)"
+        );
+        assert!(results[2].is_ok(), "third record should be ok");
+    }
 }

--- a/crates/chematic-perception/src/aromaticity.rs
+++ b/crates/chematic-perception/src/aromaticity.rs
@@ -22,6 +22,27 @@
 //!    - Other: non-aromatic
 //! 5. Record all aromatic atoms, bonds, and antiaromatic rings in an `AromaticityModel`.
 
+// ---------------------------------------------------------------------------
+// Algorithm selector
+// ---------------------------------------------------------------------------
+
+/// Algorithm used to classify ring aromaticity.
+///
+/// Passed to [`assign_aromaticity_ex`] and [`apply_aromaticity_ex`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AromaticityAlgorithm {
+    /// Strict Hückel 4n+2 rule (default). Supports C, N, O, S.
+    #[default]
+    Huckel,
+    /// RDKit-compatible extension. Adds Se (34) and Te (52) as chalcogen lone-pair
+    /// donors (2π), matching the RDKit DEFAULT aromaticity model for common
+    /// organic and chalcogen heteroaromatics.
+    ///
+    /// P-containing aromatic rings are NOT supported in this mode (separate sprint).
+    /// Keto-lactam aromaticity is NOT included (TautomerMode, separate sprint).
+    RdkitLike,
+}
+
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use chematic_core::{AtomIdx, BondIdx, BondOrder, Molecule, implicit_hcount};
@@ -136,7 +157,19 @@ fn mark_ring_aromatic(
 ///
 /// For kekulized input from aromatic SMILES, call `chematic_core::kekulize`
 /// then `chematic_core::apply_kekule` first.
+///
+/// Uses [`AromaticityAlgorithm::Huckel`] (default). See [`assign_aromaticity_ex`]
+/// for the RdkitLike variant.
 pub fn assign_aromaticity(mol: &Molecule) -> AromaticityModel {
+    assign_aromaticity_ex(mol, AromaticityAlgorithm::Huckel)
+}
+
+/// Assign aromaticity using the specified algorithm.
+///
+/// The default ([`assign_aromaticity`]) uses [`AromaticityAlgorithm::Huckel`].
+/// Pass [`AromaticityAlgorithm::RdkitLike`] to additionally recognise Se/Te
+/// as lone-pair donors in aromatic rings.
+pub fn assign_aromaticity_ex(mol: &Molecule, algo: AromaticityAlgorithm) -> AromaticityModel {
     let ring_set = find_sssr(mol);
     let sssr_rings = ring_set.rings();
 
@@ -159,7 +192,7 @@ pub fn assign_aromaticity(mol: &Molecule) -> AromaticityModel {
     // ----- Pass 1: independent Hückel per ring -----
     let empty_context = FxHashSet::default();
     for (ring_idx, ring) in rings.iter().enumerate() {
-        match ring_pi_electrons(mol, ring, &empty_context) {
+        match ring_pi_electrons(mol, ring, &empty_context, algo) {
             Some(pi) => {
                 let (cls, count) = classify_ring_aromaticity(pi);
                 classifications[ring_idx] = Some((cls, count));
@@ -197,7 +230,7 @@ pub fn assign_aromaticity(mol: &Molecule) -> AromaticityModel {
                 still_pending.push(ring_idx);
                 continue;
             }
-            match ring_pi_electrons(mol, ring, &aromatic_atoms) {
+            match ring_pi_electrons(mol, ring, &aromatic_atoms, algo) {
                 Some(pi) => {
                     let (cls, count) = classify_ring_aromaticity(pi);
                     classifications[ring_idx] = Some((cls, count));
@@ -243,10 +276,20 @@ pub fn assign_aromaticity(mol: &Molecule) -> AromaticityModel {
 ///
 /// The input may be kekulized (no `Aromatic` bond orders) or may retain
 /// aromatic bond orders from the SMILES parser.
+///
+/// Uses [`AromaticityAlgorithm::Huckel`] (default). See [`apply_aromaticity_ex`]
+/// for the RdkitLike variant.
 pub fn apply_aromaticity(mol: &Molecule) -> Molecule {
+    apply_aromaticity_ex(mol, AromaticityAlgorithm::Huckel)
+}
+
+/// Apply aromaticity using the specified algorithm.
+///
+/// Returns a new [`Molecule`] with aromatic flags set according to `algo`.
+pub fn apply_aromaticity_ex(mol: &Molecule, algo: AromaticityAlgorithm) -> Molecule {
     use chematic_core::{BondOrder, MoleculeBuilder};
 
-    let model = assign_aromaticity(mol);
+    let model = assign_aromaticity_ex(mol, algo);
     let mut builder = MoleculeBuilder::new();
 
     for (idx, atom) in mol.atoms() {
@@ -672,11 +715,13 @@ pub fn count_aromatic_rings(mol: &Molecule) -> usize {
 ///   5. Already in `aromatic_context` → 1π.
 ///   6. Otherwise → None.
 /// - **O/S**: ring_degree must be 2; contributes 2π (lone pair).
+/// - **Se (34) / Te (52)**: analogous to S; only in [`AromaticityAlgorithm::RdkitLike`] mode.
 /// - **Other elements**: None (unsupported).
 fn ring_pi_electrons(
     mol: &Molecule,
     ring: &[AtomIdx],
     aromatic_context: &FxHashSet<AtomIdx>,
+    algo: AromaticityAlgorithm,
 ) -> Option<u32> {
     let ring_atom_set: FxHashSet<AtomIdx> = ring.iter().copied().collect();
     let mut total_pi: u32 = 0;
@@ -778,6 +823,24 @@ fn ring_pi_electrons(
                         !ring_atom_set.contains(&nb) && mol.bond(bidx).order == BondOrder::Double
                     })
                 {
+                    return None;
+                }
+                2
+            }
+
+            // Se (34) / Te (52): chalcogen lone-pair donors (2π), analogous to S.
+            // Only recognised in RdkitLike mode.
+            34 | 52 => {
+                if algo != AromaticityAlgorithm::RdkitLike {
+                    return None;
+                }
+                if ring_degree != 2 {
+                    return None;
+                }
+                // Exocyclic Se=O / Te=O ties up the lone pair.
+                if mol.neighbors(atom_idx).any(|(nb, bidx)| {
+                    !ring_atom_set.contains(&nb) && mol.bond(bidx).order == BondOrder::Double
+                }) {
                     return None;
                 }
                 2
@@ -1551,6 +1614,80 @@ mod tests {
             model.aromatic_atom_count(),
             0,
             "cyclopentadiene not aromatic"
+        );
+    }
+
+    // =========================================================================
+    // RdkitLike mode: Se/Te chalcogen heteroaromatics
+    // =========================================================================
+
+    #[test]
+    fn test_selenophene_huckel_not_aromatic() {
+        // c1cc[se]c1 — in strict Hückel mode, Se is unsupported → 0 aromatic atoms
+        // (assign_aromaticity_ex re-derives from scratch, ignoring parser's aromatic flags)
+        let mol = mol_aromatic("c1cc[se]c1");
+        let m = assign_aromaticity(&mol); // default Hückel
+        assert_eq!(
+            m.aromatic_atom_count(),
+            0,
+            "selenophene: Se not aromatic in Hückel mode"
+        );
+    }
+
+    #[test]
+    fn test_selenophene_rdkit_aromatic() {
+        // c1cc[se]c1 — in RdkitLike mode, Se donates 2π → 6π total → aromatic
+        let mol = mol_aromatic("c1cc[se]c1");
+        let m = assign_aromaticity_ex(&mol, AromaticityAlgorithm::RdkitLike);
+        assert_eq!(
+            m.aromatic_atom_count(),
+            5,
+            "selenophene: all 5 atoms aromatic in RdkitLike"
+        );
+    }
+
+    #[test]
+    fn test_tellurophene_rdkit_aromatic() {
+        // c1cc[te]c1 — Te analogous to Se (2π donor)
+        let mol = mol_aromatic("c1cc[te]c1");
+        let m = assign_aromaticity_ex(&mol, AromaticityAlgorithm::RdkitLike);
+        assert_eq!(
+            m.aromatic_atom_count(),
+            5,
+            "tellurophene: all 5 atoms aromatic in RdkitLike"
+        );
+    }
+
+    #[test]
+    fn test_benzoselenophene_rdkit() {
+        // Fused benzene + selenophene
+        let mol = mol_aromatic("c1ccc2[se]ccc2c1");
+        let m = assign_aromaticity_ex(&mol, AromaticityAlgorithm::RdkitLike);
+        assert_eq!(
+            m.aromatic_atom_count(),
+            9,
+            "benzoselenophene: 9 atoms aromatic"
+        );
+    }
+
+    #[test]
+    fn test_rdkit_mode_does_not_break_benzene() {
+        // Benzene must give same result in both modes
+        let mol = mol_aromatic("c1ccccc1");
+        let m_h = assign_aromaticity(&mol);
+        let m_r = assign_aromaticity_ex(&mol, AromaticityAlgorithm::RdkitLike);
+        assert_eq!(m_h.aromatic_atom_count(), m_r.aromatic_atom_count());
+    }
+
+    #[test]
+    fn test_rdkit_mode_does_not_break_thiophene() {
+        let mol = mol_aromatic("c1ccsc1");
+        let m_h = assign_aromaticity(&mol);
+        let m_r = assign_aromaticity_ex(&mol, AromaticityAlgorithm::RdkitLike);
+        assert_eq!(
+            m_h.aromatic_atom_count(),
+            m_r.aromatic_atom_count(),
+            "thiophene same in both modes"
         );
     }
 }

--- a/crates/chematic-perception/src/lib.rs
+++ b/crates/chematic-perception/src/lib.rs
@@ -16,8 +16,9 @@ pub mod stereo_validation;
 pub mod stereo2d;
 
 pub use aromaticity::{
-    AromaticityModel, RingAromaticity, all_ring_list, apply_aromaticity, aromatic_ring_list,
-    assign_aromaticity, augmented_ring_set, count_aromatic_rings, ring_bonds_all_aromatic,
+    AromaticityAlgorithm, AromaticityModel, RingAromaticity, all_ring_list, apply_aromaticity,
+    apply_aromaticity_ex, aromatic_ring_list, assign_aromaticity, assign_aromaticity_ex,
+    augmented_ring_set, count_aromatic_rings, ring_bonds_all_aromatic,
 };
 pub use chematic_core::{ValenceError, validate_valence};
 pub use pharmacophore::{Feature, FeatureType, detect_features, features_to_bitvec};

--- a/crates/chematic-py/README.md
+++ b/crates/chematic-py/README.md
@@ -89,6 +89,48 @@ df = pd.DataFrame([chematic.from_smiles(s).descriptors() for s in smiles])
 - **SVG / PDF / EPS depiction**: `mol.to_svg()`, `mol.to_pdf()`, `mol.to_eps()`
 - **ChemicalJSON**: `mol.to_cjson(coords=[])`, `chematic.from_cjson(s)` — Avogadro 2 / MolSSI compatible
 
+## RDKit compatibility
+
+`chematic.rdkit_compat` provides a lightweight RDKit-compatible subset for environments where RDKit is unavailable (WASM, serverless, conda-free CI):
+
+```python
+from chematic import rdkit_compat as Chem
+from chematic.rdkit_compat import Descriptors, rdMolDescriptors, DataStructs
+
+mol = Chem.MolFromSmiles("CC(=O)Oc1ccccc1C(=O)O")
+
+# Descriptors
+Descriptors.MolWt(mol)          # 180.16
+rdMolDescriptors.CalcTPSA(mol)  # 63.6
+
+# Fingerprint (ExplicitBitVect)
+fp = rdMolDescriptors.GetMorganFingerprintAsBitVect(mol, 2)
+fp.GetNumBits()                         # 2048
+DataStructs.TanimotoSimilarity(fp, fp)  # 1.0
+DataStructs.BulkTanimotoSimilarity(fp, [fp])  # [1.0]
+
+# Atom / Bond traversal
+for atom in mol.GetAtoms():
+    atom.GetSymbol(), atom.GetAtomicNum(), atom.IsInRing()
+for bond in mol.GetBonds():
+    bond.GetBondType(), bond.GetBondTypeAsDouble(), bond.IsInRing()
+
+# Ring information
+ri = mol.GetRingInfo()
+ri.NumRings()       # 1
+ri.AtomRings()      # tuple of tuples of atom indices
+ri.NumAtomRings(0)  # rings containing atom 0
+
+# SDF I/O with SD properties
+with Chem.SDWriter("out.sdf") as w:
+    mol.SetProp("ID", "aspirin")
+    w.write(mol)
+for m in Chem.SDMolSupplier("out.sdf"):
+    print(m.GetProp("ID"))
+```
+
+Unsupported options raise `NotImplementedError` or `TypeError` — they are never silently ignored.
+
 ## License
 
 MIT OR Apache-2.0

--- a/crates/chematic-py/python/chematic/rdkit_compat.py
+++ b/crates/chematic-py/python/chematic/rdkit_compat.py
@@ -24,8 +24,8 @@ Known differences vs RDKit:
   bit patterns differ from RDKit's due to different hash implementations.
 - ``SanitizeMol`` / ``Kekulize`` are no-ops — chematic sanitizes on parse.
 - ``SDMolSupplier.__len__`` performs an O(n) scan; avoid in hot loops.
-- Atom/bond object access (``GetAtomWithIdx``, ``GetBonds``, ``GetPropNames``)
-  is not supported in this compatibility layer.
+- Atom/bond objects (``GetAtomWithIdx``, ``GetBonds``) are read-only;
+  structure editing (``RWMol``) is not supported.
 - ``MolFromSmarts`` returns a lightweight query object; SMARTS pattern
   matching is delegated to ``chematic.smarts_match``.
 """
@@ -33,7 +33,8 @@ Known differences vs RDKit:
 from __future__ import annotations
 
 __all__ = [
-    "Mol",
+    "Mol", "Atom", "Bond", "BondType", "RingInfo",
+    "ExplicitBitVect",
     "MolFromSmiles", "MolToSmiles", "MolFromMolBlock", "MolFromMolFile",
     "MolToMolBlock", "SanitizeMol", "Kekulize", "AddHs", "RemoveHs",
     "MolFromSmarts",
@@ -46,16 +47,251 @@ import chematic as _ch
 
 
 # ---------------------------------------------------------------------------
+# ExplicitBitVect — RDKit-compatible bit vector
+# ---------------------------------------------------------------------------
+
+class ExplicitBitVect:
+    """RDKit-compatible bit vector backed by a bytearray (LSB-first)."""
+
+    __slots__ = ("_nbits", "_bits")
+
+    def __init__(self, nBits: int) -> None:
+        self._nbits = nBits
+        self._bits = bytearray((nBits + 7) // 8)
+
+    def GetNumBits(self) -> int:
+        return self._nbits
+
+    def GetBit(self, i: int) -> bool:
+        if i < 0 or i >= self._nbits:
+            raise IndexError(i)
+        return bool(self._bits[i >> 3] & (1 << (i & 7)))
+
+    def SetBit(self, i: int) -> None:
+        if i < 0 or i >= self._nbits:
+            raise IndexError(i)
+        self._bits[i >> 3] |= 1 << (i & 7)
+
+    def GetOnBits(self) -> list:
+        return [i for i in range(self._nbits) if self.GetBit(i)]
+
+    def ToBitString(self) -> str:
+        return "".join("1" if self.GetBit(i) else "0" for i in range(self._nbits))
+
+    def _to_bytes(self) -> bytes:
+        return bytes(self._bits)
+
+    @classmethod
+    def _from_bytes(cls, data: bytes, nBits: int) -> "ExplicitBitVect":
+        bv = cls(nBits)
+        n = min(len(data), len(bv._bits))
+        bv._bits[:n] = data[:n]
+        return bv
+
+    def __repr__(self) -> str:
+        return f"ExplicitBitVect({self._nbits})"
+
+
+def _fp_bytes(fp) -> bytes:
+    return fp._to_bytes() if isinstance(fp, ExplicitBitVect) else fp
+
+
+# ---------------------------------------------------------------------------
+# BondType constants
+# ---------------------------------------------------------------------------
+
+class BondType:
+    """RDKit-compatible bond type constants."""
+    SINGLE   = "SINGLE"
+    DOUBLE   = "DOUBLE"
+    TRIPLE   = "TRIPLE"
+    AROMATIC = "AROMATIC"
+    OTHER    = "OTHER"
+
+
+# ---------------------------------------------------------------------------
+# Atom wrapper
+# ---------------------------------------------------------------------------
+
+class Atom:
+    """Read-only wrapper around a chematic atom (RDKit-compatible)."""
+
+    __slots__ = ("_mol", "_idx")
+
+    def __init__(self, mol: "Mol", idx: int) -> None:
+        self._mol = mol
+        self._idx = idx
+
+    def _d(self):
+        # (symbol, atomic_num, formal_charge, is_aromatic, implicit_h, degree, is_in_ring)
+        return self._mol._get_atom_cache()[self._idx]
+
+    def GetIdx(self) -> int:           return self._idx
+    def GetSymbol(self) -> str:        return self._d()[0]
+    def GetAtomicNum(self) -> int:     return self._d()[1]
+    def GetFormalCharge(self) -> int:  return self._d()[2]
+    def GetIsAromatic(self) -> bool:   return self._d()[3]
+    def GetTotalNumHs(self) -> int:    return self._d()[4]
+    def GetDegree(self) -> int:        return self._d()[5]
+    def GetTotalDegree(self) -> int:   return self._d()[5] + self._d()[4]
+    def IsInRing(self) -> bool:        return self._d()[6]
+
+    def IsInRingSize(self, n: int) -> bool:
+        ri = self._mol._get_ring_info()
+        return any(len(r) == n and self._idx in r for r in ri.AtomRings())
+
+    def __repr__(self) -> str:
+        return f"Atom({self._idx}, {self._d()[0]})"
+
+
+# ---------------------------------------------------------------------------
+# Bond wrapper
+# ---------------------------------------------------------------------------
+
+_BOND_TYPE_TO_DOUBLE = {"SINGLE": 1.0, "DOUBLE": 2.0, "TRIPLE": 3.0, "AROMATIC": 1.5}
+
+
+class Bond:
+    """Read-only wrapper around a chematic bond (RDKit-compatible)."""
+
+    __slots__ = ("_mol", "_idx")
+
+    def __init__(self, mol: "Mol", idx: int) -> None:
+        self._mol = mol
+        self._idx = idx
+
+    def _d(self):
+        # (atom1_idx, atom2_idx, bond_type_str, is_aromatic)
+        return self._mol._get_bond_cache()[self._idx]
+
+    def GetIdx(self) -> int:           return self._idx
+    def GetBeginAtomIdx(self) -> int:  return self._d()[0]
+    def GetEndAtomIdx(self) -> int:    return self._d()[1]
+    def GetBeginAtom(self) -> Atom:    return Atom(self._mol, self._d()[0])
+    def GetEndAtom(self) -> Atom:      return Atom(self._mol, self._d()[1])
+    def GetBondType(self) -> str:      return self._d()[2]
+    def GetIsAromatic(self) -> bool:   return self._d()[3]
+
+    def GetBondTypeAsDouble(self) -> float:
+        return _BOND_TYPE_TO_DOUBLE.get(self._d()[2], 0.0)
+
+    def GetOtherAtomIdx(self, idx: int) -> int:
+        a1, a2 = self._d()[0], self._d()[1]
+        if idx == a1: return a2
+        if idx == a2: return a1
+        raise ValueError(f"Atom {idx} is not an endpoint of bond {self._idx}")
+
+    def IsInRing(self) -> bool:
+        return self._mol._get_ring_info().NumBondRings(self._idx) > 0
+
+    def __repr__(self) -> str:
+        d = self._d()
+        return f"Bond({d[0]}-{d[1]}, {d[2]})"
+
+
+# ---------------------------------------------------------------------------
+# RingInfo wrapper
+# ---------------------------------------------------------------------------
+
+class RingInfo:
+    """RDKit-compatible ring information wrapper.
+
+    .. note::
+       Uses SSSR. Fused-ring SSSR decomposition may differ from RDKit's
+       in degenerate cases (e.g. indolizine).
+    """
+
+    __slots__ = ("_atom_rings", "_bond_rings", "_atom_rc", "_bond_rc")
+
+    def __init__(self, mol: "Mol") -> None:
+        atom_rings_raw = mol._mol.sssr_atom_rings
+        self._atom_rings = tuple(tuple(r) for r in atom_rings_raw)
+
+        bond_cache = mol._get_bond_cache()
+        bond_lookup = {
+            (min(b[0], b[1]), max(b[0], b[1])): i
+            for i, b in enumerate(bond_cache)
+        }
+
+        bond_rings = []
+        for ring in atom_rings_raw:
+            n = len(ring)
+            br = []
+            for i in range(n):
+                key = (min(ring[i], ring[(i + 1) % n]), max(ring[i], ring[(i + 1) % n]))
+                if key in bond_lookup:
+                    br.append(bond_lookup[key])
+            bond_rings.append(tuple(br))
+        self._bond_rings = tuple(bond_rings)
+
+        n_atoms = len(mol._get_atom_cache())
+        ac = [0] * n_atoms
+        for ring in self._atom_rings:
+            for a in ring:
+                ac[a] += 1
+        self._atom_rc = tuple(ac)
+
+        n_bonds = len(bond_cache)
+        bc = [0] * n_bonds
+        for ring in self._bond_rings:
+            for b in ring:
+                bc[b] += 1
+        self._bond_rc = tuple(bc)
+
+    def NumRings(self) -> int:
+        return len(self._atom_rings)
+
+    def AtomRings(self):
+        return self._atom_rings
+
+    def BondRings(self):
+        return self._bond_rings
+
+    def NumAtomRings(self, i: int) -> int:
+        if i < 0 or i >= len(self._atom_rc):
+            raise IndexError(i)
+        return self._atom_rc[i]
+
+    def NumBondRings(self, i: int) -> int:
+        if i < 0 or i >= len(self._bond_rc):
+            raise IndexError(i)
+        return self._bond_rc[i]
+
+
+# ---------------------------------------------------------------------------
 # Mol wrapper
 # ---------------------------------------------------------------------------
 
 class Mol:
     """Thin wrapper around ``chematic.Mol`` with RDKit-compatible methods."""
 
-    __slots__ = ("_mol",)
+    __slots__ = ("_mol", "_atom_cache", "_bond_cache", "_ring_info_cache")
 
     def __init__(self, mol: _ch.Mol) -> None:
         self._mol = mol
+        self._atom_cache = None
+        self._bond_cache = None
+        self._ring_info_cache = None
+
+    # -- lazy caches for atom/bond tables ------------------------------------
+
+    def _get_atom_cache(self):
+        if self._atom_cache is None:
+            self._atom_cache = self._mol.atom_table
+        return self._atom_cache
+
+    def _get_bond_cache(self):
+        if self._bond_cache is None:
+            self._bond_cache = self._mol.bond_table
+        return self._bond_cache
+
+    def _get_ring_info(self) -> "RingInfo":
+        if self._ring_info_cache is None:
+            self._ring_info_cache = RingInfo(self)
+        return self._ring_info_cache
+
+    def GetRingInfo(self) -> "RingInfo":
+        return self._get_ring_info()
 
     # -- atom / bond counts --------------------------------------------------
 
@@ -65,6 +301,29 @@ class Mol:
 
     def GetNumHeavyAtoms(self) -> int:
         return self._mol.heavy_atoms
+
+    def GetNumBonds(self) -> int:
+        return len(self._get_bond_cache())
+
+    # -- atom / bond iteration -----------------------------------------------
+
+    def GetAtoms(self):
+        """Iterate over all heavy atoms as ``Atom`` objects."""
+        return (Atom(self, i) for i in range(self.GetNumAtoms()))
+
+    def GetBonds(self):
+        """Iterate over all bonds as ``Bond`` objects."""
+        return (Bond(self, i) for i in range(self.GetNumBonds()))
+
+    def GetAtomWithIdx(self, i: int) -> "Atom":
+        if i < 0 or i >= self.GetNumAtoms():
+            raise IndexError(i)
+        return Atom(self, i)
+
+    def GetBondWithIdx(self, i: int) -> "Bond":
+        if i < 0 or i >= self.GetNumBonds():
+            raise IndexError(i)
+        return Bond(self, i)
 
     # -- SMILES / InChI ------------------------------------------------------
 
@@ -96,6 +355,35 @@ class Mol:
 
     def ToMolBlock(self) -> str:
         return self._mol.to_mol_block()
+
+    # -- SD properties (RDKit-compatible) ------------------------------------
+
+    def GetProp(self, key: str) -> str:
+        return self._mol.GetProp(key)
+
+    def SetProp(self, key: str, val: str) -> None:
+        self._mol.SetProp(key, val)
+
+    def HasProp(self, key: str) -> bool:
+        return self._mol.HasProp(key)
+
+    def GetPropsAsDict(self) -> dict:
+        return self._mol.GetPropsAsDict()
+
+    def GetPropNames(self) -> list:
+        return self._mol.GetPropNames()
+
+    def ClearProp(self, key: str) -> None:
+        self._mol.ClearProp(key)
+
+    def SetIntProp(self, key: str, val: int) -> None:
+        self._mol.SetIntProp(key, val)
+
+    def SetDoubleProp(self, key: str, val: float) -> None:
+        self._mol.SetDoubleProp(key, val)
+
+    def SetBoolProp(self, key: str, val: bool) -> None:
+        self._mol.SetBoolProp(key, val)
 
     # -- repr ----------------------------------------------------------------
 
@@ -197,6 +485,9 @@ def RemoveHs(mol: Mol) -> Mol:
 class SDMolSupplier:
     """Iterate over molecules in an SDF file, yielding ``Mol | None``.
 
+    SD properties are attached to each molecule and accessible via
+    ``GetProp`` / ``GetPropsAsDict``.
+
     .. note::
        ``__len__`` performs an O(n) file scan. Avoid in hot loops.
     """
@@ -208,13 +499,19 @@ class SDMolSupplier:
         removeHs: bool = True,
     ) -> None:
         self._filename = filename
+        self._sanitize = sanitize
+        self._removeHs = removeHs
 
     def __iter__(self):
-        for rec in _ch.iter_sdf(self._filename):
-            if rec.mol is not None:
-                yield Mol(rec.mol)
-            else:
-                yield None
+        # Use chematic.SDMolSupplier which propagates SD props onto mol.props
+        sup = _ch.SDMolSupplier(
+            self._filename,
+            sanitize=self._sanitize,
+            removeHs=self._removeHs,
+            strictParsing=False,
+        )
+        for mol in sup:
+            yield Mol(mol) if mol is not None else None
 
     def __len__(self) -> int:
         # ponytail: O(n) scan; document limitation
@@ -228,6 +525,9 @@ class SDMolSupplier:
 class SDWriter:
     """Write molecules to an SDF file, one record at a time.
 
+    SD properties set on the molecule are written as SD data fields.
+    Use ``SetProps`` to restrict which fields are written.
+
     Supports context-manager protocol::
 
         with SDWriter("out.sdf") as w:
@@ -235,21 +535,29 @@ class SDWriter:
     """
 
     def __init__(self, filename: str) -> None:
-        self._f = open(filename, "w")
+        self._writer = _ch.SDWriter(filename)
 
     def write(self, mol: Mol, confId: int = -1) -> None:
-        """Append *mol* as an SDF record (MOL block + ``$$$$``)."""
-        block = mol._mol.to_mol_block()
-        self._f.write(block)
-        if not block.endswith("\n"):
-            self._f.write("\n")
-        self._f.write("$$$$\n")
+        """Append *mol* as an SDF record including its SD properties."""
+        self._writer.write(mol._mol)
+
+    def SetProps(self, props) -> None:
+        """Restrict which SD properties are written (list of key names)."""
+        self._writer.SetProps(list(props))
+
+    def SetKekulize(self, val: bool) -> None:
+        """No-op: chematic does not need explicit kekulization."""
+        self._writer.SetKekulize(val)
+
+    def SetForceV3000(self, val: bool) -> None:
+        """No-op: V3000 output is not yet supported."""
+        self._writer.SetForceV3000(val)
 
     def flush(self) -> None:
-        self._f.flush()
+        self._writer.flush()
 
     def close(self) -> None:
-        self._f.close()
+        self._writer.close()
 
     def __enter__(self) -> "SDWriter":
         return self
@@ -375,19 +683,43 @@ class rdMolDescriptors:
         radius: int,
         nBits: int = 2048,
         useChirality: bool = False,
-    ) -> bytes:
-        """Return ECFP fingerprint as bytes.
+        useFeatures: bool = False,
+        useBondTypes: bool = True,
+        bitInfo=None,
+        **kwargs,
+    ) -> "ExplicitBitVect":
+        """Return ECFP fingerprint as ExplicitBitVect.
 
         .. note::
            Bit patterns differ from RDKit's Morgan fingerprints due to
            different hash implementations. Use for similarity ranking, not
            for cross-library bit-level comparison.
         """
-        # ponytail: radius→ECFP variant; nBits other than 2048 not supported
-        if radius <= 2:
-            return mol._mol.ecfp4()
+        if useFeatures:
+            raise NotImplementedError("useFeatures=True is not supported")
+        if not useBondTypes:
+            raise NotImplementedError("useBondTypes=False is not supported")
+        if kwargs:
+            raise TypeError(f"Unsupported keyword arguments: {sorted(kwargs)}")
+        if bitInfo is not None:
+            raise NotImplementedError(
+                "bitInfo requires Rust-side atom+radius tracking; not yet implemented"
+            )
+        if nBits != 2048:
+            raise NotImplementedError(
+                f"nBits={nBits} is not supported; only 2048-bit fingerprints are available"
+            )
+        if useChirality:
+            if radius > 2:
+                raise NotImplementedError(
+                    "useChirality=True is only supported for radius≤2 (ECFP4)"
+                )
+            raw = mol._mol.ecfp4_chiral()
+        elif radius <= 2:
+            raw = mol._mol.ecfp4()
         else:
-            return mol._mol.ecfp6()
+            raw = mol._mol.ecfp6()
+        return ExplicitBitVect._from_bytes(bytes(raw), 2048)
 
 
 # ---------------------------------------------------------------------------
@@ -398,9 +730,15 @@ class DataStructs:
     """Mirrors ``rdkit.DataStructs``."""
 
     @staticmethod
-    def TanimotoSimilarity(fp1: bytes, fp2: bytes) -> float:
-        return _ch.tanimoto(fp1, fp2)
+    def TanimotoSimilarity(fp1, fp2) -> float:
+        return _ch.tanimoto(_fp_bytes(fp1), _fp_bytes(fp2))
 
     @staticmethod
-    def DiceSimilarity(fp1: bytes, fp2: bytes) -> float:
-        return _ch.dice_similarity(fp1, fp2)
+    def DiceSimilarity(fp1, fp2) -> float:
+        return _ch.dice_similarity(_fp_bytes(fp1), _fp_bytes(fp2))
+
+    @staticmethod
+    def BulkTanimotoSimilarity(fp, fps) -> list:
+        """Return Tanimoto similarity of *fp* against each fingerprint in *fps*."""
+        b = _fp_bytes(fp)
+        return [_ch.tanimoto(b, _fp_bytes(f)) for f in fps]

--- a/crates/chematic-py/python/chematic/rdkit_compat.py
+++ b/crates/chematic-py/python/chematic/rdkit_compat.py
@@ -1,0 +1,406 @@
+"""
+chematic.rdkit_compat — RDKit API compatibility layer for chematic.
+
+Provides a drop-in subset of the RDKit Python API so that common RDKit
+workflows can run with minimal changes in environments where RDKit is
+unavailable (WASM, serverless, pure-Rust services, no-conda Python envs).
+
+Usage::
+
+    from chematic import rdkit_compat as Chem
+    from chematic.rdkit_compat import Descriptors, rdMolDescriptors, DataStructs
+
+    mol = Chem.MolFromSmiles("CC(=O)Oc1ccccc1C(=O)O")
+    print(Descriptors.MolWt(mol))            # 180.16
+    print(rdMolDescriptors.CalcTPSA(mol))    # 63.6
+    fp = rdMolDescriptors.GetMorganFingerprintAsBitVect(mol, 2)
+    print(DataStructs.TanimotoSimilarity(fp, fp))  # 1.0
+
+Known differences vs RDKit:
+
+- ``GetNumAtoms()`` returns heavy-atom count regardless of ``onlyHeavy``.
+  Use ``mol.add_hydrogens()`` before calling if you need H-inclusive counts.
+- ``GetMorganFingerprintAsBitVect`` uses chematic's ECFP algorithm; Morgan
+  bit patterns differ from RDKit's due to different hash implementations.
+- ``SanitizeMol`` / ``Kekulize`` are no-ops — chematic sanitizes on parse.
+- ``SDMolSupplier.__len__`` performs an O(n) scan; avoid in hot loops.
+- Atom/bond object access (``GetAtomWithIdx``, ``GetBonds``, ``GetPropNames``)
+  is not supported in this compatibility layer.
+- ``MolFromSmarts`` returns a lightweight query object; SMARTS pattern
+  matching is delegated to ``chematic.smarts_match``.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "Mol",
+    "MolFromSmiles", "MolToSmiles", "MolFromMolBlock", "MolFromMolFile",
+    "MolToMolBlock", "SanitizeMol", "Kekulize", "AddHs", "RemoveHs",
+    "MolFromSmarts",
+    "SDMolSupplier", "SDWriter",
+    "Descriptors", "rdMolDescriptors", "DataStructs",
+]
+
+
+import chematic as _ch
+
+
+# ---------------------------------------------------------------------------
+# Mol wrapper
+# ---------------------------------------------------------------------------
+
+class Mol:
+    """Thin wrapper around ``chematic.Mol`` with RDKit-compatible methods."""
+
+    __slots__ = ("_mol",)
+
+    def __init__(self, mol: _ch.Mol) -> None:
+        self._mol = mol
+
+    # -- atom / bond counts --------------------------------------------------
+
+    def GetNumAtoms(self, onlyHeavy: bool = True) -> int:
+        # ponytail: always heavy-atom count; AddHs not tracked in this wrapper
+        return self._mol.heavy_atoms
+
+    def GetNumHeavyAtoms(self) -> int:
+        return self._mol.heavy_atoms
+
+    # -- SMILES / InChI ------------------------------------------------------
+
+    def GetSmiles(self) -> str:
+        return self._mol.smiles
+
+    # -- Substructure --------------------------------------------------------
+
+    def HasSubstructMatch(self, query) -> bool:
+        """SMARTS string or another Mol (matched by SMILES as query)."""
+        if isinstance(query, _SmartsQuery):
+            return _ch.smarts_match(query._pattern, self._mol)
+        if isinstance(query, Mol):
+            return _ch.smarts_match(query._mol.smiles, self._mol)
+        if isinstance(query, str):
+            return _ch.smarts_match(query, self._mol)
+        return False
+
+    def GetSubstructMatches(self, query) -> list:
+        if isinstance(query, _SmartsQuery):
+            return _ch.smarts_find(query._pattern, self._mol)
+        if isinstance(query, Mol):
+            return _ch.smarts_find(query._mol.smiles, self._mol)
+        if isinstance(query, str):
+            return _ch.smarts_find(query, self._mol)
+        return []
+
+    # -- MOL block -----------------------------------------------------------
+
+    def ToMolBlock(self) -> str:
+        return self._mol.to_mol_block()
+
+    # -- repr ----------------------------------------------------------------
+
+    def __repr__(self) -> str:
+        return f"Mol({self._mol.smiles!r})"
+
+
+class _SmartsQuery:
+    """Internal: stores a raw SMARTS string for substructure matching."""
+    __slots__ = ("_pattern",)
+
+    def __init__(self, pattern: str) -> None:
+        self._pattern = pattern
+
+
+# ---------------------------------------------------------------------------
+# Module-level functions (Chem.*)
+# ---------------------------------------------------------------------------
+
+def MolFromSmiles(smi: str, sanitize: bool = True) -> Mol | None:
+    """Parse SMILES, return ``Mol`` or ``None`` on failure."""
+    try:
+        return Mol(_ch.from_smiles(smi))
+    except Exception:
+        return None
+
+
+def MolToSmiles(
+    mol: Mol,
+    isomericSmiles: bool = True,
+    kekuleSmiles: bool = False,
+    canonical: bool = True,
+) -> str:
+    """Return canonical SMILES for *mol*."""
+    return mol._mol.smiles
+
+
+def MolFromMolBlock(
+    block: str,
+    sanitize: bool = True,
+    removeHs: bool = True,
+) -> Mol | None:
+    """Parse a MOL/SDF block string."""
+    try:
+        return Mol(_ch.from_mol_block(block))
+    except Exception:
+        return None
+
+
+def MolFromMolFile(
+    filename: str,
+    sanitize: bool = True,
+    removeHs: bool = True,
+) -> Mol | None:
+    """Read the first molecule from a MOL file."""
+    try:
+        text = open(filename).read()
+        return MolFromMolBlock(text, sanitize=sanitize, removeHs=removeHs)
+    except Exception:
+        return None
+
+
+def MolToMolBlock(
+    mol: Mol,
+    includeStereo: bool = True,
+    confId: int = -1,
+) -> str:
+    """Return a MOL block string for *mol*."""
+    return mol._mol.to_mol_block()
+
+
+def MolFromSmarts(pattern: str) -> _SmartsQuery:
+    """Parse a SMARTS pattern for use with ``HasSubstructMatch``."""
+    return _SmartsQuery(pattern)
+
+
+def SanitizeMol(mol: Mol) -> None:
+    """No-op: chematic sanitizes on parse."""
+
+
+def Kekulize(mol: Mol, clearAromaticFlags: bool = False) -> None:
+    """No-op: chematic kekulizes on demand internally."""
+
+
+def AddHs(mol: Mol, addCoords: bool = False) -> Mol:
+    """Return a new ``Mol`` with explicit hydrogens added."""
+    return Mol(mol._mol.add_hydrogens())
+
+
+def RemoveHs(mol: Mol) -> Mol:
+    """Return a new ``Mol`` with explicit hydrogens removed."""
+    return Mol(mol._mol.remove_hydrogens())
+
+
+# ---------------------------------------------------------------------------
+# SDMolSupplier — streaming SDF reader
+# ---------------------------------------------------------------------------
+
+class SDMolSupplier:
+    """Iterate over molecules in an SDF file, yielding ``Mol | None``.
+
+    .. note::
+       ``__len__`` performs an O(n) file scan. Avoid in hot loops.
+    """
+
+    def __init__(
+        self,
+        filename: str,
+        sanitize: bool = True,
+        removeHs: bool = True,
+    ) -> None:
+        self._filename = filename
+
+    def __iter__(self):
+        for rec in _ch.iter_sdf(self._filename):
+            if rec.mol is not None:
+                yield Mol(rec.mol)
+            else:
+                yield None
+
+    def __len__(self) -> int:
+        # ponytail: O(n) scan; document limitation
+        return sum(1 for _ in _ch.iter_sdf(self._filename))
+
+
+# ---------------------------------------------------------------------------
+# SDWriter — streaming SDF writer
+# ---------------------------------------------------------------------------
+
+class SDWriter:
+    """Write molecules to an SDF file, one record at a time.
+
+    Supports context-manager protocol::
+
+        with SDWriter("out.sdf") as w:
+            w.write(mol)
+    """
+
+    def __init__(self, filename: str) -> None:
+        self._f = open(filename, "w")
+
+    def write(self, mol: Mol, confId: int = -1) -> None:
+        """Append *mol* as an SDF record (MOL block + ``$$$$``)."""
+        block = mol._mol.to_mol_block()
+        self._f.write(block)
+        if not block.endswith("\n"):
+            self._f.write("\n")
+        self._f.write("$$$$\n")
+
+    def flush(self) -> None:
+        self._f.flush()
+
+    def close(self) -> None:
+        self._f.close()
+
+    def __enter__(self) -> "SDWriter":
+        return self
+
+    def __exit__(self, *args) -> None:
+        self.close()
+
+
+# ---------------------------------------------------------------------------
+# Descriptors namespace
+# ---------------------------------------------------------------------------
+
+class Descriptors:
+    """Mirrors ``rdkit.Chem.Descriptors``."""
+
+    @staticmethod
+    def MolWt(mol: Mol) -> float:
+        return mol._mol.mw
+
+    @staticmethod
+    def ExactMolWt(mol: Mol) -> float:
+        return mol._mol.exact_mass
+
+    @staticmethod
+    def MolLogP(mol: Mol) -> float:
+        return mol._mol.logp
+
+    @staticmethod
+    def TPSA(mol: Mol) -> float:
+        return mol._mol.tpsa
+
+    @staticmethod
+    def NumHDonors(mol: Mol) -> int:
+        return mol._mol.hbd
+
+    @staticmethod
+    def NumHAcceptors(mol: Mol) -> int:
+        return mol._mol.hba
+
+    @staticmethod
+    def NumRotatableBonds(mol: Mol) -> int:
+        return mol._mol.rotatable_bonds
+
+    @staticmethod
+    def NumHeavyAtoms(mol: Mol) -> int:
+        return mol._mol.heavy_atoms
+
+    @staticmethod
+    def FractionCSP3(mol: Mol) -> float:
+        return mol._mol.fsp3
+
+    @staticmethod
+    def MolMR(mol: Mol) -> float:
+        return mol._mol.molar_refractivity
+
+
+# ---------------------------------------------------------------------------
+# rdMolDescriptors namespace
+# ---------------------------------------------------------------------------
+
+class rdMolDescriptors:
+    """Mirrors ``rdkit.Chem.rdMolDescriptors``."""
+
+    @staticmethod
+    def CalcTPSA(mol: Mol, includeSandP: bool = True) -> float:
+        return mol._mol.tpsa
+
+    @staticmethod
+    def CalcNumHBA(mol: Mol) -> int:
+        return mol._mol.hba
+
+    @staticmethod
+    def CalcNumHBD(mol: Mol) -> int:
+        return mol._mol.hbd
+
+    @staticmethod
+    def CalcNumAtomStereoCenters(mol: Mol) -> int:
+        return mol._mol.num_stereocenters
+
+    @staticmethod
+    def CalcNumRotatableBonds(mol: Mol) -> int:
+        return mol._mol.rotatable_bonds
+
+    @staticmethod
+    def CalcNumHeavyAtoms(mol: Mol) -> int:
+        return mol._mol.heavy_atoms
+
+    @staticmethod
+    def CalcExactMolWt(mol: Mol) -> float:
+        return mol._mol.exact_mass
+
+    @staticmethod
+    def CalcFractionCSP3(mol: Mol) -> float:
+        return mol._mol.fsp3
+
+    @staticmethod
+    def CalcNumAromaticRings(mol: Mol) -> int:
+        return mol._mol.aromatic_ring_count
+
+    @staticmethod
+    def CalcNumRings(mol: Mol) -> int:
+        return mol._mol.aromatic_ring_count + mol._mol.num_aliphatic_rings
+
+    @staticmethod
+    def CalcNumSpiroAtoms(mol: Mol) -> int:
+        return mol._mol.num_spiro_atoms
+
+    @staticmethod
+    def CalcNumBridgeheadAtoms(mol: Mol) -> int:
+        return mol._mol.num_bridgehead_atoms
+
+    @staticmethod
+    def CalcNumAmideBonds(mol: Mol) -> int:
+        return mol._mol.num_amide_bonds
+
+    @staticmethod
+    def CalcNumHeteroatoms(mol: Mol) -> int:
+        return mol._mol.num_heteroatoms
+
+    @staticmethod
+    def GetMorganFingerprintAsBitVect(
+        mol: Mol,
+        radius: int,
+        nBits: int = 2048,
+        useChirality: bool = False,
+    ) -> bytes:
+        """Return ECFP fingerprint as bytes.
+
+        .. note::
+           Bit patterns differ from RDKit's Morgan fingerprints due to
+           different hash implementations. Use for similarity ranking, not
+           for cross-library bit-level comparison.
+        """
+        # ponytail: radius→ECFP variant; nBits other than 2048 not supported
+        if radius <= 2:
+            return mol._mol.ecfp4()
+        else:
+            return mol._mol.ecfp6()
+
+
+# ---------------------------------------------------------------------------
+# DataStructs namespace
+# ---------------------------------------------------------------------------
+
+class DataStructs:
+    """Mirrors ``rdkit.DataStructs``."""
+
+    @staticmethod
+    def TanimotoSimilarity(fp1: bytes, fp2: bytes) -> float:
+        return _ch.tanimoto(fp1, fp2)
+
+    @staticmethod
+    def DiceSimilarity(fp1: bytes, fp2: bytes) -> float:
+        return _ch.dice_similarity(fp1, fp2)

--- a/crates/chematic-py/src/bulk.rs
+++ b/crates/chematic-py/src/bulk.rs
@@ -40,6 +40,7 @@ pub fn parse(smiles: Vec<String>) -> Vec<Option<Mol>> {
         .map(|opt| {
             opt.map(|mol| Mol {
                 inner: Arc::new(mol),
+                props: Default::default(),
             })
         })
         .collect()
@@ -1011,7 +1012,7 @@ pub fn standardize(mols: Vec<Mol>) -> Vec<Mol> {
     mols.par_iter()
         .map(|m| {
             let s = chematic_chem::standardize(&m.inner, &opts);
-            Mol { inner: Arc::new(s) }
+            Mol::bare(s)
         })
         .collect()
 }

--- a/crates/chematic-py/src/io.rs
+++ b/crates/chematic-py/src/io.rs
@@ -353,6 +353,7 @@ impl SdMolSupplier {
 #[pyclass(name = "SDWriter")]
 pub struct SdWriter {
     writer: Option<std::io::BufWriter<std::fs::File>>,
+    props_filter: Option<Vec<String>>,
 }
 
 #[pymethods]
@@ -363,6 +364,7 @@ impl SdWriter {
             .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{path}: {e}")))?;
         Ok(SdWriter {
             writer: Some(std::io::BufWriter::new(file)),
+            props_filter: None,
         })
     }
 
@@ -379,9 +381,40 @@ impl SdWriter {
             name,
             comment: String::new(),
         };
-        let record = chematic_mol::write_sdf_record(&mol.inner, &meta, &coords, &mol.props);
+        let props = match &self.props_filter {
+            None => mol.props.clone(),
+            Some(keys) => keys
+                .iter()
+                .filter_map(|k| mol.props.get(k).map(|v| (k.clone(), v.clone())))
+                .collect(),
+        };
+        let record = chematic_mol::write_sdf_record(&mol.inner, &meta, &coords, &props);
         w.write_all(record.as_bytes())
             .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))
+    }
+
+    /// Restrict which SD properties are written. Pass ``None`` to reset (write all).
+    #[pyo3(name = "SetProps")]
+    fn set_props(&mut self, props: Vec<String>) {
+        self.props_filter = Some(props);
+    }
+
+    /// No-op: chematic always writes aromatic SMILES internally.
+    #[pyo3(name = "SetKekulize")]
+    fn set_kekulize(&mut self, _val: bool) {}
+
+    /// No-op: V3000 output is not yet supported.
+    #[pyo3(name = "SetForceV3000")]
+    fn set_force_v3000(&mut self, _val: bool) {}
+
+    /// Flush buffered data to disk.
+    fn flush(&mut self) -> PyResult<()> {
+        use std::io::Write as _;
+        if let Some(w) = self.writer.as_mut() {
+            w.flush()
+                .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+        }
+        Ok(())
     }
 
     fn close(&mut self) {

--- a/crates/chematic-py/src/io.rs
+++ b/crates/chematic-py/src/io.rs
@@ -89,6 +89,7 @@ fn parse_to_iter(content: &str) -> SdfIter {
         .map(|rec| PySdfRecord {
             mol: Mol {
                 inner: Arc::new(rec.mol),
+                props: Default::default(),
             },
             name: rec.meta.name,
             props: rec.properties,
@@ -191,6 +192,7 @@ impl SdfFileIter {
                     return Ok(Some(PySdfRecord {
                         mol: Mol {
                             inner: Arc::new(rec.mol),
+                            props: Default::default(),
                         },
                         name: rec.meta.name,
                         props: rec.properties,
@@ -243,6 +245,7 @@ impl SdfBatchIter {
                     batch.push(PySdfRecord {
                         mol: Mol {
                             inner: Arc::new(rec.mol),
+                            props: Default::default(),
                         },
                         name: rec.meta.name,
                         props: rec.properties,
@@ -263,6 +266,145 @@ impl SdfBatchIter {
 }
 
 // ---------------------------------------------------------------------------
+// SDMolSupplier — RDKit-compatible streaming SDF reader
+// ---------------------------------------------------------------------------
+
+/// Streaming SDF reader that yields ``Mol`` objects with SD properties attached.
+///
+/// RDKit-compatible API:
+///
+///     sup = chematic.SDMolSupplier("compounds.sdf")
+///     for mol in sup:
+///         if mol is None:
+///             continue          # malformed record (strict_parsing=False only)
+///         print(mol.smiles, mol.GetProp("Activity"))
+///
+/// ``sanitize`` and ``remove_hs`` are accepted for API compatibility but are no-ops:
+/// chematic's parser already applies default aromaticity perception and stores
+/// only heavy atoms.
+#[pyclass(name = "SDMolSupplier")]
+pub struct SdMolSupplier {
+    inner: chematic_mol::SdfFileReader<std::io::BufReader<std::fs::File>>,
+    strict_parsing: bool,
+}
+
+#[pymethods]
+impl SdMolSupplier {
+    #[new]
+    #[allow(non_snake_case)]
+    #[pyo3(signature = (path, sanitize=true, removeHs=true, strictParsing=true))]
+    fn new(path: &str, sanitize: bool, removeHs: bool, strictParsing: bool) -> PyResult<Self> {
+        let _ = (sanitize, removeHs); // accepted, no-op
+        let file = std::fs::File::open(path)
+            .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{path}: {e}")))?;
+        Ok(SdMolSupplier {
+            inner: chematic_mol::SdfFileReader::new(std::io::BufReader::new(file)),
+            strict_parsing: strictParsing,
+        })
+    }
+
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(&mut self, py: Python<'_>) -> PyResult<Option<pyo3::Py<pyo3::PyAny>>> {
+        match self.inner.next() {
+            None => Ok(None),
+            Some(Ok(rec)) => {
+                let mut props = rec.properties;
+                if !rec.meta.name.is_empty() {
+                    props.insert("_Name".to_string(), rec.meta.name);
+                }
+                let mol = Mol {
+                    inner: std::sync::Arc::new(rec.mol),
+                    props,
+                };
+                Ok(Some(pyo3::Py::new(py, mol)?.into_any()))
+            }
+            Some(Err(chematic_mol::MolParseError::Io(msg))) => {
+                Err(pyo3::exceptions::PyIOError::new_err(msg))
+            }
+            Some(Err(_)) => {
+                if self.strict_parsing {
+                    return Err(pyo3::exceptions::PyValueError::new_err(
+                        "malformed SDF record",
+                    ));
+                }
+                Ok(Some(py.None()))
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SDWriter — RDKit-compatible SDF writer
+// ---------------------------------------------------------------------------
+
+/// Streaming SDF writer that writes ``Mol`` objects with their SD properties.
+///
+///     with chematic.SDWriter("output.sdf") as w:
+///         mol = chematic.from_smiles("c1ccccc1")
+///         mol.SetProp("Activity", "7.2")
+///         w.write(mol)
+///
+/// 2D coordinates are computed automatically. The ``_Name`` property, if set,
+/// is written into the MOL header line; other ``_``-prefixed properties are
+/// omitted from the SD block.
+#[pyclass(name = "SDWriter")]
+pub struct SdWriter {
+    writer: Option<std::io::BufWriter<std::fs::File>>,
+}
+
+#[pymethods]
+impl SdWriter {
+    #[new]
+    fn new(path: &str) -> PyResult<Self> {
+        let file = std::fs::File::create(path)
+            .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{path}: {e}")))?;
+        Ok(SdWriter {
+            writer: Some(std::io::BufWriter::new(file)),
+        })
+    }
+
+    fn write(&mut self, mol: &Mol) -> PyResult<()> {
+        use std::io::Write as _;
+        let w = self
+            .writer
+            .as_mut()
+            .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("SDWriter is already closed"))?;
+        let layout = chematic_depict::compute_layout(&mol.inner);
+        let coords: Vec<(f64, f64)> = layout.coords.iter().map(|p| (p.x, p.y)).collect();
+        let name = mol.props.get("_Name").cloned().unwrap_or_default();
+        let meta = chematic_mol::MolMetadata {
+            name,
+            comment: String::new(),
+        };
+        let record = chematic_mol::write_sdf_record(&mol.inner, &meta, &coords, &mol.props);
+        w.write_all(record.as_bytes())
+            .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))
+    }
+
+    fn close(&mut self) {
+        self.writer.take();
+    }
+
+    fn __enter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    #[allow(unused_variables)]
+    fn __exit__(
+        &mut self,
+        exc_type: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+        exc_val: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+        exc_tb: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+    ) -> bool {
+        self.close();
+        false
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Register
 // ---------------------------------------------------------------------------
 
@@ -271,6 +413,8 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<SdfIter>()?;
     m.add_class::<SdfFileIter>()?;
     m.add_class::<SdfBatchIter>()?;
+    m.add_class::<SdMolSupplier>()?;
+    m.add_class::<SdWriter>()?;
     m.add_function(wrap_pyfunction!(iter_sdf, m)?)?;
     m.add_function(wrap_pyfunction!(iter_sdf_str, m)?)?;
     m.add_function(wrap_pyfunction!(iter_sdf_batched, m)?)?;

--- a/crates/chematic-py/src/lib.rs
+++ b/crates/chematic-py/src/lib.rs
@@ -51,6 +51,16 @@ impl Report {
 #[derive(Clone)]
 struct Mol {
     inner: Arc<chematic_core::Molecule>,
+    props: std::collections::HashMap<String, String>,
+}
+
+impl Mol {
+    fn bare(mol: chematic_core::Molecule) -> Self {
+        Mol {
+            inner: Arc::new(mol),
+            props: Default::default(),
+        }
+    }
 }
 
 #[pymethods]
@@ -537,6 +547,7 @@ impl Mol {
         let new_mol = chematic_perception::apply_aromaticity_ex(&self.inner, algo);
         Ok(Mol {
             inner: Arc::new(new_mol),
+            props: Default::default(),
         })
     }
 
@@ -1554,6 +1565,7 @@ impl Mol {
         let opts = chematic_chem::StandardizeOptions::default();
         Mol {
             inner: Arc::new(chematic_chem::standardize(&self.inner, &opts)),
+            props: Default::default(),
         }
     }
 
@@ -1561,6 +1573,7 @@ impl Mol {
     fn scaffold(&self) -> Mol {
         Mol {
             inner: Arc::new(chematic_chem::murcko_scaffold(&self.inner)),
+            props: Default::default(),
         }
     }
 
@@ -1568,6 +1581,7 @@ impl Mol {
     fn canonical_tautomer(&self) -> Mol {
         Mol {
             inner: Arc::new(chematic_chem::canonical_tautomer(&self.inner)),
+            props: Default::default(),
         }
     }
 
@@ -1607,7 +1621,7 @@ impl Mol {
     fn enumerate_tautomers(&self) -> Vec<Mol> {
         chematic_chem::enumerate_tautomers(&self.inner)
             .into_iter()
-            .map(|m| Mol { inner: Arc::new(m) })
+            .map(Mol::bare)
             .collect()
     }
 
@@ -1619,7 +1633,7 @@ impl Mol {
     fn enumerate_stereoisomers(&self) -> Vec<Mol> {
         chematic_chem::enumerate_stereoisomers(&self.inner)
             .into_iter()
-            .map(|m| Mol { inner: Arc::new(m) })
+            .map(Mol::bare)
             .collect()
     }
 
@@ -1627,6 +1641,7 @@ impl Mol {
     fn add_hydrogens(&self) -> Mol {
         Mol {
             inner: Arc::new(chematic_chem::add_hydrogens(&self.inner)),
+            props: Default::default(),
         }
     }
 
@@ -1634,6 +1649,7 @@ impl Mol {
     fn remove_hydrogens(&self) -> Mol {
         Mol {
             inner: Arc::new(chematic_chem::remove_hydrogens(&self.inner)),
+            props: Default::default(),
         }
     }
 
@@ -1641,6 +1657,7 @@ impl Mol {
     fn remove_stereo(&self) -> Mol {
         Mol {
             inner: Arc::new(chematic_chem::remove_stereo(&self.inner)),
+            props: Default::default(),
         }
     }
 
@@ -1648,6 +1665,7 @@ impl Mol {
     fn remove_isotopes(&self) -> Mol {
         Mol {
             inner: Arc::new(chematic_chem::remove_isotopes(&self.inner)),
+            props: Default::default(),
         }
     }
 
@@ -1655,6 +1673,7 @@ impl Mol {
     fn largest_fragment(&self) -> Mol {
         Mol {
             inner: Arc::new(chematic_chem::largest_fragment(&self.inner)),
+            props: Default::default(),
         }
     }
 
@@ -1670,11 +1689,7 @@ impl Mol {
     ///     parts = mol.connected_components()
     ///     # [Mol("CC"), Mol("N")]
     fn connected_components(&self) -> Vec<Mol> {
-        self.inner
-            .fragments()
-            .into_iter()
-            .map(|m| Mol { inner: Arc::new(m) })
-            .collect()
+        self.inner.fragments().into_iter().map(Mol::bare).collect()
     }
 
     /// Return ``True`` if this molecule and ``other`` represent the same chemical structure.
@@ -1693,6 +1708,7 @@ impl Mol {
     fn neutralize(&self) -> Mol {
         Mol {
             inner: Arc::new(chematic_chem::neutralize_charges(&self.inner)),
+            props: Default::default(),
         }
     }
 
@@ -1700,6 +1716,7 @@ impl Mol {
     fn generic_scaffold(&self) -> Mol {
         Mol {
             inner: Arc::new(chematic_chem::generic_murcko_scaffold(&self.inner)),
+            props: Default::default(),
         }
     }
 
@@ -1710,7 +1727,7 @@ impl Mol {
     fn brics_fragments(&self) -> Vec<Mol> {
         chematic_chem::brics_fragments(&self.inner)
             .into_iter()
-            .map(|m| Mol { inner: Arc::new(m) })
+            .map(Mol::bare)
             .collect()
     }
 
@@ -2814,6 +2831,7 @@ impl Mol {
     fn normalize_groups(&self) -> Mol {
         Mol {
             inner: Arc::new(chematic_chem::normalize_groups(&self.inner)),
+            props: Default::default(),
         }
     }
 
@@ -2823,6 +2841,7 @@ impl Mol {
     fn prefer_organic(&self) -> Mol {
         Mol {
             inner: Arc::new(chematic_chem::prefer_organic(&self.inner)),
+            props: Default::default(),
         }
     }
 
@@ -2832,6 +2851,7 @@ impl Mol {
     fn reionize(&self) -> Mol {
         Mol {
             inner: Arc::new(chematic_chem::reionize(&self.inner)),
+            props: Default::default(),
         }
     }
 
@@ -2839,6 +2859,7 @@ impl Mol {
     fn uncharge(&self) -> Mol {
         Mol {
             inner: Arc::new(chematic_chem::uncharge(&self.inner)),
+            props: Default::default(),
         }
     }
 
@@ -3365,6 +3386,7 @@ impl Mol {
     fn normalize_zwitterion(&self) -> Mol {
         Mol {
             inner: Arc::new(chematic_chem::normalize_zwitterion(&self.inner)),
+            props: Default::default(),
         }
     }
 
@@ -3377,6 +3399,7 @@ impl Mol {
     fn remove_salts(&self) -> Mol {
         Mol {
             inner: Arc::new(chematic_chem::standardize::remove_salts(&self.inner)),
+            props: Default::default(),
         }
     }
 
@@ -3391,6 +3414,7 @@ impl Mol {
         let idx = chematic_core::AtomIdx(atom_idx as u32);
         Mol {
             inner: Arc::new(chematic_chem::invert_stereocenter(&self.inner, idx)),
+            props: Default::default(),
         }
     }
 
@@ -3750,6 +3774,41 @@ impl Mol {
     }
 
     // -----------------------------------------------------------------------
+    // SD properties (RDKit-compatible)
+    // -----------------------------------------------------------------------
+
+    /// Get an SD property by name. Raises ``KeyError`` if not present.
+    #[pyo3(name = "GetProp")]
+    fn get_prop(&self, key: &str) -> PyResult<String> {
+        self.props
+            .get(key)
+            .cloned()
+            .ok_or_else(|| pyo3::exceptions::PyKeyError::new_err(format!("'{key}' not found")))
+    }
+
+    /// Set an SD property.
+    #[pyo3(name = "SetProp")]
+    fn set_prop(&mut self, key: String, value: String) {
+        self.props.insert(key, value);
+    }
+
+    /// Return ``True`` if the property exists.
+    #[pyo3(name = "HasProp")]
+    fn has_prop(&self, key: &str) -> bool {
+        self.props.contains_key(key)
+    }
+
+    /// Return all SD properties as a Python dict.
+    #[pyo3(name = "GetPropsAsDict")]
+    fn get_props_as_dict<'py>(&self, py: Python<'py>) -> Bound<'py, PyDict> {
+        let d = PyDict::new(py);
+        for (k, v) in &self.props {
+            d.set_item(k, v).ok();
+        }
+        d
+    }
+
+    // -----------------------------------------------------------------------
     // Dunder methods
     // -----------------------------------------------------------------------
 
@@ -3877,6 +3936,7 @@ fn from_smiles(smiles: &str) -> PyResult<Mol> {
     chematic_smiles::parse(smiles)
         .map(|mol| Mol {
             inner: Arc::new(mol),
+            props: Default::default(),
         })
         .map_err(|e| PyValueError::new_err(e.to_string()))
 }
@@ -3920,6 +3980,7 @@ fn from_cxsmiles<'py>(py: Python<'py>, s: &str) -> PyResult<(Mol, Bound<'py, PyD
     Ok((
         Mol {
             inner: Arc::new(cx.mol),
+            props: Default::default(),
         },
         d,
     ))
@@ -3944,6 +4005,7 @@ fn from_cxsmiles<'py>(py: Python<'py>, s: &str) -> PyResult<(Mol, Bound<'py, PyD
 fn from_condensed(formula: &str) -> Option<Mol> {
     chematic_chem::parse_condensed(formula).ok().map(|mol| Mol {
         inner: Arc::new(mol),
+        props: Default::default(),
     })
 }
 
@@ -3953,6 +4015,7 @@ fn from_mol_block(block: &str) -> PyResult<Mol> {
     chematic_mol::parse_mol(block)
         .map(|(mol, _meta)| Mol {
             inner: Arc::new(mol),
+            props: Default::default(),
         })
         .map_err(|e| PyValueError::new_err(e.to_string()))
 }
@@ -3981,6 +4044,7 @@ fn from_mol_block_with_coords(block: &str) -> PyResult<(Mol, String, Vec<Vec<f64
             (
                 Mol {
                     inner: Arc::new(mol),
+                    props: Default::default(),
                 },
                 meta.name,
                 py_coords,
@@ -4024,6 +4088,7 @@ fn parse_sdf_with_coords(text: &str) -> Vec<(Mol, String, Vec<Vec<f64>>)> {
                 results.push((
                     Mol {
                         inner: Arc::new(mol),
+                        props: Default::default(),
                     },
                     meta.name,
                     py_coords,
@@ -4049,6 +4114,7 @@ fn from_cml(cml_str: &str) -> PyResult<Mol> {
     chematic_mol::parse_cml(cml_str)
         .map(|(mol, _coords)| Mol {
             inner: Arc::new(mol),
+            props: Default::default(),
         })
         .map_err(|e| PyValueError::new_err(e.to_string()))
 }
@@ -4076,6 +4142,7 @@ fn from_cjson(cjson_str: &str) -> PyResult<(Mol, Vec<Vec<f64>>)> {
     Ok((
         Mol {
             inner: Arc::new(mol),
+            props: Default::default(),
         },
         py_coords,
     ))
@@ -4097,6 +4164,7 @@ fn from_moljson(json_str: &str) -> PyResult<Mol> {
     chematic_mol::parse_moljson(json_str)
         .map(|mol| Mol {
             inner: Arc::new(mol),
+            props: Default::default(),
         })
         .map_err(|e| PyValueError::new_err(e.to_string()))
 }
@@ -4112,6 +4180,7 @@ fn from_cdxml(cdxml_str: &str) -> PyResult<Mol> {
     chematic_mol::parse_cdxml(cdxml_str)
         .map(|(mol, _coords)| Mol {
             inner: Arc::new(mol),
+            props: Default::default(),
         })
         .map_err(|e| PyValueError::new_err(e.to_string()))
 }
@@ -4127,6 +4196,7 @@ fn from_mol_v3000(block: &str) -> PyResult<Mol> {
     chematic_mol::parse_mol_v3000(block)
         .map(|(mol, _meta)| Mol {
             inner: Arc::new(mol),
+            props: Default::default(),
         })
         .map_err(|e| PyValueError::new_err(e.to_string()))
 }
@@ -4148,6 +4218,7 @@ fn from_mol_v3000_with_coords(block: &str) -> PyResult<(Mol, String, Vec<Vec<f64
             (
                 Mol {
                     inner: Arc::new(mol),
+                    props: Default::default(),
                 },
                 meta.name,
                 py_coords,
@@ -4170,6 +4241,7 @@ fn from_mol2(mol2_str: &str) -> PyResult<Mol> {
     chematic_mol::parse_mol2(mol2_str)
         .map(|(mol, _coords)| Mol {
             inner: Arc::new(mol),
+            props: Default::default(),
         })
         .map_err(|e| PyValueError::new_err(e.to_string()))
 }
@@ -4193,6 +4265,7 @@ fn from_pdbqt(pdbqt_str: &str) -> PyResult<Mol> {
     chematic_mol::parse_pdbqt(pdbqt_str)
         .map(|(mol, _coords, _charges)| Mol {
             inner: Arc::new(mol),
+            props: Default::default(),
         })
         .map_err(|e| PyValueError::new_err(e.to_string()))
 }
@@ -4210,6 +4283,7 @@ fn from_gjf(gjf_str: &str) -> PyResult<Mol> {
     chematic_mol::parse_gjf(gjf_str)
         .map(|(mol, _coords, _charge, _mult)| Mol {
             inner: Arc::new(mol),
+            props: Default::default(),
         })
         .map_err(|e| PyValueError::new_err(e.to_string()))
 }
@@ -4231,6 +4305,7 @@ fn parse_gaussian_log<'py>(
         .map_err(|e| PyValueError::new_err(e.to_string()))?;
     let mol = Mol {
         inner: Arc::new(result.mol),
+        props: Default::default(),
     };
     let coords: Vec<Vec<f64>> = result
         .coords
@@ -4290,6 +4365,7 @@ fn parse_cif<'py>(py: Python<'py>, cif_str: &str) -> PyResult<Bound<'py, pyo3::t
         chematic_mol::parse_cif(cif_str).map_err(|e| PyValueError::new_err(e.to_string()))?;
     let mol = Mol {
         inner: Arc::new(result.mol),
+        props: Default::default(),
     };
     let coords: Vec<Vec<f64>> = result
         .coords
@@ -4407,6 +4483,7 @@ fn from_inchi(inchi: &str) -> PyResult<Mol> {
     chematic_inchi::parse_inchi(inchi)
         .map(|mol| Mol {
             inner: Arc::new(mol),
+            props: Default::default(),
         })
         .map_err(|e| PyValueError::new_err(e.to_string()))
 }
@@ -4463,6 +4540,7 @@ fn from_pdb(pdb_str: &str) -> PyResult<(Mol, Vec<Vec<f64>>)> {
     Ok((
         Mol {
             inner: Arc::new(mol),
+            props: Default::default(),
         },
         coords,
     ))
@@ -4481,6 +4559,7 @@ fn from_xyz(xyz_str: &str) -> PyResult<(Mol, Vec<Vec<f64>>)> {
     Ok((
         Mol {
             inner: Arc::new(mol),
+            props: Default::default(),
         },
         coords,
     ))
@@ -4937,6 +5016,7 @@ fn abbreviations<'py>(py: Python<'py>) -> PyResult<Bound<'py, pyo3::types::PyDic
 fn expand_abbreviation(symbol: &str) -> Option<Mol> {
     chematic_chem::expand_abbreviation(symbol).map(|mol| Mol {
         inner: Arc::new(mol),
+        props: Default::default(),
     })
 }
 
@@ -5602,6 +5682,7 @@ fn parse_smi_file(content: &str) -> Vec<(Mol, String)> {
             (
                 Mol {
                     inner: Arc::new(mol),
+                    props: Default::default(),
                 },
                 name,
             )
@@ -6163,11 +6244,7 @@ fn run_smirks(smirks: &str, reactants: Vec<Mol>) -> PyResult<Vec<Vec<Mol>>> {
     chematic_rxn::run_reactants(smirks, &refs)
         .map(|sets| {
             sets.into_iter()
-                .map(|set| {
-                    set.into_iter()
-                        .map(|m| Mol { inner: Arc::new(m) })
-                        .collect()
-                })
+                .map(|set| set.into_iter().map(Mol::bare).collect())
                 .collect()
         })
         .map_err(|e| PyValueError::new_err(e.to_string()))
@@ -6194,11 +6271,7 @@ fn run_smirks_strict(smirks: &str, reactants: Vec<Mol>) -> PyResult<Vec<Vec<Mol>
     chematic_rxn::run_reactants_strict(smirks, &refs)
         .map(|sets| {
             sets.into_iter()
-                .map(|set| {
-                    set.into_iter()
-                        .map(|m| Mol { inner: Arc::new(m) })
-                        .collect()
-                })
+                .map(|set| set.into_iter().map(Mol::bare).collect())
                 .collect()
         })
         .map_err(|e| PyValueError::new_err(e.to_string()))
@@ -6269,6 +6342,7 @@ fn find_mcs(
     }
     Some(Mol {
         inner: Arc::new(builder.build()),
+        props: Default::default(),
     })
 }
 

--- a/crates/chematic-py/src/lib.rs
+++ b/crates/chematic-py/src/lib.rs
@@ -2126,6 +2126,76 @@ impl Mol {
         chematic_chem::implicit_hcount_per_atom(&self.inner)
     }
 
+    /// Per-atom structural data for RDKit-compat wrappers.
+    ///
+    /// Returns one tuple per heavy atom:
+    /// ``(symbol, atomic_num, formal_charge, is_aromatic, implicit_h, heavy_degree, is_in_ring)``
+    #[getter]
+    fn atom_table(&self) -> Vec<(String, u8, i8, bool, u8, usize, bool)> {
+        use chematic_core::AtomIdx;
+        use chematic_perception::find_sssr;
+        use std::collections::HashSet;
+        let mol = &self.inner;
+        let ring_atoms: HashSet<AtomIdx> = find_sssr(mol)
+            .rings()
+            .iter()
+            .flat_map(|r| r.iter().copied())
+            .collect();
+        (0..mol.atom_count())
+            .map(|i| {
+                let idx = AtomIdx(i as u32);
+                let atom = mol.atom(idx);
+                (
+                    atom.element.symbol().to_string(),
+                    atom.element.atomic_number(),
+                    atom.charge,
+                    atom.aromatic,
+                    chematic_core::implicit_hcount(mol, idx),
+                    mol.degree(idx),
+                    ring_atoms.contains(&idx),
+                )
+            })
+            .collect()
+    }
+
+    /// Per-bond structural data for RDKit-compat wrappers.
+    ///
+    /// Returns one tuple per bond:
+    /// ``(atom1_idx, atom2_idx, bond_type_str, is_aromatic)``
+    #[getter]
+    fn bond_table(&self) -> Vec<(usize, usize, &'static str, bool)> {
+        use chematic_core::BondOrder;
+        let mol = &self.inner;
+        mol.bonds()
+            .map(|(_, b)| {
+                let (type_str, is_aromatic) = match b.order {
+                    BondOrder::Single | BondOrder::Up | BondOrder::Down => ("SINGLE", false),
+                    BondOrder::Double => ("DOUBLE", false),
+                    BondOrder::Triple => ("TRIPLE", false),
+                    BondOrder::Aromatic => ("AROMATIC", true),
+                    _ => ("OTHER", false),
+                };
+                (
+                    b.atom1.0 as usize,
+                    b.atom2.0 as usize,
+                    type_str,
+                    is_aromatic,
+                )
+            })
+            .collect()
+    }
+
+    /// SSSR rings as lists of atom indices. Used by the Python RingInfo wrapper.
+    #[getter]
+    fn sssr_atom_rings(&self) -> Vec<Vec<usize>> {
+        use chematic_perception::find_sssr;
+        find_sssr(&self.inner)
+            .rings()
+            .iter()
+            .map(|r| r.iter().map(|idx| idx.0 as usize).collect())
+            .collect()
+    }
+
     /// Isotopic distribution — list of ``(mass, relative_intensity)`` pairs.
     ///
     /// The highest-intensity peak is normalised to 1.0.
@@ -3806,6 +3876,37 @@ impl Mol {
             d.set_item(k, v).ok();
         }
         d
+    }
+
+    /// Return a list of all property names.
+    #[pyo3(name = "GetPropNames")]
+    fn get_prop_names(&self) -> Vec<String> {
+        self.props.keys().cloned().collect()
+    }
+
+    /// Remove a property by name (no-op if not present).
+    #[pyo3(name = "ClearProp")]
+    fn clear_prop(&mut self, key: &str) {
+        self.props.remove(key);
+    }
+
+    /// Set an integer property (stored as its string representation).
+    #[pyo3(name = "SetIntProp")]
+    fn set_int_prop(&mut self, key: String, val: i64) {
+        self.props.insert(key, val.to_string());
+    }
+
+    /// Set a float property (stored as its string representation).
+    #[pyo3(name = "SetDoubleProp")]
+    fn set_double_prop(&mut self, key: String, val: f64) {
+        self.props.insert(key, val.to_string());
+    }
+
+    /// Set a boolean property (stored as ``"1"`` / ``"0"``).
+    #[pyo3(name = "SetBoolProp")]
+    fn set_bool_prop(&mut self, key: String, val: bool) {
+        self.props
+            .insert(key, if val { "1" } else { "0" }.to_string());
     }
 
     // -----------------------------------------------------------------------

--- a/crates/chematic-py/src/lib.rs
+++ b/crates/chematic-py/src/lib.rs
@@ -511,6 +511,35 @@ impl Mol {
         chematic_chem::aromatic_ring_count(&self.inner)
     }
 
+    /// Apply aromaticity perception and return a new Mol.
+    ///
+    /// Args:
+    ///     mode: ``"huckel"`` (default) or ``"rdkit"``. The ``"rdkit"`` mode
+    ///           additionally recognises Se and Te as lone-pair donors in aromatic rings.
+    ///
+    /// Returns:
+    ///     A new :class:`Mol` with aromatic flags set.
+    ///
+    ///     mol2 = mol.apply_aromaticity(mode="rdkit")
+    #[pyo3(signature = (mode = "huckel"))]
+    fn apply_aromaticity(&self, mode: &str) -> PyResult<Mol> {
+        let algo = match mode {
+            "huckel" | "hückel" | "" => chematic_perception::AromaticityAlgorithm::Huckel,
+            "rdkit" | "rdkit_like" | "rdkit-like" => {
+                chematic_perception::AromaticityAlgorithm::RdkitLike
+            }
+            other => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "Unknown aromaticity mode {other:?}. Choose 'huckel' or 'rdkit'."
+                )));
+            }
+        };
+        let new_mol = chematic_perception::apply_aromaticity_ex(&self.inner, algo);
+        Ok(Mol {
+            inner: Arc::new(new_mol),
+        })
+    }
+
     /// Number of assigned stereocenters (R/S).
     #[getter]
     fn num_stereocenters(&self) -> usize {

--- a/crates/chematic-py/tests/test_rdkit_compat.py
+++ b/crates/chematic-py/tests/test_rdkit_compat.py
@@ -1,0 +1,600 @@
+"""Tests for chematic.rdkit_compat — RDKit API compatibility layer."""
+import pytest
+import chematic
+from chematic import rdkit_compat as Chem
+from chematic.rdkit_compat import (
+    Descriptors, rdMolDescriptors, DataStructs, ExplicitBitVect,
+    Atom, Bond, BondType, RingInfo,
+)
+
+
+# ---------------------------------------------------------------------------
+# Import style
+# ---------------------------------------------------------------------------
+
+def test_import_style():
+    assert hasattr(Chem, "MolFromSmiles")
+    assert hasattr(Chem, "SDMolSupplier")
+    assert hasattr(Chem, "SDWriter")
+    assert Descriptors is not None
+    assert rdMolDescriptors is not None
+    assert DataStructs is not None
+
+
+# ---------------------------------------------------------------------------
+# Mol property methods
+# ---------------------------------------------------------------------------
+
+def test_setprop_getprop():
+    mol = Chem.MolFromSmiles("CCO")
+    mol.SetProp("ID", "ethanol")
+    assert mol.GetProp("ID") == "ethanol"
+
+
+def test_hasprop():
+    mol = Chem.MolFromSmiles("CCO")
+    assert not mol.HasProp("x")
+    mol.SetProp("x", "1")
+    assert mol.HasProp("x")
+
+
+def test_getpropsasdict():
+    mol = Chem.MolFromSmiles("CCO")
+    mol.SetProp("A", "1")
+    mol.SetProp("B", "2")
+    d = mol.GetPropsAsDict()
+    assert d["A"] == "1" and d["B"] == "2"
+
+
+def test_getpropnames():
+    mol = Chem.MolFromSmiles("CCO")
+    mol.SetProp("foo", "bar")
+    assert "foo" in mol.GetPropNames()
+
+
+def test_clearprop():
+    mol = Chem.MolFromSmiles("CCO")
+    mol.SetProp("x", "1")
+    mol.ClearProp("x")
+    assert not mol.HasProp("x")
+
+
+def test_clearprop_missing_noop():
+    mol = Chem.MolFromSmiles("CCO")
+    mol.ClearProp("nonexistent")  # must not raise
+
+
+def test_setintprop():
+    mol = Chem.MolFromSmiles("CCO")
+    mol.SetIntProp("rank", 42)
+    assert mol.GetProp("rank") == "42"
+
+
+def test_setdoubleprop():
+    mol = Chem.MolFromSmiles("CCO")
+    mol.SetDoubleProp("score", 3.14)
+    assert mol.GetProp("score") == "3.14"
+
+
+def test_setboolprop():
+    mol = Chem.MolFromSmiles("CCO")
+    mol.SetBoolProp("active", True)
+    assert mol.GetProp("active") == "1"
+    mol.SetBoolProp("active", False)
+    assert mol.GetProp("active") == "0"
+
+
+def test_getprop_missing_raises():
+    mol = Chem.MolFromSmiles("CCO")
+    with pytest.raises(KeyError):
+        mol.GetProp("missing")
+
+
+# ---------------------------------------------------------------------------
+# SDWriter + SDMolSupplier roundtrip
+# ---------------------------------------------------------------------------
+
+def test_sdf_roundtrip_props(tmp_path):
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    mol.SetProp("ID", "benzene")
+    mol.SetProp("MW", "78.11")
+
+    out = tmp_path / "out.sdf"
+    with Chem.SDWriter(str(out)) as w:
+        w.write(mol)
+
+    mols = list(Chem.SDMolSupplier(str(out)))
+    assert len(mols) == 1
+    m = mols[0]
+    assert m is not None
+    assert m.GetProp("ID") == "benzene"
+    assert m.GetProp("MW") == "78.11"
+
+
+def test_sdf_name_in_header_not_sd_field(tmp_path):
+    mol = Chem.MolFromSmiles("CCO")
+    mol.SetProp("_Name", "ethanol")
+    mol.SetProp("Activity", "7.2")
+
+    out = tmp_path / "out.sdf"
+    with Chem.SDWriter(str(out)) as w:
+        w.write(mol)
+
+    raw = out.read_text()
+    assert "ethanol" in raw              # name in MOL header
+    assert "> <_Name>" not in raw        # must not appear as SD field
+    assert "> <Activity>" in raw
+
+
+def test_setprops_filters_output(tmp_path):
+    mol = Chem.MolFromSmiles("CCO")
+    mol.SetProp("ID", "ethanol")
+    mol.SetProp("MW", "46.07")
+    mol.SetProp("Source", "internal")
+
+    out = tmp_path / "out.sdf"
+    w = Chem.SDWriter(str(out))
+    w.SetProps(["ID", "MW"])
+    w.write(mol)
+    w.close()
+
+    raw = out.read_text()
+    assert "> <ID>" in raw
+    assert "> <MW>" in raw
+    assert "> <Source>" not in raw
+
+
+def test_setprops_empty_writes_no_sd_fields(tmp_path):
+    mol = Chem.MolFromSmiles("CCO")
+    mol.SetProp("ID", "ethanol")
+
+    out = tmp_path / "out.sdf"
+    w = Chem.SDWriter(str(out))
+    w.SetProps([])
+    w.write(mol)
+    w.close()
+
+    raw = out.read_text()
+    assert "> <ID>" not in raw
+    assert "$$$$" in raw
+
+
+def test_typed_props_roundtrip(tmp_path):
+    mol = Chem.MolFromSmiles("CCO")
+    mol.SetIntProp("rank", 7)
+    mol.SetDoubleProp("score", 1.5)
+    mol.SetBoolProp("active", True)
+
+    out = tmp_path / "out.sdf"
+    with Chem.SDWriter(str(out)) as w:
+        w.write(mol)
+
+    mols = list(Chem.SDMolSupplier(str(out)))
+    m = mols[0]
+    assert m.GetProp("rank") == "7"
+    assert m.GetProp("score") == "1.5"
+    assert m.GetProp("active") == "1"
+
+
+# ---------------------------------------------------------------------------
+# flush / close idempotency
+# ---------------------------------------------------------------------------
+
+def test_flush_and_close_idempotent(tmp_path):
+    out = tmp_path / "out.sdf"
+    w = Chem.SDWriter(str(out))
+    w.write(Chem.MolFromSmiles("CCO"))
+    w.flush()
+    w.flush()   # second flush must not crash
+    w.close()
+    w.close()   # second close must not crash
+
+
+# ---------------------------------------------------------------------------
+# SetKekulize / SetForceV3000 are no-ops (must not crash)
+# ---------------------------------------------------------------------------
+
+def test_noop_writer_flags(tmp_path):
+    out = tmp_path / "out.sdf"
+    w = Chem.SDWriter(str(out))
+    w.SetKekulize(False)
+    w.SetForceV3000(True)
+    w.write(Chem.MolFromSmiles("c1ccccc1"))
+    w.close()
+    assert out.exists()
+
+
+# ---------------------------------------------------------------------------
+# Context manager
+# ---------------------------------------------------------------------------
+
+def test_context_manager(tmp_path):
+    out = tmp_path / "out.sdf"
+    with Chem.SDWriter(str(out)) as w:
+        w.write(Chem.MolFromSmiles("c1ccccc1"))
+    assert out.exists()
+    mols = list(Chem.SDMolSupplier(str(out)))
+    assert len(mols) == 1
+
+
+# ---------------------------------------------------------------------------
+# SDMolSupplier __len__
+# ---------------------------------------------------------------------------
+
+def test_sdmolsupplier_len(tmp_path):
+    out = tmp_path / "out.sdf"
+    with Chem.SDWriter(str(out)) as w:
+        for smi in ["CCO", "c1ccccc1", "CC(=O)O"]:
+            w.write(Chem.MolFromSmiles(smi))
+    assert len(Chem.SDMolSupplier(str(out))) == 3
+
+
+# ---------------------------------------------------------------------------
+# Descriptors / rdMolDescriptors smoke tests
+# ---------------------------------------------------------------------------
+
+def test_descriptors_mw():
+    mol = Chem.MolFromSmiles("CCO")
+    assert abs(Descriptors.MolWt(mol) - 46.07) < 0.1
+
+
+def test_rdmoldescriptors_tpsa():
+    mol = Chem.MolFromSmiles("CCO")
+    assert rdMolDescriptors.CalcTPSA(mol) >= 0
+
+
+def test_tanimoto_self():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    fp = rdMolDescriptors.GetMorganFingerprintAsBitVect(mol, 2)
+    assert DataStructs.TanimotoSimilarity(fp, fp) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# ExplicitBitVect
+# ---------------------------------------------------------------------------
+
+def test_explicit_bit_vect_basic():
+    bv = ExplicitBitVect(16)
+    assert bv.GetNumBits() == 16
+    assert bv.GetBit(0) is False
+
+    bv.SetBit(0)
+    bv.SetBit(7)
+    bv.SetBit(15)
+    assert bv.GetBit(0) is True
+    assert bv.GetBit(7) is True
+    assert bv.GetBit(15) is True
+    assert bv.GetBit(1) is False
+
+    assert bv.GetOnBits() == [0, 7, 15]
+    bs = bv.ToBitString()
+    assert len(bs) == 16
+    assert bs[0] == "1" and bs[7] == "1" and bs[15] == "1" and bs[1] == "0"
+
+
+def test_explicit_bit_vect_index_error():
+    bv = ExplicitBitVect(8)
+    with pytest.raises(IndexError):
+        bv.GetBit(8)
+    with pytest.raises(IndexError):
+        bv.SetBit(-1)
+
+
+# ---------------------------------------------------------------------------
+# GetMorganFingerprintAsBitVect returns ExplicitBitVect
+# ---------------------------------------------------------------------------
+
+def test_morgan_returns_explicit_bit_vect():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    fp = rdMolDescriptors.GetMorganFingerprintAsBitVect(mol, 2)
+    assert isinstance(fp, ExplicitBitVect)
+    assert fp.GetNumBits() == 2048
+    bs = fp.ToBitString()
+    assert len(bs) == 2048
+    assert "1" in bs  # benzene must set some bits
+
+
+def test_morgan_radius3():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    fp = rdMolDescriptors.GetMorganFingerprintAsBitVect(mol, 3)
+    assert isinstance(fp, ExplicitBitVect)
+
+
+# ---------------------------------------------------------------------------
+# Tanimoto with ExplicitBitVect
+# ---------------------------------------------------------------------------
+
+def test_tanimoto_identical_bitvect():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    fp = rdMolDescriptors.GetMorganFingerprintAsBitVect(mol, 2)
+    assert DataStructs.TanimotoSimilarity(fp, fp) == 1.0
+
+
+def test_tanimoto_disjoint():
+    bv1 = ExplicitBitVect(8)
+    bv2 = ExplicitBitVect(8)
+    bv1.SetBit(0)
+    bv2.SetBit(7)
+    assert DataStructs.TanimotoSimilarity(bv1, bv2) == 0.0
+
+
+def test_bulk_tanimoto():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    fp = rdMolDescriptors.GetMorganFingerprintAsBitVect(mol, 2)
+    results = DataStructs.BulkTanimotoSimilarity(fp, [fp, fp])
+    assert results == [1.0, 1.0]
+
+
+def test_bulk_tanimoto_different_mols():
+    benzene = rdMolDescriptors.GetMorganFingerprintAsBitVect(
+        Chem.MolFromSmiles("c1ccccc1"), 2
+    )
+    ethanol = rdMolDescriptors.GetMorganFingerprintAsBitVect(
+        Chem.MolFromSmiles("CCO"), 2
+    )
+    results = DataStructs.BulkTanimotoSimilarity(benzene, [benzene, ethanol])
+    assert results[0] == 1.0
+    assert 0.0 <= results[1] < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Unsupported options fail loudly
+# ---------------------------------------------------------------------------
+
+def test_morgan_use_features_raises():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    with pytest.raises(NotImplementedError):
+        rdMolDescriptors.GetMorganFingerprintAsBitVect(mol, 2, useFeatures=True)
+
+
+def test_morgan_unknown_kwarg_raises():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    with pytest.raises(TypeError):
+        rdMolDescriptors.GetMorganFingerprintAsBitVect(mol, 2, unknownParam=True)
+
+
+def test_morgan_bit_info_raises():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    with pytest.raises(NotImplementedError):
+        rdMolDescriptors.GetMorganFingerprintAsBitVect(mol, 2, bitInfo={})
+
+
+def test_morgan_nbits_not_2048_raises():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    with pytest.raises(NotImplementedError):
+        rdMolDescriptors.GetMorganFingerprintAsBitVect(mol, 2, nBits=1024)
+
+
+# ---------------------------------------------------------------------------
+# Mol / Atom / Bond read-only surface
+# ---------------------------------------------------------------------------
+
+def test_atom_bond_counts():
+    mol = Chem.MolFromSmiles("CCO")  # ethanol: C, C, O = 3 heavy atoms, 2 bonds
+    assert mol.GetNumAtoms() == 3
+    assert mol.GetNumBonds() == 2
+
+
+def test_atom_symbols():
+    mol = Chem.MolFromSmiles("CCO")
+    symbols = [a.GetSymbol() for a in mol.GetAtoms()]
+    assert "C" in symbols
+    assert "O" in symbols
+
+
+def test_atomic_num():
+    mol = Chem.MolFromSmiles("CCO")
+    nums = {a.GetSymbol(): a.GetAtomicNum() for a in mol.GetAtoms()}
+    assert nums["C"] == 6
+    assert nums["O"] == 8
+
+
+def test_formal_charge_neutral():
+    mol = Chem.MolFromSmiles("CCO")
+    assert all(a.GetFormalCharge() == 0 for a in mol.GetAtoms())
+
+
+def test_aromatic_atoms_benzene():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    assert all(a.GetIsAromatic() for a in mol.GetAtoms())
+
+
+def test_aromatic_atoms_ethanol():
+    mol = Chem.MolFromSmiles("CCO")
+    assert not any(a.GetIsAromatic() for a in mol.GetAtoms())
+
+
+def test_aromatic_bonds_benzene():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    assert all(b.GetIsAromatic() for b in mol.GetBonds())
+    assert all(b.GetBondType() == BondType.AROMATIC for b in mol.GetBonds())
+
+
+def test_bond_type_single():
+    mol = Chem.MolFromSmiles("CC")
+    bond = mol.GetBondWithIdx(0)
+    assert bond.GetBondType() == BondType.SINGLE
+    assert bond.GetBondTypeAsDouble() == 1.0
+
+
+def test_bond_type_double():
+    mol = Chem.MolFromSmiles("C=C")
+    bond = mol.GetBondWithIdx(0)
+    assert bond.GetBondType() == BondType.DOUBLE
+    assert bond.GetBondTypeAsDouble() == 2.0
+
+
+def test_bond_type_aromatic_double():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    assert mol.GetBondWithIdx(0).GetBondTypeAsDouble() == 1.5
+
+
+def test_degree():
+    mol = Chem.MolFromSmiles("CO")  # methanol: C has degree 1 (one O neighbor)
+    o_atom = next(a for a in mol.GetAtoms() if a.GetSymbol() == "O")
+    assert o_atom.GetDegree() == 1
+
+
+def test_total_num_hs():
+    mol = Chem.MolFromSmiles("CCO")  # CH3-CH2-OH: first C has 3 implicit Hs
+    atoms = list(mol.GetAtoms())
+    # The methyl carbon (degree 1 in ethanol) has 3 implicit Hs
+    methyl_c = next(a for a in atoms if a.GetSymbol() == "C" and a.GetDegree() == 1)
+    assert methyl_c.GetTotalNumHs() == 3
+
+
+def test_is_in_ring():
+    benzene = Chem.MolFromSmiles("c1ccccc1")
+    assert all(a.IsInRing() for a in benzene.GetAtoms())
+    ethanol = Chem.MolFromSmiles("CCO")
+    assert not any(a.IsInRing() for a in ethanol.GetAtoms())
+
+
+def test_get_atom_with_idx():
+    mol = Chem.MolFromSmiles("CCO")
+    atom = mol.GetAtomWithIdx(0)
+    assert isinstance(atom, Atom)
+    assert atom.GetIdx() == 0
+
+
+def test_get_bond_with_idx():
+    mol = Chem.MolFromSmiles("CCO")
+    bond = mol.GetBondWithIdx(0)
+    assert isinstance(bond, Bond)
+    assert bond.GetIdx() == 0
+
+
+def test_atom_index_error():
+    mol = Chem.MolFromSmiles("CCO")
+    with pytest.raises(IndexError):
+        mol.GetAtomWithIdx(-1)
+    with pytest.raises(IndexError):
+        mol.GetAtomWithIdx(99)
+
+
+def test_bond_index_error():
+    mol = Chem.MolFromSmiles("CCO")
+    with pytest.raises(IndexError):
+        mol.GetBondWithIdx(999)
+
+
+def test_get_begin_end_atom():
+    mol = Chem.MolFromSmiles("CO")
+    bond = mol.GetBondWithIdx(0)
+    a1 = bond.GetBeginAtom()
+    a2 = bond.GetEndAtom()
+    assert isinstance(a1, Atom)
+    assert isinstance(a2, Atom)
+    assert {a1.GetIdx(), a2.GetIdx()} == {bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()}
+
+
+def test_get_other_atom_idx():
+    mol = Chem.MolFromSmiles("CO")
+    bond = mol.GetBondWithIdx(0)
+    a1, a2 = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
+    assert bond.GetOtherAtomIdx(a1) == a2
+    assert bond.GetOtherAtomIdx(a2) == a1
+
+
+def test_get_other_atom_idx_invalid():
+    mol = Chem.MolFromSmiles("CO")
+    bond = mol.GetBondWithIdx(0)
+    with pytest.raises(ValueError):
+        bond.GetOtherAtomIdx(99)
+
+
+def test_pyridine_n_atomic_num():
+    mol = Chem.MolFromSmiles("c1ccncc1")
+    atomic_nums = [a.GetAtomicNum() for a in mol.GetAtoms()]
+    assert 7 in atomic_nums  # nitrogen
+
+
+# ---------------------------------------------------------------------------
+# RingInfo
+# ---------------------------------------------------------------------------
+
+def test_ring_info_acyclic():
+    mol = Chem.MolFromSmiles("CCO")
+    ri = mol.GetRingInfo()
+    assert isinstance(ri, RingInfo)
+    assert ri.NumRings() == 0
+    assert ri.AtomRings() == ()
+    assert ri.BondRings() == ()
+
+
+def test_ring_info_cyclohexane():
+    mol = Chem.MolFromSmiles("C1CCCCC1")
+    ri = mol.GetRingInfo()
+    assert ri.NumRings() == 1
+    assert len(ri.AtomRings()) == 1
+    assert len(ri.AtomRings()[0]) == 6
+    assert len(ri.BondRings()[0]) == 6
+
+
+def test_ring_info_benzene():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    ri = mol.GetRingInfo()
+    assert ri.NumRings() == 1
+    assert len(ri.BondRings()[0]) == 6
+
+
+def test_ring_info_naphthalene():
+    mol = Chem.MolFromSmiles("c1ccc2ccccc2c1")
+    ri = mol.GetRingInfo()
+    assert ri.NumRings() == 2
+    # The shared bond must appear in 2 bond rings
+    flat_bonds = [b for ring in ri.BondRings() for b in ring]
+    # At least one bond appears twice (shared bond)
+    assert max(flat_bonds.count(b) for b in flat_bonds) == 2
+
+
+def test_atom_rings_type():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    ar = mol.GetRingInfo().AtomRings()
+    assert isinstance(ar, tuple)
+    assert isinstance(ar[0], tuple)
+
+
+def test_bond_rings_type():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    br = mol.GetRingInfo().BondRings()
+    assert isinstance(br, tuple)
+    assert isinstance(br[0], tuple)
+
+
+def test_num_atom_rings_benzene():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    ri = mol.GetRingInfo()
+    assert all(ri.NumAtomRings(i) == 1 for i in range(mol.GetNumAtoms()))
+
+
+def test_num_bond_rings_benzene():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    ri = mol.GetRingInfo()
+    assert all(ri.NumBondRings(i) == 1 for i in range(mol.GetNumBonds()))
+
+
+def test_ring_info_invalid_idx():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    ri = mol.GetRingInfo()
+    with pytest.raises(IndexError):
+        ri.NumAtomRings(-1)
+    with pytest.raises(IndexError):
+        ri.NumBondRings(999)
+
+
+def test_bond_is_in_ring_cyclohexane():
+    mol = Chem.MolFromSmiles("C1CCCCC1")
+    assert all(b.IsInRing() for b in mol.GetBonds())
+
+
+def test_bond_not_in_ring_ethanol():
+    mol = Chem.MolFromSmiles("CCO")
+    assert not any(b.IsInRing() for b in mol.GetBonds())
+
+
+def test_atom_is_in_ring_size_benzene():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    atom = mol.GetAtomWithIdx(0)
+    assert atom.IsInRingSize(6) is True
+    assert atom.IsInRingSize(5) is False

--- a/examples/rdkit_compat_migration.py
+++ b/examples/rdkit_compat_migration.py
@@ -1,0 +1,93 @@
+"""
+RDKit → chematic migration guide (10 common patterns).
+
+Each block shows the original RDKit code (commented) and the chematic
+equivalent using chematic.rdkit_compat for minimal diffs.
+"""
+
+from chematic import rdkit_compat as Chem
+from chematic.rdkit_compat import Descriptors, rdMolDescriptors, DataStructs
+
+ASPIRIN = "CC(=O)Oc1ccccc1C(=O)O"
+
+# ── 1. Parse SMILES ─────────────────────────────────────────────────────────
+# RDKit:  from rdkit import Chem;  mol = Chem.MolFromSmiles("CCO")
+mol = Chem.MolFromSmiles(ASPIRIN)
+assert mol is not None
+
+# ── 2. Convert back to SMILES ────────────────────────────────────────────────
+# RDKit:  Chem.MolToSmiles(mol)
+smi = Chem.MolToSmiles(mol)
+print(f"SMILES: {smi}")
+
+# ── 3. Molecular weight / logP / TPSA ───────────────────────────────────────
+# RDKit:  from rdkit.Chem import Descriptors
+#         Descriptors.MolWt(mol), Descriptors.MolLogP(mol)
+mw   = Descriptors.MolWt(mol)
+logp = Descriptors.MolLogP(mol)
+tpsa = rdMolDescriptors.CalcTPSA(mol)
+print(f"MW={mw:.2f}  LogP={logp:.2f}  TPSA={tpsa:.1f}")
+
+# ── 4. H-bond donors / acceptors ─────────────────────────────────────────────
+# RDKit:  rdMolDescriptors.CalcNumHBD(mol), rdMolDescriptors.CalcNumHBA(mol)
+hbd = rdMolDescriptors.CalcNumHBD(mol)
+hba = rdMolDescriptors.CalcNumHBA(mol)
+print(f"HBD={hbd}  HBA={hba}")
+
+# ── 5. Heavy atom count ──────────────────────────────────────────────────────
+# RDKit:  mol.GetNumHeavyAtoms()
+n_heavy = mol.GetNumHeavyAtoms()
+print(f"Heavy atoms: {n_heavy}")
+
+# ── 6. Substructure search (SMARTS) ─────────────────────────────────────────
+# RDKit:  patt = Chem.MolFromSmarts("[OH]");  mol.HasSubstructMatch(patt)
+patt = Chem.MolFromSmarts("[OH]")
+has_oh = mol.HasSubstructMatch(patt)
+print(f"Has [OH]: {has_oh}")
+
+# ── 7. Morgan fingerprint + Tanimoto similarity ──────────────────────────────
+# RDKit:  from rdkit.Chem import rdMolDescriptors, DataStructs
+#         fp1 = rdMolDescriptors.GetMorganFingerprintAsBitVect(mol, 2)
+#         DataStructs.TanimotoSimilarity(fp1, fp2)
+fp1 = rdMolDescriptors.GetMorganFingerprintAsBitVect(mol, 2)
+fp2 = rdMolDescriptors.GetMorganFingerprintAsBitVect(
+    Chem.MolFromSmiles("CC(=O)O"), 2  # acetic acid
+)
+sim = DataStructs.TanimotoSimilarity(fp1, fp2)
+print(f"Tanimoto(aspirin, acetic acid): {sim:.3f}")
+
+# ── 8. Parse MOL block (e.g., from SDF file) ─────────────────────────────────
+# RDKit:  mol2 = Chem.MolFromMolBlock(block)
+block = Chem.MolToMolBlock(mol)
+mol2 = Chem.MolFromMolBlock(block)
+assert mol2 is not None
+print(f"MolFromMolBlock: {mol2}")
+
+# ── 9. SDMolSupplier — iterate over SDF file ────────────────────────────────
+# RDKit:  suppl = Chem.SDMolSupplier("mols.sdf")
+#         for mol in suppl:
+#             if mol is not None: process(mol)
+#
+# (Write a temporary SDF first for the demo)
+import tempfile, os
+with tempfile.NamedTemporaryFile(suffix=".sdf", mode="w", delete=False) as tmp:
+    tmp.write(block + "\n$$$$\n")
+    tmp_path = tmp.name
+
+count = 0
+with Chem.SDWriter(tmp_path.replace(".sdf", "_out.sdf")) as w:
+    for m in Chem.SDMolSupplier(tmp_path):
+        if m is not None:
+            w.write(m)
+            count += 1
+os.unlink(tmp_path)
+os.unlink(tmp_path.replace(".sdf", "_out.sdf"))
+print(f"SDMolSupplier / SDWriter: processed {count} molecule(s)")
+
+# ── 10. AddHs / RemoveHs ────────────────────────────────────────────────────
+# RDKit:  mol_h = Chem.AddHs(mol);  mol_noh = Chem.RemoveHs(mol_h)
+mol_h   = Chem.AddHs(mol)
+mol_noh = Chem.RemoveHs(mol_h)
+print(f"AddHs → RemoveHs: {mol_noh.GetNumHeavyAtoms()} heavy atoms (was {n_heavy})")
+
+print("\nAll 10 patterns OK.")

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,6 @@
 # chematic — Status & Roadmap
 
-Current version: **v0.4.23** (2026-06-26)
+Current version: **v0.4.24** (2026-06-29)
 
 ---
 
@@ -113,6 +113,9 @@ Current version: **v0.4.23** (2026-06-26)
 | done: | Bridgehead atoms 98.5% → **100%** (2026-06-28): bond-intersection algorithm — an atom is bridgehead iff some ring pair shares ≥ 2 bonds and the atom is incident to exactly 1; fixes both over-count (peroxide cages) and under-count (spiro+bridgehead co-occurrence) |
 | done: | `chematic.screen(smiles, profile="druglike")` — bundles lipinski/veber/pains/brenk/qed/sa_score into one call; profiles: druglike/fragment/leadlike; returns list[dict] with per-filter _pass flags and overall_pass |
 | done: | `scripts/analyze_logp_mismatches.py` — compare chematic vs RDKit Crippen LogP, output buckets + TSV; confirmed 0 mismatches (100% at ±0.01 on 5k corpus) |
+| done: | `chematic.rdkit_compat` Sprint 2 (v0.4.24): `ExplicitBitVect` (GetNumBits/GetBit/SetBit/GetOnBits/ToBitString/IndexError); `DataStructs.BulkTanimotoSimilarity`; `GetMorganFingerprintAsBitVect` returns `ExplicitBitVect`; unsupported opts fail loudly (useFeatures/bitInfo/nBits≠2048/unknown kwargs) |
+| done: | `chematic.rdkit_compat` Sprint 3 (v0.4.24): Rust `atom_table`+`bond_table` getters; `BondType` constants; `Atom` wrapper (GetIdx/Symbol/AtomicNum/FormalCharge/IsAromatic/Degree/TotalDegree/TotalNumHs/IsInRing/IsInRingSize); `Bond` wrapper (GetIdx/BeginAtomIdx/EndAtomIdx/BeginAtom/EndAtom/BondType/BondTypeAsDouble/IsAromatic/OtherAtomIdx); `Mol` GetNumBonds/GetAtoms/GetBonds/GetAtomWithIdx/GetBondWithIdx |
+| done: | `chematic.rdkit_compat` Sprint 4 (v0.4.24): Rust `sssr_atom_rings` getter; `RingInfo` (NumRings/AtomRings/BondRings/NumAtomRings/NumBondRings); `Mol.GetRingInfo()` with lazy cache; `Bond.IsInRing()` implemented; `Atom.IsInRingSize(n)` uses ring info cache |
 | done: | SDF true streaming: `SdfFileReader<R: BufRead>` + Python `iter_sdf(path)` → lazy streaming, `iter_sdf_batched(path, batch_size=1000)` new; `iter_sdf_str()` unchanged; `MolParseError::Io` added |
 | done: | `bulk.descriptors_array(smiles, columns)` — columnar numpy output, ~25% faster than `descriptors()+DataFrame()`; float64/bool/NaN for optional |
 | done: | Stereocenters 99.8% → 99.98% (legacy) / 98.7% (new CIP) — CIP Rule 5 tie-breaking via provisional R/S + equality-based signature comparison; cage false-positives correctly avoided |
@@ -123,6 +126,7 @@ Current version: **v0.4.23** (2026-06-26)
 
 | Version | Date | Highlights |
 |---------|------|-----------|
+| v0.4.24 | 2026-06-29 | `chematic.rdkit_compat` Sprints 2-4: ExplicitBitVect, DataStructs, BulkTanimoto, Mol/Atom/Bond surface, RingInfo; RDKit-compatible SDF I/O (SDMolSupplier/SDWriter + property roundtrip) |
 | v0.4.23 | 2026-06-28 | `screen()`+LogP analyzer+SDF streaming+`descriptors_array()`; bridgehead/spiro/rotatable 100% |
 | v0.4.23 | 2026-06-26 | LogP 96.5% → 99.7% (symmetric triple bond VF2 dedup fix); OSS sprint: badges, CI hardening, cargo-deny, check.sh, bump_version.py |
 | v0.4.19 | 2026-06-23 | PDF/EPS 出力、ChemicalJSON、Schultz/Gutman MTI・VABC・Gravitational index、bulk.substructure_match、bulk.generate_3d、bulk.tanimoto_matrix、bulk.standardize、inline SHA-256 (sha2 dep 除去)、WASM 819→504 KB gzip (-38.5%) |

--- a/validation/rdkit_issues/aromaticity/rdkit_like_heteroatoms.smi
+++ b/validation/rdkit_issues/aromaticity/rdkit_like_heteroatoms.smi
@@ -1,0 +1,8 @@
+# Chalcogen heteroaromatics for RdkitLike aromaticity mode.
+# These compounds are aromatic in RDKit's default model but NOT in Hückel 4n+2.
+# chematic: Hückel mode → not aromatic; RdkitLike mode → aromatic (expected).
+
+c1cc[se]c1    selenophene
+c1cc[te]c1    tellurophene
+c1ccc2[se]ccc2c1    benzoselenophene
+c1ccc2[te]ccc2c1    benzotellurophene


### PR DESCRIPTION
## Summary

- **Sprint 1**: `chematic.rdkit_compat` compatibility layer — `MolFromSmiles`, `MolToSmiles`, `SDMolSupplier`, `SDWriter`, `Descriptors`, `rdMolDescriptors`, `SanitizeMol`, `Kekulize`, `AddHs`/`RemoveHs`; SD property roundtrip (`GetProp`/`SetProp`/`HasProp`/`GetPropsAsDict`/`SetIntProp`/`SetDoubleProp`/`SetBoolProp`/`ClearProp`); `SDWriter.SetProps` filtering
- **Sprint 2**: `ExplicitBitVect` (GetNumBits/GetBit/SetBit/GetOnBits/ToBitString, IndexError on bad index); `DataStructs.BulkTanimotoSimilarity`; `GetMorganFingerprintAsBitVect` returns `ExplicitBitVect`; unsupported options (`useFeatures`, `bitInfo`, `nBits≠2048`, unknown kwargs) raise loudly
- **Sprint 3**: Rust `atom_table` + `bond_table` getters; `BondType` constants; `Atom`/`Bond` read-only wrappers; `Mol.GetNumBonds/GetAtoms/GetBonds/GetAtomWithIdx/GetBondWithIdx`
- **Sprint 4**: Rust `sssr_atom_rings` getter; `RingInfo` (NumRings/AtomRings/BondRings/NumAtomRings/NumBondRings); `Mol.GetRingInfo()` with lazy cache; `Bond.IsInRing()` implemented
- **AromaticityAlgorithm::RdkitLike**: Se/Te chalcogen aromatic perception

## Test plan

- [x] `bash scripts/check.sh` — all 2319 lib tests pass, clippy clean, fmt clean, version consistent
- [x] `python -m pytest crates/chematic-py/tests/test_rdkit_compat.py -v` — 68/68 pass