### PR TITLE
feat(chematic-cip): Milestone 4A -- Rule 5 (pseudoasymmetry), scoped to 2 verified rows

### DIFF
--- a/crates/chematic-cip/examples/corpus_snapshot.rs
+++ b/crates/chematic-cip/examples/corpus_snapshot.rs
@@ -39,6 +39,8 @@ fn code_str(c: CipCode) -> &'static str {
         CipCode::S => "S",
         CipCode::E => "E",
         CipCode::Z => "Z",
+        CipCode::LowerR => "r",
+        CipCode::LowerS => "s",
     }
 }
 

--- a/crates/chematic-cip/src/assign.rs
+++ b/crates/chematic-cip/src/assign.rs
@@ -1,9 +1,46 @@
 //! A minimal, tetrahedral-only R/S assignment, built on the new comparator, for the
 //! sole purpose of producing labels the Milestone 2 corpus report can diff against
 //! RDKit's oracle. **Not** wired into `chematic_chem::assign_cip()` or any public
-//! surface beyond this crate -- explicitly experimental. No E/Z, no allene, no Rule 5 /
-//! pseudoasymmetry (Milestone 4's scope); this module only touches atoms with a
-//! `Chirality` annotation and exactly 4 resolvable substituent positions.
+//! surface beyond this crate -- explicitly experimental. No E/Z, no allene; this module
+//! only touches atoms with a `Chirality` annotation and exactly 4 resolvable substituent
+//! positions.
+//!
+//! # Rule 5 (pseudoasymmetry) -- Milestone 4A, deliberately narrow scope
+//!
+//! [`assign_cip_accurate_experimental`] runs a second pass ([`apply_rule5_pass`]) after
+//! the Rules-1a/1b/2 pass ([`assign_all`]) completes, refining only atoms the first pass
+//! left [`SkipReason::Tied`]. It resolves exactly one shape: a tie between precisely 2 of
+//! the 4 physical positions, where each tied branch's *nearest* embedded, already-
+//! Pass-1-resolved stereocenter (unambiguous: only one atom at that minimum depth) has a
+//! code that differs from the other branch's (one R, one S) -- CIP's textbook
+//! pseudoasymmetric-center pattern. "Nearest," not "only one in the whole subtree": in a
+//! monocyclic ring, both ring-direction branches from the pseudoasymmetric center
+//! eventually wrap around and reach *every* embedded stereocenter on the ring, just in
+//! opposite order, so distinguishing "which one is closer per branch" is required, not
+//! "does this branch contain only one at all" (verified empirically on both target
+//! rows -- an earlier "exactly one in the whole subtree" version of this check
+//! wrongly disqualified both). The resolved atom is labeled
+//! [`chematic_core::CipCode::LowerR`]/[`chematic_core::CipCode::LowerS`], not `R`/`S`.
+//!
+//! **What this deliberately does not attempt**: a three-armed, locally-symmetric cage
+//! family (verified present in the validation corpus -- flipping one arm's stereo tag
+//! reclassifies all three embedded centers at once) has no seed for this pairwise
+//! provisional-map approach to refine from -- every relevant neighbor is *also* tied in
+//! Pass 1. That family needs symmetry/automorphism-aware joint resolution, a different
+//! architecture, and is out of scope here (tracked as Milestone 4A-2 in
+//! `docs/cip_accurate_rfc.md`). [`apply_rule5_pass`] is a structural no-op on it: the tie
+//! detection requires *exactly* 2 physical positions in *exactly* one tied group, which
+//! the cage family's 3-way (or worse) ties never satisfy.
+//!
+//! **Auxiliary vs. molecular descriptor**: real CIP Rule 4c/5 compares an embedded
+//! center's *auxiliary* descriptor -- computed within the digraph rooted at the outer
+//! stereocenter -- not necessarily its own independently-computed molecular R/S. This
+//! pass uses the molecular descriptor (`provisional`, built from Pass 1's whole-molecule
+//! results) as a stand-in. That is verified, not assumed, correct for this milestone's
+//! 2-row target: both target molecules' embedded reference centers are already
+//! independently and uniquely resolved by Pass 1 with no ring-duplicate/phantom-atom
+//! complication in their own ranking. It is not a general auxiliary-descriptor
+//! implementation and should not be trusted as one outside this scope.
 //!
 //! # Positions come from `stereo_neighbor_order`, ranks come from the new comparator
 //!
