### PR TITLE
test(smiles)+docs: canonical idempotency root cause = aromaticity round-trip, not Morgan ranks

### DIFF
--- a/crates/chematic-py/tests/test_canonical_diff.py
+++ b/crates/chematic-py/tests/test_canonical_diff.py
@@ -52,6 +52,45 @@ def test_canonical_idempotent(smi):
 
 
 # ---------------------------------------------------------------------------
+# Aromaticity round-trip consistency (chematic-internal; Sprint 9 diagnostic)
+#
+# The residual ~1.6% canonical idempotency failures on large fused polycyclics
+# are caused by aromaticity perception disagreeing between a molecule and the
+# re-parse of its own canonical SMILES (e.g. 16 vs 17 aromatic bonds), which
+# shifts Morgan ranks and the emitted atom order. This guards the property on
+# fused aromatics that DO round-trip consistently; it can be extended once the
+# aromaticity/parser-core fix lands (see docs/rdkit_compat.md).
+# ---------------------------------------------------------------------------
+
+AROMATIC_ROUNDTRIP_CORPUS = [
+    "c1ccccc1", "c1ccncc1", "c1ccoc1", "c1ccsc1",
+    "c1ccc2ccccc2c1",          # naphthalene
+    "c1ccc2ncccc2c1",          # quinoline
+    "c1ccc2c(c1)cc[nH]2",      # indole
+    "c1ccc2cc3ccccc3cc2c1",    # anthracene
+    "c1ccc2[nH]c3ccccc3c2c1",  # carbazole
+    "c1ccc2c(c1)oc1ccccc12",   # dibenzofuran
+]
+
+
+def _arom_counts(smi):
+    m = chematic.from_smiles(smi)
+    return (sum(1 for a in m.atom_table if a[3]),
+            sum(1 for b in m.bond_table if b[3]))
+
+
+@pytest.mark.parametrize("smi", AROMATIC_ROUNDTRIP_CORPUS)
+def test_aromaticity_roundtrip_consistent(smi):
+    before = _arom_counts(smi)
+    canon = chematic.from_smiles(smi).smiles
+    after = _arom_counts(canon)
+    assert before == after, (
+        f"aromatic (atoms, bonds) changed across canonical round-trip for {smi}: "
+        f"{before} -> {after}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Round-trip semantic equivalence vs RDKit
 # ---------------------------------------------------------------------------
 

--- a/crates/chematic-smiles/src/canonical.rs
+++ b/crates/chematic-smiles/src/canonical.rs
@@ -1049,4 +1049,31 @@ mod tests {
             );
         }
     }
+
+    // ── Fused-aromatic canonical idempotency (Sprint 9) ─────────────────────
+    //
+    // Lock in the fused aromatics that DO round-trip consistently. The residual
+    // ~1.6% canonical idempotency failures on large fused polycyclics are caused
+    // by aromaticity-perception round-trip inconsistency (a molecule vs the
+    // re-parse of its own canonical SMILES can disagree on which bonds are
+    // aromatic — e.g. 16 vs 17 on a fluorene-type linkage — which shifts Morgan
+    // ranks). That is an aromaticity/parser-core issue, not a canonical-ranking
+    // bug; see docs/rdkit_compat.md. These cases are stable and guarded here.
+
+    #[test]
+    fn fused_aromatic_canonical_is_idempotent() {
+        for s in [
+            "c1ccc2ccccc2c1",         // naphthalene
+            "c1ccc2ncccc2c1",         // quinoline
+            "c1ccc2c(c1)cc[nH]2",     // indole
+            "c1ccc2cc3ccccc3cc2c1",   // anthracene
+            "c1ccc2[nH]c3ccccc3c2c1", // carbazole
+            "c1ccc2c(c1)oc1ccccc12",  // dibenzofuran
+        ] {
+            assert!(
+                is_stable(s),
+                "fused-aromatic canonical SMILES must be idempotent for {s}"
+            );
+        }
+    }
 }

