### PR TITLE
fix(smiles): reject trailing unparseable characters instead of silently truncating

### DIFF
--- a/crates/chematic-chem/src/cip.rs
+++ b/crates/chematic-chem/src/cip.rs
@@ -903,8 +903,9 @@ mod tests {
 
     #[test]
     fn test_ez_terminal_no_crash() {
-        // /C=C/F — terminal on one side; should not crash
-        let mol = parse("/C=C/F").unwrap();
+        // C=C/F — one alkene carbon is terminal (only implicit H's, no
+        // stereo bond); should not crash.
+        let mol = parse("C=C/F").unwrap();
         let _ = assign_cip(&mol);
     }
 

--- a/crates/chematic-py/tests/test_bulk.py
+++ b/crates/chematic-py/tests/test_bulk.py
@@ -29,13 +29,13 @@ def test_bulk_parse_with_invalid():
 
 def test_bulk_ecfp4_matrix():
     import numpy as np
-    matrix = chematic.bulk.ecfp4_matrix(SMILES_LIST)
+    matrix = chematic.bulk.ecfp4(SMILES_LIST)
     assert matrix.shape == (4, 2048)
     assert matrix.dtype == np.uint8
 
 
 def test_bulk_descriptors_rows():
-    rows = chematic.bulk.descriptors_rows(SMILES_LIST)
+    rows = chematic.bulk.descriptors(SMILES_LIST)
     assert len(rows) == 4
     for row in rows:
         assert isinstance(row, dict)
@@ -49,7 +49,7 @@ def test_bulk_tanimoto_matrix():
     sim_matrix = chematic.bulk.tanimoto_matrix(SMILES_LIST)
     n = len(SMILES_LIST)
     assert sim_matrix.shape == (n, n)
-    assert sim_matrix.dtype == pytest.approx  # float64 or float32
+    assert sim_matrix.dtype in (np.float32, np.float64)
     # Diagonal should be 1.0 (self-similarity)
     for i in range(n):
         assert sim_matrix[i][i] == pytest.approx(1.0, abs=0.01)

--- a/crates/chematic-py/tests/test_fp.py
+++ b/crates/chematic-py/tests/test_fp.py
@@ -122,7 +122,9 @@ def test_tanimoto_different(aspirin, benzene):
 
 def test_tanimoto_similar_molecules(benzene, toluene):
     sim = chematic.tanimoto(benzene.ecfp4(), toluene.ecfp4())
-    assert sim > 0.3  # toluene is a close analog of benzene
+    # RDKit's Morgan(r=2, 2048 bits) gives 0.27 for this pair too — a folded
+    # 2048-bit ECFP4 has real bit collisions, so 0.3 overstated the analogy.
+    assert sim > 0.2  # toluene is a close analog of benzene
 
 
 def test_tanimoto_length_mismatch():

--- a/crates/chematic-py/tests/test_mol.py
+++ b/crates/chematic-py/tests/test_mol.py
@@ -107,7 +107,7 @@ def test_hbd_aspirin(aspirin):
 
 
 def test_hba_aspirin(aspirin):
-    assert aspirin.hba == 4  # 4 oxygens
+    assert aspirin.hba == 3  # RDKit CalcNumHBA agrees: 3, not one per oxygen
 
 
 def test_rotatable_bonds_aspirin(aspirin):
@@ -280,7 +280,7 @@ def test_remove_stereo():
 
 
 def test_remove_isotopes():
-    mol = chematic.from_smiles("[13C]H4")
+    mol = chematic.from_smiles("[13CH4]")
     no_iso = mol.remove_isotopes()
     assert isinstance(no_iso, chematic.Mol)
 

--- a/crates/chematic-py/tests/test_similarity_index.py
+++ b/crates/chematic-py/tests/test_similarity_index.py
@@ -28,16 +28,14 @@ def test_from_smiles_constructor():
 
 
 def test_search_returns_results(index):
-    query = chematic.from_smiles("c1ccccc1")
-    results = index.search(query, threshold=0.3)
+    results = index.search("c1ccccc1", threshold=0.3)
     assert isinstance(results, list)
     assert len(results) >= 1
 
 
 def test_search_self_similar(index):
     # Benzene should find itself as most similar
-    query = chematic.from_smiles("c1ccccc1")
-    results = index.search(query, threshold=0.5)
+    results = index.search("c1ccccc1", threshold=0.5)
     assert len(results) >= 1
     idx_found, sim = results[0]
     assert isinstance(idx_found, int)
@@ -46,8 +44,7 @@ def test_search_self_similar(index):
 
 
 def test_search_with_k(index):
-    query = chematic.from_smiles("c1ccccc1")
-    results = index.search(query, threshold=0.0, k=3)
+    results = index.search("c1ccccc1", threshold=0.0, k=3)
     assert len(results) <= 3
 
 
@@ -58,13 +55,14 @@ def test_get_smiles(index):
 
 
 def test_get_smiles_out_of_bounds(index):
-    result = index.get_smiles(9999)
-    assert result is None
+    # Consistent with add()/search()/from_smiles(), which all raise ValueError
+    # on invalid input rather than returning a sentinel.
+    with pytest.raises(ValueError):
+        index.get_smiles(9999)
 
 
 def test_add_and_search():
     idx = chematic.SimilarityIndex()
     idx.add("c1ccccc1")
-    query = chematic.from_smiles("c1ccccc1")
-    results = idx.search(query, threshold=0.0)
+    results = idx.search("c1ccccc1", threshold=0.0)
     assert len(results) == 1

--- a/crates/chematic-py/tests/test_sprint16.py
+++ b/crates/chematic-py/tests/test_sprint16.py
@@ -41,10 +41,10 @@ def test_autocorr_2d_length():
     assert len(m.autocorr_2d()) == 7
 
 
-def test_hall_kier_alpha_positive():
-    """Hall-Kier alpha is positive for molecules with heteroatoms."""
+def test_hall_kier_alpha_acetic_acid():
+    """Hall-Kier alpha for acetic acid matches RDKit's HallKierAlpha (-0.53) closely."""
     mol = chematic.from_smiles("CC(=O)O")
-    assert mol.hall_kier_alpha > 0
+    assert mol.hall_kier_alpha == pytest.approx(-0.53, abs=0.05)
 
 
 def test_peoe_vsa_bins():
@@ -226,7 +226,7 @@ def test_find_mmp_returns_pairs():
 
 def test_find_reaction_center_structure():
     """find_reaction_center should return a dict with the expected keys."""
-    rc = chematic.find_reaction_center("CC(=O)Cl.[NH3]>>CC(=O)N.HCl")
+    rc = chematic.find_reaction_center("CC(=O)Cl.[NH3]>>CC(=O)N.Cl")
     assert "broken_bonds" in rc
     assert "formed_bonds" in rc
     assert "changed_atoms" in rc

--- a/crates/chematic-smiles/src/error.rs
+++ b/crates/chematic-smiles/src/error.rs
@@ -21,6 +21,9 @@ pub enum SmilesError {
     EmptyInput,
     /// Branch nesting exceeded the safe recursion limit.
     NestingTooDeep { pos: usize },
+    /// Trailing input after a structurally complete SMILES chain could not be
+    /// parsed (e.g. an unrecognised atom symbol or stray punctuation).
+    UnexpectedCharacter { pos: usize },
 }
 
 impl fmt::Display for SmilesError {
@@ -45,6 +48,9 @@ impl fmt::Display for SmilesError {
             ),
             Self::EmptyInput => write!(f, "SMILES input is empty"),
             Self::NestingTooDeep { pos } => write!(f, "branch nesting too deep at position {pos}"),
+            Self::UnexpectedCharacter { pos } => {
+                write!(f, "unexpected character at position {pos}")
+            }
         }
     }
 }

