### PR TITLE
fix(3d): align_coords Kabsch rotation bug + RDKit-parity gaps (V3000/CDXML/Avalon/O3A PR1)

### DIFF
--- a/crates/chematic-3d/src/align.rs
+++ b/crates/chematic-3d/src/align.rs
@@ -131,18 +131,19 @@ pub fn align_coords(reference: &[[f64; 3]], mobile: &[[f64; 3]]) -> AlignResult 
         }
     }
 
-    // R = V * U^T.
+    // R = U * V^T (maximises trace(H^T R), the Kabsch objective).
     let mut rot = [[0.0f64; 3]; 3];
     let mut v_final = v;
     for r in 0..3 {
         for c in 0..3 {
             for k in 0..3 {
-                rot[r][c] += v_final[r][k] * u[c][k];
+                rot[r][c] += u[r][k] * v_final[c][k];
             }
         }
     }
 
-    // Reflection correction.
+    // Reflection correction: flip the column of V paired with the smallest
+    // singular value (index 0, ascending order) when det(R) < 0.
     let det = det3(rot);
     if det < 0.0 {
         for r in 0..3 {
@@ -152,7 +153,7 @@ pub fn align_coords(reference: &[[f64; 3]], mobile: &[[f64; 3]]) -> AlignResult 
         for r in 0..3 {
             for c in 0..3 {
                 for k in 0..3 {
-                    rot[r][c] += v_final[r][k] * u[c][k];
+                    rot[r][c] += u[r][k] * v_final[c][k];
                 }
             }
         }
@@ -307,6 +308,83 @@ mod tests {
         assert!(
             approx_eq(rmsd_after, result.rmsd, 1e-6),
             "apply_alignment should match reported RMSD"
+        );
+    }
+
+    /// Regression test for a rotation-direction bug: `align_coords` once
+    /// returned the reference→mobile rotation instead of mobile→reference,
+    /// which is invisible under pure translation (H is symmetric there, so
+    /// U == V and the two directions coincide) but produces a large bogus
+    /// RMSD once an actual rotation is involved.
+    #[test]
+    fn test_align_pure_rotation_recovers_zero_rmsd() {
+        let reference = vec![
+            [0.0, 0.0, 0.0],
+            [2.0, 0.0, 0.0],
+            [0.0, 3.0, 0.0],
+            [1.0, 1.0, 4.0],
+        ];
+        // 90° rotation about z (x,y,z) -> (-y,x,z), plus a translation.
+        let mobile: Vec<[f64; 3]> = reference
+            .iter()
+            .map(|p| [-p[1] + 5.0, p[0] - 3.0, p[2] + 2.0])
+            .collect();
+        let result = align_coords(&reference, &mobile);
+        assert!(
+            approx_eq(result.rmsd, 0.0, 1e-6),
+            "pure rotation + translation → RMSD ~0 after Kabsch, got {}",
+            result.rmsd
+        );
+    }
+
+    #[test]
+    fn test_apply_alignment_under_rotation_matches_reference_pointwise() {
+        let reference = vec![
+            [0.0, 0.0, 0.0],
+            [2.0, 0.0, 0.0],
+            [0.0, 3.0, 0.0],
+            [1.0, 1.0, 4.0],
+        ];
+        let mobile: Vec<[f64; 3]> = reference
+            .iter()
+            .map(|p| [-p[1] + 5.0, p[0] - 3.0, p[2] + 2.0])
+            .collect();
+        let result = align_coords(&reference, &mobile);
+        let aligned = apply_alignment(&mobile, &result);
+        for (r, a) in reference.iter().zip(aligned.iter()) {
+            for k in 0..3 {
+                assert!(
+                    approx_eq(r[k], a[k], 1e-6),
+                    "aligned point {a:?} should match reference point {r:?}"
+                );
+            }
+        }
+    }
+
+    /// Forces the det<0 reflection-correction branch: a mirror image of a
+    /// genuinely non-planar (chiral) point set cannot be superposed by any
+    /// proper rotation, so the corrected result must still have det(R) = +1
+    /// and a nonzero residual RMSD (never a silent improper "rotation").
+    #[test]
+    fn test_align_mirror_image_forces_reflection_correction() {
+        let reference = vec![
+            [0.0, 0.0, 0.0],
+            [2.0, 0.0, 0.0],
+            [0.0, 3.0, 0.0],
+            [1.0, 1.0, 4.0],
+        ];
+        // Reflect through the xy-plane (z -> -z): improper for a non-planar set.
+        let mobile: Vec<[f64; 3]> = reference.iter().map(|p| [p[0], p[1], -p[2]]).collect();
+        let result = align_coords(&reference, &mobile);
+        assert!(
+            approx_eq(det3(result.rotation), 1.0, 1e-6),
+            "corrected rotation must be proper (det=+1), got det={}",
+            det3(result.rotation)
+        );
+        assert!(
+            result.rmsd > 0.5,
+            "a chiral point set can't be superposed onto its mirror image by any rotation, rmsd={}",
+            result.rmsd
         );
     }
 }

--- a/crates/chematic-3d/src/lib.rs
+++ b/crates/chematic-3d/src/lib.rs
@@ -23,6 +23,7 @@ pub mod etkdg_knowledge;
 pub mod md;
 pub mod minimize;
 pub mod mol_transforms;
+pub mod o3a;
 pub mod pdb;
 pub mod pharmacophore_fp_3d;
 pub(crate) mod prng;

--- a/crates/chematic-3d/src/o3a.rs
+++ b/crates/chematic-3d/src/o3a.rs
@@ -1,0 +1,470 @@
+//! Open3DAlign (O3A)-style atom correspondence search for 3D molecular alignment.
+//!
+//! Unlike simple RMSD superposition ([`crate::align::align_coords`]), which
+//! requires atom pairs to already be known, O3A finds the atom correspondence
+//! itself. This module implements only the correspondence-search primitive —
+//! the riskier, genuinely novel piece — as an isolated, directly-testable
+//! unit. The full `o3a_align` pipeline (which feeds this correspondence into
+//! the already-tested [`crate::align::align_coords`]) is a separate, thin
+//! wrapper built on top of this.
+//!
+//! # Algorithm
+//! 1. Assign MMFF94 atom types to both molecules; two atoms are considered
+//!    "compatible" only when their types match exactly.
+//! 2. Pre-align by principal axes (via the inertia-like covariance tensor's
+//!    eigenvectors). Principal axes have a sign ambiguity — of the 8 possible
+//!    per-axis sign combinations only 4 are proper rotations (det = +1); all
+//!    4 are tried as independent seeds, since picking the wrong one can
+//!    converge to a mirrored, degenerate correspondence.
+//! 3. For each seed: greedily pair each mol1 atom (farthest-from-centroid
+//!    first, to anchor asymmetric ends) with its nearest compatible-type,
+//!    not-yet-used mol2 atom within a distance cutoff, then alternate
+//!    "refit rotation for the current pairing" (reusing `align_coords`) and
+//!    "re-pair against the newly rotated coordinates" until the overlap
+//!    score stops improving.
+//! 4. Return the correspondence from whichever seed reached the best score.
+//!
+//! ponytail: `correspondence_search` and its helpers are only exercised by
+//! this module's tests until the PR2 `o3a_align` wrapper lands and wires
+//! them into the public API — hence the blanket dead_code allow below.
+#![allow(dead_code)]
+
+use chematic_core::Molecule;
+use chematic_ff::MMFF94Type;
+
+use crate::align::{align_coords, apply_alignment};
+use crate::shape_descriptors::jacobi3;
+
+/// Error returned by O3A correspondence search.
+#[derive(Debug)]
+pub enum O3AError {
+    /// `coords.len()` did not match `mol.atom_count()`.
+    CoordinateMismatch,
+    /// MMFF94 atom-type assignment failed for one of the molecules.
+    TypeAssignment(chematic_ff::AssignError),
+}
+
+impl std::fmt::Display for O3AError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            O3AError::CoordinateMismatch => write!(f, "coords length does not match atom count"),
+            O3AError::TypeAssignment(e) => write!(f, "MMFF94 type assignment failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for O3AError {}
+
+const DIST_CUTOFF: f64 = 4.0; // Å — candidate pairs beyond this are rejected
+const MAX_REFINE_ITERS: usize = 20;
+const SCORE_SIGMA: f64 = 1.0; // Å, Gaussian overlap score width
+const CONVERGENCE_EPS: f64 = 1e-4;
+
+// ---------------------------------------------------------------------------
+// Small linear-algebra helpers (local to this module — not a general
+// utility, so kept private rather than widening align.rs's visibility)
+// ---------------------------------------------------------------------------
+
+fn centroid(coords: &[[f64; 3]]) -> [f64; 3] {
+    let n = coords.len().max(1) as f64;
+    let mut c = [0.0; 3];
+    for p in coords {
+        for k in 0..3 {
+            c[k] += p[k];
+        }
+    }
+    for v in &mut c {
+        *v /= n;
+    }
+    c
+}
+
+/// Unweighted (geometric) covariance tensor of `coords` about `center`.
+///
+/// Used only to seed a rough pre-alignment via principal axes — not a
+/// physically accurate mass-weighted inertia tensor.
+fn covariance_tensor(coords: &[[f64; 3]], center: [f64; 3]) -> [[f64; 3]; 3] {
+    let mut t = [[0.0; 3]; 3];
+    for p in coords {
+        let x = p[0] - center[0];
+        let y = p[1] - center[1];
+        let z = p[2] - center[2];
+        t[0][0] += x * x;
+        t[1][1] += y * y;
+        t[2][2] += z * z;
+        t[0][1] += x * y;
+        t[0][2] += x * z;
+        t[1][2] += y * z;
+    }
+    t[1][0] = t[0][1];
+    t[2][0] = t[0][2];
+    t[2][1] = t[1][2];
+    t
+}
+
+fn det3(m: [[f64; 3]; 3]) -> f64 {
+    m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
+        - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
+        + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0])
+}
+
+/// Flip the third column's sign if needed so `axes` is a proper rotation
+/// (det = +1). `jacobi3`'s eigenvector accumulation is always a proper
+/// rotation, but its eigenvalue-ascending sort permutes columns and can
+/// introduce an odd (det-flipping) permutation.
+fn normalize_proper(mut axes: [[f64; 3]; 3]) -> [[f64; 3]; 3] {
+    if det3(axes) < 0.0 {
+        for row in axes.iter_mut() {
+            row[2] *= -1.0;
+        }
+    }
+    axes
+}
+
+fn matmul3(a: [[f64; 3]; 3], b_transposed: [[f64; 3]; 3]) -> [[f64; 3]; 3] {
+    let mut r = [[0.0; 3]; 3];
+    for (row, r_row) in r.iter_mut().enumerate() {
+        for (col, r_val) in r_row.iter_mut().enumerate() {
+            *r_val = (0..3).map(|k| a[row][k] * b_transposed[col][k]).sum();
+        }
+    }
+    r
+}
+
+fn apply_rotation_translation(
+    coords: &[[f64; 3]],
+    center: [f64; 3],
+    rot: [[f64; 3]; 3],
+    target_center: [f64; 3],
+) -> Vec<[f64; 3]> {
+    coords
+        .iter()
+        .map(|p| {
+            let cp = [p[0] - center[0], p[1] - center[1], p[2] - center[2]];
+            let mut out = [0.0; 3];
+            for (row, out_val) in out.iter_mut().enumerate() {
+                *out_val = (0..3).map(|k| rot[row][k] * cp[k]).sum::<f64>() + target_center[row];
+            }
+            out
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Correspondence search
+// ---------------------------------------------------------------------------
+
+fn overlap_score(pairs: &[(usize, usize)], coords1: &[[f64; 3]], coords2: &[[f64; 3]]) -> f64 {
+    pairs
+        .iter()
+        .map(|&(i, j)| {
+            let d2: f64 = (0..3)
+                .map(|k| (coords1[i][k] - coords2[j][k]).powi(2))
+                .sum();
+            (-d2 / (2.0 * SCORE_SIGMA * SCORE_SIGMA)).exp()
+        })
+        .sum()
+}
+
+/// Greedily pair each mol1 atom (farthest-from-centroid first) with its
+/// nearest not-yet-used, type-compatible mol2 atom within `DIST_CUTOFF`.
+fn greedy_correspondence(
+    coords1: &[[f64; 3]],
+    types1: &[MMFF94Type],
+    coords2: &[[f64; 3]],
+    types2: &[MMFF94Type],
+) -> Vec<(usize, usize)> {
+    let c1 = centroid(coords1);
+    let mut order: Vec<usize> = (0..coords1.len()).collect();
+    order.sort_by(|&a, &b| {
+        let da: f64 = (0..3).map(|k| (coords1[a][k] - c1[k]).powi(2)).sum();
+        let db: f64 = (0..3).map(|k| (coords1[b][k] - c1[k]).powi(2)).sum();
+        db.partial_cmp(&da).unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let mut used = vec![false; coords2.len()];
+    let mut pairs = Vec::new();
+    for i in order {
+        let mut best_j: Option<usize> = None;
+        let mut best_d2 = f64::INFINITY;
+        for j in 0..coords2.len() {
+            if used[j] || types1[i] != types2[j] {
+                continue;
+            }
+            let d2: f64 = (0..3)
+                .map(|k| (coords1[i][k] - coords2[j][k]).powi(2))
+                .sum();
+            if d2 < best_d2 {
+                best_d2 = d2;
+                best_j = Some(j);
+            }
+        }
+        if let Some(j) = best_j
+            && best_d2.sqrt() <= DIST_CUTOFF
+        {
+            used[j] = true;
+            pairs.push((i, j));
+        }
+    }
+    pairs
+}
+
+/// Alternate re-fitting the rotation for the current pairing (reusing
+/// [`align_coords`]) and re-pairing against the newly rotated coordinates,
+/// tracking the best-scoring pairing seen (not just the last — the
+/// alternating optimization is not guaranteed monotonic once the pairing
+/// set itself changes between iterations).
+fn refine(
+    coords1: &[[f64; 3]],
+    types1: &[MMFF94Type],
+    seeded_coords2: &[[f64; 3]],
+    types2: &[MMFF94Type],
+) -> (Vec<(usize, usize)>, f64) {
+    let mut current2 = seeded_coords2.to_vec();
+    let mut best_pairs: Vec<(usize, usize)> = Vec::new();
+    let mut best_score = f64::NEG_INFINITY;
+    let mut prev_score = f64::NEG_INFINITY;
+
+    for _ in 0..MAX_REFINE_ITERS {
+        let pairs = greedy_correspondence(coords1, types1, &current2, types2);
+        if pairs.is_empty() {
+            break;
+        }
+        let s = overlap_score(&pairs, coords1, &current2);
+        if s > best_score {
+            best_score = s;
+            best_pairs = pairs.clone();
+        }
+        if (s - prev_score).abs() < CONVERGENCE_EPS {
+            break;
+        }
+        prev_score = s;
+
+        let sub1: Vec<[f64; 3]> = pairs.iter().map(|&(i, _)| coords1[i]).collect();
+        let sub2: Vec<[f64; 3]> = pairs.iter().map(|&(_, j)| current2[j]).collect();
+        let result = align_coords(&sub1, &sub2);
+        current2 = apply_alignment(&current2, &result);
+    }
+
+    (best_pairs, best_score)
+}
+
+/// Proper-rotation sign combinations for the 3 principal-axis columns —
+/// exactly the 4 (of 8 possible) that preserve det = +1.
+const SEED_SIGNS: [[f64; 3]; 4] = [
+    [1.0, 1.0, 1.0],
+    [1.0, -1.0, -1.0],
+    [-1.0, 1.0, -1.0],
+    [-1.0, -1.0, 1.0],
+];
+
+/// Find an atom correspondence between `mol1` and `mol2` given their 3D
+/// coordinates, without requiring atom pairs to be known in advance.
+///
+/// Returns `(mol1_atom_idx, mol2_atom_idx)` pairs. Returns an empty `Vec`
+/// when no compatible correspondence is found (e.g. no shared MMFF94 types
+/// within the distance cutoff at any seed orientation).
+pub(crate) fn correspondence_search(
+    mol1: &Molecule,
+    coords1: &[[f64; 3]],
+    mol2: &Molecule,
+    coords2: &[[f64; 3]],
+) -> Result<Vec<(usize, usize)>, O3AError> {
+    if coords1.len() != mol1.atom_count() || coords2.len() != mol2.atom_count() {
+        return Err(O3AError::CoordinateMismatch);
+    }
+    let types1 = chematic_ff::assign_mmff94_types(mol1).map_err(O3AError::TypeAssignment)?;
+    let types2 = chematic_ff::assign_mmff94_types(mol2).map_err(O3AError::TypeAssignment)?;
+
+    let c1 = centroid(coords1);
+    let c2 = centroid(coords2);
+    let (_, axes1) = jacobi3(covariance_tensor(coords1, c1));
+    let (_, axes2) = jacobi3(covariance_tensor(coords2, c2));
+    let axes1 = normalize_proper(axes1);
+    let axes2 = normalize_proper(axes2);
+
+    let mut best_pairs: Vec<(usize, usize)> = Vec::new();
+    let mut best_score = f64::NEG_INFINITY;
+
+    for signs in &SEED_SIGNS {
+        let mut axes2_signed = axes2;
+        for row in axes2_signed.iter_mut() {
+            for (col, sign) in signs.iter().enumerate() {
+                row[col] *= sign;
+            }
+        }
+        // Signed rotation matrix mapping mol2's (signed) principal frame
+        // onto mol1's: R = axes1 * axes2_signed^T.
+        let rot = matmul3(axes1, axes2_signed);
+        let seeded = apply_rotation_translation(coords2, c2, rot, c1);
+
+        let (pairs, score) = refine(coords1, &types1, &seeded, &types2);
+        if score > best_score {
+            best_score = score;
+            best_pairs = pairs;
+        }
+    }
+
+    Ok(best_pairs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chematic_smiles::parse;
+    use std::collections::HashSet;
+
+    /// Rotate `coords` by a fixed, non-trivial rotation and translate.
+    fn rotate_translate(coords: &[[f64; 3]]) -> Vec<[f64; 3]> {
+        // 90° rotation about z, plus a translation.
+        coords
+            .iter()
+            .map(|p| [-p[1] + 5.0, p[0] - 3.0, p[2] + 2.0])
+            .collect()
+    }
+
+    #[test]
+    fn self_alignment_recovers_identity_correspondence() {
+        // Asymmetric molecule so the identity mapping is the only sane answer.
+        let mol = parse("CC(=O)Oc1ccccc1C(=O)O").unwrap();
+        let n = mol.atom_count();
+        // Deterministic pseudo-3D layout: spread atoms out non-degenerately.
+        let coords1: Vec<[f64; 3]> = (0..n)
+            .map(|i| {
+                let t = i as f64;
+                [t * 1.3, (t * 0.7).sin() * 2.0, (t * 0.3).cos() * 1.5]
+            })
+            .collect();
+        let coords2 = rotate_translate(&coords1);
+
+        let pairs = correspondence_search(&mol, &coords1, &mol, &coords2).unwrap();
+        assert_eq!(pairs.len(), n, "every atom should find its rotated self");
+        for (i, j) in &pairs {
+            assert_eq!(i, j, "self-alignment must recover the identity mapping");
+        }
+    }
+
+    #[test]
+    fn correspondence_is_injective() {
+        let mol = parse("CC(=O)Oc1ccccc1C(=O)O").unwrap();
+        let n = mol.atom_count();
+        let coords1: Vec<[f64; 3]> = (0..n)
+            .map(|i| {
+                let t = i as f64;
+                [t * 1.3, (t * 0.7).sin() * 2.0, (t * 0.3).cos() * 1.5]
+            })
+            .collect();
+        let coords2 = rotate_translate(&coords1);
+
+        let pairs = correspondence_search(&mol, &coords1, &mol, &coords2).unwrap();
+        let js: HashSet<usize> = pairs.iter().map(|&(_, j)| j).collect();
+        assert_eq!(js.len(), pairs.len(), "no mol2 atom should be used twice");
+    }
+
+    #[test]
+    fn small_hand_built_system_finds_expected_pairing() {
+        // Methanol's two heavy atoms (C, O) have distinct MMFF94 types,
+        // giving an unambiguous, hand-verifiable 2-atom pairing.
+        let mol = parse("CO").unwrap();
+        let coords1: Vec<[f64; 3]> = vec![[0.0, 0.0, 0.0], [1.4, 0.0, 0.0]];
+        let coords2 = rotate_translate(&coords1);
+
+        let pairs = correspondence_search(&mol, &coords1, &mol, &coords2).unwrap();
+        assert_eq!(pairs.len(), 2);
+        let mut sorted = pairs.clone();
+        sorted.sort();
+        assert_eq!(sorted, vec![(0, 0), (1, 1)]);
+    }
+
+    #[test]
+    fn coordinate_mismatch_is_rejected() {
+        let mol = parse("CO").unwrap();
+        let coords_short = vec![[0.0, 0.0, 0.0]];
+        let coords_ok = vec![[0.0, 0.0, 0.0], [1.4, 0.0, 0.0]];
+        let err = correspondence_search(&mol, &coords_short, &mol, &coords_ok).unwrap_err();
+        assert!(matches!(err, O3AError::CoordinateMismatch));
+    }
+
+    #[test]
+    fn real_conformer_self_alignment() {
+        // Sanity check on a realistically-shaped conformer (not a synthetic
+        // sine/cosine layout): generate_coords's actual 3D geometry.
+        let mol = parse("CC(=O)Oc1ccccc1C(=O)O").unwrap();
+        let coords = crate::dg::generate_coords(&mol);
+        let n = mol.atom_count();
+        let coords1: Vec<[f64; 3]> = (0..n)
+            .map(|i| {
+                let p = coords.get(chematic_core::AtomIdx(i as u32));
+                [p.x, p.y, p.z]
+            })
+            .collect();
+        let coords2 = rotate_translate(&coords1);
+
+        let pairs = correspondence_search(&mol, &coords1, &mol, &coords2).unwrap();
+        assert_eq!(pairs.len(), n, "every atom should find its rotated self");
+        for (i, j) in &pairs {
+            assert_eq!(
+                i, j,
+                "self-alignment on a real conformer must recover identity"
+            );
+        }
+
+        // The correspondence should also be a Kabsch-perfect fit: aligning
+        // coords1 onto coords2 via the found pairing must reproduce
+        // rotate_translate's rigid transform (near-zero RMSD).
+        let sub1: Vec<[f64; 3]> = pairs.iter().map(|&(i, _)| coords1[i]).collect();
+        let sub2: Vec<[f64; 3]> = pairs.iter().map(|&(_, j)| coords2[j]).collect();
+        let result = align_coords(&sub1, &sub2);
+        assert!(result.rmsd < 1e-6, "rmsd={} should be ~0", result.rmsd);
+    }
+
+    #[test]
+    fn benzene_toluene_shared_ring_atoms_match() {
+        // Toluene = benzene + methyl. The 6 aromatic ring atoms should all
+        // find compatible-type matches in toluene's own ring.
+        let benzene = parse("c1ccccc1").unwrap();
+        let toluene = parse("Cc1ccccc1").unwrap();
+        let bc = crate::dg::generate_coords(&benzene);
+        let tc = crate::dg::generate_coords(&toluene);
+        let bn = benzene.atom_count();
+        let tn = toluene.atom_count();
+        let coords1: Vec<[f64; 3]> = (0..bn)
+            .map(|i| {
+                let p = bc.get(chematic_core::AtomIdx(i as u32));
+                [p.x, p.y, p.z]
+            })
+            .collect();
+        let coords2: Vec<[f64; 3]> = (0..tn)
+            .map(|i| {
+                let p = tc.get(chematic_core::AtomIdx(i as u32));
+                [p.x, p.y, p.z]
+            })
+            .collect();
+
+        let pairs = correspondence_search(&benzene, &coords1, &toluene, &coords2).unwrap();
+        assert!(
+            pairs.len() >= 4,
+            "expected most of benzene's 6 ring atoms to find a match in toluene's ring, got {}",
+            pairs.len()
+        );
+    }
+
+    #[test]
+    fn unrelated_molecules_still_return_a_correspondence() {
+        // Different molecules can still share some compatible atom types;
+        // this just checks the function doesn't panic and returns pairs
+        // that are individually within the distance cutoff.
+        let mol1 = parse("CC(=O)Oc1ccccc1C(=O)O").unwrap();
+        let mol2 = parse("c1ccccc1").unwrap();
+        let n1 = mol1.atom_count();
+        let n2 = mol2.atom_count();
+        let coords1: Vec<[f64; 3]> = (0..n1).map(|i| [i as f64 * 1.4, 0.0, 0.0]).collect();
+        let coords2: Vec<[f64; 3]> = (0..n2).map(|i| [i as f64 * 1.4, 0.5, 0.0]).collect();
+
+        let pairs = correspondence_search(&mol1, &coords1, &mol2, &coords2).unwrap();
+        for &(i, j) in &pairs {
+            assert!(i < n1);
+            assert!(j < n2);
+        }
+    }
+}

--- a/crates/chematic-chem/src/cip.rs
+++ b/crates/chematic-chem/src/cip.rs
@@ -570,12 +570,9 @@ fn assign_tetrahedral(mol: &Molecule, idx: AtomIdx) -> Option<CipCode> {
         let mut swaps = 0usize;
         for i in 0..3 {
             if r[i] != target[i] {
-                if let Some(j_rel) = r[i + 1..].iter().position(|&x| x == target[i]) {
-                    r.swap(i, j_rel + i + 1);
-                    swaps += 1;
-                } else {
-                    return None; // invalid ranks (should not happen)
-                }
+                let j_rel = r[i + 1..].iter().position(|&x| x == target[i])?;
+                r.swap(i, j_rel + i + 1);
+                swaps += 1;
             }
         }
         swaps % 2 == 1

--- a/crates/chematic-fp/src/avalon.rs
+++ b/crates/chematic-fp/src/avalon.rs
@@ -1,0 +1,265 @@
+//! Avalon-style structural fingerprint.
+//!
+//! Loosely modelled on the Avalon Cheminformatics Toolkit fingerprint
+//! (`rdkit.Avalon.pyAvalonTools.GetAvalonFP`): a broad mix of atom, bond,
+//! ring, and path features hashed into a fixed-width bitset. This is not a
+//! bit-exact reimplementation of RDKit's Avalon fingerprint — like Morgan
+//! (FNV-1a here vs RDKit's MurmurHash), bit positions differ; the bar is
+//! deterministic, isomorphism-invariant, similarity-preserving hashing, not
+//! cross-library bit parity.
+
+use chematic_core::Molecule;
+use chematic_perception::find_sssr;
+
+use crate::bitvec::BitVec2048;
+use crate::ecfp::{bond_type_int, fnv1a, initial_atom_id};
+
+/// Configuration for Avalon fingerprint computation.
+#[derive(Debug, Clone)]
+pub struct AvalonConfig {
+    /// Maximum number of atoms in a path feature (default: 7).
+    pub max_path_len: usize,
+    /// Bitvector size in bits (default: 2048).
+    pub nbits: usize,
+}
+
+impl Default for AvalonConfig {
+    fn default() -> Self {
+        Self {
+            max_path_len: 7,
+            nbits: 2048,
+        }
+    }
+}
+
+// Category tags keep identical byte sequences from different feature kinds
+// from colliding into the same hash input.
+const TAG_ATOM: u8 = 0x01;
+const TAG_BOND: u8 = 0x02;
+const TAG_RING: u8 = 0x03;
+const TAG_PATH: u8 = 0x04;
+
+fn set_feature_bytes(tag: u8, bytes: &[u8], fp: &mut BitVec2048, nbits: usize) {
+    let mut tagged = Vec::with_capacity(bytes.len() + 1);
+    tagged.push(tag);
+    tagged.extend_from_slice(bytes);
+    let hash = fnv1a(&tagged);
+    fp.set((hash % nbits as u64) as usize);
+}
+
+/// Compute an Avalon-style fingerprint for `mol` using the default configuration.
+pub fn avalon_fp(mol: &Molecule) -> BitVec2048 {
+    avalon_fp_with_config(mol, &AvalonConfig::default())
+}
+
+/// Compute an Avalon-style fingerprint for `mol` with explicit configuration.
+pub fn avalon_fp_with_config(mol: &Molecule, config: &AvalonConfig) -> BitVec2048 {
+    let mut fp = BitVec2048::new();
+    if mol.atom_count() == 0 {
+        return fp;
+    }
+    let ring_set = find_sssr(mol);
+    let nbits = config.nbits;
+
+    // 1. Atom features.
+    for (idx, _) in mol.atoms() {
+        let id = initial_atom_id(mol, idx, &ring_set, false);
+        set_feature_bytes(TAG_ATOM, &id.to_le_bytes(), &mut fp, nbits);
+    }
+
+    // 2. Bond features: (bond type, aromatic, in-ring, sorted endpoint degrees).
+    for (_, bond) in mol.bonds() {
+        let a1 = bond.atom1;
+        let a2 = bond.atom2;
+        let deg1 = mol.neighbors(a1).count().min(255) as u8;
+        let deg2 = mol.neighbors(a2).count().min(255) as u8;
+        let (deg_lo, deg_hi) = if deg1 <= deg2 {
+            (deg1, deg2)
+        } else {
+            (deg2, deg1)
+        };
+        let in_ring = (ring_set.contains_atom(a1) && ring_set.contains_atom(a2)) as u8;
+        let bytes = [
+            bond_type_int(bond.order),
+            (bond.order == chematic_core::BondOrder::Aromatic) as u8,
+            in_ring,
+            deg_lo,
+            deg_hi,
+        ];
+        set_feature_bytes(TAG_BOND, &bytes, &mut fp, nbits);
+    }
+
+    // 3. Ring features: (size, all-aromatic flag, sorted atomic-number multiset).
+    for ring in ring_set.rings() {
+        let size = ring.len().min(255) as u8;
+        let n = ring.len();
+        let all_aromatic = (0..n).all(|i| {
+            let a = ring[i];
+            let b = ring[(i + 1) % n];
+            mol.bond_between(a, b)
+                .is_some_and(|(_, bd)| bd.order == chematic_core::BondOrder::Aromatic)
+        });
+        let mut elems: Vec<u8> = ring
+            .iter()
+            .map(|&a| mol.atom(a).element.atomic_number())
+            .collect();
+        elems.sort_unstable();
+        let mut bytes = Vec::with_capacity(2 + elems.len());
+        bytes.push(size);
+        bytes.push(all_aromatic as u8);
+        bytes.extend_from_slice(&elems);
+        set_feature_bytes(TAG_RING, &bytes, &mut fp, nbits);
+    }
+
+    // 4. Path features: simple paths of 2..=max_path_len atoms, canonicalised
+    // forward-vs-reverse (same scheme as topo_path::hash_path).
+    let n = mol.atom_count();
+    let mut path_atoms: Vec<u8> = Vec::with_capacity(config.max_path_len);
+    let mut path_bonds: Vec<u8> = Vec::with_capacity(config.max_path_len.saturating_sub(1));
+    let mut visited: Vec<bool> = vec![false; n];
+    for start in 0..n {
+        let start_idx = chematic_core::AtomIdx(start as u32);
+        path_atoms.push(mol.atom(start_idx).element.atomic_number());
+        visited[start] = true;
+        path_dfs(
+            mol,
+            start_idx,
+            None,
+            &mut path_atoms,
+            &mut path_bonds,
+            &mut visited,
+            &mut fp,
+            config,
+        );
+        path_atoms.pop();
+        visited[start] = false;
+    }
+
+    fp
+}
+
+#[allow(clippy::too_many_arguments)]
+fn path_dfs(
+    mol: &Molecule,
+    atom: chematic_core::AtomIdx,
+    from_bond: Option<chematic_core::BondIdx>,
+    path_atoms: &mut Vec<u8>,
+    path_bonds: &mut Vec<u8>,
+    visited: &mut Vec<bool>,
+    fp: &mut BitVec2048,
+    config: &AvalonConfig,
+) {
+    if path_atoms.len() >= 2 {
+        hash_path(path_atoms, path_bonds, fp, config.nbits);
+    }
+    if path_atoms.len() >= config.max_path_len {
+        return;
+    }
+    for (nbr, bid) in mol.neighbors(atom) {
+        if Some(bid) == from_bond {
+            continue;
+        }
+        if visited[nbr.0 as usize] {
+            continue;
+        }
+        let order = mol.bond(bid).order;
+        path_bonds.push(bond_type_int(order));
+        path_atoms.push(mol.atom(nbr).element.atomic_number());
+        visited[nbr.0 as usize] = true;
+        path_dfs(
+            mol,
+            nbr,
+            Some(bid),
+            path_atoms,
+            path_bonds,
+            visited,
+            fp,
+            config,
+        );
+        visited[nbr.0 as usize] = false;
+        path_atoms.pop();
+        path_bonds.pop();
+    }
+}
+
+fn hash_path(atoms: &[u8], bonds: &[u8], fp: &mut BitVec2048, nbits: usize) {
+    let len = atoms.len() * 2 - 1;
+    let mut fwd = Vec::with_capacity(len);
+    let mut rev = Vec::with_capacity(len);
+    for i in 0..atoms.len() {
+        fwd.push(atoms[i]);
+        if i + 1 < atoms.len() {
+            fwd.push(bonds[i]);
+        }
+    }
+    for i in (0..atoms.len()).rev() {
+        rev.push(atoms[i]);
+        if i > 0 {
+            rev.push(bonds[i - 1]);
+        }
+    }
+    let canonical = if fwd <= rev { fwd } else { rev };
+    set_feature_bytes(TAG_PATH, &canonical, fp, nbits);
+}
+
+/// Tanimoto similarity between two molecules using Avalon-style fingerprints.
+pub fn tanimoto_avalon(a: &Molecule, b: &Molecule) -> f64 {
+    avalon_fp(a).tanimoto(&avalon_fp(b))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chematic_smiles::parse;
+
+    #[test]
+    fn deterministic() {
+        let mol = parse("CC(=O)Oc1ccccc1C(=O)O").unwrap();
+        assert_eq!(avalon_fp(&mol), avalon_fp(&mol));
+    }
+
+    #[test]
+    fn isomorphism_invariant() {
+        // Same molecule (aspirin), two different SMILES atom orderings.
+        let a = parse("CC(=O)Oc1ccccc1C(=O)O").unwrap();
+        let b = parse("O=C(C)Oc1ccccc1C(=O)O").unwrap();
+        assert_eq!(avalon_fp(&a), avalon_fp(&b));
+    }
+
+    #[test]
+    fn non_degenerate() {
+        for smi in ["c1ccccc1", "Cc1ccccc1", "CC(=O)Oc1ccccc1C(=O)O"] {
+            let mol = parse(smi).unwrap();
+            let fp = avalon_fp(&mol);
+            assert!(fp.popcount() > 0, "{smi}: fingerprint must be non-empty");
+            assert!(fp.popcount() < 2048, "{smi}: fingerprint must not saturate");
+        }
+    }
+
+    #[test]
+    fn similarity_ordering() {
+        let benzene = parse("c1ccccc1").unwrap();
+        let toluene = parse("Cc1ccccc1").unwrap();
+        let aspirin = parse("CC(=O)Oc1ccccc1C(=O)O").unwrap();
+        let t_toluene = avalon_fp(&benzene).tanimoto(&avalon_fp(&toluene));
+        let t_aspirin = avalon_fp(&benzene).tanimoto(&avalon_fp(&aspirin));
+        assert!(
+            t_toluene > t_aspirin,
+            "toluene ({t_toluene}) should be closer to benzene than aspirin ({t_aspirin})"
+        );
+    }
+
+    #[test]
+    fn bond_order_sensitivity() {
+        let single = parse("CC").unwrap();
+        let double = parse("C=C").unwrap();
+        assert_ne!(avalon_fp(&single), avalon_fp(&double));
+    }
+
+    #[test]
+    fn aromaticity_sensitivity() {
+        let aromatic = parse("c1ccccc1").unwrap();
+        let aliphatic = parse("C1CCCCC1").unwrap();
+        assert_ne!(avalon_fp(&aromatic), avalon_fp(&aliphatic));
+    }
+}

--- a/crates/chematic-fp/src/lib.rs
+++ b/crates/chematic-fp/src/lib.rs
@@ -14,6 +14,7 @@
 #![forbid(unsafe_code)]
 
 pub mod atom_pair;
+pub mod avalon;
 pub mod bitvec;
 pub mod bulk;
 pub mod ecfp;
@@ -33,6 +34,7 @@ pub mod search;
 pub mod topo_path;
 
 pub use atom_pair::{atom_pair_fp, torsion_fp};
+pub use avalon::{AvalonConfig, avalon_fp, avalon_fp_with_config, tanimoto_avalon};
 pub use bitvec::{BitVec2048, BitVecN};
 pub use bulk::{tanimoto_matrix, tanimoto_slice, top_k_similar};
 pub use ecfp::{

--- a/crates/chematic-mol/src/cdxml.rs
+++ b/crates/chematic-mol/src/cdxml.rs
@@ -1,8 +1,8 @@
-//! ChemDraw XML (CDXML) parser — **read-only**.
+//! ChemDraw XML (CDXML) parser and writer.
 //!
 //! CDXML is a proprietary XML format produced by ChemDraw (PerkinElmer /
-//! Revvity).  This parser handles the minimal subset needed to extract
-//! molecular structure from a CDXML document.
+//! Revvity).  This module handles the minimal subset needed to read and
+//! write molecular structure through a CDXML document.
 //!
 //! # Supported elements / attributes
 //!
@@ -17,8 +17,10 @@
 //! - Only the first `<fragment>` in the document is returned as a single
 //!   molecule.  Multi-molecule documents (multiple fragments) are not yet
 //!   supported.
-//! - Write support is **not** implemented (CDXML is a proprietary format;
-//!   writing files that ChemDraw will accept requires undocumented attributes).
+//! - [`write_cdxml`] targets **self-round-trip** correctness (this parser
+//!   can read what this writer produces), not full ChemDraw-application
+//!   compatibility — CDXML is a proprietary format and writing files
+//!   ChemDraw itself will accept requires undocumented attributes.
 //! - Wedge/hash bond stereo (tetrahedral) is derived from `Display` attribute.
 //! - E/Z double-bond stereo is derived from 2D coordinates via `assign_ez_from_2d`.
 //! - Presentation-only nodes (text boxes, arrows, etc.) are silently skipped.
@@ -294,6 +296,68 @@ fn is_b_tag(line: &str) -> bool {
 }
 
 // ---------------------------------------------------------------------------
+// Writer
+// ---------------------------------------------------------------------------
+
+/// Serialise `mol` to a minimal CDXML document that [`parse_cdxml`] can read
+/// back. See the module docs for the self-round-trip scope of this writer.
+///
+/// `coords[i]` is the `(x, y)` position for atom `i`, in the same
+/// **ChemDraw Y-down convention** `parse_cdxml` produces. Atoms beyond
+/// `coords.len()` receive `(0.0, 0.0)`.
+pub fn write_cdxml(mol: &Molecule, coords: &[(f64, f64)]) -> String {
+    let mut out =
+        String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<CDXML>\n<page>\n<fragment>\n");
+
+    for (i, (idx, atom)) in mol.atoms().enumerate() {
+        let id = idx.0 + 1;
+        let (x, y) = coords.get(i).copied().unwrap_or((0.0, 0.0));
+        let mut parts = vec![
+            format!("id=\"{id}\""),
+            format!("p=\"{x} {y}\""),
+            format!("Element=\"{}\"", atom.element.atomic_number()),
+        ];
+        if let Some(h) = atom.hydrogen_count {
+            parts.push(format!("NumHydrogens=\"{h}\""));
+        }
+        if atom.charge != 0 {
+            parts.push(format!("Charge=\"{}\"", atom.charge));
+        }
+        if let Some(iso) = atom.isotope {
+            parts.push(format!("Isotope=\"{iso}\""));
+        }
+        out.push_str(&format!("<n {}/>\n", parts.join(" ")));
+    }
+
+    for (_, bond) in mol.bonds() {
+        let b = bond.atom1.0 + 1;
+        let e = bond.atom2.0 + 1;
+        // Wedge/hash stereo is Single order + Display attribute (mirrors the
+        // parser's decoding at is_b_tag handling above); other orders map
+        // straight to the Order attribute and ignore Display.
+        let (order_attr, display_attr) = match bond.order {
+            BondOrder::Double => ("2", None),
+            BondOrder::Triple => ("3", None),
+            BondOrder::Aromatic => ("1.5", None),
+            BondOrder::Up => ("1", Some("WedgeBegin")),
+            BondOrder::Down => ("1", Some("Hash")),
+            _ => ("1", None),
+        };
+        match display_attr {
+            Some(d) => out.push_str(&format!(
+                "<b B=\"{b}\" E=\"{e}\" Order=\"{order_attr}\" Display=\"{d}\"/>\n"
+            )),
+            None => out.push_str(&format!(
+                "<b B=\"{b}\" E=\"{e}\" Order=\"{order_attr}\"/>\n"
+            )),
+        }
+    }
+
+    out.push_str("</fragment>\n</page>\n</CDXML>\n");
+    out
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -504,5 +568,69 @@ mod tests {
         assert_eq!(mol.bond_count(), 6, "benzene has 6 bonds");
         let all_aromatic = mol.bonds().all(|(_, b)| b.order == BondOrder::Aromatic);
         assert!(all_aromatic, "all bonds must be Aromatic");
+    }
+
+    // -----------------------------------------------------------------------
+    // write_cdxml round-trip
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn write_cdxml_roundtrip_ethanol() {
+        let (mol, coords) = parse_cdxml(ETHANOL_CDXML).unwrap();
+        let written = write_cdxml(&mol, &coords);
+        let (mol2, coords2) = parse_cdxml(&written).unwrap();
+
+        assert_eq!(mol2.atom_count(), mol.atom_count());
+        assert_eq!(mol2.bond_count(), mol.bond_count());
+        let elems: Vec<&str> = mol.atoms().map(|(_, a)| a.element.symbol()).collect();
+        let elems2: Vec<&str> = mol2.atoms().map(|(_, a)| a.element.symbol()).collect();
+        assert_eq!(elems, elems2);
+        for (c1, c2) in coords.iter().zip(coords2.iter()) {
+            assert!((c1.0 - c2.0).abs() < 0.01);
+            assert!((c1.1 - c2.1).abs() < 0.01);
+        }
+    }
+
+    #[test]
+    fn write_cdxml_roundtrip_double_bond() {
+        let cdxml = r#"<CDXML><fragment>
+<n id="1" Element="6" p="0 0"/>
+<n id="2" Element="8" p="10 0"/>
+<b B="1" E="2" Order="2"/>
+</fragment></CDXML>"#;
+        let (mol, coords) = parse_cdxml(cdxml).unwrap();
+        let written = write_cdxml(&mol, &coords);
+        let (mol2, _) = parse_cdxml(&written).unwrap();
+        let bond2 = mol2.bond(chematic_core::BondIdx(0));
+        assert_eq!(bond2.order, BondOrder::Double);
+    }
+
+    #[test]
+    fn write_cdxml_roundtrip_wedge_bond() {
+        let cdxml = r#"<CDXML><fragment>
+<n id="1" Element="6" p="0 0"/>
+<n id="2" Element="6" p="10 0"/>
+<b B="1" E="2" Order="1" Display="WedgeBegin"/>
+</fragment></CDXML>"#;
+        let (mol, coords) = parse_cdxml(cdxml).unwrap();
+        let written = write_cdxml(&mol, &coords);
+        assert!(written.contains("Display=\"WedgeBegin\""));
+        let (mol2, _) = parse_cdxml(&written).unwrap();
+        let bond2 = mol2.bond(chematic_core::BondIdx(0));
+        assert_eq!(bond2.order, BondOrder::Up);
+    }
+
+    #[test]
+    fn write_cdxml_roundtrip_charge_isotope_hcount() {
+        let cdxml = r#"<CDXML><fragment>
+<n id="1" Element="7" Charge="1" Isotope="15" NumHydrogens="2" p="0 0"/>
+</fragment></CDXML>"#;
+        let (mol, coords) = parse_cdxml(cdxml).unwrap();
+        let written = write_cdxml(&mol, &coords);
+        let (mol2, _) = parse_cdxml(&written).unwrap();
+        let atom2 = mol2.atom(chematic_core::AtomIdx(0));
+        assert_eq!(atom2.charge, 1);
+        assert_eq!(atom2.isotope, Some(15));
+        assert_eq!(atom2.hydrogen_count, Some(2));
     }
 }

--- a/crates/chematic-mol/src/lib.rs
+++ b/crates/chematic-mol/src/lib.rs
@@ -34,7 +34,7 @@ pub mod sdf;
 // Convenient re-exports at crate root.
 pub use error::MolParseError;
 // Re-export MolParseError under the alias MolError as specified by the public API.
-pub use cdxml::{CdxmlError, parse_cdxml, parse_cdxml_all};
+pub use cdxml::{CdxmlError, parse_cdxml, parse_cdxml_all, write_cdxml};
 pub use cif::{CifError, CifResult, UnitCell, parse_cif, write_cif};
 pub use cjson::{CjsonError, parse_cjson, write_cjson};
 pub use cml::{CmlError, parse_cml, write_cml};
@@ -44,7 +44,8 @@ pub use ket::{KetError, parse_ket, parse_ket_3d, write_ket, write_ket_3d};
 pub use mol2_tripos::{Mol2Error, parse_mol2, write_mol2};
 pub use mol2000::{
     MolMetadata, parse_mol, parse_mol_with_coords, parse_sdf_with_coords, write_mol,
-    write_mol_with_coords, write_sdf, write_sdf_record, write_sdf_with_charges,
+    write_mol_with_coords, write_sdf, write_sdf_record, write_sdf_record_v3000,
+    write_sdf_with_charges,
 };
 pub use mol3000::{parse_mol_v3000, parse_mol_v3000_with_coords, write_mol_v3000};
 pub use moljson::{MolJsonError, parse_moljson, write_moljson};

--- a/crates/chematic-mol/src/mol2000.rs
+++ b/crates/chematic-mol/src/mol2000.rs
@@ -486,6 +486,25 @@ pub fn write_sdf_record(
     out
 }
 
+/// Like [`write_sdf_record`] but emits a MOL V3000 (Extended Ctab) block
+/// instead of V2000 — required for molecules with more than 999 atoms or
+/// bonds, which don't fit V2000's fixed-width count fields.
+pub fn write_sdf_record_v3000(
+    mol: &Molecule,
+    meta: &MolMetadata,
+    coords: &[(f64, f64)],
+    props: &std::collections::HashMap<String, String>,
+) -> String {
+    let mut out = crate::mol3000::write_mol_v3000(mol, meta, coords);
+    for (k, v) in props {
+        if !k.starts_with('_') {
+            out.push_str(&format!("> <{k}>\n{v}\n\n"));
+        }
+    }
+    out.push_str("$$$$\n");
+    out
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------

--- a/crates/chematic-mol/src/mol3000.rs
+++ b/crates/chematic-mol/src/mol3000.rs
@@ -483,11 +483,10 @@ fn parse_stereo_group_line(payload: &str, atom_idx_map: &[(u32, AtomIdx)]) -> Op
     } else if let Some(n_str) = first_tok.strip_prefix("MDLV30/STEOR") {
         let n: u32 = n_str.parse().ok()?;
         StereoGroupKind::Or(n)
-    } else if let Some(n_str) = first_tok.strip_prefix("MDLV30/STEAND") {
+    } else {
+        let n_str = first_tok.strip_prefix("MDLV30/STEAND")?;
         let n: u32 = n_str.parse().ok()?;
         StereoGroupKind::And(n)
-    } else {
-        return None; // not a stereo group line
     };
 
     // Extract the ATOMS=(...) value from the remainder of the payload.

--- a/crates/chematic-py/python/chematic/rdkit_compat.py
+++ b/crates/chematic-py/python/chematic/rdkit_compat.py
@@ -41,7 +41,7 @@ __all__ = [
     "MolToMolBlock", "SanitizeMol", "Kekulize", "AddHs", "RemoveHs",
     "MolFromSmarts",
     "SDMolSupplier", "SDWriter", "SmilesMolSupplier", "SmilesWriter",
-    "Descriptors", "rdMolDescriptors", "DataStructs",
+    "Descriptors", "rdMolDescriptors", "DataStructs", "pyAvalonTools",
 ]
 
 
@@ -996,6 +996,34 @@ class rdMolDescriptors:
         else:
             raw = mol._mol.ecfp6()
         raw = bytes(raw)
+        if nBits == 2048:
+            return ExplicitBitVect._from_bytes(raw, 2048)
+        # ponytail: modulo fold of the internal 2048-bit fp; not RDKit bit-exact
+        return _fold_bits(raw, nBits)
+
+
+# ---------------------------------------------------------------------------
+# pyAvalonTools namespace (mirrors rdkit.Avalon.pyAvalonTools import path)
+# ---------------------------------------------------------------------------
+
+class pyAvalonTools:
+    """Mirrors ``rdkit.Avalon.pyAvalonTools``."""
+
+    @staticmethod
+    def GetAvalonFP(mol: Mol, nBits: int = 512, **kwargs) -> "ExplicitBitVect":
+        """Return an Avalon-style structural fingerprint as ExplicitBitVect.
+
+        .. note::
+           Bit patterns differ from RDKit's Avalon fingerprint (chematic uses
+           a broad atom/bond/ring/path feature mix hashed with FNV-1a; RDKit
+           uses its own C++ Avalon toolkit implementation). Use for
+           similarity ranking, not cross-library bit-level comparison.
+        """
+        if kwargs:
+            raise TypeError(f"Unsupported keyword arguments: {sorted(kwargs)}")
+        if nBits <= 0:
+            raise ValueError(f"nBits must be positive, got {nBits}")
+        raw = bytes(mol._mol.avalon_fp())
         if nBits == 2048:
             return ExplicitBitVect._from_bytes(raw, 2048)
         # ponytail: modulo fold of the internal 2048-bit fp; not RDKit bit-exact

--- a/crates/chematic-py/src/io.rs
+++ b/crates/chematic-py/src/io.rs
@@ -354,6 +354,7 @@ impl SdMolSupplier {
 pub struct SdWriter {
     writer: Option<std::io::BufWriter<std::fs::File>>,
     props_filter: Option<Vec<String>>,
+    force_v3000: bool,
 }
 
 #[pymethods]
@@ -365,6 +366,7 @@ impl SdWriter {
         Ok(SdWriter {
             writer: Some(std::io::BufWriter::new(file)),
             props_filter: None,
+            force_v3000: false,
         })
     }
 
@@ -388,7 +390,11 @@ impl SdWriter {
                 .filter_map(|k| mol.props.get(k).map(|v| (k.clone(), v.clone())))
                 .collect(),
         };
-        let record = chematic_mol::write_sdf_record(&mol.inner, &meta, &coords, &props);
+        let record = if self.force_v3000 {
+            chematic_mol::write_sdf_record_v3000(&mol.inner, &meta, &coords, &props)
+        } else {
+            chematic_mol::write_sdf_record(&mol.inner, &meta, &coords, &props)
+        };
         w.write_all(record.as_bytes())
             .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))
     }
@@ -403,9 +409,13 @@ impl SdWriter {
     #[pyo3(name = "SetKekulize")]
     fn set_kekulize(&mut self, _val: bool) {}
 
-    /// No-op: V3000 output is not yet supported.
+    /// When ``True``, subsequent ``write()`` calls emit MOL V3000 (Extended
+    /// Ctab) blocks instead of V2000 — required for molecules with more
+    /// than 999 atoms or bonds.
     #[pyo3(name = "SetForceV3000")]
-    fn set_force_v3000(&mut self, _val: bool) {}
+    fn set_force_v3000(&mut self, val: bool) {
+        self.force_v3000 = val;
+    }
 
     /// Flush buffered data to disk.
     fn flush(&mut self) -> PyResult<()> {

--- a/crates/chematic-py/src/mol_methods.rs
+++ b/crates/chematic-py/src/mol_methods.rs
@@ -263,6 +263,27 @@ impl Mol {
         chematic_mol::write_cml(&self.inner, coords_2d.as_deref())
     }
 
+    /// Serialize this molecule to ChemDraw XML (CDXML).
+    ///
+    /// ``coords``: optional list of ``[x, y]`` pairs — one per heavy atom,
+    /// in ChemDraw's Y-down convention. If omitted, atoms are written at
+    /// ``(0, 0)``.
+    ///
+    /// Targets self-round-trip correctness (``chematic.from_cdxml`` can read
+    /// what this writes), not full ChemDraw-application compatibility.
+    ///
+    ///     cdxml = mol.to_cdxml()
+    ///     cdxml_with_layout = mol.to_cdxml(coords_2d)
+    #[pyo3(signature = (coords = None))]
+    fn to_cdxml(&self, coords: Option<Vec<[f64; 2]>>) -> String {
+        let coords_2d: Vec<(f64, f64)> = coords
+            .unwrap_or_default()
+            .iter()
+            .map(|xy| (xy[0], xy[1]))
+            .collect();
+        chematic_mol::write_cdxml(&self.inner, &coords_2d)
+    }
+
     /// Write this molecule to AutoDock PDBQT format.
     ///
     /// Args:
@@ -2865,6 +2886,16 @@ impl Mol {
             &self.inner,
             &chematic_fp::TopoPathConfig::default(),
         ))
+    }
+
+    /// Avalon-style structural fingerprint as bytes (256 bytes = 2048 bits).
+    ///
+    /// A broad mix of atom, bond, ring, and path features, loosely modelled
+    /// on RDKit's Avalon fingerprint (``rdkit.Avalon.pyAvalonTools.GetAvalonFP``).
+    /// Bit positions are not RDKit-identical (see :mod:`chematic.rdkit_compat`
+    /// notes on Morgan fingerprints for the same caveat).
+    fn avalon_fp(&self) -> Vec<u8> {
+        bitvec2048_to_bytes(&chematic_fp::avalon_fp(&self.inner))
     }
 
     /// 3D pharmacophore fingerprint as bytes (256 bytes = 2048 bits).

--- a/crates/chematic-py/tests/test_fp.py
+++ b/crates/chematic-py/tests/test_fp.py
@@ -144,3 +144,27 @@ def test_layered_fp_vs_ecfp4(aspirin):
 def test_layered_fp_tanimoto(benzene, toluene):
     sim = chematic.tanimoto(benzene.layered_fp(), toluene.layered_fp())
     assert 0.0 <= sim <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Avalon fingerprint
+# ---------------------------------------------------------------------------
+
+def test_avalon_fp_length(aspirin):
+    fp = aspirin.avalon_fp()
+    assert isinstance(fp, bytes)
+    assert len(fp) == 256
+
+
+def test_avalon_fp_deterministic(aspirin):
+    assert aspirin.avalon_fp() == aspirin.avalon_fp()
+
+
+def test_avalon_fp_different_mols(aspirin, benzene):
+    assert aspirin.avalon_fp() != benzene.avalon_fp()
+
+
+def test_avalon_fp_tanimoto_similarity_ordering(benzene, toluene, aspirin):
+    sim_toluene = chematic.tanimoto(benzene.avalon_fp(), toluene.avalon_fp())
+    sim_aspirin = chematic.tanimoto(benzene.avalon_fp(), aspirin.avalon_fp())
+    assert sim_toluene > sim_aspirin

--- a/crates/chematic-py/tests/test_rdkit_compat.py
+++ b/crates/chematic-py/tests/test_rdkit_compat.py
@@ -4,7 +4,7 @@ import chematic
 from chematic import rdkit_compat as Chem
 from chematic.rdkit_compat import (
     Descriptors, rdMolDescriptors, DataStructs, ExplicitBitVect,
-    Atom, Bond, BondType, RingInfo, RWMol,
+    Atom, Bond, BondType, RingInfo, RWMol, pyAvalonTools,
 )
 
 
@@ -191,17 +191,28 @@ def test_flush_and_close_idempotent(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# SetKekulize / SetForceV3000 are no-ops (must not crash)
+# SetKekulize is a no-op (must not crash); SetForceV3000 actually switches
+# the writer to MOL V3000 output.
 # ---------------------------------------------------------------------------
 
 def test_noop_writer_flags(tmp_path):
     out = tmp_path / "out.sdf"
     w = Chem.SDWriter(str(out))
     w.SetKekulize(False)
-    w.SetForceV3000(True)
     w.write(Chem.MolFromSmiles("c1ccccc1"))
     w.close()
     assert out.exists()
+
+
+def test_force_v3000_writes_v3000_block(tmp_path):
+    out = tmp_path / "out_v3000.sdf"
+    w = Chem.SDWriter(str(out))
+    w.SetForceV3000(True)
+    w.write(Chem.MolFromSmiles("c1ccccc1"))
+    w.close()
+    text = out.read_text()
+    assert "V3000" in text
+    assert "$$$$" in text
 
 
 # ---------------------------------------------------------------------------
@@ -656,6 +667,46 @@ def test_morgan_nbits_zero_raises():
     mol = Chem.MolFromSmiles("c1ccccc1")
     with pytest.raises(ValueError):
         rdMolDescriptors.GetMorganFingerprintAsBitVect(mol, 2, nBits=0)
+
+
+# ---------------------------------------------------------------------------
+# pyAvalonTools.GetAvalonFP
+# ---------------------------------------------------------------------------
+
+def test_avalon_fp_default_nbits():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    fp = pyAvalonTools.GetAvalonFP(mol)
+    assert fp.GetNumBits() == 512
+
+
+def test_avalon_fp_nbits_2048():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    fp = pyAvalonTools.GetAvalonFP(mol, nBits=2048)
+    assert fp.GetNumBits() == 2048
+
+
+def test_avalon_fp_nbits_folded():
+    mol = Chem.MolFromSmiles("CC(=O)Oc1ccccc1C(=O)O")
+    fp = pyAvalonTools.GetAvalonFP(mol, nBits=1024)
+    assert fp.GetNumBits() == 1024
+
+
+def test_avalon_fp_self_tanimoto():
+    mol = Chem.MolFromSmiles("CC(=O)Oc1ccccc1C(=O)O")
+    fp = pyAvalonTools.GetAvalonFP(mol)
+    assert DataStructs.TanimotoSimilarity(fp, fp) == 1.0
+
+
+def test_avalon_fp_nbits_zero_raises():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    with pytest.raises(ValueError):
+        pyAvalonTools.GetAvalonFP(mol, nBits=0)
+
+
+def test_avalon_fp_unknown_kwarg_raises():
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    with pytest.raises(TypeError):
+        pyAvalonTools.GetAvalonFP(mol, bogus=True)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Critical fix**: `align_coords` computed the Kabsch rotation in the wrong direction (`V·Uᵀ` instead of `U·Vᵀ`). Invisible under pure translation (H is symmetric, U==V), but produces a large bogus RMSD whenever an actual rotation is involved. This shipped in v0.4.28 (crates.io/PyPI/npm) — a v0.4.29 patch release will follow this merge.
- Wires up SDF V3000 write (`SDWriter.SetForceV3000` was previously a no-op)
- Adds CDXML write (was read-only)
- Adds Avalon fingerprint (`pyAvalonTools.GetAvalonFP`)
- Adds O3A `correspondence_search` (PR1 of 2) — the atom-correspondence primitive for 3D alignment. `o3a_align` wrapper + Python binding to follow as PR2.

## Test plan
- [x] `cargo test --workspace --lib` — all green, including new rotation-direction regression tests in `align.rs` (pure rotation, apply_alignment under rotation, mirror-image forcing the det<0 reflection branch)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Python: `maturin develop` + full pytest suite (495 tests) — all green
- [x] O3A correspondence quality manually inspected on benzene/toluene (perfect ring mapping) and aspirin/salicylic acid (valid but non-canonical overlay — documented as a known characteristic of independently-generated conformers + 4-seed search, acceptable per plan's PR2 gate)