@@ -87,7 +124,8 @@ pub fn assign_cip_accurate_experimental(
     budget: CipBudget,
 ) -> Result<AccurateCipAssignment, CipCompareError> {
     let kekule = prepare_kekule_form(mol).ok();
-    assign_all(mol, budget, kekule.as_ref())
+    let pass1 = assign_all(mol, budget, kekule.as_ref())?;
+    Ok(apply_rule5_pass(mol, budget, kekule.as_ref(), pass1))
 }
 
 /// Identical to [`assign_cip_accurate_experimental`], but never attaches a
@@ -143,6 +181,222 @@ fn assign_all(
     Ok(result)
 }
 
+/// Milestone 4A's Rule 5 refinement -- see module docs for scope. Only ever touches
+/// atoms Pass 1 (`assign_all`, above) left [`SkipReason::Tied`]; every other atom
+/// (resolved or skipped for any other reason) is carried through unchanged. Not called
+/// by [`assign_cip_accurate_experimental_without_mancude`] -- that function's whole
+/// purpose is to stay a frozen, Rule-5-independent reference point (see its own doc
+/// comment), so Rule 5 is deliberately only wired into the main, live entry point.
+fn apply_rule5_pass(
+    mol: &Molecule,
+    budget: CipBudget,
+    kekule: Option<&(Molecule, MancudeContext)>,
+    pass1: AccurateCipAssignment,
+) -> AccurateCipAssignment {
+    let provisional: HashMap<AtomIdx, CipCode> = pass1.assignments.iter().copied().collect();
+
+    let mut assignments = pass1.assignments;
+    let mut skipped = Vec::with_capacity(pass1.skipped.len());
+
+    for (idx, reason) in pass1.skipped {
+        if reason != SkipReason::Tied {
+            skipped.push((idx, reason));
+            continue;
+        }
+
+        let atom = mol.atom(idx);
+        let Some(stereo_order) = mol.stereo_neighbor_order(idx) else {
+            skipped.push((idx, reason));
+            continue;
+        };
+        if stereo_order.len() != 4 {
+            skipped.push((idx, reason));
+            continue;
+        }
+
+        match assign_one_with_rule5(
+            mol,
+            idx,
+            atom.chirality,
+            stereo_order,
+            budget,
+            kekule,
+            &provisional,
+        ) {
+            Ok(Some(code)) => assignments.push((idx, code)),
+            _ => skipped.push((idx, reason)),
+        }
+    }
+
+    AccurateCipAssignment {
+        assignments,
+        skipped,
+    }
+}
+
+/// Retry a Pass-1-tied atom with Rule 5. Identical digraph/ranking setup to
+/// [`assign_one`]; the only new logic is locating a single, exactly-2-physical-position
+/// tied group and, if each side embeds exactly one already-resolved stereocenter with a
+/// differing `provisional` code, breaking the tie by that code (R precedes S) before
+/// handing the (now fully split) group partition to the same
+/// [`resolve_is_r_from_groups`] parity math Pass 1 uses. Any shape this narrow detector
+/// doesn't recognize -- 0 or 2+ tied groups, a tied group of size != 2, an
+/// unresolved/ambiguous embedded center, or matching codes on both sides -- returns
+/// `Err(SkipReason::Tied)` unchanged, exactly Pass 1's own outcome.
+fn assign_one_with_rule5(
+    mol: &Molecule,
+    idx: AtomIdx,
+    chirality: Chirality,
+    stereo_order: &[u32],
+    budget: CipBudget,
+    kekule: Option<&(Molecule, MancudeContext)>,
+    provisional: &HashMap<AtomIdx, CipCode>,
+) -> Result<Option<CipCode>, SkipReason> {
+    let mut graph = match kekule {
+        Some((kekule_mol, ctx)) => {
+            CipDigraph::new_with_mancude(kekule_mol, idx, budget, ctx).map_err(map_digraph_err)?
+        }
+        None => CipDigraph::new(mol, idx, budget).map_err(map_digraph_err)?,
+    };
+    let root = graph.root();
+    let root_children = graph.expand_children(root).map_err(map_digraph_err)?;
+
+    let Some(position_nodes) = position_node_ids(&graph, &root_children, stereo_order) else {
+        return Ok(None);
+    };
+
+    let mut ctx = CompareContext::new();
+    let groups = rank_children(&mut graph, &root_children, &mut ctx).map_err(map_compare_err)?;
+
+    let position_set: HashSet<NodeId> = position_nodes.iter().copied().collect();
+    let mut tied_group_idx = None;
+    for (gi, group) in groups.iter().enumerate() {
+        let physical_count = group.iter().filter(|n| position_set.contains(n)).count();
+        if physical_count > 1 {
+            // A 3+-way tie in one group, or a second independently-tied group, is
+            // outside this milestone's narrow scope -- stay tied rather than guess.
+            if physical_count != 2 || tied_group_idx.is_some() {
+                return Err(SkipReason::Tied);
+            }
+            tied_group_idx = Some(gi);
+        }
+    }
+    let Some(tied_group_idx) = tied_group_idx else {
+        // Pass 2 only ever runs on atoms Pass 1 already found tied, so this shouldn't
+        // happen -- stay conservative rather than assume Pass 1/Pass 2 agree.
+        return Err(SkipReason::Tied);
+    };
+
+    let tied_group = &groups[tied_group_idx];
+    let physical_in_tied: Vec<NodeId> = tied_group
+        .iter()
+        .copied()
+        .filter(|n| position_set.contains(n))
+        .collect();
+    let (pos_a, pos_b) = (physical_in_tied[0], physical_in_tied[1]);
+
+    let Some(atom_a) =
+        nearest_embedded_stereocenter(&mut graph, mol, pos_a).map_err(map_digraph_err)?
+    else {
+        return Err(SkipReason::Tied);
+    };
+    let Some(atom_b) =
+        nearest_embedded_stereocenter(&mut graph, mol, pos_b).map_err(map_digraph_err)?
+    else {
+        return Err(SkipReason::Tied);
+    };
+    let (Some(&code_a), Some(&code_b)) = (provisional.get(&atom_a), provisional.get(&atom_b))
+    else {
+        return Err(SkipReason::Tied);
+    };
+    if code_a == code_b {
+        // Both R or both S -- not a distinguishing pseudoasymmetric pair in this scope;
+        // stay tied rather than guess.
+        return Err(SkipReason::Tied);
+    }
+
+    // Rule 5: R precedes S. Verified against this milestone's own 2-row corpus target
+    // (both currently-known cases resolve to lowercase `r`), not assumed from the
+    // textbook statement alone -- see module docs.
+    let (higher, lower) = if code_a == CipCode::R {
+        (pos_a, pos_b)
+    } else {
+        (pos_b, pos_a)
+    };
+
+    // Split the one tied group into two singleton-physical-position groups (higher
+    // priority first), leaving every other group's relative order untouched. Any
+    // non-physical (duplicate) sibling that was in the tied group rides along with
+    // `lower` -- harmless, since `resolve_is_r_from_groups` only ever looks up ranks
+    // for the 4 physical `position_nodes`, never for duplicates directly.
+    let mut resolved_groups: Vec<Vec<NodeId>> = Vec::with_capacity(groups.len() + 1);
+    for (gi, group) in groups.iter().enumerate() {
+        if gi == tied_group_idx {
+            resolved_groups.push(vec![higher]);
+            let mut lower_group = vec![lower];
+            lower_group.extend(group.iter().copied().filter(|&n| n != higher && n != lower));
+            resolved_groups.push(lower_group);
+        } else {
+            resolved_groups.push(group.clone());
+        }
+    }
+
+    let Some(is_r) = resolve_is_r_from_groups(&resolved_groups, &position_nodes, chirality) else {
+        return Ok(None);
+    };
+    Ok(Some(if is_r {
+        CipCode::LowerR
+    } else {
+        CipCode::LowerS
+    }))
+}
+
+/// Breadth-first search from `node`, level by level, for the *nearest* atom with its own
+/// `Chirality` set (checked on `mol`, the original un-kekulized molecule -- chirality is
+/// atom-level SMILES stereo info, unaffected by kekulization). Returns `None` if the
+/// nearest level containing a chirality-bearing atom contains more than one (ambiguous --
+/// which one is "nearest" is undefined), or if no such atom exists anywhere in the
+/// subtree.
+///
+/// Deliberately "nearest," not "the only one in the whole subtree": in a monocyclic
+/// ring, walking either ring-direction branch from the pseudoasymmetric center
+/// eventually wraps all the way around and reaches *every* embedded stereocenter on the
+/// ring (just in opposite order per branch) -- so a whole-subtree "exactly one" count
+/// would find 2+ in both branches and always disqualify, which is wrong (verified
+/// against this milestone's own 2-row target, which are both single-ring cases). The
+/// three-armed cage family this milestone excludes (see module docs) instead fails via
+/// *ambiguity at the nearest level* (that family's branches reach 2+ equally-near
+/// embedded stereocenters), which still safely falls through to `SkipReason::Tied`
+/// rather than producing a wrong lowercase label.
+fn nearest_embedded_stereocenter(
+    graph: &mut CipDigraph,
+    mol: &Molecule,
+    node: NodeId,
+) -> Result<Option<AtomIdx>, CipError> {
+    let mut frontier = vec![node];
+    while !frontier.is_empty() {
+        let mut found_this_level: Option<AtomIdx> = None;
+        let mut next_frontier = Vec::new();
+        for &current in &frontier {
+            if let CipNodeKind::Atom { atom_idx } = graph.node(current).kind
+                && mol.atom(atom_idx).chirality != Chirality::None
+            {
+                match found_this_level {
+                    None => found_this_level = Some(atom_idx),
+                    Some(existing) if existing == atom_idx => {}
+                    Some(_) => return Ok(None),
+                }
+            }
+            next_frontier.extend(graph.expand_children(current)?);
+        }
+        if let Some(atom_idx) = found_this_level {
+            return Ok(Some(atom_idx));
+        }
+        frontier = next_frontier;
+    }
+    Ok(None)
+}
+
 fn assign_one(
     mol: &Molecule,
     idx: AtomIdx,
@@ -181,6 +435,23 @@ fn assign_one(
         }
     }
 