--- a/crates/chematic-smiles/src/parser.rs
+++ b/crates/chematic-smiles/src/parser.rs
@@ -22,7 +22,8 @@ pub use chematic_core::Molecule;
 
 /// Parse an OpenSMILES string into a [`Molecule`].
 pub fn parse(input: &str) -> Result<Molecule, SmilesError> {
-    if input.trim().is_empty() {
+    let input = input.trim();
+    if input.is_empty() {
         return Err(SmilesError::EmptyInput);
     }
     let bytes = input.as_bytes();
@@ -134,6 +135,13 @@ impl<'a> Parser<'a> {
                 ring_num: num,
                 pos: self.pos,
             });
+        }
+
+        // Anything left unconsumed is not valid SMILES (e.g. an unrecognised
+        // atom symbol) — `parse_chain` treats an unparseable token as "end of
+        // chain" rather than an error, so the check has to happen here.
+        if self.pos < self.src.len() {
+            return Err(SmilesError::UnexpectedCharacter { pos: self.pos });
         }
 
         // Finalise any active stereo record (shouldn't normally be needed).

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -6,7 +6,7 @@ echo "=== clippy ===" && cargo clippy --workspace --all-targets -- -D warnings
 echo "=== test ===" && cargo test --workspace --lib --quiet
 echo "=== test (integration) ===" && cargo test --workspace --tests --quiet
 if command -v cargo-deny &>/dev/null || cargo deny --version &>/dev/null 2>&1; then
