### PR TITLE
ci(bench-gate): process-level Criterion gate redesign (issue #70, partial)

### DIFF
--- a/.github/workflows/bench-pr-gate.yml
+++ b/.github/workflows/bench-pr-gate.yml
@@ -192,20 +192,64 @@ jobs:
           (cd main && cargo bench --workspace --no-run)
           (cd pr && cargo bench --workspace --no-run)
 
-      # Measure main and PR back-to-back per benchmark (not "all of main's 13
-      # benchmarks, then all of PR's 13") and alternate which side goes
-      # first. Running the full suite for one side, then the other, leaves
-      # ~15 minutes between a benchmark's two measurements — enough for
-      # runner thermal/frequency drift to move the *average* level of
-      # whichever side happens to run second. Confirmed empirically: a
-      # version/docs-only PR with byte-identical Rust source (kent-tokyo/
-      # chematic#58) still showed 10/13 benchmarks "regressed" under the old
-      # main-then-PR-in-full ordering. Interleaving per-benchmark shrinks
-      # that gap to seconds; alternating which side leads spreads any
-      # residual same-gap bias across both sides instead of always
-      # penalizing the PR.
-      - name: Run Criterion benchmarks (interleaved, alternating order)
+      # Process-level redesign (issue #70): the old approach paired one
+      # Criterion process's ~100 internal batch samples as if they were 100
+      # independent A/B trials. They are not -- they all share one process's
+      # runner-environment state, so a single environment difference (CPU
+      # frequency scaling, VM steal time, scheduler contention) gets
+      # amplified into an extreme-looking uniform win rate (see issue #70:
+      # a version/docs-only PR with byte-identical Rust source showed nearly
+      # every benchmark, including ones in untouched crates, with
+      # baseline_count 96-100/100).
+      #
+      # scripts/criterion_gate.sh takes one Criterion *process run* as a
+      # single observation (median per-iteration time) and assembles N
+      # independent {baseline, candidate} records from N "ABBA" blocks
+      # (order A,B,B,A or B,A,A,B; geometric mean of each side's 2 runs
+      # within a block cancels slow thermal/frequency drift) -- locally
+      # validated (same-binary null control comes out "inconclusive", a
+      # genuinely large synthetic difference comes out "fail" once enough
+      # blocks accumulate).
+      #
+      # Two-stage screening keeps CI time bounded: Stage 1 is a cheap,
+      # coarse screen (3 blocks); only a Stage-1 "fail" triggers Stage 2 (10
+      # blocks, reversed A/B order, longer measurement) as an independent
+      # confirmation. The final gate only fails a benchmark if BOTH stages
+      # independently say fail -- reproduction-under-reversed-order is this
+      # design's multiple-testing correction (simpler than a Bonferroni/Holm
+      # family correction across 16 benchmarks, per issue #70's own
+      # suggested alternative).
+      #
+      # A same-binary null control (main vs itself, run through the exact
+      # same pipeline) runs once per stage. If IT shows a biased verdict,
+      # the whole run's environment is suspect -- every real "fail" that
+      # stage is downgraded to `environment-inconclusive` and never blocks,
+      # rather than trusting any individual benchmark's verdict.
+      - name: "Run process-level Criterion gate (issue #70 redesign)"
         run: |
+          set +e
+          chmod +x pr/scripts/criterion_gate.sh
+
+          bin_path() { pr/scripts/criterion_gate.sh bin-path "$1" "$2" "$3"; }
+
+          # Same-binary null control: main's own binary on both sides, run
+          # through the identical pipeline, once per stage. `parse_smiles_10mol`
+          # is the fastest benchmark in the suite -- cheap to run repeatedly as
+          # a canary.
+          null_control_bin=$(bin_path main chematic-smiles parse_bench)
+          run_null_control() {
+            local n_blocks="$1" order="$2" out="$3"
+            if [ -z "$null_control_bin" ]; then
+              echo "::warning::null control: parse_bench missing on main, skipping contamination check this stage" >&2
+              return 1
+            fi
+            pr/scripts/criterion_gate.sh run-blocks \
+              "$null_control_bin" "$null_control_bin" "parse_smiles_10mol" \
+              "$n_blocks" 0.5 1 15 "$order" "$out"
+            veridict compare "$out" --metric sign-test --confidence 0.95 --min-effect 0.2 \
+              --report-json "${out%.jsonl}_report.json"
+          }
+
           BENCHES=(
             "smarts_compile_5pat:chematic-smarts:smarts_bench"
             "smarts_match_nocache_10mol:chematic-smarts:smarts_bench"
@@ -224,100 +268,92 @@ jobs:
             "find_sssr_polycyclic_5mol:chematic-perception:sssr_bench"
             "count_aromatic_rings_10mol:chematic-perception:sssr_bench"
           )
-          idx=0
+
+          mkdir -p artifacts
+          any_fail=0
+          stage1_fail_count=0
+
+          # Stage 1: cheap screen across every benchmark first, so the (rare)
+          # same-binary null-control fail check below reflects this run's
+          # actual environment during the bulk of the work, not a check done
+          # in isolation before/after.
+          declare -a stage1_fail_names=()
           for entry in "${BENCHES[@]}"; do
             IFS=':' read -r name crate benchfile <<< "$entry"
-            if [ $((idx % 2)) -eq 0 ]; then
-              sides=(main pr)
-            else
-              sides=(pr main)
-            fi
-            for side in "${sides[@]}"; do
-              # A bench target (or the crate itself) can legitimately exist on only
-              # one side -- newly added in this PR (no baseline yet) or removed by it
-              # (no candidate). `cargo bench -p <crate> --bench <file>` errors ("no
-              # bench target named ...") in either case, which under this step's
-              # default `set -e` would otherwise abort the whole job on the first
-              # such benchmark, hiding every other benchmark's result behind an
-              # unrelated bootstrap gap (see kent-tokyo/chematic#68's Criterion gate
-              # failure: sssr_bench existed on the PR side but not yet on main).
-              # Tolerated here, not silently: sample.json's absence on the missing
-              # side is exactly what the gate step below uses to classify and report
-              # this case (new/removed benchmark) instead of pairing garbage.
-              if ! (cd "$side" && cargo bench -p "$crate" --bench "$benchfile" -- "^${name}$"); then
-                echo "::warning::$name: no bench target \`$benchfile\` in \`$crate\` on $side (new or removed benchmark?) -- continuing without it"
-              fi
-            done
-            idx=$((idx + 1))
-          done
+            main_bin=$(bin_path main "$crate" "$benchfile")
+            pr_bin=$(bin_path pr "$crate" "$benchfile")
 
-      # Criterion (0.8, no csv_output feature enabled) writes raw per-sample
-      # batch measurements to target/criterion/<bench>/new/sample.json as
-      # {iters: [...], times: [...]} (nanoseconds per batch, not per
-      # iteration) — times[i]/iters[i] gives the per-iteration time.
-      # sign-test (not mean-diff) is used because its effect is a
-      # scale-invariant win-rate centered on 0: one --min-effect threshold
-      # applies uniformly across benchmarks that differ by orders of
-      # magnitude in absolute time, without per-benchmark tuning.
-      - name: Pair & gate Criterion benchmarks
-        run: |
-          set +e
-          any_fail=0
-          for name in \
-            smarts_compile_5pat smarts_match_nocache_10mol smarts_match_cached_10mol smarts_recursive_10mol \
-            parse_smiles_10mol canonical_smiles_10mol \
-            ecfp4_10mol tanimoto_ecfp4_pairs \
-            descriptors_5x10mol qed_10mol pka_predict_10mol pka_acid_base_10mol admet_profile_10mol \
-            find_sssr_10mol find_sssr_polycyclic_5mol count_aromatic_rings_10mol
-          do
-            b="main/target/criterion/$name/new/sample.json"
-            c="pr/target/criterion/$name/new/sample.json"
-            b_exists=0; [ -f "$b" ] && b_exists=1
-            c_exists=0; [ -f "$c" ] && c_exists=1
-
-            # Three-way classification, not one "missing on either side, skip"
-            # bucket: only "both present" is a real regression signal. A brand-new
-            # benchmark (candidate only) has no baseline to compare against yet --
-            # that's expected on the PR that introduces it, not a gate failure, and
-            # must not block every *other* benchmark's verdict either (previously a
-            # missing bench *target* aborted the whole job before reaching this
-            # step at all -- see the previous step's comment). A benchmark present
-            # only on main (removed by this PR) is flagged for visibility but also
-            # not gated -- intentional removals shouldn't need a perf-gate override.
-            if [ "$b_exists" -eq 0 ] && [ "$c_exists" -eq 0 ]; then
-              echo "::warning::$name: sample.json missing on both sides, skipping"
+            # A bench target (or the crate itself) can legitimately exist on
+            # only one side -- newly added in this PR (no baseline yet) or
+            # removed by it (no candidate). Three-way classification: only
+            # "both present" is a real regression signal.
+            if [ -z "$main_bin" ] && [ -z "$pr_bin" ]; then
+              echo "::warning::$name: missing on both sides, skipping"
               continue
-            elif [ "$b_exists" -eq 0 ] && [ "$c_exists" -eq 1 ]; then
+            elif [ -z "$main_bin" ]; then
               echo "::notice::$name: new benchmark, no baseline on main yet -- not gated this run"
               continue
-            elif [ "$b_exists" -eq 1 ] && [ "$c_exists" -eq 0 ]; then
+            elif [ -z "$pr_bin" ]; then
               echo "::warning::$name: present on main but missing on the PR branch (removed?) -- not gated, please confirm this removal is intentional"
               continue
             fi
 
-            jq -c -n --slurpfile b "$b" --slurpfile c "$c" '
-              ($b[0].times) as $bt | ($b[0].iters) as $bi |
-              ($c[0].times) as $ct | ($c[0].iters) as $ci |
-              [range(0; ($bt | length))]
-              | map(select($bt[.] != null and $bi[.] != null and $ct[.] != null and $ci[.] != null))
-              | map({id: (. | tostring), baseline: (-($bt[.] / $bi[.])), candidate: (-($ct[.] / $ci[.]))})
-              | .[]
-            ' > "${name}_import.jsonl"
-
-            if [ ! -s "${name}_import.jsonl" ]; then
-              echo "::warning::$name: no usable paired samples, skipping"
-              continue
-            fi
-
-            veridict compare "${name}_import.jsonl" --metric sign-test --confidence 0.95 \
-              --min-effect 0.2 --report-json "${name}_report.json"
+            out="artifacts/${name}_stage1.jsonl"
+            pr/scripts/criterion_gate.sh run-blocks "$main_bin" "$pr_bin" "$name" 3 0.5 1 15 abba "$out"
+            veridict compare "$out" --metric sign-test --confidence 0.95 --min-effect 0.2 \
+              --report-json "artifacts/${name}_stage1_report.json"
             code=$?
-            echo "=== $name: exit $code ==="
-            cat "${name}_report.json"
+            echo "=== $name stage1: exit $code ==="
+            cat "artifacts/${name}_stage1_report.json"
             if [ "$code" -eq 1 ] || [ "$code" -eq 3 ]; then
-              echo "::error::$name regressed (exit $code)"
-              any_fail=1
+              stage1_fail_count=$((stage1_fail_count + 1))
+              stage1_fail_names+=("${name}:${crate}:${benchfile}")
             fi
           done
+
+          # Null control, this run's actual environment.
+          run_null_control 7 abba artifacts/null_control.jsonl
+          null_code=$?
+          echo "=== null control: exit $null_code ==="
+          environment_contaminated=0
+          if [ "$null_code" -eq 1 ] || [ "$null_code" -eq 3 ]; then
+            echo "::error::null control (main vs itself) shows a biased verdict -- this run's environment is contaminated. No individual benchmark fail is trustworthy this run."
+            environment_contaminated=1
+          fi
+
+          # Stage 2: confirmation only for Stage-1 fail candidates, reversed
+          # order, more blocks.
+          for entry in "${stage1_fail_names[@]}"; do
+            IFS=':' read -r name crate benchfile <<< "$entry"
+            main_bin=$(bin_path main "$crate" "$benchfile")
+            pr_bin=$(bin_path pr "$crate" "$benchfile")
+            out="artifacts/${name}_stage2.jsonl"
+            pr/scripts/criterion_gate.sh run-blocks "$main_bin" "$pr_bin" "$name" 10 1 2 20 baab "$out"
+            veridict compare "$out" --metric sign-test --confidence 0.95 --min-effect 0.2 \
+              --report-json "artifacts/${name}_stage2_report.json"
+            code=$?
+            echo "=== $name stage2 (confirmation, reversed order): exit $code ==="
+            cat "artifacts/${name}_stage2_report.json"
+            if [ "$code" -eq 1 ] || [ "$code" -eq 3 ]; then
+              if [ "$environment_contaminated" -eq 1 ]; then
+                echo "::warning::$name: Stage 1 and Stage 2 both failed, but this run's environment is contaminated (null control failed too) -- reporting environment-inconclusive, not blocking."
+              else
+                echo "::error::$name regressed -- reproduced independently in Stage 2 (reversed order, 10 blocks)"
+                any_fail=1
+              fi
+            else
+              echo "::notice::$name: Stage 1 flagged a possible regression but Stage 2 (reversed order) did not reproduce it -- treating as noise, not gating."
+            fi
+          done
+
+          echo "stage1_fail_count=$stage1_fail_count, environment_contaminated=$environment_contaminated, any_fail=$any_fail" >> "$GITHUB_STEP_SUMMARY"
           set -e
           [ "$any_fail" -eq 0 ]
+
+      - name: Upload Criterion gate artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: criterion-gate-artifacts
+          path: artifacts/
+          retention-days: 30

--- a/scripts/criterion_gate.sh
+++ b/scripts/criterion_gate.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Process-level Criterion A/B runner for the CI regression gate (issue #70).
+#
+# Replaces the old approach of pairing one Criterion process's ~100 internal
+# batch samples as if they were 100 independent trials (pseudo-replication --
+# they all share one process's runner-environment state, so a single
+# environment difference gets amplified into an extreme-looking uniform win
+# rate). Instead: one Criterion *process run* -> one point estimate (median
+# per-iteration time). N independent process-pair "ABBA" blocks (order
+# A,B,B,A; geometric mean of each side's 2 runs within a block cancels slow
+# thermal/frequency drift) -> N independent {baseline, candidate} records,
+# fed to `veridict compare --metric sign-test`.
+#
+# Usage:
+#   criterion_gate.sh run-blocks <bin_a> <bin_b> <bench_name> <n_blocks> \
+#       <warm_up_secs> <measurement_secs> <sample_size> <order> <out_jsonl>
+#
+# <bin_a>/<bin_b> are compiled Criterion bench executable paths (from
+# `cargo bench --no-run --message-format=json`, not a glob over
+# target/release/deps -- multiple hash-suffixed binaries for the same bench
+# name can coexist in a restored cache). Pass the SAME path for both to get a
+# same-binary null control (locally validated: a same-binary run through this
+# exact pipeline comes out "inconclusive", not "fail" -- see the criterion-gate
+# job's null-control step).
+#
+# <order> is `abba` (block = a,b,b,a) or `baab` (block = b,a,a,b) -- output
+# `baseline`/`candidate` fields always mean bin_a/bin_b regardless of which
+# physically ran first, only the *order* of execution within the block
+# flips. Used for two-stage confirmation: Stage 2 re-runs a Stage-1 fail
+# candidate with reversed order, so a real regression must reproduce under
+# genuinely different execution order, not just the same measurement twice.
+set -euo pipefail
+
+run_point_estimate() {
+  local bin="$1" bench_name="$2" warm_up="$3" measurement="$4" sample_size="$5"
+  local sample_json="target/criterion/${bench_name}/new/sample.json"
+  "$bin" --bench "$bench_name" \
+    --warm-up-time "$warm_up" --measurement-time "$measurement" \
+    --sample-size "$sample_size" --noplot >/dev/null 2>&1
+  jq '
+    [ .times, .iters ] as $ti
+    | [range(0; ($ti[0] | length))] | map($ti[0][.] / $ti[1][.]) | sort
+    | .[length / 2 | floor]
+  ' "$sample_json"
+}
+
+cmd_run_blocks() {
+  local bin_a="$1" bin_b="$2" bench_name="$3" n_blocks="$4"
+  local warm_up="$5" measurement="$6" sample_size="$7" order="$8" out="$9"
+  : > "$out"
+  for i in $(seq 1 "$n_blocks"); do
+    local a1 b1 b2 a2
+    if [ "$order" = "baab" ]; then
+      b1=$(run_point_estimate "$bin_b" "$bench_name" "$warm_up" "$measurement" "$sample_size")
+      a1=$(run_point_estimate "$bin_a" "$bench_name" "$warm_up" "$measurement" "$sample_size")
+      a2=$(run_point_estimate "$bin_a" "$bench_name" "$warm_up" "$measurement" "$sample_size")
+      b2=$(run_point_estimate "$bin_b" "$bench_name" "$warm_up" "$measurement" "$sample_size")
+    else
+      a1=$(run_point_estimate "$bin_a" "$bench_name" "$warm_up" "$measurement" "$sample_size")
+      b1=$(run_point_estimate "$bin_b" "$bench_name" "$warm_up" "$measurement" "$sample_size")
+      b2=$(run_point_estimate "$bin_b" "$bench_name" "$warm_up" "$measurement" "$sample_size")
+      a2=$(run_point_estimate "$bin_a" "$bench_name" "$warm_up" "$measurement" "$sample_size")
+    fi
+    # Negate: veridict's mean-diff/sign-test treat a larger candidate-baseline
+    # as an improvement, but for latency lower is better.
+    jq -c -n --argjson a1 "$a1" --argjson a2 "$a2" --argjson b1 "$b1" --argjson b2 "$b2" --arg id "$i" '
+      {
+        id: $id,
+        baseline: (-(($a1 * $a2) | sqrt)),
+        candidate: (-(($b1 * $b2) | sqrt))
+      }
+    ' >> "$out"
+  done
+}
+
+cmd_bin_path() {
+  local crate_dir="$1" crate="$2" benchfile="$3"
+  (cd "$crate_dir" && cargo bench -p "$crate" --bench "$benchfile" --no-run --message-format=json 2>/dev/null) \
+    | jq -r 'select(.reason == "compiler-artifact" and .executable != null) | .executable' \
+    | tail -1
+}
+
+case "${1:-}" in
+  run-blocks)
+    shift
+    cmd_run_blocks "$@"
+    ;;
+  bin-path)
+    shift
+    cmd_bin_path "$@"
+    ;;
+  *)
+    echo "usage: $0 run-blocks <bin_a> <bin_b> <bench_name> <n_blocks> <warm_up_secs> <measurement_secs> <sample_size> <order:abba|baab> <out_jsonl>" >&2
+    echo "       $0 bin-path <crate_dir> <crate> <benchfile>" >&2
+    exit 64
+    ;;
+esac

