### PR TITLE
release: v0.4.27

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,5 +22,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.4.26
+version: 0.4.27
 date-released: "2026-06-26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.4.26"
+version = "0.4.27"
 edition = "2024"
 rust-version = "1.85"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -184,10 +184,10 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.4.26
+# chematic v0.4.27
 # Python 3.12.x  |  darwin arm64
 #
-# Descriptor accuracy (benchmark 2026-06, v0.4.26 vs RDKit 2026.03.3):
+# Descriptor accuracy (benchmark 2026-06, v0.4.27 vs RDKit 2026.03.3):
 #   MW / HBA / HBD / ARC  100%   (4,999-mol ChEMBL subset)
 #   TPSA                  100%   within ±0.1 Å²
 #   LogP (Crippen)        100%*  (max Δ = 1.1×10⁻¹³)

--- a/README_ja.md
+++ b/README_ja.md
@@ -110,10 +110,10 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.4.26
+# chematic v0.4.27
 # Python 3.12.x  |  darwin arm64
 #
-# Descriptor accuracy (benchmark 2026-06, v0.4.26 vs RDKit 2026.03.3):
+# Descriptor accuracy (benchmark 2026-06, v0.4.27 vs RDKit 2026.03.3):
 #   MW / HBA / HBD / ARC  100%   (4,999-mol ChEMBL subset)
 #   TPSA                  98.1%
 #   LogP (Crippen)        ~99%

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.4.26 | Yes | Current release — active support |
+| v0.4.27 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.4.26) receives all security updates.  
+**Active Support**: Latest release (v0.4.27) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -16,12 +16,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.4.26" }
-chematic-perception = { path = "../chematic-perception", version = "0.4.26" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.4.26" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.4.26" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.4.26" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.26" }
+chematic-core       = { path = "../chematic-core",       version = "0.4.27" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.27" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.4.27" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.4.27" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.4.27" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.27" }
 
 [dev-dependencies]
-chematic-smiles = { path = "../chematic-smiles", version = "0.4.26" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.4.27" }

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -16,13 +16,13 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.4.26" }
+chematic-core       = { path = "../chematic-core",       version = "0.4.27" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.4.26" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.26" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.26" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.4.26" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.4.26" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.27" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.27" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.27" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.4.27" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.4.27" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -22,10 +22,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.4.26" }
-chematic-perception = { path = "../chematic-perception", version = "0.4.26" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.4.26" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.4.26" }
+chematic-core = { path = "../chematic-core", version = "0.4.27" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.27" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.4.27" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.4.27" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.4.26" }
+chematic-core = { path = "../chematic-core", version = "0.4.27" }
 rustfft = "6.4"
 
 [dev-dependencies]
-chematic-3d = { path = "../chematic-3d", version = "0.4.26" }
+chematic-3d = { path = "../chematic-3d", version = "0.4.27" }

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.4.26" }
-chematic-perception = { path = "../chematic-perception", version = "0.4.26" }
+chematic-core       = { path = "../chematic-core",       version = "0.4.27" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.27" }
 
 [dev-dependencies]
-chematic-smiles = { path = "../chematic-smiles", version = "0.4.26" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.4.27" }

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -16,13 +16,13 @@ documentation = "https://docs.rs/chematic-fp"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.4.26" }
+chematic-core = { path = "../chematic-core", version = "0.4.27" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.4.26" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.4.26" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.4.26" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.4.26" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.27" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.4.27" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.4.27" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.4.27" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -18,10 +18,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.4.26", path = "../chematic-core" }
-chematic-smiles = { version = "0.4.26", path = "../chematic-smiles" }
-chematic-chem = { version = "0.4.26", path = "../chematic-chem" }
-chematic-rxn = { version = "0.4.26", path = "../chematic-rxn" }
+chematic-core = { version = "0.4.27", path = "../chematic-core" }
+chematic-smiles = { version = "0.4.27", path = "../chematic-smiles" }
+chematic-chem = { version = "0.4.27", path = "../chematic-chem" }
+chematic-rxn = { version = "0.4.27", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.4.26" }
-chematic-perception = { path = "../chematic-perception", version = "0.4.26" }
+chematic-core       = { path = "../chematic-core",       version = "0.4.27" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.27" }
 
 [dev-dependencies]
-chematic-smiles = { path = "../chematic-smiles", version = "0.4.26" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.4.27" }

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -17,12 +17,12 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.4.26" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.26" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.4.26", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.4.26" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.26" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.4.26" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.4.26" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.4.26" }
-chematic-perception = { path = "../chematic-perception", version = "0.4.26" }
+chematic-core       = { path = "../chematic-core",       version = "0.4.27" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.27" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.4.27", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.4.27" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.27" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.4.27" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.4.27" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.4.27" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.27" }

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -16,10 +16,10 @@ documentation = "https://docs.rs/chematic-mol"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.4.26" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.4.26" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.4.26" }
+chematic-core        = { path = "../chematic-core",        version = "0.4.27" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.4.27" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.4.27" }
 serde_json           = "1.0"
 
 [dev-dependencies]
-chematic-smiles = { path = "../chematic-smiles", version = "0.4.26" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.4.27" }

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-perception"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.4.26" }
+chematic-core = { path = "../chematic-core", version = "0.4.27" }
 rustc-hash = "2"
 
 [dev-dependencies]
-chematic-smiles = { path = "../chematic-smiles", version = "0.4.26" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.4.27" }

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,16 +25,16 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.4.26" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.26" }
-chematic-perception = { path = "../chematic-perception", version = "0.4.26" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.4.26" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.4.26" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.4.26", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.4.26" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.26" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.4.26" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.4.26" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.4.26" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.4.26" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.4.26" }
+chematic-core       = { path = "../chematic-core",       version = "0.4.27" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.27" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.27" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.4.27" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.4.27" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.4.27", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.4.27" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.27" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.4.27" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.4.27" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.4.27" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.4.27" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.4.27" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-rxn"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.4.26" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.4.26" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.4.26" }
+chematic-core   = { path = "../chematic-core",   version = "0.4.27" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.4.27" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.4.27" }
 rustc-hash = "2"

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.4.26" }
-chematic-perception = { path = "../chematic-perception", version = "0.4.26" }
+chematic-core = { path = "../chematic-core", version = "0.4.27" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.27" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.4.26" }
+chematic-core = { path = "../chematic-core", version = "0.4.27" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -25,16 +25,16 @@ crate-type = ["cdylib", "rlib"]
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["console"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.4.26" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.26" }
-chematic-perception = { path = "../chematic-perception", version = "0.4.26" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.4.26", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.4.26" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.4.26", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.4.26" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.26" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.4.26" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.4.26" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.4.26" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.4.26" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.4.26" }
+chematic-core       = { path = "../chematic-core",       version = "0.4.27" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.27" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.27" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.4.27", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.4.27" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.4.27", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.4.27" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.27" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.4.27" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.4.27" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.4.27" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.4.27" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.4.27" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -33,15 +33,15 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.4.26", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.26", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.4.26", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.4.26", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.4.26", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.4.26", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.4.26", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.26", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.4.26", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.4.26", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.4.26", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.4.26", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.4.27", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.27", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.4.27", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.4.27", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.4.27", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.4.27", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.4.27", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.27", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.4.27", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.4.27", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.4.27", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.4.27", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,6 +1,6 @@
 # Benchmark
 
-Measured environment: Python 3.12, Apple M-series, chematic v0.4.26, RDKit 2026.03.3.
+Measured environment: Python 3.12, Apple M-series, chematic v0.4.27, RDKit 2026.03.3.
 
 ---
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -2,7 +2,7 @@
 
 Summary of descriptor accuracy against RDKit on a ChEMBL-derived corpus.
 
-**Environment:** Python 3.12, Apple M-series, chematic v0.4.26, RDKit 2026.03.3
+**Environment:** Python 3.12, Apple M-series, chematic v0.4.27, RDKit 2026.03.3
 
 ---
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -101,11 +101,15 @@ def main() -> None:
         ]),
     ]
 
-    # Intra-workspace path-dependency version pins, e.g.
+    # Intra-workspace path-dependency version pins — key order varies between
+    # crates ("path, version" in most, "version, path" in chematic-inchi), so
+    # match both:
     #   chematic-core = { path = "../chematic-core", version = "0.4.19" }
+    #   chematic-core = { version = "0.4.19", path = "../chematic-core" }
     for cargo_toml in sorted((ROOT / "crates").glob("*/Cargo.toml")):
         targets.append((cargo_toml, [
             re.compile(r'path\s*=\s*"[^"]+",\s*version\s*=\s*"' + re.escape(old) + r'"'),
+            re.compile(r'version\s*=\s*"' + re.escape(old) + r'",\s*path\s*=\s*"[^"]+"'),
         ]))
 
     updated = []


### PR DESCRIPTION
## Summary
Version bump bundling PR #57 (descriptor fixes, RWMol/FCFP, veridict CI gates) for release, plus a `bump_version.py` regex fix (missed `chematic-inchi`'s reversed `version, path` key order).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib --quiet` / `--tests --quiet`
- [x] Manual version-consistency check (check.sh's deny step fails locally on an unrelated pre-existing cargo-deny CLI version mismatch; version-sync portion verified manually)