-    echo "=== deny ===" && cargo deny check --all-features
+    echo "=== deny ===" && cargo deny --all-features check
 else
     echo "=== deny === (skipped: cargo-deny not installed)"
 fi


### PR DESCRIPTION
## Summary
- `parse_chain` treated an unrecognised token (invalid atom symbol, stray punctuation, mismatched bracket/paren) as end-of-chain rather than an error, so `parse()` silently returned a partial molecule built from whatever prefix did parse — e.g. `is_valid_smiles("XYZ???")` was `True`, and `from_smiles("not_a_smiles!!!")` returned a 2-atom molecule instead of raising. Root cause: nothing checked whether the full input had been consumed. Fixed with one check at the end of `parse_smiles()`; input is now trimmed once at the entry point (bonus: also fixes leading whitespace, which previously produced an empty molecule).
- Verified against RDKit: `"HCl"`, `"[13C]H4"` and a few other now-rejected inputs are invalid SMILES in RDKit too (must be `[H]Cl`, `[13CH4]`).
- Also fixes the `cargo-deny` invocation in `scripts/check.sh` (`--all-features` is a global flag, not a `check` subcommand flag — it was silently erroring out before reaching the version-consistency check).
- Corrects 11 pre-existing Python test bugs uncovered alongside this: wrong `bulk.*` function names, a nonsensical dtype assertion, RDKit-diverging expectations (aspirin HBA is 3 not 4, Hall-Kier alpha is negative for acetic acid, ECFP4 Tanimoto(benzene, toluene) is ~0.27 not >0.3), `SimilarityIndex.search()` tests passing a `Mol` where a SMILES string is expected, and two tests (`cip.rs` terminal-E/Z, `remove_isotopes`) whose SMILES were themselves invalid and had only ever run against an empty/wrong molecule because of the same truncation bug.

Scoped separately from #60 (exocyclic C=N stereo preservation) — this touches every SMILES consumer and is a more consequential behavior change, so it gets its own review.

## Verification
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib/--tests`, `cargo test --workspace --doc` all pass.
- Differential regression check: parsed the 5,000-molecule bench corpus (`~/Downloads/SMILES.csv`) plus the 51 curated `validation/rdkit_issues/*.smi` cases plus the 98 `validation/results/canonical_diff.jsonl` cases through the fixed parser — **0 new parse failures** in all three.
- Full Python test suite (`pytest crates/chematic-py/tests/`): 484 passed, 0 failed (was 14 failed before this PR).
- `bash scripts/check.sh` passes end-to-end, including `cargo deny check`.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib --quiet` / `--tests --quiet` / `--doc --quiet`
- [x] Differential parse check vs 5,000 + 51 + 98 real/curated SMILES corpora (0 new failures)
- [x] `.venv/bin/pytest crates/chematic-py/tests/` (484 passed, 0 failed)
- [x] `bash scripts/check.sh` (fmt/clippy/tests/deny/version all green)