+    let Some(is_r) = resolve_is_r_from_groups(&groups, &position_nodes, chirality) else {
+        return Ok(None);
+    };
+    Ok(Some(if is_r { CipCode::R } else { CipCode::S }))
+}
+
+/// Given a fully-ranked group partition (highest-priority group first, matching
+/// [`rank_children`]'s convention) and the 4 physical positions in `stereo_order`
+/// order, compute whether the center is *rectus* (R). Shared by [`assign_one`] (Rules
+/// 1a/1b/2 only) and [`assign_one_with_rule5`] (which passes a `groups` partition with
+/// one tied group already split by a Rule 5 tiebreak) -- the swap-counting parity math
+/// itself doesn't know or care which rule produced the ordering.
+fn resolve_is_r_from_groups(
+    groups: &[Vec<NodeId>],
+    position_nodes: &[NodeId],
+    chirality: Chirality,
+) -> Option<bool> {
     // Rank every node in every group (not just each group's first member) -- a duplicate
     // can share a physical position's group, and that position's rank_of lookup below
     // must still resolve. Highest-priority group first (rank_children's own convention)
@@ -208,9 +479,7 @@ fn assign_one(
     // Mirrors crates/chematic-chem/src/cip.rs::assign_tetrahedral's parity computation
     // verbatim (already correct there, fixed in d0e726b) -- only the source of
     // `ranks` differs (the new recursive comparator, not the old shell-pooling one).
-    let Some(lowest_pos) = ranks.iter().position(|&r| r == 1) else {
-        return Ok(None);
-    };
+    let lowest_pos = ranks.iter().position(|&r| r == 1)?;
     let parity_odd = lowest_pos % 2 == 1;
     let smiles_cw = chirality == Chirality::Clockwise;
     let cw_from_lowest = smiles_cw ^ parity_odd;
@@ -219,12 +488,9 @@ fn assign_one(
         .filter(|&i| i != lowest_pos)
         .map(|i| ranks[i])
         .collect();
-    let Some(remaining_swaps_odd) = swap_parity(&remaining_ranks) else {
-        return Ok(None);
-    };
+    let remaining_swaps_odd = swap_parity(&remaining_ranks)?;
 
-    let is_r = cw_from_lowest ^ remaining_swaps_odd;
-    Ok(Some(if is_r { CipCode::R } else { CipCode::S }))
+    Some(cw_from_lowest ^ remaining_swaps_odd)
 }
 
 fn map_digraph_err(e: CipError) -> SkipReason {

--- a/crates/chematic-cip/src/tests.rs
+++ b/crates/chematic-cip/src/tests.rs
@@ -482,3 +482,33 @@ fn test_phantom_padding_is_local_to_its_own_position() {
          without being corrupted by (or itself corrupting) the methyl-vs-ethyl position"
     );
 }
+
+#[test]
+fn rule5_resolves_the_two_verified_milestone_4a_target_rows() {
+    use chematic_core::CipCode;
+
+    let cases: &[(&str, u32)] = &[
+        ("N[C@]1(C(=O)O)C[C@H](C(=O)O)[C@H](C(=O)O)C1", 1),
+        (
+            "CCCCc1cn([C@H]2[C@H](C)CCC[C@@H]2C)c(=O)n1Cc1ccc(-c2ccccc2-c2nn[nH]n2)nc1",
+            7,
+        ),
+    ];
+
+    for (smiles, atom_idx) in cases {
+        let mol = chematic_smiles::parse(smiles).expect("valid SMILES");
+        let assignment =
+            crate::assign_cip_accurate_experimental(&mol, crate::CipBudget::default_budget())
+                .expect("assignment succeeds");
+        let code = assignment
+            .assignments
+            .iter()
+            .find(|(idx, _)| idx.0 == *atom_idx)
+            .map(|(_, code)| *code);
+        assert_eq!(
+            code,
+            Some(CipCode::LowerR),
+            "{smiles} atom {atom_idx}: expected lowercase r (RDKit oracle), got {code:?}"
+        );
+    }
+}

--- a/crates/chematic-cip/tests/common/mod.rs
+++ b/crates/chematic-cip/tests/common/mod.rs
@@ -13,6 +13,8 @@ pub fn code_str(code: CipCode) -> &'static str {
         CipCode::S => "S",
         CipCode::E => "E",
         CipCode::Z => "Z",
+        CipCode::LowerR => "r",
+        CipCode::LowerS => "s",
     }
 }
 