--- a/scripts/test_criterion_gate.sh
+++ b/scripts/test_criterion_gate.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Minimal self-check for criterion_gate.sh's block-pairing math (geomean +
+# negate), without needing a real Criterion binary. Full end-to-end
+# validation (does this actually avoid pseudo-replication on real timing
+# noise, does it actually detect a real regression) was done manually against
+# real compiled benchmarks on this machine -- see docs/cip_accurate_rfc.md's
+# sibling issue #70 thread for those results; this script only guards the
+# arithmetic against a future accidental edit.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Stub out run_point_estimate with fixed values keyed by binary path, so
+# cmd_run_blocks's block-assembly logic runs unmodified against known inputs.
+# (Extract to a real temp file rather than `source <(...)` -- macOS's bash
+# 3.2 doesn't reliably persist function defs sourced via process substitution.)
+extracted_fn=$(mktemp)
+sed -n '/^cmd_run_blocks/,/^}/p' scripts/criterion_gate.sh > "$extracted_fn"
+source "$extracted_fn"
+rm -f "$extracted_fn"
+run_point_estimate() {
+  case "$1" in
+    fast) echo 100 ;;
+    slow) echo 200 ;;
+  esac
+}
+
+out=$(mktemp)
+cmd_run_blocks fast slow bench_name 1 0 0 1 abba "$out"
+record=$(cat "$out")
+echo "abba record: $record"
+
+baseline=$(echo "$record" | jq '.baseline')
+candidate=$(echo "$record" | jq '.candidate')
+# fast=100 both runs -> geomean 100 -> negated -100; slow=200 both runs -> geomean 200 -> negated -200
+[ "$baseline" = "-100" ] || { echo "FAIL: expected baseline -100, got $baseline"; exit 1; }
+[ "$candidate" = "-200" ] || { echo "FAIL: expected candidate -200, got $candidate"; exit 1; }
+
+cmd_run_blocks fast slow bench_name 1 0 0 1 baab "$out"
+record_baab=$(cat "$out")
+echo "baab record: $record_baab"
+# order must not change which side is labeled baseline/candidate
+[ "$(echo "$record_baab" | jq '.baseline')" = "-100" ] || { echo "FAIL: baab changed baseline label"; exit 1; }
+[ "$(echo "$record_baab" | jq '.candidate')" = "-200" ] || { echo "FAIL: baab changed candidate label"; exit 1; }
+
+rm -f "$out"
+echo "OK"


