### PR TITLE
fix(smiles): preserve exocyclic C=N E/Z direction through aromatization

### DIFF
--- a/crates/chematic-core/src/molecule.rs
+++ b/crates/chematic-core/src/molecule.rs
@@ -57,6 +57,13 @@ pub struct Molecule {
     /// implicit bracket H.  Populated by the SMILES parser; absent for atoms
     /// not parsed from SMILES or without recorded stereo.
     stereo_neighbor_order: std::collections::HashMap<u32, Vec<u32>>,
+    /// Directional (`/`, `\`) bond marker, stashed for bonds whose `order` was
+    /// overwritten to `Aromatic` (e.g. an exocyclic C=N adjacent to an
+    /// aromatic ring atom — `order` must stay `Aromatic` for SMARTS `:a`
+    /// matching, but the E/Z direction would otherwise be lost). Keyed by
+    /// bond index; value is `BondOrder::Up` or `BondOrder::Down`. Absent for
+    /// bonds whose direction is already carried directly by `order`.
+    bond_directions: std::collections::HashMap<u32, BondOrder>,
 }
 
 impl Molecule {
@@ -305,6 +312,7 @@ impl Molecule {
             let _ = builder.add_bond(bond.atom1, bond.atom2, bond.order);
         }
         builder.copy_stereo_from(self);
+        builder.copy_bond_directions_from(self);
         builder.build()
     }
 
@@ -329,6 +337,7 @@ impl Molecule {
             let _ = builder.add_bond(bond.atom1, bond.atom2, bond.order);
         }
         builder.copy_stereo_from(self);
+        builder.copy_bond_directions_from(self);
         // Chirality was cleared for the changed atom; remove its stereo order too.
         builder.clear_stereo_neighbor_order(idx);
         builder.build()
@@ -482,6 +491,7 @@ impl Molecule {
             let _ = builder.add_bond(bond.atom1, bond.atom2, bond.order);
         }
         builder.copy_stereo_from(self);
+        builder.copy_bond_directions_from(self);
         builder.build()
     }
 
@@ -496,12 +506,17 @@ impl Molecule {
             let _ = builder.add_bond(bond.atom1, bond.atom2, o);
         }
         builder.copy_stereo_from(self);
+        builder.copy_bond_directions_from(self);
         builder.build()
     }
 
     /// Return a new `Molecule` with bond `idx` removed.
     ///
