### PR TITLE
release: v0.4.25

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,5 +22,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.4.24
+version: 0.4.25
 date-released: "2026-06-26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.4.24"
+version = "0.4.25"
 edition = "2024"
 rust-version = "1.85"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ For Rust and JavaScript/TypeScript examples, see the [documentation](https://ken
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.4.24
+# chematic v0.4.25
 # Python 3.12.x  |  darwin arm64
 #
-# Descriptor accuracy (benchmark 2026-06, v0.4.24 vs RDKit 2026.03.3):
+# Descriptor accuracy (benchmark 2026-06, v0.4.25 vs RDKit 2026.03.3):
 #   MW / HBA / HBD / ARC  100%   (4,999-mol ChEMBL subset)
 #   TPSA                  100%   within ±0.1 Å²
 #   LogP (Crippen)        100%*  (max Δ = 1.1×10⁻¹³)

--- a/README_ja.md
+++ b/README_ja.md
@@ -110,10 +110,10 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.4.24
+# chematic v0.4.25
 # Python 3.12.x  |  darwin arm64
 #
-# Descriptor accuracy (benchmark 2026-06, v0.4.24 vs RDKit 2026.03.3):
+# Descriptor accuracy (benchmark 2026-06, v0.4.25 vs RDKit 2026.03.3):
 #   MW / HBA / HBD / ARC  100%   (4,999-mol ChEMBL subset)
 #   TPSA                  98.1%
 #   LogP (Crippen)        ~99%

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.4.24 | Yes | Current release — active support |
+| v0.4.25 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.4.24) receives all security updates.  
+**Active Support**: Latest release (v0.4.25) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,6 +1,6 @@
 # Benchmark
 
-Measured environment: Python 3.12, Apple M-series, chematic v0.4.24, RDKit 2026.03.3.
+Measured environment: Python 3.12, Apple M-series, chematic v0.4.25, RDKit 2026.03.3.
 
 ---
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -2,7 +2,7 @@
 
 Summary of descriptor accuracy against RDKit on a ChEMBL-derived corpus.
 
-**Environment:** Python 3.12, Apple M-series, chematic v0.4.24, RDKit 2026.03.3
+**Environment:** Python 3.12, Apple M-series, chematic v0.4.25, RDKit 2026.03.3
 
 ---
 


### PR DESCRIPTION
Version bump 0.4.24 → 0.4.25 for rdkit_compat Sprint 5 (Morgan bitInfo, compat matrix, differential tests — merged in #47).

Synced via scripts/bump_version.py: README/README_ja/CITATION.cff/SECURITY.md/docs.

- [x] bash scripts/check.sh — version consistent 0.4.25, all checks pass