--- a/crates/chematic-cip/tests/corpus_report.rs
+++ b/crates/chematic-cip/tests/corpus_report.rs
@@ -27,6 +27,8 @@ fn code_str(code: CipCode) -> &'static str {
         CipCode::S => "S",
         CipCode::E => "E",
         CipCode::Z => "Z",
+        CipCode::LowerR => "r",
+        CipCode::LowerS => "s",
     }
 }
 

--- a/crates/chematic-cip/tests/uncharacterized_diagnosis.rs
+++ b/crates/chematic-cip/tests/uncharacterized_diagnosis.rs
@@ -52,6 +52,8 @@ fn code_str(code: CipCode) -> &'static str {
         CipCode::S => "S",
         CipCode::E => "E",
         CipCode::Z => "Z",
+        CipCode::LowerR => "r",
+        CipCode::LowerS => "s",
     }
 }
 

--- a/crates/chematic-core/src/atom.rs
+++ b/crates/chematic-core/src/atom.rs
@@ -28,6 +28,12 @@ pub enum CipCode {
     E,
     /// Double-bond *zusammen* (together, cis) geometry.
     Z,
+    /// Pseudoasymmetric center, *rectus*-like (Rule 5, lowercase `r`). Emitted only by
+    /// `chematic_cip::assign_cip_accurate_experimental`'s Rule 5 pass; the default
+    /// `chematic_chem::assign_cip` never produces this variant.
+    LowerR,
+    /// Pseudoasymmetric center, *sinister*-like (Rule 5, lowercase `s`). See [`Self::LowerR`].
+    LowerS,
 }
 
 /// A single atom in a molecular graph.