--- a/docs/rdkit_compat.md
+++ b/docs/rdkit_compat.md
@@ -70,13 +70,19 @@ why it is or isn't pursued.
 | Aromatic ring-junction carbonyls (`c(=O)` in fused aromatics) | chematic and RDKit model these atoms differently, shifting a few `c` / `C=O` matches and aromatic atom/bond counts. | Documented; small tail (~1–3%). |
 | Morgan bit positions | FNV-1a (chematic) vs MurmurHash (RDKit). | By design — similarity **ranking** is consistent; individual bit indices are not comparable across libraries. |
 | Exocyclic C=N E/Z in canonical SMILES (~0.4% round-trip) | The **parser** drops `/`,`\` directional bonds that flank an aromatic ring atom during aromatization (`crates/chematic-smiles/src/parser.rs`), *before* the canonical writer runs — so the geometry is already gone by write time. | **Deferred** — a parser + aromaticity change (broad blast radius), not a writer fix. |
-| Idempotency on large fused polycyclics (~1.6%) | Canonical Morgan-rank ordering converges in ~3 passes, not 1, on large bridged/fused systems — so `canonical(canonical(s))` re-roots the traversal. The E/Z markers ride along; the `/`,`\` direction itself is **not** the cause. | **Deferred** — a core Morgan-ranking change touching every canonical SMILES. |
+| Canonical idempotency on large fused polycyclics (~1.6%) | **Aromaticity-perception round-trip inconsistency** — *not* Morgan-rank tie-breaking (the failing molecules have all-distinct ranks). A molecule and the re-parse of its own canonical SMILES can disagree on which bonds are aromatic (e.g. 16 vs 17 on a fluorene/carbazole-type linkage); because Morgan ranks weight aromatic vs single bonds differently (`bond_order_value`), this shifts the canonical atom order and the emitted string. The molecule is preserved (**InChI invariant**); only the representation differs. | **Deferred** — the fix is in the aromaticity/parser core (which delivers the 100% aromatic-ring-count + exact descriptors), gated on full descriptor regression; not a canonicalizer patch. Pairs with the exocyclic-C=N parser work above. |
 
 **The `/`,`\` direction choice itself is deterministic and idempotent on stable skeletons**
 (verified on a 12-molecule E/Z corpus — see `crates/chematic-smiles/src/canonical.rs`
 tests and `tests/test_canonical_diff.py`). Canonical-SMILES E/Z is therefore reliable for the
 overwhelming majority of molecules; the residue is confined to the two named structural
 classes above.
+
+**The canonical Morgan ranking itself is order-invariant for distinct-rank molecules** — the
+residual idempotency failures are upstream in aromaticity perception, not in the ranking or the
+writer. Canonical SMILES is idempotent for the ~98.4% of a 5k corpus whose aromaticity round-trips
+consistently (guarded by `fused_aromatic_canonical_is_idempotent` and
+`test_aromaticity_roundtrip_consistent`).
 
 ---
 


### PR DESCRIPTION
Sprint 9 (diagnostic-first) targeted the 79/5000 (~1.6%) canonical-SMILES idempotency failures on large fused polycyclics, scoped as "Morgan rank convergence". **Five reproduced mechanism revisions show the scoped target is wrong** and there is no safe minimal fix in the canonicalizer — so this lands diagnostics + regression guards + accurate docs, not a speculative core patch.

## Diagnostic findings (all reproduced, not assumed)
1. **Not a rank tie-break.** Smallest failing case `CCOc1ccc2c(c1)c(CCNC(C)=O)c1n2Cc2ccccc2-1` (25 atoms) has **25 distinct Morgan classes — zero ties** — yet output is still input-order-dependent (pass1 roots at O, pass2 at c).
2. **Not multi-fixed-point ranking.** Of 79, 31 reach >1 fixed point across random orderings, but **30/31 are parse∘render stereo loss** (InChI varies — the Sprint-8 exocyclic-C=N parser artifact, injected by the measurement loop), only 1 genuinely constitutional.
3. **Root cause: aromaticity perception is not round-trip-consistent.** A molecule and the re-parse of its own canonical SMILES can disagree on aromatic bonds (e.g. **16 vs 17** on a fluorene/carbazole linkage). Morgan ranks weight aromatic vs single bonds (`bond_order_value`), so one flipped bond shifts the canonical atom order and the emitted string. **InChI is invariant** — the molecule is preserved; only the representation differs.

Net: the canonical ranking is sound; it's fed inconsistent aromatic flags across a SMILES round trip. The fix is an aromaticity/parser-core change (gated on full descriptor regression), not a canonicalizer patch — deferred to its own sprint, pairing with the exocyclic-C=N parser work.

## Changes (no behavior change, no version bump)
- `canonical.rs`: `fused_aromatic_canonical_is_idempotent` — locks the fused aromatics that round-trip (naphthalene/quinoline/indole/anthracene/carbazole/dibenzofuran).
- `test_canonical_diff.py`: `test_aromaticity_roundtrip_consistent` — guards aromatic atom/bond counts invariant across a canonical round-trip.
- `docs/rdkit_compat.md`: correct the idempotency root cause; note the ranking is order-invariant for distinct-rank molecules.

## Test plan
- [x] `cargo test -p chematic-smiles --lib` — 109 pass
- [x] `pytest test_canonical_diff.py` — 116 pass
- [x] `bash scripts/check.sh` — green
- [x] `canonical_diff.py` baseline unchanged (99.4% round-trip, behavior untouched)