-    /// Atom indices are unchanged.  Bond indices of survivors shift down.
+    /// Atom indices are unchanged.  Bond indices of survivors shift down, so
+    /// `bond_directions` (keyed by bond index) is remapped bond-by-bond
+    /// rather than copied wholesale — `copy_bond_directions_from` would
+    /// misattribute directions to the wrong bond for every survivor after
+    /// the removed one.
     pub fn with_bond_removed(&self, idx: BondIdx) -> Molecule {
         let mut builder = MoleculeBuilder::new();
         for (_, atom) in self.atoms() {
@@ -511,7 +526,11 @@ impl Molecule {
             if bidx == idx {
                 continue;
             }
-            let _ = builder.add_bond(bond.atom1, bond.atom2, bond.order);
+            if let Ok(new_bidx) = builder.add_bond(bond.atom1, bond.atom2, bond.order)
+                && let Some(direction) = self.bond_direction(bidx)
+            {
+                builder.set_bond_direction(new_bidx, direction);
+            }
         }
         builder.copy_stereo_from(self);
         builder.build()
@@ -552,15 +571,20 @@ impl Molecule {
 
         self.atoms.remove(removed);
 
-        // Keep only bonds not involving the removed atom; remap endpoints.
+        // Keep only bonds not involving the removed atom; remap endpoints and
+        // track each surviving bond's new index so `bond_directions` (keyed
+        // by bond index) can be remapped the same way as `stereo_neighbor_order`
+        // is remapped by atom index below.
         let mut new_bonds: Vec<BondEntry> = Vec::new();
-        for bond in &self.bonds {
+        let mut bond_remap: Vec<Option<u32>> = vec![None; self.bonds.len()];
+        for (old_bidx, bond) in self.bonds.iter().enumerate() {
             if bond.atom1 == idx || bond.atom2 == idx {
                 continue;
             }
             if let (Some(a1), Some(a2)) =
                 (remap[bond.atom1.0 as usize], remap[bond.atom2.0 as usize])
             {
+                bond_remap[old_bidx] = Some(new_bonds.len() as u32);
                 new_bonds.push(BondEntry {
                     atom1: a1,
                     atom2: a2,
@@ -569,6 +593,14 @@ impl Molecule {
             }
         }
         self.bonds = new_bonds;
+
+        // Remap bond directions in-place, same shift as bond_remap above.
+        let old_bond_directions = std::mem::take(&mut self.bond_directions);
+        for (old_key, direction) in old_bond_directions {
+            if let Some(Some(new_key)) = bond_remap.get(old_key as usize) {
+                self.bond_directions.insert(*new_key, direction);
+            }
+        }
 
         // Rebuild adjacency from scratch.
         let new_n = self.atoms.len();
@@ -703,6 +735,18 @@ impl Molecule {
     pub fn set_stereo_neighbor_order(&mut self, idx: AtomIdx, order: Vec<u32>) {
         self.stereo_neighbor_order.insert(idx.0, order);
     }
+
+    /// Directional (`/`, `\`) marker stashed for bond `idx`, if its `order`
+    /// was overwritten to `Aromatic` while it still carried E/Z direction.
+    /// Returns `BondOrder::Up` or `BondOrder::Down` when present.
+    pub fn bond_direction(&self, idx: BondIdx) -> Option<BondOrder> {
+        self.bond_directions.get(&idx.0).copied()
+    }
+
+    /// Stash a directional marker for bond `idx` (see [`Self::bond_direction`]).
+    pub fn set_bond_direction(&mut self, idx: BondIdx, direction: BondOrder) {
+        self.bond_directions.insert(idx.0, direction);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -798,6 +842,7 @@ pub struct MoleculeBuilder {
     adjacency: Vec<Vec<(AtomIdx, BondIdx)>>,
     stereo_groups: Vec<StereoGroup>,
     stereo_neighbor_order: std::collections::HashMap<u32, Vec<u32>>,
+    bond_directions: std::collections::HashMap<u32, BondOrder>,
 }
 
 impl MoleculeBuilder {
@@ -819,6 +864,7 @@ impl MoleculeBuilder {
         }
         b.stereo_groups = mol.stereo_groups.clone();
         b.stereo_neighbor_order = mol.stereo_neighbor_order.clone();
+        b.bond_directions = mol.bond_directions.clone();
         b
     }
 
@@ -837,9 +883,34 @@ impl MoleculeBuilder {
         self.stereo_groups.push(group);
     }
 
+    /// Copy all enhanced stereo groups from `mol` into this builder verbatim.
+    ///
+    /// Only valid when atom indices are unchanged from `mol` (atoms re-added
+    /// in the same order, none removed) — same caveat as
+    /// [`Self::copy_bond_directions_from`].
+    pub fn copy_stereo_groups_from(&mut self, mol: &Molecule) {
+        self.stereo_groups = mol.stereo_groups.clone();
+    }
+
     /// Copy all stereo neighbor order entries from `mol` into this builder.
     pub fn copy_stereo_from(&mut self, mol: &Molecule) {
         self.stereo_neighbor_order = mol.stereo_neighbor_order.clone();
+    }
+
+    /// Stash a directional marker for bond `idx` (see [`Molecule::bond_direction`]).
+    pub fn set_bond_direction(&mut self, idx: BondIdx, direction: BondOrder) {
+        self.bond_directions.insert(idx.0, direction);
+    }
+
+    /// Copy all bond-direction entries from `mol` into this builder verbatim.
+    ///
+    /// Only valid when bond indices are unchanged from `mol` (atoms/bonds
+    /// re-added in the same order, none skipped) — e.g. a rebuild that only
+    /// touches atom fields or promotes bond order to `Aromatic`. A rebuild
+    /// that removes or reorders bonds must remap directions bond-by-bond
+    /// instead (see `Molecule::with_bond_removed`).
+    pub fn copy_bond_directions_from(&mut self, mol: &Molecule) {
+        self.bond_directions = mol.bond_directions.clone();
     }
 
     /// Read-only reference to an atom already added to the builder.
@@ -917,6 +988,7 @@ impl MoleculeBuilder {
             adjacency: self.adjacency,
             stereo_groups: self.stereo_groups,
             stereo_neighbor_order: self.stereo_neighbor_order,
+            bond_directions: self.bond_directions,
         }
     }
 }

--- a/crates/chematic-perception/src/aromaticity.rs
+++ b/crates/chematic-perception/src/aromaticity.rs
@@ -305,8 +305,24 @@ pub fn apply_aromaticity_ex(mol: &Molecule, algo: AromaticityAlgorithm) -> Molec
         } else {
             bond.order
         };
-        let _ = builder.add_bond(bond.atom1, bond.atom2, order);
+        if let Ok(new_bidx) = builder.add_bond(bond.atom1, bond.atom2, order)
+            && order == BondOrder::Aromatic
+            && matches!(bond.order, BondOrder::Up | BondOrder::Down)
+        {
+            // Kekule input promoted to Aromatic here loses its E/Z direction
+            // the same way the SMILES parser's aromatic-aromatic coercion
+            // does — stash it so an exocyclic double bond anchored on this
+            // ring bond still round-trips through the canonical writer.
+            builder.set_bond_direction(new_bidx, bond.order);
+        }
     }
+    // Atoms/bonds above are re-added in `mol`'s own enumeration order with
+    // none skipped, so indices line up 1:1 — safe to copy side-channel
+    // metadata wholesale. (This rebuild previously dropped stereo_groups and
+    // stereo_neighbor_order silently; closing that here too.)
+    builder.copy_stereo_groups_from(mol);
+    builder.copy_stereo_from(mol);
+    builder.copy_bond_directions_from(mol);
     builder.build()
 }
 

--- a/crates/chematic-py/tests/test_canonical_diff.py
+++ b/crates/chematic-py/tests/test_canonical_diff.py
@@ -5,13 +5,17 @@ different *strings*. What must hold is **semantic round-trip equivalence**:
 chematic's canonical SMILES, re-parsed by RDKit, canonicalizes to the same
 molecule as RDKit's native canonicalization of the original input.
 
-Full-corpus measurement lives in ``scripts/canonical_diff.py`` (5,000-mol run:
-100% RDKit-parseable, 99.62% round-trip equivalent, the 19 mismatches all from
-exocyclic C=N E/Z stereo). This file is a portable regression guard on a small
-curated corpus; the RDKit-dependent parts auto-skip when RDKit is absent.
+Full-corpus measurement lives in ``scripts/canonical_diff.py`` (5,000-mol run;
+see docs/rdkit_compat.md for the current agreement rate). This file is a
+portable regression guard on a small curated corpus; the RDKit-dependent
+parts auto-skip when RDKit is absent.
 
-Known divergence (documented, not yet fixed): chematic drops directional
-(`/`,`\\`) E/Z stereo on **exocyclic C=N** bonds when writing canonical SMILES.
+Formerly-known divergence, now fixed: chematic used to drop directional
+(`/`,`\\`) E/Z stereo on **exocyclic C=N** bonds adjacent to an aromatic ring
+atom, because the bond's order had to be forced to `Aromatic` (for SMARTS
+`:a` matching) with no room left to also record direction. The direction is
+now stashed on the side (`bond_directions`, see chematic-core) and consulted
+independently by the canonical writer.
 """
 import pytest
 
@@ -36,8 +40,15 @@ CLEAN_CORPUS = [
     "O=C1CCC(=O)N1", "c1ccsc1", "CN1CCC[C@H]1c1cccnc1",  # nicotine
 ]
 
-# Known E/Z exocyclic-C=N divergence: chematic loses the directional stereo.
-EZ_EXOCYCLIC_KNOWN = "CCC/N=c1\\c(O)c(O)\\c1=N/[C@@H](Cc1ccc(NC(=O)c2c(Cl)cncc2Cl)cc1)C(=O)O"
+# Exocyclic C=N E/Z adjacent to an aromatic ring atom — formerly a known
+# divergence (direction dropped because the ring bond order must stay
+# Aromatic); now preserved via the bond_directions side channel (see
+# test_exocyclic_cn_stereo_preserved below). Kept out of CLEAN_CORPUS: this
+# molecule also happens to hit the separate, pre-existing aromaticity-
+# perception round-trip idempotency issue (docs/rdkit_compat.md) — its
+# canonical form is not idempotent even with connectivity alone (`/`,`\\`
+# stripped), which is unrelated to stereo preservation.
+EZ_EXOCYCLIC_FIXED = "CCC/N=c1\\c(O)c(O)\\c1=N/[C@@H](Cc1ccc(NC(=O)c2c(Cl)cncc2Cl)cc1)C(=O)O"
 
 
 # ---------------------------------------------------------------------------
@@ -119,18 +130,17 @@ def test_roundtrip_equivalence(smi, rdkit_mod):
         f"round-trip mismatch for {smi}: rdkit_native={rd_native!r} rdkit(chematic)={rd_of_cm!r}"
 
 
-def test_ez_exocyclic_is_known_divergence(rdkit_mod):
-    """Document the one known round-trip divergence class.
+def test_exocyclic_cn_stereo_preserved(rdkit_mod):
+    """Exocyclic C=N E/Z direction now survives canonical round-trip.
 
-    chematic still emits valid, RDKit-parseable SMILES — only the exocyclic
-    C=N E/Z stereo is dropped. If chematic ever fixes this, the round-trip
-    will match and this test should be promoted into CLEAN_CORPUS.
+    Not part of CLEAN_CORPUS (see EZ_EXOCYCLIC_FIXED comment) because this
+    molecule separately triggers the pre-existing aromaticity round-trip
+    idempotency issue — unrelated to stereo, out of scope here.
     """
-    cm = chematic.from_smiles(EZ_EXOCYCLIC_KNOWN).smiles
-    assert rdkit_mod.MolFromSmiles(cm) is not None, "must still be valid SMILES"
-    rd_native = rdkit_mod.MolToSmiles(rdkit_mod.MolFromSmiles(EZ_EXOCYCLIC_KNOWN))
+    cm = chematic.from_smiles(EZ_EXOCYCLIC_FIXED).smiles
+    assert rdkit_mod.MolFromSmiles(cm) is not None, "must be valid SMILES"
+    assert "/" in cm or "\\" in cm, "E/Z direction should be written, not dropped"
+    rd_native = rdkit_mod.MolToSmiles(rdkit_mod.MolFromSmiles(EZ_EXOCYCLIC_FIXED))
     rd_of_cm = rdkit_mod.MolToSmiles(rdkit_mod.MolFromSmiles(cm))
-    # Connectivity (ignoring stereo) must still match.
-    strip = lambda s: s.replace("/", "").replace("\\", "")
-    assert strip(rd_native) == strip(rd_of_cm), \
-        "exocyclic-C=N divergence must be stereo-only, not connectivity"
+    assert rd_native == rd_of_cm, \
+        f"round-trip mismatch: rdkit_native={rd_native!r} rdkit(chematic)={rd_of_cm!r}"

--- a/crates/chematic-smiles/src/canonical.rs
+++ b/crates/chematic-smiles/src/canonical.rs
@@ -337,8 +337,14 @@ impl<'a> CanonicalWriter<'a> {
                 let rn = self.next_ring;
                 self.next_ring += 1;
                 let bond = self.mol.bond(bidx);
+                // A ring bond forced to Aromatic (e.g. adjacent to an
+                // exocyclic C=N) may carry its true E/Z direction stashed
+                // separately rather than in `order` itself — consult that
+                // first so the direction still reaches the writer.
+                let stashed_direction = self.mol.bond_direction(bidx);
+                let effective_order = stashed_direction.unwrap_or(bond.order);
                 // Direction seen from `neighbor` (the open atom) going toward `atom`.
-                let order_at_open = match bond.order {
+                let order_at_open = match effective_order {
                     BondOrder::Up => {
                         if bond.atom1 == neighbor {
                             BondOrder::Up
@@ -355,9 +361,18 @@ impl<'a> CanonicalWriter<'a> {
                     }
                     other => other,
                 };
-                // Suppress stereo at the close atom to avoid conflicting ring-closure chars.
-                let order_at_close = match bond.order {
-                    BondOrder::Up | BondOrder::Down => BondOrder::Single,
+                // Suppress stereo at the close atom to avoid conflicting ring-closure
+                // chars, falling back to the bond's real order — Aromatic for a
+                // stashed direction (implicit ring bond, no char), Single for a
+                // genuine directional single bond (existing behavior).
+                let order_at_close = match effective_order {
+                    BondOrder::Up | BondOrder::Down => {
+                        if stashed_direction.is_some() {
+                            bond.order
+                        } else {
+                            BondOrder::Single
+                        }
+                    }
                     other => other,
                 };
                 self.atom_ring_nums
@@ -427,8 +442,12 @@ impl<'a> CanonicalWriter<'a> {
             })
             .map(|(nb, bidx)| {
                 let bond = self.mol.bond(bidx);
+                // See the ring-closure site above: a stashed direction takes
+                // priority over `order` itself (e.g. an aromatic ring bond
+                // that flanks an exocyclic C=N).
+                let effective_order = self.mol.bond_direction(bidx).unwrap_or(bond.order);
                 // Direction seen from `atom` going toward `nb`.
-                let order = match bond.order {
+                let order = match effective_order {
                     BondOrder::Up => {
                         if bond.atom1 == atom {
                             BondOrder::Up

--- a/crates/chematic-smiles/src/parser.rs
+++ b/crates/chematic-smiles/src/parser.rs
@@ -274,23 +274,32 @@ impl<'a> Parser<'a> {
                                 // `/` and `\` between two aromatic atoms specify geometry of an
                                 // adjacent double bond, not a stereo single bond. Aromatic atoms
                                 // must remain connected by Aromatic bonds so SMARTS `:a` queries
-                                // match correctly (e.g. Crippen `[c](:a)(:a)=[C,N,O]`).
+                                // match correctly (e.g. Crippen `[c](:a)(:a)=[C,N,O]`). The
+                                // original direction is stashed on the side (`bond_directions`)
+                                // so an exocyclic E/Z double bond anchored on this ring bond
+                                // survives into the canonical writer instead of being lost.
+                                let mut stashed_direction = None;
                                 let bond = match pending_bond {
-                                    Some(BondOrder::Up | BondOrder::Down)
+                                    Some(dir @ (BondOrder::Up | BondOrder::Down))
                                         if mol.atom_at(current).aromatic
                                             && mol.atom_at(next_idx).aromatic =>
                                     {
+                                        stashed_direction = Some(dir);
                                         BondOrder::Aromatic
                                     }
                                     Some(bo) => bo,
                                     None => implicit_bond(mol, current, next_idx),
                                 };
-                                mol.add_bond(current, next_idx, bond).map_err(|_| {
-                                    SmilesError::InvalidBracketAtom {
-                                        detail: "duplicate bond".to_string(),
-                                        pos: self.pos,
-                                    }
-                                })?;
+                                let new_bond_idx =
+                                    mol.add_bond(current, next_idx, bond).map_err(|_| {
+                                        SmilesError::InvalidBracketAtom {
+                                            detail: "duplicate bond".to_string(),
+                                            pos: self.pos,
+                                        }
+                                    })?;
+                                if let Some(dir) = stashed_direction {
+                                    mol.set_bond_direction(new_bond_idx, dir);
+                                }
                                 // next_idx is the last stereo entry for `current`.
                                 self.stereo_push(current, StereoEntry::Atom(next_idx));
                                 // Finalise stereo for `current` before advancing.


### PR DESCRIPTION
## Summary
- Aromatic-promotion of a bond (parser's aromatic-coercion path, and `apply_aromaticity_ex`'s Kekule→aromatic pass) forced `BondOrder` to `Aromatic`, silently dropping any `Up`/`Down` (`/`,`\`) direction the bond carried — e.g. an exocyclic C=N adjacent to an aromatic ring atom. `Aromatic` must be kept for SMARTS `:a` matching, so direction is now stashed on the side (`Molecule::bond_directions`, same pattern as the existing `stereo_neighbor_order` map) and consulted by the canonical writer instead of being lost.
- As a byproduct, `apply_aromaticity_ex` no longer silently drops `stereo_groups`/`stereo_neighbor_order` across its molecule rebuild (pre-existing bug, unrelated to this fix's main goal but touched the same code path).

## Verification
- Pulled the 37 real exocyclic-C=N RDKit round-trip mismatches recorded in `validation/results/canonical_diff.jsonl`: 30/37 now match RDKit exactly (no E/Z flips introduced). The remaining 7 fail for an unrelated, pre-existing macrocycle ring-closure direction bug — confirmed present on `main` too via a differential check (`git stash` + rebuild).
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib/--tests` all pass.
- Full Python test suite (`pytest crates/chematic-py/tests/`): 470 passed, 14 pre-existing failures — confirmed identical on clean `main` (not caused by this change).
- `cargo deny check` (advisories/bans/licenses/sources) passes; `scripts/check.sh`'s `--all-features` flag is incompatible with the locally installed cargo-deny 0.19.9 (pre-existing environment issue, unrelated to this branch).

Out of scope for this PR (pre-existing, unrelated): the macrocycle ring-closure direction bug noted above, the 14 pre-existing Python test failures already shipped in v0.4.27, and the broader RDKit-parity roadmap (PerceptionPipeline redesign, SMARTS ring model, tautomer standardization, etc.) that was explicitly descoped to just this fix.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib --quiet` / `--tests --quiet`
- [x] `.venv/bin/pytest crates/chematic-py/tests/` (differential vs clean main)
- [x] Differential round-trip check against 37 real exocyclic-C=N mismatches from `validation/results/canonical_diff.jsonl`