--- a/crates/chematic-py/src/mol_methods.rs
+++ b/crates/chematic-py/src/mol_methods.rs
@@ -2643,6 +2643,8 @@ impl Mol {
                     CipCode::S => "S",
                     CipCode::E => "E",
                     CipCode::Z => "Z",
+                    CipCode::LowerR => "r",
+                    CipCode::LowerS => "s",
                 };
                 d.set_item("descriptor", label)?;
                 Ok(d)
@@ -3814,6 +3816,8 @@ impl Mol {
                     CipCode::S => "S",
                     CipCode::E => "E",
                     CipCode::Z => "Z",
+                    CipCode::LowerR => "r",
+                    CipCode::LowerS => "s",
                 };
                 d.set_item("code", code_str).unwrap();
                 d
@@ -3853,6 +3857,8 @@ impl Mol {
                     CipCode::S => "S",
                     CipCode::E => "E",
                     CipCode::Z => "Z",
+                    CipCode::LowerR => "r",
+                    CipCode::LowerS => "s",
                 };
                 d.set_item("code", code_str).unwrap();
                 d

--- a/crates/chematic-wasm/src/lib.rs
+++ b/crates/chematic-wasm/src/lib.rs
@@ -488,6 +488,8 @@ impl MolHandle {
                     CipCode::S => "S",
                     CipCode::E => "E",
                     CipCode::Z => "Z",
+                    CipCode::LowerR => "r",
+                    CipCode::LowerS => "s",
                 };
                 format!(r#"{{"atom":{},"code":"{}"}}"#, idx.0, code_str)
             })

