### PR TITLE
docs: sync CHANGELOG/README/todo with chematic-cip Milestone 3B closeout + CI work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `chematic-cip` (new crate, experimental)
+
+- **Hierarchical-digraph CIP (Cahn-Ingold-Prelog) engine** — `assign_cip_accurate_experimental`, a from-scratch, provenance-carrying digraph replacement for the existing shell-pooling comparator in `chematic-chem`. Not yet wired into `chematic_chem::assign_cip()`; a separate, non-default, `publish = false` crate for now. See `docs/cip_accurate_rfc.md` for the full design and milestone history.
+- Rules 1a (atomic number) / 1b (ring-duplicate handling) / 2 (isotope) comparator, genuinely sphere-by-sphere (breadth-first, not depth-first) — fixes a class of bug the old shell-pooling comparator couldn't (a shallow sibling difference must decide a comparison before a much deeper, irrelevant one is reached).
+- **MANCUDE (maximum non-cumulated double bonds) fractional atomic numbers** — `AtomicNumberKey`/`RationalAtomicNumber` give aromatic ring atoms (e.g. pyridine's N-adjacent carbons) a Kekulé-invariant fractional value instead of one arbitrary Kekulé form's integer, matching RDKit's own `calcFracAtomNums` formula (verified against RDKit source, not paraphrase).
+- **Full-corpus accuracy on this experimental engine: 96.68% → 99.14%** (4047/4186 → 4150/4186 vs modern RDKit `rdCIPLabeler`, net +103, 0 regressions confirmed by two independently-computed methods). The entire gain is attributable to Kekulé-respelling structurally (aromatic bonds finally contributing real digraph duplicate nodes) — the fractional MANCUDE values themselves are implemented and RDKit-formula-verified but measured inert (0/4188 rows) on the available corpus, kept rather than reverted since there's no efficiency cost.
+- Post-milestone reclassification of the remaining 36/4186 residual: 17 pseudoasymmetric (Rule 5, confirmed via RDKit's own lowercase r/s label), 11 phosphorus, 8 unclassified — Milestone 4A (Rule 5) is next.
+
 ### Added — `chematic-chem`
 
 - **`schultz_mti(mol) -> f64`** — Schultz Molecular Topological Index (MTI): weighted sum of adjacency × distance matrix entries.
@@ -58,6 +66,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `[profile.release] opt-level="z" lto=true codegen-units=1` added to workspace `Cargo.toml`.
 - Removed `run_md_json`, `coulomb_energy_json`, `torsion_scan_json`, `determine_bonds_from_xyz_json` from WASM exports.
 - Removed `chematic-ewald` from `chematic-wasm` dependencies.
+
+### Performance — `chematic-cip` MANCUDE ring-bond check (30ms → microseconds on large fused-ring molecules)
+
+- `mancude.rs::ring_bond_set` was calling `chematic_perception::find_sssr` (a full minimum cycle basis) on the whole molecule just to answer a boolean "is this bond in some ring" question — replaced with a direct O(V+E) bridge-edge (cut-edge) DFS, since ring-bond membership is exactly the complement of the bridge set. Verified byte-identical output across the full corpus before/after.
+
+### CI
+
+- **Criterion regression gate bootstrap fix** (`bench-pr-gate.yml`) — a new or removed Criterion benchmark target used to abort the whole gate job (`cargo bench --bench <missing>` erroring under `set -e`), hiding every other benchmark's verdict. Now tolerated per-side with a three-way classification: both sides present gates normally; candidate-only is a new benchmark with no baseline yet (not gated); baseline-only is a possibly-removed benchmark (warned, not gated).
+- **Criterion gate reliability finding** — the gate currently treats one Criterion process's ~100 internal samples as 100 independent A/B trials; they aren't (all share one process's runner state), so a single environment difference can be amplified into an extreme-looking win rate for every benchmark at once. Confirmed empirically (a run showed unrelated benchmarks all failing with near-identical effect sizes). The gate stays non-required and its `fail` verdicts are not currently reliable evidence of a real regression — process-level redesign tracked in [#70](https://github.com/kent-tokyo/chematic/issues/70).
 - Added `wasm-opt -O3` step to `.github/workflows/pages.yml` CI.
 
 ---

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ than RDKit.js. One codebase runs on Linux, macOS, Windows, and in every browser.
 
 \*LogP max Δ = 1.1×10⁻¹³ across 4,999 molecules — within float64 rounding error.  
 †Stereocenter count: 99.98% vs legacy `CalcNumAtomStereoCenters` (1 molecule where chematic matches `FindPotentialStereo`=4 and legacy under-counts at 2); 98.7% vs new-CIP `FindPotentialStereo` (67 cage/bridgehead molecules where both chematic and legacy correctly return fewer than the new oracle). chematic is calibrated between both extremes. This measures whether an atom is *flagged* as a stereocenter, not whether its R/S label is correct — see the next row.  
-‡CIP R/S label agreement measures, for atoms both oracles agree are stereocenters, whether the assigned R/S descriptor matches — a stricter, separate check from stereocenter count agreement above. See [`docs/cip_accurate_rfc.md`](docs/cip_accurate_rfc.md) for the residual's root cause and remediation plan.
+‡CIP R/S label agreement measures, for atoms both oracles agree are stereocenters, whether the assigned R/S descriptor matches — a stricter, separate check from stereocenter count agreement above. See [`docs/cip_accurate_rfc.md`](docs/cip_accurate_rfc.md) for the residual's root cause and remediation plan — now underway in the new, separate `chematic-cip` experimental engine (99.14% on its own full-corpus metric; not yet `chematic_chem::assign_cip()`'s default path, so this row's 96.30% is unaffected).
 
 All numbers are reproducible with the scripts in this repo.  
 Full history → [benchmarks/](benchmarks/) · Methodology → [validation/](validation/)
@@ -403,6 +403,11 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +1
 ---
 
 ## Recent Development (v0.4.x Era)
+
+**Unreleased** (in progress): **`chematic-cip` — new experimental hierarchical-digraph CIP engine**
+- New crate, not yet wired into `chematic_chem::assign_cip()`: a provenance-carrying, sphere-by-sphere digraph comparator (Rules 1a/1b/2) plus RDKit-compatible MANCUDE fractional atomic numbers for aromatic ring stereocenters
+- Full-corpus accuracy on this experimental engine 96.68% → 99.14% vs modern RDKit `rdCIPLabeler` (4047/4186 → 4150/4186, 0 regressions) — see `docs/cip_accurate_rfc.md` for the milestone history and honest attribution (the gain is the Kekulé-respelling structural effect, not the fractional values, which are correct but currently inert on this corpus)
+- Found and fixed a real ~10-14x perf regression (SSSR misused for a boolean ring-bond check, replaced with an O(V+E) bridge-edge DFS); CI Criterion-gate bootstrap fix; a Criterion-gate reliability finding (pseudo-replication, [#70](https://github.com/kent-tokyo/chematic/issues/70))
 
 **v0.4.29** (2026-07-10): **Kabsch rotation bug fix + SDF V3000/CDXML write, Avalon FP, O3A**
 - `chematic-3d`: fixed `align_coords`'s Kabsch rotation computed in the wrong direction — was giving grossly inflated RMSD for any non-pure-translation alignment (live on v0.4.28 across crates.io/PyPI/npm before this patch); `correspondence_search` for O3A atom correspondence

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -120,6 +120,10 @@ Current version: **v0.4.26** (2026-06-29)
 | done: | SDF true streaming: `SdfFileReader<R: BufRead>` + Python `iter_sdf(path)` → lazy streaming, `iter_sdf_batched(path, batch_size=1000)` new; `iter_sdf_str()` unchanged; `MolParseError::Io` added |
 | done: | `bulk.descriptors_array(smiles, columns)` — columnar numpy output, ~25% faster than `descriptors()+DataFrame()`; float64/bool/NaN for optional |
 | done: | Stereocenters 99.8% → 99.98% (legacy) / 98.7% (new CIP) — CIP Rule 5 tie-breaking via provisional R/S + equality-based signature comparison; cage false-positives correctly avoided |
+| done: | `chematic-cip` new crate, Milestone 1 → 3B closeout: hierarchical-digraph CIP engine (`assign_cip_accurate_experimental`), sphere-by-sphere Rules 1a/1b/2 comparator, RDKit-compatible MANCUDE fractional atomic numbers; full-corpus accuracy on this experimental engine 96.68% → 99.14% (4047/4186 → 4150/4186), 0 regressions; not yet wired into `chematic_chem::assign_cip()` — see `docs/cip_accurate_rfc.md` |
+| done: | `chematic-cip` perf fix: `ring_bond_set` was calling full `find_sssr` for a boolean ring-bond check (30ms vs 27us on a 182-atom molecule, ~1000x); replaced with an O(V+E) bridge-edge DFS, byte-identical output verified |
+| done: | CI: Criterion regression gate bootstrap fix (PR #69) — a new/removed bench target no longer aborts the whole gate job |
+| found, not yet fixed: | Criterion regression gate pseudo-replication — ~100 samples/side from one process aren't independent trials, single-run environment differences amplify into false-looking uniform failures across unrelated benchmarks; gate is non-required and its fail verdicts aren't currently trusted; redesign tracked in issue #70 |
 
 ---
 


### PR DESCRIPTION
## Summary
- Documents work not yet reflected anywhere: the new `chematic-cip` experimental CIP engine (Milestones 1 through the 3B closeout, 96.68%→99.14% full-corpus accuracy, 0 regressions), the SSSR-misuse perf fix, the Criterion gate bootstrap fix (#69), and the Criterion gate pseudo-replication reliability finding (#70).
- `CHANGELOG.md`: new `### Added — chematic-cip (new crate, experimental)`, a perf entry, and a `### CI` entry under `[Unreleased]`.
- `README.md`: new entry at the top of "Recent Development"; the `docs/cip_accurate_rfc.md` footnote updated to note remediation is underway (99.14% on the new engine's own metric).
- `tasks/todo.md`: `done:` rows for the milestone series + CI fix, plus a `found, not yet fixed:` row for the Criterion gate reliability issue.

## Deliberately not touched
- `chematic_chem::assign_cip()`'s own accuracy numbers (doctor() output, README comparison table row) — a separate, unaffected engine. The new 99.14% appears only as additive, explicitly-caveated context, never replacing the existing 96.30% row.

## Test plan
- [x] `bash scripts/check.sh` (docs-only change; workspace checks pass)
- [x] Diff-reviewed to confirm no existing accuracy number was altered, only additions/footnote clarification