### PR DESCRIPTION
## Summary

Redesigns the Criterion regression gate's core measurement methodology per #70's diagnosis: pairing one Criterion process's ~100 internal batch samples as independent trials is pseudo-replication (they share one process's runner-environment state), which is what produced the spurious near-unanimous "fail" run after PR #69.

- `scripts/criterion_gate.sh`: one Criterion **process run** -> one point estimate (median per-iteration time), assembled into **N independent ABBA blocks** (order A,B,B,A or reversed B,A,A,B; geometric mean of each side's 2 runs cancels thermal/frequency drift) -> N independent `{baseline, candidate}` records for `veridict compare --metric sign-test`.
- Workflow: **two-stage screening** (3-block cheap screen; 10-block reversed-order confirmation only for Stage-1 fail candidates -- a benchmark only gates on independent reproduction across both stages, which is this design's multiple-testing correction).
- **Same-binary null control**: main vs itself through the identical pipeline, once per run. If it shows a biased verdict too, every real "fail" that run is downgraded to non-blocking rather than trusted.
- Artifacts (jsonl records + veridict reports per stage, per benchmark) uploaded via `actions/upload-artifact` for post-hoc review.

## What this PR does NOT do (by design)

Per #70's own acceptance criteria, full calibration needs multiple real CI runs over time, not one PR:
- >=10 no-op PRs at 0/10 false-fail rate
- a +5% regression fixture PR (majority detection expected)
- a +10% regression fixture PR (stable fail expected)
- a runner-contamination simulation (must report environment-inconclusive, never a per-benchmark fail)

**Issue #70 stays open** with these as a follow-up calibration checklist. The gate also stays **non-required** in branch protection until calibration passes -- no change to required status checks in this PR. This PR itself will not be merged without explicit approval.

## Local validation (before any CI push)

- `scripts/test_criterion_gate.sh`: unit self-check on the block-pairing/geomean/negate/order-reversal math.
- Same-binary null control run against real compiled benchmarks on this machine: verdict `inconclusive` (not `fail`), effect within noise.
- A large synthetic difference (comparing two genuinely different-cost benchmarks as a stand-in) correctly resolved to `fail` once enough blocks accumulated (5 blocks: still inconclusive; 10 blocks: fail) -- confirms the design isn't just conservative, it can actually detect a real signal.
- Full orchestration (bin-path resolution, stage1 loop, 3-way new/removed-benchmark classification, null control, artifact writes, exit code) dry-run against two symlinked identical checkouts.
- Stage-2 escalation branch (array handling, reversed order, contamination-gating conditional) tested in isolation against real binaries.

## Test plan

- [x] `bash scripts/check.sh` (no Rust changes this PR, trivially green)
- [x] `scripts/test_criterion_gate.sh` passes locally
- [ ] Required checks (Test/Clippy/Format Check/Build Check) green on this PR
- [ ] Criterion gate itself runs without erroring (non-required; its verdict is not evidence of a real regression until calibrated, per standing policy)