--- a/crates/chematic-wasm/src/mol_descriptors.rs
+++ b/crates/chematic-wasm/src/mol_descriptors.rs
@@ -328,6 +328,8 @@ pub fn cip_assignments_json(mol: &MolHandle) -> String {
                 chematic_core::CipCode::S => "S",
                 chematic_core::CipCode::E => "E",
                 chematic_core::CipCode::Z => "Z",
+                chematic_core::CipCode::LowerR => "r",
+                chematic_core::CipCode::LowerS => "s",
             };
             format!("{{\"atomIdx\":{},\"cipCode\":\"{}\"}}", idx.0, code_str)
         })

--- a/docs/cip_accurate_rfc.md
+++ b/docs/cip_accurate_rfc.md
@@ -637,16 +637,68 @@ explicit resumption conditions — any one of these reopens it:
 - RDKit's own MANCUDE implementation changes and chematic needs to track it
 
 **Next: Milestone 4 direction (not started this round).** ROI ordering, not resonance
-analysis: **M4A** — reclassify the 8 still-uncharacterized residual rows into Rule 3/4
-territory; **M4B** — Rule 5 (pseudoasymmetry) for the 16 pseudoasymmetric residual cases;
-**M4C** — phosphorus (9 wrong + 2 tied). 99.5% (4166/4186) needs 16 more correct beyond
-the current 4150 — M4A alone (8) plus roughly half of M4B or M4C would clear it.
+analysis: reclassify the 8 still-uncharacterized residual rows into Rule 3/4 territory;
+Rule 5 (pseudoasymmetry) for the 16 pseudoasymmetric residual cases; phosphorus (9 wrong
++ 2 tied). 99.5% (4166/4186) needs 16 more correct beyond the current 4150.
+
+*Naming note (added at Milestone 4A closeout, below): this paragraph's original A/B/C
+letters (reclassification=A, Rule 5=B, phosphorus=C) were superseded before any of them
+shipped. The post-M3B residual reclassification ran separately and un-labeled
+(findings: 17 pseudoasymmetric / 11 phosphorus / 8 unclassified — supersedes the 16/9+2/8
+counts above), and this conversation settled on **Milestone 4A = Rule 5** going forward
+(matching the closeout entry immediately below), not the reclassification task. Treat
+"M4A" everywhere after this point as Rule 5; a future phosphorus milestone would be 4B
+(unnumbered as of this closeout).*
 
 **Milestone 4 — Stereo-dependent rules + phosphorus.** Rule 5 / pseudoasymmetry
 multi-pass resolution, plus the frozen corpus's 15 phosphorus stereocenters. Kept last
 and separate from Milestone 3 deliberately: phosphorus stereocenters raise valence/
 lone-pair representation questions that could otherwise contaminate the ring/aromatic
 gate's signal.
