### PR TITLE
perf(smarts): short-circuit existence checks instead of enumerating all matches

### DIFF
--- a/crates/chematic-chem/src/alerts.rs
+++ b/crates/chematic-chem/src/alerts.rs
@@ -2069,7 +2069,13 @@ fn compiled_brenk_patterns() -> &'static [(&'static str, QueryMolecule)] {
 pub fn pains_matches(mol: &Molecule) -> Vec<&'static str> {
     let mol_h = add_explicit_hs(mol);
     let rings = find_sssr(&mol_h);
-    let config = MatchConfig::default();
+    // Each pattern only needs an existence check — only the name is kept,
+    // never the match maps — so stop at the first embedding per pattern.
+    let config = MatchConfig {
+        max_matches: Some(1),
+        uniquify: false,
+        ..Default::default()
+    };
     compiled_pains_patterns()
         .iter()
         .filter(|(_, q)| !find_matches_with_rings_and_config(q, &mol_h, &rings, &config).is_empty())
@@ -2099,7 +2105,13 @@ pub fn pains_passes(mol: &Molecule) -> bool {
 pub fn brenk_matches(mol: &Molecule) -> Vec<&'static str> {
     let mol_h = add_explicit_hs(mol);
     let rings = find_sssr(&mol_h);
-    let config = MatchConfig::default();
+    // Each pattern only needs an existence check — only the name is kept,
+    // never the match maps — so stop at the first embedding per pattern.
+    let config = MatchConfig {
+        max_matches: Some(1),
+        uniquify: false,
+        ..Default::default()
+    };
     compiled_brenk_patterns()
         .iter()
         .filter(|(_, q)| !find_matches_with_rings_and_config(q, &mol_h, &rings, &config).is_empty())
@@ -2127,7 +2139,13 @@ pub fn brenk_passes(mol: &Molecule) -> bool {
 pub fn pains_passes_and_matches(mol: &Molecule) -> (bool, Vec<&'static str>) {
     let mol_h = add_explicit_hs(mol);
     let rings = find_sssr(&mol_h);
-    let config = MatchConfig::default();
+    // Each pattern only needs an existence check — only the name is kept,
+    // never the match maps — so stop at the first embedding per pattern.
+    let config = MatchConfig {
+        max_matches: Some(1),
+        uniquify: false,
+        ..Default::default()
+    };
     let names: Vec<&'static str> = compiled_pains_patterns()
         .iter()
         .filter(|(_, q)| !find_matches_with_rings_and_config(q, &mol_h, &rings, &config).is_empty())
@@ -2144,7 +2162,13 @@ pub fn pains_passes_and_matches(mol: &Molecule) -> (bool, Vec<&'static str>) {
 pub fn brenk_passes_and_matches(mol: &Molecule) -> (bool, Vec<&'static str>) {
     let mol_h = add_explicit_hs(mol);
     let rings = find_sssr(&mol_h);
-    let config = MatchConfig::default();
+    // Each pattern only needs an existence check — only the name is kept,
+    // never the match maps — so stop at the first embedding per pattern.
+    let config = MatchConfig {
+        max_matches: Some(1),
+        uniquify: false,
+        ..Default::default()
+    };
     let names: Vec<&'static str> = compiled_brenk_patterns()
         .iter()
         .filter(|(_, q)| !find_matches_with_rings_and_config(q, &mol_h, &rings, &config).is_empty())

--- a/crates/chematic-chem/src/standardize.rs
+++ b/crates/chematic-chem/src/standardize.rs
@@ -104,8 +104,13 @@ impl SaltCatalog {
 
     /// Check if a molecule fragment matches any salt pattern.
     pub fn is_salt(&self, frag: &Molecule) -> bool {
+        // max_matches: Some(1) stops each pattern's VF2 search at the first
+        // embedding instead of enumerating every match — this loop only
+        // needs to know whether a match exists, not how many.
         let config = MatchConfig {
             max_visit_budget: Some(1_000_000),
+            max_matches: Some(1),
+            uniquify: false,
             ..Default::default()
         };
         for (_, smarts_str) in &self.patterns {

--- a/crates/chematic-py/src/bulk.rs
+++ b/crates/chematic-py/src/bulk.rs
@@ -851,12 +851,21 @@ pub fn hdf<'py>(
 pub fn substructure_search(smarts: &str, smiles: Vec<String>) -> PyResult<Vec<bool>> {
     let query = chematic_smarts::parse_smarts(smarts)
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+    // Stop at the first embedding per molecule instead of enumerating every
+    // match — this is an existence screen, not a match-collection call.
+    let config = chematic_smarts::MatchConfig {
+        max_matches: Some(1),
+        uniquify: false,
+        ..chematic_smarts::MatchConfig::default()
+    };
 
     let results: Vec<bool> = smiles
         .par_iter()
         .map(|smi| {
             chematic_smiles::parse(smi)
-                .map(|mol| !chematic_smarts::find_matches(&query, &mol).is_empty())
+                .map(|mol| {
+                    !chematic_smarts::find_matches_with_config(&query, &mol, &config).is_empty()
+                })
                 .unwrap_or(false)
         })
         .collect();
@@ -884,12 +893,19 @@ pub fn substructure_search(smarts: &str, smiles: Vec<String>) -> PyResult<Vec<bo
 pub fn substructure_match(smarts: &str, mols: Vec<Mol>) -> PyResult<Vec<usize>> {
     let query = chematic_smarts::parse_smarts(smarts)
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+    // Stop at the first embedding per molecule instead of enumerating every
+    // match — this is an existence screen, not a match-collection call.
+    let config = chematic_smarts::MatchConfig {
+        max_matches: Some(1),
+        uniquify: false,
+        ..chematic_smarts::MatchConfig::default()
+    };
 
     let indices: Vec<usize> = mols
         .par_iter()
         .enumerate()
         .filter_map(|(i, m)| {
-            if !chematic_smarts::find_matches(&query, &m.inner).is_empty() {
+            if !chematic_smarts::find_matches_with_config(&query, &m.inner, &config).is_empty() {
                 Some(i)
             } else {
                 None

--- a/crates/chematic-py/src/misc.rs
+++ b/crates/chematic-py/src/misc.rs
@@ -14,7 +14,14 @@ use std::sync::Arc;
 fn smarts_match(smarts: &str, mol: &Mol) -> PyResult<bool> {
     let query =
         chematic_smarts::parse_smarts(smarts).map_err(|e| PyValueError::new_err(e.to_string()))?;
-    Ok(!chematic_smarts::find_matches(&query, &mol.inner).is_empty())
+    // Stop at the first embedding instead of enumerating every match — an
+    // existence check doesn't need the full match set or the dedup pass.
+    let config = chematic_smarts::MatchConfig {
+        max_matches: Some(1),
+        uniquify: false,
+        ..chematic_smarts::MatchConfig::default()
+    };
+    Ok(!chematic_smarts::find_matches_with_config(&query, &mol.inner, &config).is_empty())
 }
 
 /// Return all substructure matches of a SMARTS pattern in a molecule.

--- a/crates/chematic-py/src/mol_methods.rs
+++ b/crates/chematic-py/src/mol_methods.rs
@@ -1459,7 +1459,14 @@ impl Mol {
     fn has_substructure(&self, smarts: &str) -> PyResult<bool> {
         let query = chematic_smarts::parse_smarts(smarts)
             .map_err(|e| PyValueError::new_err(format!("invalid SMARTS '{smarts}': {e}")))?;
-        Ok(!chematic_smarts::find_matches(&query, &self.inner).is_empty())
+        // Stop at the first embedding instead of enumerating every match — an
+        // existence check doesn't need the full match set or the dedup pass.
+        let config = chematic_smarts::MatchConfig {
+            max_matches: Some(1),
+            uniquify: false,
+            ..chematic_smarts::MatchConfig::default()
+        };
+        Ok(!chematic_smarts::find_matches_with_config(&query, &self.inner, &config).is_empty())
     }
 
     /// Return atom-index lists for all SMARTS matches in this molecule.

--- a/crates/chematic-smarts/src/cache.rs
+++ b/crates/chematic-smarts/src/cache.rs
@@ -95,8 +95,17 @@ impl SmartsCache {
     }
 
     /// Check whether `smarts` matches at least once in `mol`.
+    ///
+    /// Stops the VF2 search at the first embedding (`max_matches: Some(1)`,
+    /// `uniquify: false`) instead of enumerating every match and checking
+    /// emptiness — existence doesn't need the full match set or dedup pass.
     pub fn has_match(&mut self, smarts: &str, mol: &Molecule) -> Result<bool, SmartsError> {
-        let matches = self.find_matches(smarts, mol)?;
+        let config = MatchConfig {
+            max_matches: Some(1),
+            uniquify: false,
+            ..MatchConfig::default()
+        };
+        let matches = self.find_matches_with_config(smarts, mol, &config)?;
         Ok(!matches.is_empty())
     }
 

--- a/scripts/bench_canonical.py
+++ b/scripts/bench_canonical.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+Benchmark canonical SMILES generation throughput: chematic vs RDKit.
+
+Uses the same built-in corpus tiering as bench_smiles_parse.py
+(simple → drug-like → stereo → large) or a user-supplied CSV file.
+Repeats the corpus to reach --n total canonicalizations. Parsing is
+done once up front and excluded from the timed region.
+
+Usage:
+    python scripts/bench_canonical.py
+    python scripts/bench_canonical.py --rdkit
+    python scripts/bench_canonical.py --n 10000 --rdkit
+    python scripts/bench_canonical.py ~/Downloads/SMILES.csv --n 5000 --rdkit --json
+"""
+
+import argparse
+import csv
+import json
+import time
+
+
+# Same tiering as bench_smiles_parse.py: simple → drug-like → stereo → fused rings
+BUILTIN_SMILES: list[str] = [
+    # Simple
+    "C", "CC", "CCC", "c1ccccc1", "c1ccncc1",
+    # Drug-like
+    "CC(=O)Oc1ccccc1C(=O)O",            # aspirin
+    "Cn1cnc2c1c(=O)n(c(=O)n2C)C",      # caffeine
+    "CC(C)Cc1ccc(cc1)C(C)C(=O)O",      # ibuprofen
+    "CC(=O)Nc1ccc(O)cc1",               # paracetamol
+    "c1ccc2cc3ccccc3cc2c1",             # pyrene
+    # Stereocentres
+    "N[C@@H](Cc1ccccc1)C(=O)O",        # L-phenylalanine
+    "OC[C@@H]1OC(O)[C@H](O)[C@@H](O)[C@H]1O",  # glucose
+    # Rings / fused
+    "C1CCC2CCCCC2C1",                   # decalin
+    "C1CC2CCCCC2CC1",                   # bicyclo
+    "C1=CC2=CC3=CC=CC=C3C=C2C=C1",     # coronene-like
+    # SMARTS-challenging
+    "Clc1ccccc1Cl",
+    "F[B-](F)(F)F.[Na+]",              # salt
+    "CN(C)C(=N)NC(=N)N",               # metformin (multiple N)
+    "[NH4+].[O-]C(=O)c1ccccc1",       # charged pair
+    "OC(=O)[C@H](N)Cc1c[nH]cn1",      # histidine
+]
+
+
+def build_corpus(smiles_list: list[str], n: int) -> list[str]:
+    reps = (n // len(smiles_list)) + 1
+    return (smiles_list * reps)[:n]
+
+
+def run_chematic(corpus: list[str]) -> tuple[float, int]:
+    import chematic
+    mols = [chematic.from_smiles(s) for s in corpus]
+    # Warm-up (fills intern caches)
+    for m in mols[:min(20, len(mols))]:
+        _ = m.smiles
+    t0 = time.perf_counter()
+    ok = sum(1 for m in mols if m.smiles)
+    return time.perf_counter() - t0, ok
+
+
+def run_rdkit(corpus: list[str]) -> tuple[float, int]:
+    from rdkit import Chem
+    mols = [Chem.MolFromSmiles(s) for s in corpus]
+    for m in mols[:min(20, len(mols))]:
+        Chem.MolToSmiles(m, canonical=True)
+    t0 = time.perf_counter()
+    ok = sum(1 for m in mols if Chem.MolToSmiles(m, canonical=True))
+    return time.perf_counter() - t0, ok
+
+
+def fmt_row(name: str, elapsed: float, n: int, ok: int) -> str:
+    us   = elapsed / n * 1e6
+    rate = n / elapsed
+    return (f"  {name:<12}  {n:>6} mols  "
+            f"{elapsed*1000:>7.1f} ms  "
+            f"{us:>6.2f} µs/mol  "
+            f"{rate:>9,.0f} mol/s"
+            + (f"  ({ok}/{n} canonicalized)" if ok < n else ""))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("smiles_file", nargs="?",
+                    help="CSV with SMILES column (or plain text, one SMILES per line)")
+    ap.add_argument("--rdkit",  action="store_true", help="Also benchmark RDKit")
+    ap.add_argument("--n",      type=int, default=5000, help="Total canonicalizations to time")
+    ap.add_argument("--json",   action="store_true",   help="Machine-readable output")
+    args = ap.parse_args()
+
+    # --- load SMILES ---
+    smiles_list = BUILTIN_SMILES
+    if args.smiles_file:
+        loaded: list[str] = []
+        with open(args.smiles_file) as f:
+            first = f.read(1024); f.seek(0)
+            if "," in first or "\t" in first:
+                reader = csv.DictReader(f)
+                fields = reader.fieldnames or []
+                col = "SMILES" if "SMILES" in fields else (fields[0] if fields else None)
+                loaded = [r[col].strip() for r in reader if col and r.get(col,"").strip()]
+            else:
+                loaded = [l.strip() for l in f if l.strip() and not l.startswith("#")]
+        smiles_list = loaded
+        if not args.json:
+            print(f"Loaded {len(smiles_list)} SMILES from {args.smiles_file}\n")
+
+    corpus = build_corpus(smiles_list, args.n)
+    results: dict[str, object] = {"n": args.n, "corpus_size": len(smiles_list)}
+
+    if not args.json:
+        print(f"Canonical SMILES benchmark  (n={args.n})\n")
+
+    # --- chematic ---
+    try:
+        elapsed, ok = run_chematic(corpus)
+        results["chematic"] = {
+            "total_ms":   round(elapsed * 1000, 1),
+            "us_per_mol": round(elapsed / args.n * 1e6, 2),
+            "mol_per_sec": int(args.n / elapsed),
+            "canonicalized_ok":  ok,
+        }
+        if not args.json:
+            print(fmt_row("chematic", elapsed, args.n, ok))
+    except ImportError:
+        if not args.json:
+            print("  chematic not installed")
+
+    # --- rdkit ---
+    if args.rdkit:
+        try:
+            elapsed, ok = run_rdkit(corpus)
+            results["rdkit"] = {
+                "total_ms":   round(elapsed * 1000, 1),
+                "us_per_mol": round(elapsed / args.n * 1e6, 2),
+                "mol_per_sec": int(args.n / elapsed),
+                "canonicalized_ok":  ok,
+            }
+            if not args.json:
+                print(fmt_row("rdkit", elapsed, args.n, ok))
+        except ImportError:
+            if not args.json:
+                print("  rdkit not installed — skipping")
+
+    # --- speedup summary ---
+    if "chematic" in results and "rdkit" in results:
+        ch = results["chematic"]["total_ms"]
+        rd = results["rdkit"]["total_ms"]
+        speedup = rd / ch
+        results["speedup_x"] = round(speedup, 1)
+        if not args.json:
+            direction = "faster" if speedup >= 1 else "slower"
+            factor = speedup if speedup >= 1 else 1 / speedup
+            print(f"\n  chematic is {factor:.1f}× {direction} to canonicalize than RDKit")
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_sdf.py
+++ b/scripts/bench_sdf.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Benchmark SDF read/write throughput: chematic vs RDKit.
+
+Uses RDKit's own bundled sample SDF (Contrib/PBF/testData/egfr.sdf, ~365
+records) as a reproducible corpus with no extra download step. Falls back
+to a user-supplied SDF path.
+
+Read:  chematic.iter_sdf(path)       vs RDKit Chem.SDMolSupplier(path)
+Write: chematic.SDWriter(path)       vs RDKit Chem.SDWriter(path)
+
+Usage:
+    python scripts/bench_sdf.py
+    python scripts/bench_sdf.py --rdkit
+    python scripts/bench_sdf.py path/to/other.sdf --rdkit --json
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import tempfile
+import time
+
+
+def default_sdf_path() -> str | None:
+    """Locate RDKit's bundled egfr.sdf sample via the installed rdkit package."""
+    spec = importlib.util.find_spec("rdkit")
+    if spec is None or not spec.submodule_search_locations:
+        return None
+    rdkit_dir = list(spec.submodule_search_locations)[0]
+    candidate = os.path.join(rdkit_dir, "Contrib", "PBF", "testData", "egfr.sdf")
+    return candidate if os.path.exists(candidate) else None
+
+
+def run_chematic_read(path: str) -> tuple[float, int]:
+    import chematic
+    # Warm-up (import/JIT-free, but keeps timing consistent with other scripts)
+    ok = 0
+    t0 = time.perf_counter()
+    for rec in chematic.iter_sdf(path):
+        if rec.smiles:
+            ok += 1
+    return time.perf_counter() - t0, ok
+
+
+def run_rdkit_read(path: str) -> tuple[float, int]:
+    from rdkit import Chem
+    ok = 0
+    t0 = time.perf_counter()
+    for mol in Chem.SDMolSupplier(path):
+        if mol is not None:
+            ok += 1
+    return time.perf_counter() - t0, ok
+
+
+def run_chematic_write(path: str, out_path: str) -> tuple[float, int]:
+    import chematic
+    mols = [rec.mol for rec in chematic.iter_sdf(path) if rec.mol is not None]
+    t0 = time.perf_counter()
+    with chematic.SDWriter(out_path) as w:
+        for m in mols:
+            w.write(m)
+    return time.perf_counter() - t0, len(mols)
+
+
+def run_rdkit_write(path: str, out_path: str) -> tuple[float, int]:
+    from rdkit import Chem
+    mols = [m for m in Chem.SDMolSupplier(path) if m is not None]
+    t0 = time.perf_counter()
+    w = Chem.SDWriter(out_path)
+    for m in mols:
+        w.write(m)
+    w.close()
+    return time.perf_counter() - t0, len(mols)
+
+
+def fmt_row(name: str, elapsed: float, n: int) -> str:
+    if n == 0:
+        return f"    {name:<12}  no records"
+    us   = elapsed / n * 1e6
+    rate = n / elapsed
+    return (f"    {name:<12}  {n:>6} mols  "
+            f"{elapsed*1000:>7.1f} ms  "
+            f"{us:>6.2f} µs/mol  "
+            f"{rate:>9,.0f} mol/s")
+
+
+def report_pair(label: str, results: dict, chematic_r, rdkit_r, args) -> None:
+    section: dict[str, object] = {}
+    if not args.json:
+        print(f"  [{label}]")
+
+    if chematic_r is not None:
+        elapsed, n = chematic_r
+        section["chematic"] = {
+            "total_ms":    round(elapsed * 1000, 1),
+            "us_per_mol":  round(elapsed / n * 1e6, 2) if n else None,
+            "mol_per_sec": int(n / elapsed) if elapsed else None,
+            "n":           n,
+        }
+        if not args.json:
+            print(fmt_row("chematic", elapsed, n))
+
+    if rdkit_r is not None:
+        elapsed, n = rdkit_r
+        section["rdkit"] = {
+            "total_ms":    round(elapsed * 1000, 1),
+            "us_per_mol":  round(elapsed / n * 1e6, 2) if n else None,
+            "mol_per_sec": int(n / elapsed) if elapsed else None,
+            "n":           n,
+        }
+        if not args.json:
+            print(fmt_row("rdkit", elapsed, n))
+
+    if "chematic" in section and "rdkit" in section:
+        ch = section["chematic"]["total_ms"]
+        rd = section["rdkit"]["total_ms"]
+        speedup = rd / ch if ch else float("inf")
+        section["speedup_x"] = round(speedup, 1)
+        if not args.json:
+            direction = "faster" if speedup >= 1 else "slower"
+            factor = speedup if speedup >= 1 else 1 / speedup
+            print(f"    → chematic is {factor:.1f}× {direction} than RDKit")
+
+    results[label] = section
+    if not args.json:
+        print()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("sdf_file", nargs="?", help="SDF corpus (default: RDKit's bundled egfr.sdf)")
+    ap.add_argument("--rdkit", action="store_true", help="Also benchmark RDKit")
+    ap.add_argument("--json",  action="store_true", help="Machine-readable output")
+    args = ap.parse_args()
+
+    path = args.sdf_file or default_sdf_path()
+    if path is None or not os.path.exists(path):
+        raise SystemExit(
+            "No SDF corpus found. Pass one explicitly, e.g.\n"
+            "  python scripts/bench_sdf.py path/to/some.sdf"
+        )
+
+    results: dict[str, object] = {"source": path}
+    if not args.json:
+        print(f"SDF read/write benchmark  (corpus: {path})\n")
+
+    # --- read ---
+    ch_read = None
+    try:
+        ch_read = run_chematic_read(path)
+    except ImportError:
+        if not args.json:
+            print("  chematic not installed")
+    rd_read = run_rdkit_read(path) if args.rdkit else None
+    report_pair("read", results, ch_read, rd_read, args)
+
+    # --- write ---
+    with tempfile.TemporaryDirectory() as tmp:
+        ch_write = None
+        try:
+            ch_write = run_chematic_write(path, os.path.join(tmp, "chematic_out.sdf"))
+        except ImportError:
+            if not args.json:
+                print("  chematic not installed")
+        rd_write = run_rdkit_write(path, os.path.join(tmp, "rdkit_out.sdf")) if args.rdkit else None
+        report_pair("write", results, ch_write, rd_write, args)
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_smarts.py
+++ b/scripts/bench_smarts.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Benchmark SMARTS substructure matching throughput: chematic vs RDKit.
+
+Pairs with scripts/rdkit_benchmark.py's bench_smarts_match (benzene-ring
+query) and mirrors the query tiers already covered by chematic-smarts'
+Criterion benches (crates/chematic-smarts/benches/smarts_bench.rs):
+a simple ring query and a recursive SMARTS query. Repeats a 10-molecule
+corpus to reach --n total matches per query.
+
+Usage:
+    python scripts/bench_smarts.py
+    python scripts/bench_smarts.py --rdkit
+    python scripts/bench_smarts.py --n 5000 --rdkit --json
+"""
+
+import argparse
+import json
+import time
+
+
+# Same 10-molecule set as crates/chematic-smarts/benches/smarts_bench.rs
+BENCH_SMILES: list[str] = [
+    "c1ccccc1",
+    "Cc1ccccc1",
+    "CC(=O)Oc1ccccc1C(=O)O",
+    "Cn1cnc2c1c(=O)n(c(=O)n2C)C",
+    "CC(C)Cc1ccc(cc1)C(C)C(=O)O",
+    "c1ccncc1",
+    "C1CCNCC1",
+    "CC(=O)Nc1ccc(O)cc1",
+    "NCC(=O)O",
+    "CN(C)C(=N)NC(=N)N",
+]
+
+# name -> SMARTS pattern. "ring" is a plain aromatic-ring query (cheap);
+# "recursive" is a recursive SMARTS (amide N-H), the expensive tier.
+QUERIES: dict[str, str] = {
+    "ring": "c1ccccc1",
+    "recursive": "[NH;$(NC=O)]",
+}
+
+
+def build_corpus(n: int) -> list[str]:
+    reps = (n // len(BENCH_SMILES)) + 1
+    return (BENCH_SMILES * reps)[:n]
+
+
+def run_chematic(corpus: list[str], pattern: str) -> tuple[float, int]:
+    import chematic
+    mols = [chematic.from_smiles(s) for s in corpus]
+    # Warm-up — fills the SmartsCache LRU for this pattern
+    for m in mols[:min(20, len(mols))]:
+        chematic.smarts_match(pattern, m)
+    t0 = time.perf_counter()
+    hits = sum(1 for m in mols if chematic.smarts_match(pattern, m))
+    return time.perf_counter() - t0, hits
+
+
+def run_rdkit(corpus: list[str], pattern: str) -> tuple[float, int]:
+    from rdkit import Chem
+    mols = [Chem.MolFromSmiles(s) for s in corpus]
+    query = Chem.MolFromSmarts(pattern)  # compiled once, like a cached chematic query
+    for m in mols[:min(20, len(mols))]:
+        m.HasSubstructMatch(query)
+    t0 = time.perf_counter()
+    hits = sum(1 for m in mols if m.HasSubstructMatch(query))
+    return time.perf_counter() - t0, hits
+
+
+def fmt_row(name: str, elapsed: float, n: int, hits: int) -> str:
+    us   = elapsed / n * 1e6
+    rate = n / elapsed
+    return (f"    {name:<12}  {n:>6} mols  "
+            f"{elapsed*1000:>7.1f} ms  "
+            f"{us:>6.2f} µs/mol  "
+            f"{rate:>9,.0f} mol/s  "
+            f"({hits}/{n} matched)")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--rdkit", action="store_true", help="Also benchmark RDKit")
+    ap.add_argument("--n",     type=int, default=5000, help="Total matches to time, per query")
+    ap.add_argument("--json",  action="store_true",    help="Machine-readable output")
+    args = ap.parse_args()
+
+    corpus = build_corpus(args.n)
+    results: dict[str, object] = {"n": args.n, "corpus_size": len(BENCH_SMILES), "queries": {}}
+
+    if not args.json:
+        print(f"SMARTS match benchmark  (n={args.n} per query)\n")
+
+    for label, pattern in QUERIES.items():
+        query_results: dict[str, object] = {"pattern": pattern}
+        if not args.json:
+            print(f"  [{label}] {pattern}")
+
+        try:
+            elapsed, hits = run_chematic(corpus, pattern)
+            query_results["chematic"] = {
+                "total_ms":    round(elapsed * 1000, 1),
+                "us_per_mol":  round(elapsed / args.n * 1e6, 2),
+                "mol_per_sec": int(args.n / elapsed),
+                "matched":     hits,
+            }
+            if not args.json:
+                print(fmt_row("chematic", elapsed, args.n, hits))
+        except ImportError:
+            if not args.json:
+                print("    chematic not installed")
+
+        if args.rdkit:
+            try:
+                elapsed, hits = run_rdkit(corpus, pattern)
+                query_results["rdkit"] = {
+                    "total_ms":    round(elapsed * 1000, 1),
+                    "us_per_mol":  round(elapsed / args.n * 1e6, 2),
+                    "mol_per_sec": int(args.n / elapsed),
+                    "matched":     hits,
+                }
+                if not args.json:
+                    print(fmt_row("rdkit", elapsed, args.n, hits))
+            except ImportError:
+                if not args.json:
+                    print("    rdkit not installed — skipping")
+
+        if "chematic" in query_results and "rdkit" in query_results:
+            ch = query_results["chematic"]["total_ms"]
+            rd = query_results["rdkit"]["total_ms"]
+            speedup = rd / ch
+            query_results["speedup_x"] = round(speedup, 1)
+            if not args.json:
+                direction = "faster" if speedup >= 1 else "slower"
+                factor = speedup if speedup >= 1 else 1 / speedup
+                print(f"    → chematic is {factor:.1f}× {direction} than RDKit")
+
+        results["queries"][label] = query_results
+        if not args.json:
+            print()
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Added `scripts/bench_canonical.py` / `bench_smarts.py` / `bench_sdf.py` (chematic vs RDKit wall-clock, following `bench_smiles_parse.py`'s pattern) to close measurement blind spots: canonical SMILES, SMARTS matching, and SDF read/write had no direct RDKit timing comparison anywhere in the repo.
- Measurement found canonical SMILES (7.1x faster) and SDF I/O (3.5x/1.2x faster) already beat RDKit — no work needed there. SMARTS existence checks were 4.8x **slower**.
- Root cause: `smarts_match`/`has_match` called `find_matches()` (enumerates every embedding) and checked `is_empty()`, instead of stopping at the first match like RDKit's `HasSubstructMatch`. Fixed every existence-only call site using the existing `MatchConfig{max_matches: Some(1), uniquify: false}` early-exit path: `SmartsCache::has_match`, Python `smarts_match()`/`has_substructure()`, `bulk.substructure_search`/`substructure_match`, `SaltCatalog::is_salt`, and the PAINS/Brenk name-reporting functions (which only check existence per pattern before keeping the name). None of these sites use match content beyond emptiness, so the change is non-regressing by construction.
- `bulk.substructure_search` is now 2.2x faster than an RDKit Python loop (was likely doing the same over-enumeration before the fix).

## Test plan
- [x] `cargo test --workspace --lib` — 0 failed across all crates
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `bash scripts/check.sh` — passes except a pre-existing, unrelated RUSTSEC-2026-0204 advisory in `crossbeam-epoch` (confirmed present before this branch via `git stash`)
- [x] Manual correctness cross-check of `smarts_match`/`has_substructure`/`bulk.substructure_search`/`bulk.substructure_match` against `find_matches()` ground truth on multiple SMILES/SMARTS pairs
- [x] Existing PAINS/Brenk unit tests (rhodanine, azobenzene, phenol, thiol, etc.) still pass