+
+**Milestone 4A closeout — Rule 5, scoped to 2 verified-independent rows (accurate
+engine: 99.14% → 99.19%, 4150/4186 → 4152/4186).** Of the 17 pseudoasymmetric residual
+rows, empirical verification (RDKit sweep + a direct stereo-tag flip test) found they
+are **not homogeneous**: 15 of them (5 of 7 distinct molecules) are a three-armed,
+locally-symmetric cage structure (dicyclopentadiene/adamantane-type) where flipping just
+one arm's tag reclassifies *all three* embedded centers at once — proof they're jointly
+determined by whether local symmetry holds, not independently resolvable via pairwise
+branch comparison. A provisional-map two-pass architecture has no seed to refine from
+here (every relevant neighbor is *also* tied), so it cannot handle this family; doing so
+needs symmetry/automorphism perception, a different architecture than what shipped here.
+
+Only 2 of the 17 rows are the textbook, single-embedded-neighbor pseudoasymmetric shape:
+both molecules' embedded reference stereocenters are already independently resolved to
+distinct uppercase codes by Pass 1 (no ring-duplicate/phantom-atom complication), so
+using the atom's own molecular R/S as the Rule 5 auxiliary descriptor is verified — not
+assumed — correct for this narrow scope (real CIP Rule 4c/5 compares an *auxiliary*
+descriptor computed within the outer stereocenter's own digraph, which need not equal
+the atom's independently-computed molecular descriptor in general).
+
+Shipped: `CipCode::LowerR`/`LowerS` (`chematic-core`); a Pass-2 refinement
+(`assign.rs::apply_rule5_pass`) that retries only atoms Pass 1 left `SkipReason::Tied`,
+detects a tie between exactly 2 physical positions whose branches' *nearest* embedded,
+already-resolved stereocenter differ (R vs S), and breaks it (R precedes S). "Nearest,"
+not "the branch's only one": in a monocyclic ring, both ring-direction branches
+eventually wrap around and reach *every* embedded stereocenter, just in opposite order —
+an early version of this check used "exactly one in the whole subtree" and wrongly
+disqualified both target rows before this was caught and fixed. Verified: exact match on
+both target rows, 0 regressions two independent ways (`corpus_snapshot.rs` diff +
+`cip_accurate_full_corpus_report.py` full recompute), and an explicit no-op diff
+confirming the only 2 changed rows across the full 4188-row corpus are the intended
+targets.
+
+**Both target rows resolve to lowercase `r`** — there is no `s`-producing row in this
+milestone's own verification corpus. `LowerS` is implemented symmetrically (the tiebreak
+logic doesn't special-case which side is which) but its correctness is not empirically
+exercised by this milestone; treat it as unverified until a real corpus row exercises it.
+
+**Milestone 4A-2 — deferred, not deleted: the 15-row three-armed cage family.** Same
+molecules described above, atoms not covered by the 2-row scope. Resumption condition: a
+symmetry/automorphism-aware joint-resolution architecture is designed and its own
+correctness argued/verified first — a provisional-map two-pass refinement cannot resolve
+this family by construction (no seed), so this is not a parameter tweak on the current
+code, it needs a different mechanism.
 
 ## Required property tests (starting Milestone 1)
 


### PR DESCRIPTION
## Summary

- Extends `CipCode` with `LowerR`/`LowerS` and adds a Pass-2 refinement in `chematic-cip` that retries only atoms Pass 1 left `SkipReason::Tied`: a tie between exactly 2 physical positions whose branches' *nearest* embedded, already-resolved stereocenter differ (R vs S) is broken via Rule 5 (R precedes S -- empirically verified, not assumed).
- Accurate-engine full-corpus accuracy: 99.14% -> 99.19% (4150/4186 -> 4152/4186), 0 regressions confirmed two independent ways, explicit diff confirms only the 2 target rows changed across the full 4188-row corpus.
- Deliberately narrow scope: of 17 pseudoasymmetric residual rows, 15 (a three-armed symmetric-cage family) are provably unreachable by this pairwise architecture -- verified via a stereo-tag flip test showing all 3 embedded centers are jointly, not independently, resolvable. Deferred as Milestone 4A-2 with an explicit resumption condition.
- `docs/cip_accurate_rfc.md` records the closeout and fixes the RFC's own internal M4A/M4B milestone-letter mislabeling.
- Not wired into `chematic_chem::assign_cip()` (production, unaffected) -- `chematic-cip` remains a separate, experimental, `publish = false` crate.

## Test plan

- [x] `bash scripts/check.sh` (fmt, clippy, test, integration test, deny, version) -- all green
- [x] New unit test (`rule5_resolves_the_two_verified_milestone_4a_target_rows`) exact-matches both target rows
- [x] Full-corpus regression via `corpus_snapshot.rs` + `cip_accurate_full_corpus_report.py`: 0 regressions (2 independent methods)
- [x] Explicit no-op diff against the pre-M4A candidate snapshot: only the 2 intended rows changed across 4188 rows