### PR TITLE
feat(cip): Milestone 4B-1 phase 1 -- artificial-ancestor digraph root, gated

### DIFF
--- a/crates/chematic-cip/examples/rule4_diagnose.rs
+++ b/crates/chematic-cip/examples/rule4_diagnose.rs
@@ -1,0 +1,359 @@
+//! Milestone 4B-0: mechanically diagnose the 8 `rule4_candidate` rows frozen in
+//! `validation/cip_m4a0_residual.jsonl` (Milestone 4A-0) into CIP Rule 4a / 4b / 4c,
+//! using only `chematic-cip`'s existing public API -- no crate changes. Read-only
+//! diagnostic, same footprint as `residual_report.rs`/`trace_report.rs`.
+//!
+//! Usage: cargo run -p chematic-cip --release --example rule4_diagnose
+//!
+//! For each row, reports:
+//! - the root-level tie shape (which 2 of the 4 physical positions tie, at what depth
+//!   the comparator exhausts Rules 1a/2 into `Equal`)
+//! - Rule 4a: N/A, since `chematic_core::Chirality` has only one non-`None` category
+//!   (tetrahedral) -- there is no "chiral vs pseudoasymmetric vs nonstereogenic unit
+//!   type" distinction this data model can even represent, so a category difference
+//!   between branches is structurally impossible here (checked, not assumed: this is
+//!   a fact about the enum itself, not about these 8 rows specifically).
+//! - Rule 4c: N/A, for the identical structural reason (no axial/planar/m/p
+//!   descriptor variant exists in `Chirality` at all).
+//! - Rule 4b: the load-bearing check. For each of the tied pair's two branches, BFS to
+//!   the *nearest* embedded stereocenter (mirroring
+//!   `assign::nearest_embedded_stereocenter`'s search, re-implemented here since it's
+//!   private to that module) and rank its own `expand_children` output. A clean
+//!   (tie-free) local ranking at that embedded node is the acyclicity evidence: Rules
+//!   1a/2 alone can already order that embedded atom's *forward* branches without
+//!   needing any other tied atom's global/molecular descriptor.
+//!
+//! **What this diagnostic does NOT do**: compute the embedded atom's actual auxiliary
+//! R/S *sign*. That requires representing the "back toward the tied root" direction as
+//! a proper 4th ligand in a digraph rooted so that direction terminates immediately
+//! (an artificial-ancestor root) -- `CipDigraph` has no such constructor today. Closing
+//! that gap is scoped to Milestone 4B-1, not this diagnosis.
+
+use std::collections::HashMap;
+
+use chematic_cip::{
+    CipBudget, CipDigraph, CipNodeKind, CompareContext, NodeId, assign_cip_accurate_experimental,
+    rank_children,
+};
+use chematic_core::{AtomIdx, CipCode, Molecule, STEREO_H_SENTINEL};
+
+/// The 8 `rule4_candidate` rows frozen in `validation/cip_m4a0_residual.jsonl`
+/// (Milestone 4A-0, commit `64f3a38`). Oracle (`modern`) is `S` for all 8.
+const ROWS: &[(&str, u32, &str)] = &[
+    (
+        "O=C(O[C@@H]1C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@@H](OC(=O)c2cc(O)c(O)c(O)c2)[C@H]1OC(=O)c1cc(O)c(O)c(O)c1)c1cc(O)c(O)c(O)c1",
+        5,
+        "tri-galloyl-a",
+    ),
+    (
+        "O=C(O[C@@H]1C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@@H](OC(=O)c2cc(O)c(O)c(O)c2)[C@H]1OC(=O)c1cc(O)c(O)c(O)c1)c1cc(O)c(O)c(O)c1",
+        35,
+        "tri-galloyl-b",
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](O)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        3,
+        "quinic-a",
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](O)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        7,
+        "quinic-b",
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        3,
+        "mono-galloyl-a",
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        7,
+        "mono-galloyl-b",
+    ),
+    (
+        "O=C(Oc1c(O)cc(C(=O)O[C@H]2[C@H](OC(=O)c3cc(O)c(O)c(O)c3)C[C@](O)(C(=O)O)C[C@H]2OC(=O)c2cc(O)c(O)c(O)c2)cc1O)c1cc(O)c(O)c(O)c1",
+        11,
+        "tetra-galloyl-a",
+    ),
+    (
+        "O=C(Oc1c(O)cc(C(=O)O[C@H]2[C@H](OC(=O)c3cc(O)c(O)c(O)c3)C[C@](O)(C(=O)O)C[C@H]2OC(=O)c2cc(O)c(O)c(O)c2)cc1O)c1cc(O)c(O)c(O)c1",
+        26,
+        "tetra-galloyl-b",
+    ),
+];
+
+/// Map `stereo_neighbor_order` positions to root-child `NodeId`s. Local re-derivation
+/// of `assign::position_node_ids` (private to that module) -- unchanged logic.
+fn position_node_ids(
+    graph: &CipDigraph,
+    root_children: &[NodeId],
+    stereo_order: &[u32],
+) -> Option<Vec<NodeId>> {
+    let mut result = Vec::with_capacity(stereo_order.len());
+    for &pos_val in stereo_order {
+        let node_id = if pos_val == STEREO_H_SENTINEL {
+            root_children
+                .iter()
+                .copied()
+                .find(|&id| matches!(graph.node(id).kind, CipNodeKind::ImplicitHydrogen))?
+        } else {
+            let atom_idx = AtomIdx(pos_val);
+            root_children.iter().copied().find(|&id| {
+                matches!(graph.node(id).kind, CipNodeKind::Atom { atom_idx: a } if a == atom_idx)
+            })?
+        };
+        result.push(node_id);
+    }
+    Some(result)
+}
+
+/// BFS, level by level, for the nearest atom with `chirality != None` in `node`'s
+/// subtree. Local re-derivation of `assign::nearest_embedded_stereocenter` (private to
+/// that module) -- unchanged logic. Returns `None` if ambiguous (2+ at the nearest
+/// level) or absent.
+fn nearest_embedded_stereocenter(
+    graph: &mut CipDigraph,
+    mol: &Molecule,
+    node: NodeId,
+) -> Option<AtomIdx> {
+    let mut frontier = vec![node];
+    while !frontier.is_empty() {
+        let mut found_this_level: Option<AtomIdx> = None;
+        let mut next_frontier = Vec::new();
+        for &current in &frontier {
+            if let CipNodeKind::Atom { atom_idx } = graph.node(current).kind
+                && mol.atom(atom_idx).chirality != chematic_core::Chirality::None
+            {
+                match found_this_level {
+                    None => found_this_level = Some(atom_idx),
+                    Some(existing) if existing == atom_idx => {}
+                    Some(_) => return None,
+                }
+            }
+            next_frontier.extend(graph.expand_children(current).ok()?);
+        }
+        if found_this_level.is_some() {
+            return found_this_level;
+        }
+        frontier = next_frontier;
+    }
+    None
+}
+
+struct CaseReport {
+    case_id: String,
+    stereocenter: u32,
+    tied_pair: (u32, u32),
+    tie_depth_note: String,
+    branch_a_embedded: Option<(AtomIdx, bool)>, // (atom, local_children_tie_free)
+    branch_b_embedded: Option<(AtomIdx, bool)>,
+    rule4a: &'static str,
+    rule4c: &'static str,
+    rule4b: String,
+}
+
+fn diagnose_one(smiles: &str, atom_idx: u32, case_id: &str) -> CaseReport {
+    let mol = chematic_smiles::parse(smiles).expect("valid SMILES");
+    let idx = AtomIdx(atom_idx);
+    let budget = CipBudget::default_budget();
+
+    let mut graph = CipDigraph::new(&mol, idx, budget).expect("digraph builds");
+    let root = graph.root();
+    let root_children = graph.expand_children(root).expect("root expands");
+    let stereo_order = mol
+        .stereo_neighbor_order(idx)
+        .expect("stereocenter has stereo_neighbor_order");
+    let position_nodes = position_node_ids(&graph, &root_children, stereo_order)
+        .expect("all 4 physical positions resolve to root children");
+
+    let mut ctx = CompareContext::new();
+    let groups = rank_children(&mut graph, &root_children, &mut ctx).expect("root children rank");
+
+    let position_set: std::collections::HashSet<NodeId> = position_nodes.iter().copied().collect();
+    let mut tied_pair: Option<(NodeId, NodeId)> = None;
+    for group in &groups {
+        let physical: Vec<NodeId> = group
+            .iter()
+            .copied()
+            .filter(|n| position_set.contains(n))
+            .collect();
+        if physical.len() == 2 {
+            tied_pair = Some((physical[0], physical[1]));
+        } else if physical.len() > 2 {
+            panic!("{case_id}: 3+-way physical tie, outside this diagnostic's scope");
+        }
+    }
+    let (pos_a, pos_b) = tied_pair.unwrap_or_else(|| {
+        panic!("{case_id}: expected exactly one 2-way physical tie among root children")
+    });
+
+    let atom_a = match graph.node(pos_a).kind {
+        CipNodeKind::Atom { atom_idx } => atom_idx,
+        _ => panic!("tied position must be a real atom"),
+    };
+    let atom_b = match graph.node(pos_b).kind {
+        CipNodeKind::Atom { atom_idx } => atom_idx,
+        _ => panic!("tied position must be a real atom"),
+    };
+
+    let tie_depth_note = format!(
+        "root's own two ring-branches (toward atom{} and atom{}) tie under Rules 1a/2 -- \
+         confirmed via M4A-0's branch_signature() as genuine constitutional identity, not \
+         a comparator gap",
+        atom_a.0, atom_b.0
+    );
+
+    // Rule 4b evidence: nearest embedded stereocenter per branch, and whether ITS OWN
+    // (parent-excluded) children rank tie-free.
+    let embedded_a = nearest_embedded_stereocenter(&mut graph, &mol, pos_a);
+    let embedded_b = nearest_embedded_stereocenter(&mut graph, &mol, pos_b);
+
+    let check_local_tie_free = |graph: &mut CipDigraph, embedded: Option<AtomIdx>| {
+        embedded.map(|atom| {
+            // Find the embedded atom's own NodeId within this branch (BFS again, since
+            // nearest_embedded_stereocenter only returned the AtomIdx).
+            let node_id = find_node_for_atom(graph, pos_a, pos_b, atom);
+            let children = graph.expand_children(node_id).expect("expands");
+            let mut local_ctx = CompareContext::new();
+            let local_groups =
+                rank_children(graph, &children, &mut local_ctx).expect("local children rank");
+            let tie_free = local_groups.iter().all(|g| g.len() == 1);
+            (atom, tie_free)
+        })
+    };
+
+    let branch_a_embedded = check_local_tie_free(&mut graph, embedded_a);
+    let branch_b_embedded = check_local_tie_free(&mut graph, embedded_b);
+
+    let rule4b = match (branch_a_embedded, branch_b_embedded) {
+        (Some((a, true)), Some((b, true))) => format!(
+            "candidate: nearest embedded stereocenters atom{} (branch toward atom{}) and \
+             atom{} (branch toward atom{}) both rank tie-free locally -- acyclic, a \
+             per-branch auxiliary computation is possible without needing the other tied \
+             atom's global descriptor. Auxiliary R/S *sign* not computed here (needs a \
+             4th-ligand/artificial-ancestor representation -- see module docs; scoped to \
+             M4B-1).",
+            a.0, atom_a.0, b.0, atom_b.0
+        ),
+        _ => "inconclusive: embedded stereocenter ambiguous or tied locally".to_string(),
+    };
+
+    CaseReport {
+        case_id: case_id.to_string(),
+        stereocenter: atom_idx,
+        tied_pair: (atom_a.0, atom_b.0),
+        tie_depth_note,
+        branch_a_embedded,
+        branch_b_embedded,
+        rule4a: "N/A -- chematic_core::Chirality has only one non-None variant family \
+                 (tetrahedral); no chiral/pseudoasymmetric/nonstereogenic unit-type \
+                 distinction exists to compare",
+        rule4c: "N/A -- chematic_core::Chirality has no axial/planar (m/p) or bond \
+                 (seqCis/seqTrans) variant at all; structurally unreachable, not just \
+                 absent from these 8 rows",
+        rule4b,
+    }
+}
+
+/// Re-walk from the tied position toward `target`, returning the `NodeId` for `target`
+/// on whichever of the two branches (`pos_a`/`pos_b`) reaches it nearest -- mirrors
+/// `nearest_embedded_stereocenter`'s own BFS so the returned id is consistent with what
+/// that search found.
+fn find_node_for_atom(
+    graph: &mut CipDigraph,
+    pos_a: NodeId,
+    pos_b: NodeId,
+    target: AtomIdx,
+) -> NodeId {
+    for start in [pos_a, pos_b] {
+        let mut frontier = vec![start];
+        let mut seen: HashMap<AtomIdx, NodeId> = HashMap::new();
+        while !frontier.is_empty() {
+            let mut next_frontier = Vec::new();
+            for current in frontier {
+                if let CipNodeKind::Atom { atom_idx } = graph.node(current).kind {
+                    seen.entry(atom_idx).or_insert(current);
+                    if atom_idx == target {
+                        return current;
+                    }
+                }
+                next_frontier.extend(graph.expand_children(current).unwrap_or_default());
+            }
+            frontier = next_frontier;
+        }
+    }
+    panic!("target atom not found on either branch");
+}
+
+fn main() {
+    println!("Milestone 4B-0: Rule 4 subtype diagnosis (8 rule4_candidate rows)\n");
+
+    let mut oracle_context_printed = false;
+    let mut tie_free_count = 0usize;
+    let mut total_embedded = 0usize;
+
+    for &(smiles, atom_idx, case_id) in ROWS {
+        let report = diagnose_one(smiles, atom_idx, case_id);
+
+        if !oracle_context_printed {
+            let mol = chematic_smiles::parse(smiles).unwrap();
+            let assignment = assign_cip_accurate_experimental(&mol, CipBudget::default_budget())
+                .expect("assignment succeeds");
+            print_reference_categories(case_id, &assignment);
+            oracle_context_printed = true;
+        }
+
+        println!("case_id: {}", report.case_id);
+        println!("  stereocenter: atom{}", report.stereocenter);
+        println!(
+            "  tied ligand pair: atom{} vs atom{}",
+            report.tied_pair.0, report.tied_pair.1
+        );
+        println!(
+            "  first descriptor-bearing sphere: {}",
+            report.tie_depth_note
+        );
+        println!("  Rule 4a result: {}", report.rule4a);
+        println!("  Rule 4c result: {}", report.rule4c);
+        println!("  Rule 4b result: {}", report.rule4b);
+        println!("  earliest deciding subrule: 4b (4a/4c ruled out structurally, see above)");
+        for (label, embedded) in [
+            ("branch A", report.branch_a_embedded),
+            ("branch B", report.branch_b_embedded),
+        ] {
+            total_embedded += 1;
+            match embedded {
+                Some((atom, tie_free)) => {
+                    if tie_free {
+                        tie_free_count += 1;
+                    }
+                    println!(
+                        "    {label}: nearest embedded stereocenter atom{} -- local rank \
+                         tie-free: {tie_free}",
+                        atom.0
+                    );
+                }
+                None => println!("    {label}: no unambiguous nearest embedded stereocenter"),
+            }
+        }
+        println!();
+    }
+
+    println!(
+        "Summary: {tie_free_count}/{total_embedded} embedded-branch local rankings tie-free \
+         (acyclicity evidence). 8/8 rows: Rule 4a N/A, Rule 4c N/A, Rule 4b sole candidate."
+    );
+}
+
+fn print_reference_categories(case_id: &str, assignment: &chematic_cip::AccurateCipAssignment) {
+    let mut resolved: Vec<(u32, CipCode)> = assignment
+        .assignments
+        .iter()
+        .map(|(idx, code)| (idx.0, *code))
+        .collect();
+    resolved.sort_by_key(|(idx, _)| *idx);
+    println!(
+        "reference (case {case_id}): Pass-1/2 resolved codes for non-tied ring \
+         stereocenters (context for Rule 4a's category check): {resolved:?}\n"
+    );
+}

--- a/crates/chematic-cip/examples/rule4b_aux_sign.rs
+++ b/crates/chematic-cip/examples/rule4b_aux_sign.rs
@@ -1,0 +1,426 @@
+//! Milestone 4B-1, gating deliverable: compute each embedded reference stereocenter's
+//! true AUXILIARY R/S sign via [`CipDigraph::new_with_artificial_ancestor`] (new this
+//! milestone -- see `crates/chematic-cip/src/digraph.rs`), then check whether the
+//! simplest Rule-4b-shaped combination (R-precedes-S tie-break on the two branches'
+//! auxiliary references, mirroring Milestone 4A's own Rule 5 convention in
+//! `assign::assign_one_with_rule5`) reproduces the oracle `S` label for all 8
+//! `rule4_candidate` rows (Milestone 4A-0/4B-0).
+//!
+//! This is the go/no-go gate for the rest of Milestone 4B: Milestone 4B-0's diagnosis
+//! confirmed the embedded reference's *local* (parent-excluded) children rank tie-free,
+//! but explicitly could not confirm its auxiliary *sign* without this construct --
+//! which is exactly where a hidden circularity (needing the other tied atom's own
+//! still-unresolved global value) would have to surface, if it exists at all.
+//!
+//! Usage: cargo run -p chematic-cip --release --example rule4b_aux_sign
+
+use std::collections::{HashMap, HashSet};
+
+use chematic_cip::{
+    CipBudget, CipDigraph, CipNodeKind, CompareContext, NodeId, assign_cip_accurate_experimental,
+    rank_children,
+};
+use chematic_core::{AtomIdx, Chirality, CipCode, Molecule, STEREO_H_SENTINEL};
+
+/// Same 8 `rule4_candidate` rows as `examples/rule4_diagnose.rs` (Milestone 4B-0).
+/// Oracle (`modern`) is `S` for all 8.
+const ROWS: &[(&str, u32, &str)] = &[
+    (
+        "O=C(O[C@@H]1C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@@H](OC(=O)c2cc(O)c(O)c(O)c2)[C@H]1OC(=O)c1cc(O)c(O)c(O)c1)c1cc(O)c(O)c(O)c1",
+        5,
+        "tri-galloyl-a",
+    ),
+    (
+        "O=C(O[C@@H]1C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@@H](OC(=O)c2cc(O)c(O)c(O)c2)[C@H]1OC(=O)c1cc(O)c(O)c(O)c1)c1cc(O)c(O)c(O)c1",
+        35,
+        "tri-galloyl-b",
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](O)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        3,
+        "quinic-a",
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](O)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        7,
+        "quinic-b",
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        3,
+        "mono-galloyl-a",
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        7,
+        "mono-galloyl-b",
+    ),
+    (
+        "O=C(Oc1c(O)cc(C(=O)O[C@H]2[C@H](OC(=O)c3cc(O)c(O)c(O)c3)C[C@](O)(C(=O)O)C[C@H]2OC(=O)c2cc(O)c(O)c(O)c2)cc1O)c1cc(O)c(O)c(O)c1",
+        11,
+        "tetra-galloyl-a",
+    ),
+    (
+        "O=C(Oc1c(O)cc(C(=O)O[C@H]2[C@H](OC(=O)c3cc(O)c(O)c(O)c3)C[C@](O)(C(=O)O)C[C@H]2OC(=O)c2cc(O)c(O)c(O)c2)cc1O)c1cc(O)c(O)c(O)c1",
+        26,
+        "tetra-galloyl-b",
+    ),
+];
+
+/// Map `stereo_neighbor_order` positions to root-child `NodeId`s, matching either a
+/// real `Atom` or -- for the artificial-ancestor slot -- a `RingDuplicate` whose
+/// `closure_atom` is the target. Generalizes `assign::position_node_ids` (private to
+/// that module, and written before this milestone's artificial-ancestor construct
+/// existed) to also recognize that duplicate as a valid physical position.
+fn position_node_ids_generalized(
+    graph: &CipDigraph,
+    root_children: &[NodeId],
+    stereo_order: &[u32],
+) -> Option<Vec<NodeId>> {
+    let mut result = Vec::with_capacity(stereo_order.len());
+    for &pos_val in stereo_order {
+        let node_id = if pos_val == STEREO_H_SENTINEL {
+            root_children
+                .iter()
+                .copied()
+                .find(|&id| matches!(graph.node(id).kind, CipNodeKind::ImplicitHydrogen))?
+        } else {
+            let atom_idx = AtomIdx(pos_val);
+            root_children
+                .iter()
+                .copied()
+                .find(|&id| match graph.node(id).kind {
+                    CipNodeKind::Atom { atom_idx: a } => a == atom_idx,
+                    CipNodeKind::RingDuplicate { closure_atom, .. } => closure_atom == atom_idx,
+                    _ => false,
+                })?
+        };
+        result.push(node_id);
+    }
+    Some(result)
+}
+
+/// Identical to `assign::resolve_is_r_from_groups` (private to that module) --
+/// duplicated here rather than exposed, since this is diagnostic/validation code, not
+/// production wiring (Milestone 4B-1's own scope limit).
+fn resolve_is_r_from_groups(
+    groups: &[Vec<NodeId>],
+    position_nodes: &[NodeId],
+    chirality: Chirality,
+) -> Option<bool> {
+    let n = groups.len() as u8;
+    let mut rank_of: HashMap<NodeId, u8> = HashMap::new();
+    for (group_idx, group) in groups.iter().enumerate() {
+        for &node in group {
+            rank_of.insert(node, n - group_idx as u8);
+        }
+    }
+
+    let raw_ranks: Vec<u8> = position_nodes.iter().map(|node| rank_of[node]).collect();
+    let mut distinct_ranks = raw_ranks.clone();
+    distinct_ranks.sort_unstable();
+    distinct_ranks.dedup();
+    let ranks: Vec<u8> = raw_ranks
+        .iter()
+        .map(|&r| distinct_ranks.iter().position(|&x| x == r).unwrap() as u8 + 1)
+        .collect();
+
+    let lowest_pos = ranks.iter().position(|&r| r == 1)?;
+    let parity_odd = lowest_pos % 2 == 1;
+    let smiles_cw = chirality == Chirality::Clockwise;
+    let cw_from_lowest = smiles_cw ^ parity_odd;
+
+    let remaining_ranks: Vec<u8> = (0..4usize)
+        .filter(|&i| i != lowest_pos)
+        .map(|i| ranks[i])
+        .collect();
+    let remaining_swaps_odd = swap_parity(&remaining_ranks)?;
+
+    Some(cw_from_lowest ^ remaining_swaps_odd)
+}
+
+/// Identical to `assign::swap_parity` (private to that module).
+fn swap_parity(remaining_ranks: &[u8]) -> Option<bool> {
+    let mut r = remaining_ranks.to_vec();
+    let target = [2u8, 3, 4];
+    let mut swaps = 0usize;
+    for i in 0..3 {
+        if r[i] != target[i] {
+            let j_rel = r[i + 1..].iter().position(|&x| x == target[i])?;
+            r.swap(i, j_rel + i + 1);
+            swaps += 1;
+        }
+    }
+    Some(swaps % 2 == 1)
+}
+
+/// BFS, level by level, for the nearest atom with `chirality != None` in `start`'s
+/// subtree, returning `(embedded_atom, arrival_atom)` -- `arrival_atom` is the real
+/// atom immediately preceding `embedded_atom` on this specific root-to-node path, i.e.
+/// exactly the atom [`CipDigraph::new_with_artificial_ancestor`] needs as its seed to
+/// reproduce this same branch-local view when rooted fresh at `embedded_atom`. `None`
+/// if ambiguous (2+ distinct atoms at the nearest level) or absent -- mirrors
+/// `assign::nearest_embedded_stereocenter`'s own ambiguity handling.
+fn nearest_embedded_with_arrival(
+    graph: &mut CipDigraph,
+    mol: &Molecule,
+    start: NodeId,
+) -> Option<(AtomIdx, AtomIdx)> {
+    let mut frontier = vec![start];
+    while !frontier.is_empty() {
+        let mut found_this_level: Option<(AtomIdx, NodeId)> = None;
+        let mut next_frontier = Vec::new();
+        for &current in &frontier {
+            if let CipNodeKind::Atom { atom_idx } = graph.node(current).kind
+                && mol.atom(atom_idx).chirality != Chirality::None
+            {
+                match found_this_level {
+                    None => found_this_level = Some((atom_idx, current)),
+                    Some((existing, _)) if existing == atom_idx => {}
+                    Some(_) => return None,
+                }
+            }
+            next_frontier.extend(graph.expand_children(current).ok()?);
+        }
+        if let Some((embedded_atom, node_id)) = found_this_level {
+            let parent_id = graph.node(node_id).parent?;
+            let arrival_atom = match graph.node(parent_id).kind {
+                CipNodeKind::Atom { atom_idx } => atom_idx,
+                _ => return None,
+            };
+            return Some((embedded_atom, arrival_atom));
+        }
+        frontier = next_frontier;
+    }
+    None
+}
+
+fn atom_of(graph: &CipDigraph, node: NodeId) -> AtomIdx {
+    match graph.node(node).kind {
+        CipNodeKind::Atom { atom_idx } => atom_idx,
+        other => panic!("expected a physical Atom node, got {other:?}"),
+    }
+}
+
+/// The embedded reference atom's true auxiliary R/S sign, computed via a fresh
+/// [`CipDigraph::new_with_artificial_ancestor`] root -- `Some(true)` = R, `Some(false)`
+/// = S, `None` if the auxiliary digraph itself can't resolve it (still tied, or budget
+/// exceeded).
+fn auxiliary_sign(
+    mol: &Molecule,
+    embedded_atom: AtomIdx,
+    arrival_atom: AtomIdx,
+    budget: CipBudget,
+) -> Option<bool> {
+    let mut graph =
+        CipDigraph::new_with_artificial_ancestor(mol, embedded_atom, arrival_atom, budget).ok()?;
+    let root = graph.root();
+    let root_children = graph.expand_children(root).ok()?;
+    let stereo_order = mol.stereo_neighbor_order(embedded_atom)?;
+    let position_nodes = position_node_ids_generalized(&graph, &root_children, stereo_order)?;
+    let mut ctx = CompareContext::new();
+    let groups = rank_children(&mut graph, &root_children, &mut ctx).ok()?;
+    resolve_is_r_from_groups(&groups, &position_nodes, mol.atom(embedded_atom).chirality)
+}
+
+struct RowResult {
+    case_id: String,
+    stereocenter: u32,
+    tied_pair: (u32, u32),
+    embedded_a: Option<(AtomIdx, AtomIdx, Option<bool>)>,
+    embedded_b: Option<(AtomIdx, AtomIdx, Option<bool>)>,
+    global_a: Option<CipCode>,
+    global_b: Option<CipCode>,
+    predicted: Option<CipCode>,
+}
+
+fn diagnose_and_resolve(smiles: &str, atom_idx: u32, case_id: &str) -> RowResult {
+    let mol = chematic_smiles::parse(smiles).expect("valid SMILES");
+    let idx = AtomIdx(atom_idx);
+    let budget = CipBudget::default_budget();
+
+    let assignment = assign_cip_accurate_experimental(&mol, budget)
+        .expect("Pass-1/2 assignment succeeds (for the reference global codes only)");
+    let global: HashMap<AtomIdx, CipCode> = assignment.assignments.into_iter().collect();
+
+    let mut graph = CipDigraph::new(&mol, idx, budget).expect("digraph builds");
+    let root = graph.root();
+    let root_children = graph.expand_children(root).expect("root expands");
+    let stereo_order = mol
+        .stereo_neighbor_order(idx)
+        .expect("stereocenter has stereo_neighbor_order");
+    let position_nodes = position_node_ids_generalized(&graph, &root_children, stereo_order)
+        .expect("all 4 physical positions resolve to root children");
+
+    let mut ctx = CompareContext::new();
+    let groups = rank_children(&mut graph, &root_children, &mut ctx).expect("root children rank");
+
+    let position_set: HashSet<NodeId> = position_nodes.iter().copied().collect();
+    let mut tied_group_idx = None;
+    let mut tied_pair_nodes = None;
+    for (gi, group) in groups.iter().enumerate() {
+        let physical: Vec<NodeId> = group
+            .iter()
+            .copied()
+            .filter(|n| position_set.contains(n))
+            .collect();
+        if physical.len() == 2 {
+            tied_group_idx = Some(gi);
+            tied_pair_nodes = Some((physical[0], physical[1]));
+        } else if physical.len() > 2 {
+            panic!("{case_id}: 3+-way physical tie, outside this validation's scope");
+        }
+    }
+    let tied_group_idx =
+        tied_group_idx.unwrap_or_else(|| panic!("{case_id}: expected exactly one physical tie"));
+    let (pos_a, pos_b) = tied_pair_nodes.unwrap();
+    let atom_a = atom_of(&graph, pos_a);
+    let atom_b = atom_of(&graph, pos_b);
+
+    let embedded_a_ids = nearest_embedded_with_arrival(&mut graph, &mol, pos_a);
+    let embedded_b_ids = nearest_embedded_with_arrival(&mut graph, &mol, pos_b);
+
+    let embedded_a = embedded_a_ids.map(|(embedded, arrival)| {
+        (
+            embedded,
+            arrival,
+            auxiliary_sign(&mol, embedded, arrival, budget),
+        )
+    });
+    let embedded_b = embedded_b_ids.map(|(embedded, arrival)| {
+        (
+            embedded,
+            arrival,
+            auxiliary_sign(&mol, embedded, arrival, budget),
+        )
+    });
+
+    let global_a = embedded_a_ids.and_then(|(e, _)| global.get(&e).copied());
+    let global_b = embedded_b_ids.and_then(|(e, _)| global.get(&e).copied());
+
+    // Candidate Rule-4b-shaped combination: R precedes S on the two branches'
+    // auxiliary references (mirrors Rule 5's own tie-break convention in
+    // `assign::assign_one_with_rule5`). Only distinguishing if the two auxiliary
+    // signs actually differ -- if they match, this convention has no discriminating
+    // power and the row is left unpredicted rather than guessed.
+    let aux_a = embedded_a.and_then(|(_, _, s)| s);
+    let aux_b = embedded_b.and_then(|(_, _, s)| s);
+    let predicted = match (aux_a, aux_b) {
+        (Some(ra), Some(rb)) if ra != rb => {
+            let (higher, lower) = if ra { (pos_a, pos_b) } else { (pos_b, pos_a) };
+            let mut resolved_groups: Vec<Vec<NodeId>> = Vec::with_capacity(groups.len() + 1);
+            for (gi, group) in groups.iter().enumerate() {
+                if gi == tied_group_idx {
+                    resolved_groups.push(vec![higher]);
+                    let mut lower_group = vec![lower];
+                    lower_group
+                        .extend(group.iter().copied().filter(|&n| n != higher && n != lower));
+                    resolved_groups.push(lower_group);
+                } else {
+                    resolved_groups.push(group.clone());
+                }
+            }
+            resolve_is_r_from_groups(&resolved_groups, &position_nodes, mol.atom(idx).chirality)
+                .map(|is_r| if is_r { CipCode::R } else { CipCode::S })
+        }
+        _ => None,
+    };
+
+    let _ = (atom_a, atom_b); // used only via tied_pair below
+
+    RowResult {
+        case_id: case_id.to_string(),
+        stereocenter: atom_idx,
+        tied_pair: (atom_a.0, atom_b.0),
+        embedded_a,
+        embedded_b,
+        global_a,
+        global_b,
+        predicted,
+    }
+}
+
+fn code_str(code: Option<CipCode>) -> String {
+    match code {
+        Some(CipCode::R) => "R".to_string(),
+        Some(CipCode::S) => "S".to_string(),
+        Some(CipCode::LowerR) => "r".to_string(),
+        Some(CipCode::LowerS) => "s".to_string(),
+        Some(CipCode::E) => "E".to_string(),
+        Some(CipCode::Z) => "Z".to_string(),
+        None => "?".to_string(),
+    }
+}
+
+fn aux_str(sign: Option<bool>) -> &'static str {
+    match sign {
+        Some(true) => "R",
+        Some(false) => "S",
+        None => "?",
+    }
+}
+
+fn main() {
+    println!("Milestone 4B-1 gate: auxiliary-sign construct vs oracle (8 rule4_candidate rows)\n");
+
+    let mut matched = 0usize;
+    let mut mismatched = 0usize;
+    let mut inconclusive = 0usize;
+
+    for &(smiles, atom_idx, case_id) in ROWS {
+        let r = diagnose_and_resolve(smiles, atom_idx, case_id);
+
+        println!("case_id: {}", r.case_id);
+        println!("  stereocenter: atom{}", r.stereocenter);
+        println!(
+            "  tied ligand pair: atom{} vs atom{}",
+            r.tied_pair.0, r.tied_pair.1
+        );
+        if let Some((embedded, arrival, sign)) = r.embedded_a {
+            println!(
+                "  branch A: embedded atom{} (arrival atom{}) -- auxiliary sign: {}, \
+                 global (Pass-1) code: {}",
+                embedded.0,
+                arrival.0,
+                aux_str(sign),
+                code_str(r.global_a)
+            );
+        }
+        if let Some((embedded, arrival, sign)) = r.embedded_b {
+            println!(
+                "  branch B: embedded atom{} (arrival atom{}) -- auxiliary sign: {}, \
+                 global (Pass-1) code: {}",
+                embedded.0,
+                arrival.0,
+                aux_str(sign),
+                code_str(r.global_b)
+            );
+        }
+        match r.predicted {
+            Some(CipCode::S) => {
+                matched += 1;
+                println!("  predicted: S -- MATCHES oracle (S)");
+            }
+            Some(other) => {
+                mismatched += 1;
+                println!(
+                    "  predicted: {} -- MISMATCHES oracle (S)",
+                    code_str(Some(other))
+                );
+            }
+            None => {
+                inconclusive += 1;
+                println!(
+                    "  predicted: inconclusive (auxiliary signs did not distinguish the \
+                     two branches, or one side unresolved)"
+                );
+            }
+        }
+        println!();
+    }
+
+    println!(
+        "Summary: {matched}/8 matched oracle, {mismatched}/8 mismatched, {inconclusive}/8 \
+         inconclusive."
+    );
+}

--- a/crates/chematic-cip/examples/rule4b_like_unlike_gate.rs
+++ b/crates/chematic-cip/examples/rule4b_like_unlike_gate.rs
@@ -1,0 +1,443 @@
+//! Milestone 4B-2, pre-implementation instrumentation: resolve a real contradiction
+//! before writing any production code. `rule4b_pair_sequence.rs`'s empirical "S
+//! precedes R" tie-break (8/8 vs oracle) is flagged by the user as likely a
+//! coincidental overfit to this 8-row family, not the true Rule 4b mechanism -- the
+//! real rule is reference-relative: choose a reference `DescriptorFamily` (majority at
+//! the first descriptor-bearing level), convert each branch's sequence to Like/Unlike
+//! relative to that reference, and Like precedes Unlike (never an absolute S>R or
+//! R>S).
+//!
+//! Hand-tracing this predicts a *disagreement* on the 4 rows whose shared position-0
+//! value is `R` (Like there = R, so a faithful Like/Unlike ranks the R-branch higher,
+//! opposite of the empirical "S precedes R" rule) -- meaning if "S precedes R"
+//! genuinely reproduces oracle 8/8, a faithful Like/Unlike implementation, fed through
+//! the exact same `resolve_is_r_from_groups` parity mapping, should only get 4/8.
+//! Rather than trust that hand-trace, this script prints both mappings' predicted
+//! final label side by side against the oracle for all 8 rows, settling which mapping
+//! (and which orientation) is actually correct by direct instrumentation.
+//!
+//! Usage: cargo run -p chematic-cip --release --example rule4b_like_unlike_gate
+
+use std::collections::{HashMap, HashSet};
+
+use chematic_cip::{CipBudget, CipDigraph, CipNodeKind, CompareContext, NodeId, rank_children};
+use chematic_core::{AtomIdx, Chirality, CipCode, Molecule, STEREO_H_SENTINEL};
+
+const ROWS: &[(&str, u32, &str)] = &[
+    (
+        "O=C(O[C@@H]1C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@@H](OC(=O)c2cc(O)c(O)c(O)c2)[C@H]1OC(=O)c1cc(O)c(O)c(O)c1)c1cc(O)c(O)c(O)c1",
+        5,
+        "tri-galloyl-a",
+    ),
+    (
+        "O=C(O[C@@H]1C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@@H](OC(=O)c2cc(O)c(O)c(O)c2)[C@H]1OC(=O)c1cc(O)c(O)c(O)c1)c1cc(O)c(O)c(O)c1",
+        35,
+        "tri-galloyl-b",
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](O)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        3,
+        "quinic-a",
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](O)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        7,
+        "quinic-b",
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        3,
+        "mono-galloyl-a",
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        7,
+        "mono-galloyl-b",
+    ),
+    (
+        "O=C(Oc1c(O)cc(C(=O)O[C@H]2[C@H](OC(=O)c3cc(O)c(O)c(O)c3)C[C@](O)(C(=O)O)C[C@H]2OC(=O)c2cc(O)c(O)c(O)c2)cc1O)c1cc(O)c(O)c(O)c1",
+        11,
+        "tetra-galloyl-a",
+    ),
+    (
+        "O=C(Oc1c(O)cc(C(=O)O[C@H]2[C@H](OC(=O)c3cc(O)c(O)c(O)c3)C[C@](O)(C(=O)O)C[C@H]2OC(=O)c2cc(O)c(O)c(O)c2)cc1O)c1cc(O)c(O)c(O)c1",
+        26,
+        "tetra-galloyl-b",
+    ),
+];
+
+const MAX_PAIR_DEPTH: usize = 4;
+
+fn position_node_ids_generalized(
+    graph: &CipDigraph,
+    root_children: &[NodeId],
+    stereo_order: &[u32],
+) -> Option<Vec<NodeId>> {
+    let mut result = Vec::with_capacity(stereo_order.len());
+    for &pos_val in stereo_order {
+        let node_id = if pos_val == STEREO_H_SENTINEL {
+            root_children
+                .iter()
+                .copied()
+                .find(|&id| matches!(graph.node(id).kind, CipNodeKind::ImplicitHydrogen))?
+        } else {
+            let atom_idx = AtomIdx(pos_val);
+            root_children
+                .iter()
+                .copied()
+                .find(|&id| match graph.node(id).kind {
+                    CipNodeKind::Atom { atom_idx: a } => a == atom_idx,
+                    CipNodeKind::RingDuplicate { closure_atom, .. } => closure_atom == atom_idx,
+                    _ => false,
+                })?
+        };
+        result.push(node_id);
+    }
+    Some(result)
+}
+
+fn resolve_is_r_from_groups(
+    groups: &[Vec<NodeId>],
+    position_nodes: &[NodeId],
+    chirality: Chirality,
+) -> Option<bool> {
+    let n = groups.len() as u8;
+    let mut rank_of: HashMap<NodeId, u8> = HashMap::new();
+    for (group_idx, group) in groups.iter().enumerate() {
+        for &node in group {
+            rank_of.insert(node, n - group_idx as u8);
+        }
+    }
+    let raw_ranks: Vec<u8> = position_nodes.iter().map(|node| rank_of[node]).collect();
+    let mut distinct_ranks = raw_ranks.clone();
+    distinct_ranks.sort_unstable();
+    distinct_ranks.dedup();
+    let ranks: Vec<u8> = raw_ranks
+        .iter()
+        .map(|&r| distinct_ranks.iter().position(|&x| x == r).unwrap() as u8 + 1)
+        .collect();
+    let lowest_pos = ranks.iter().position(|&r| r == 1)?;
+    let parity_odd = lowest_pos % 2 == 1;
+    let smiles_cw = chirality == Chirality::Clockwise;
+    let cw_from_lowest = smiles_cw ^ parity_odd;
+    let remaining_ranks: Vec<u8> = (0..4usize)
+        .filter(|&i| i != lowest_pos)
+        .map(|i| ranks[i])
+        .collect();
+    let remaining_swaps_odd = swap_parity(&remaining_ranks)?;
+    Some(cw_from_lowest ^ remaining_swaps_odd)
+}
+
+fn swap_parity(remaining_ranks: &[u8]) -> Option<bool> {
+    let mut r = remaining_ranks.to_vec();
+    let target = [2u8, 3, 4];
+    let mut swaps = 0usize;
+    for i in 0..3 {
+        if r[i] != target[i] {
+            let j_rel = r[i + 1..].iter().position(|&x| x == target[i])?;
+            r.swap(i, j_rel + i + 1);
+            swaps += 1;
+        }
+    }
+    Some(swaps % 2 == 1)
+}
+
+fn search_nearest_embedded(
+    graph: &mut CipDigraph,
+    mol: &Molecule,
+    frontier: Vec<NodeId>,
+) -> Option<(AtomIdx, AtomIdx, NodeId)> {
+    let mut frontier = frontier;
+    while !frontier.is_empty() {
+        let mut found_this_level: Option<(AtomIdx, NodeId)> = None;
+        let mut next_frontier = Vec::new();
+        for &current in &frontier {
+            if let CipNodeKind::Atom { atom_idx } = graph.node(current).kind
+                && mol.atom(atom_idx).chirality != Chirality::None
+            {
+                match found_this_level {
+                    None => found_this_level = Some((atom_idx, current)),
+                    Some((existing, _)) if existing == atom_idx => {}
+                    Some(_) => return None,
+                }
+            }
+            next_frontier.extend(graph.expand_children(current).ok()?);
+        }
+        if let Some((embedded_atom, node_id)) = found_this_level {
+            let parent_id = graph.node(node_id).parent?;
+            let arrival_atom = match graph.node(parent_id).kind {
+                CipNodeKind::Atom { atom_idx } => atom_idx,
+                _ => return None,
+            };
+            return Some((embedded_atom, arrival_atom, node_id));
+        }
+        frontier = next_frontier;
+    }
+    None
+}
+
+fn embedded_reference_chain(
+    graph: &mut CipDigraph,
+    mol: &Molecule,
+    start: NodeId,
+) -> Vec<(AtomIdx, AtomIdx)> {
+    let mut chain = Vec::new();
+    let mut frontier = vec![start];
+    for _ in 0..MAX_PAIR_DEPTH {
+        let Some((embedded_atom, arrival_atom, node_id)) =
+            search_nearest_embedded(graph, mol, frontier)
+        else {
+            break;
+        };
+        chain.push((embedded_atom, arrival_atom));
+        frontier = match graph.expand_children(node_id) {
+            Ok(children) => children,
+            Err(_) => break,
+        };
+    }
+    chain
+}
+
+fn auxiliary_sign(
+    mol: &Molecule,
+    embedded_atom: AtomIdx,
+    arrival_atom: AtomIdx,
+    budget: CipBudget,
+) -> Option<bool> {
+    let mut graph =
+        CipDigraph::new_with_artificial_ancestor(mol, embedded_atom, arrival_atom, budget).ok()?;
+    let root = graph.root();
+    let root_children = graph.expand_children(root).ok()?;
+    let stereo_order = mol.stereo_neighbor_order(embedded_atom)?;
+    let position_nodes = position_node_ids_generalized(&graph, &root_children, stereo_order)?;
+    let mut ctx = CompareContext::new();
+    let groups = rank_children(&mut graph, &root_children, &mut ctx).ok()?;
+    resolve_is_r_from_groups(&groups, &position_nodes, mol.atom(embedded_atom).chirality)
+}
+
+/// Mirror a SMILES string: swap every `@` <-> `@@` tetrahedral tag, textually. A
+/// well-defined, purely mechanical transformation (no RDKit needed) -- the resulting
+/// molecule is the enantiomer of the input, so CIP theory *guarantees* every
+/// stereocenter's oracle label flips (S<->R) uniformly, without needing to look the
+/// mirrored oracle up. This is what makes the inversion test decisive without a fresh
+/// RDKit run: the mirrored oracle is derived, not measured.
+fn mirror_smiles(smiles: &str) -> String {
+    const PLACEHOLDER: char = '\u{0}';
+    smiles
+        .replace("@@", &PLACEHOLDER.to_string())
+        .replace('@', "@@")
+        .replace(PLACEHOLDER, "@")
+}
+
+/// One of 4 candidate conventions for turning a deciding-position pair
+/// `(branch_a_is_r, branch_b_is_r, reference_is_r)` into which branch (A or B) should
+/// be treated as higher priority -- brute-forced rather than hand-derived, since two
+/// prior hand-derivations in this exact investigation were wrong.
+#[derive(Debug, Clone, Copy)]
+#[allow(clippy::enum_variant_names)]
+enum Convention {
+    /// Branch matching the (position-0-shared) reference wins.
+    LikeWinsSharedRef,
+    /// Branch NOT matching the (position-0-shared) reference wins.
+    UnlikeWinsSharedRef,
+    /// Branch matching the OPPOSITE of the position-0-shared value wins.
+    LikeWinsOppositeRef,
+    /// Branch NOT matching the opposite-of-shared value wins (= matches shared value).
+    UnlikeWinsOppositeRef,
+}
+
+const CONVENTIONS: [Convention; 4] = [
+    Convention::LikeWinsSharedRef,
+    Convention::UnlikeWinsSharedRef,
+    Convention::LikeWinsOppositeRef,
+    Convention::UnlikeWinsOppositeRef,
+];
+
+fn higher_branch(
+    convention: Convention,
+    ra: bool,
+    reference_is_r: bool,
+    pos_a: NodeId,
+    pos_b: NodeId,
+) -> (NodeId, NodeId) {
+    let effective_ref = match convention {
+        Convention::LikeWinsSharedRef | Convention::UnlikeWinsSharedRef => reference_is_r,
+        Convention::LikeWinsOppositeRef | Convention::UnlikeWinsOppositeRef => !reference_is_r,
+    };
+    let a_matches = ra == effective_ref;
+    let a_wins = match convention {
+        Convention::LikeWinsSharedRef | Convention::LikeWinsOppositeRef => a_matches,
+        Convention::UnlikeWinsSharedRef | Convention::UnlikeWinsOppositeRef => !a_matches,
+    };
+    if a_wins {
+        (pos_a, pos_b)
+    } else {
+        (pos_b, pos_a)
+    }
+}
+
+fn run_gate(
+    smiles: &str,
+    atom_idx: u32,
+    case_id: &str,
+    oracle: CipCode,
+) -> HashMap<&'static str, Option<CipCode>> {
+    let mol = chematic_smiles::parse(smiles).expect("valid SMILES");
+    let idx = AtomIdx(atom_idx);
+    let budget = CipBudget::default_budget();
+
+    let mut graph = CipDigraph::new(&mol, idx, budget).expect("digraph builds");
+    let root = graph.root();
+    let root_children = graph.expand_children(root).expect("root expands");
+    let stereo_order = mol
+        .stereo_neighbor_order(idx)
+        .expect("has stereo_neighbor_order");
+    let position_nodes = position_node_ids_generalized(&graph, &root_children, stereo_order)
+        .expect("all 4 physical positions resolve");
+
+    let mut ctx = CompareContext::new();
+    let groups = rank_children(&mut graph, &root_children, &mut ctx).expect("root children rank");
+
+    let position_set: HashSet<NodeId> = position_nodes.iter().copied().collect();
+    let mut tied_group_idx = None;
+    let mut tied_pair_nodes = None;
+    for (gi, group) in groups.iter().enumerate() {
+        let physical: Vec<NodeId> = group
+            .iter()
+            .copied()
+            .filter(|n| position_set.contains(n))
+            .collect();
+        if physical.len() == 2 {
+            tied_group_idx = Some(gi);
+            tied_pair_nodes = Some((physical[0], physical[1]));
+        }
+    }
+    let tied_group_idx = tied_group_idx.expect("expected exactly one physical tie");
+    let (pos_a, pos_b) = tied_pair_nodes.unwrap();
+
+    let chain_a_atoms = embedded_reference_chain(&mut graph, &mol, pos_a);
+    let chain_b_atoms = embedded_reference_chain(&mut graph, &mol, pos_b);
+    let chain_a: Vec<Option<bool>> = chain_a_atoms
+        .iter()
+        .map(|&(e, a)| auxiliary_sign(&mol, e, a, budget))
+        .collect();
+    let chain_b: Vec<Option<bool>> = chain_b_atoms
+        .iter()
+        .map(|&(e, a)| auxiliary_sign(&mol, e, a, budget))
+        .collect();
+
+    let reference_is_r = match (
+        chain_a.first().copied().flatten(),
+        chain_b.first().copied().flatten(),
+    ) {
+        (Some(ra), Some(rb)) if ra == rb => ra,
+        _ => {
+            println!("{case_id}: reference ambiguous/unavailable, skipping");
+            return HashMap::new();
+        }
+    };
+
+    let mut deciding: Option<(bool, bool)> = None; // (ra, rb) at the first differing position
+    for i in 0..chain_a.len().min(chain_b.len()) {
+        let (Some(ra), Some(rb)) = (chain_a[i], chain_b[i]) else {
+            break;
+        };
+        if ra != rb {
+            deciding = Some((ra, rb));
+            break;
+        }
+    }
+
+    let predict = |higher: NodeId, lower: NodeId| -> Option<CipCode> {
+        let mut resolved_groups: Vec<Vec<NodeId>> = Vec::with_capacity(groups.len() + 1);
+        for (gi, group) in groups.iter().enumerate() {
+            if gi == tied_group_idx {
+                resolved_groups.push(vec![higher]);
+                let mut lower_group = vec![lower];
+                lower_group.extend(group.iter().copied().filter(|&n| n != higher && n != lower));
+                resolved_groups.push(lower_group);
+            } else {
+                resolved_groups.push(group.clone());
+            }
+        }
+        resolve_is_r_from_groups(&resolved_groups, &position_nodes, mol.atom(idx).chirality)
+            .map(|is_r| if is_r { CipCode::R } else { CipCode::S })
+    };
+
+    let mut results = HashMap::new();
+    let Some((ra, _rb)) = deciding else {
+        println!("{case_id}: no deciding position found");
+        return results;
+    };
+    let names = [
+        "LikeWinsSharedRef",
+        "UnlikeWinsSharedRef",
+        "LikeWinsOppositeRef",
+        "UnlikeWinsOppositeRef",
+    ];
+    print!("  {case_id}: oracle={oracle:?} ");
+    for (conv, name) in CONVENTIONS.iter().zip(names.iter()) {
+        let (higher, lower) = higher_branch(*conv, ra, reference_is_r, pos_a, pos_b);
+        let pred = predict(higher, lower);
+        results.insert(*name, pred);
+        print!(
+            " {name}={}",
+            pred.map(|c| format!("{c:?}")).unwrap_or_else(|| "?".into())
+        );
+    }
+    println!();
+    results
+}
+
+fn main() {
+    println!(
+        "Milestone 4B-2 pre-implementation gate: Like/Unlike (reference-relative) vs \
+         S>R (absolute, empirical) -- side by side against oracle, then the decisive \
+         check: same two mechanisms on each molecule's ENANTIOMER (every @/@@ flipped),\n\
+         whose oracle label is *derived*, not measured: mirroring a molecule inverts \
+         every stereocenter's CIP label, always -- so the mirrored oracle is R for all \
+         8 rows.\n"
+    );
+
+    let names = [
+        "LikeWinsSharedRef",
+        "UnlikeWinsSharedRef",
+        "LikeWinsOppositeRef",
+        "UnlikeWinsOppositeRef",
+    ];
+    let mut orig_scores: HashMap<&str, usize> = HashMap::new();
+    let mut mirror_scores: HashMap<&str, usize> = HashMap::new();
+
+    println!("-- original molecules (oracle = S for all 8) --");
+    for &(smiles, atom_idx, case_id) in ROWS {
+        let results = run_gate(smiles, atom_idx, case_id, CipCode::S);
+        for name in names {
+            if results.get(name).copied().flatten() == Some(CipCode::S) {
+                *orig_scores.entry(name).or_insert(0) += 1;
+            }
+        }
+    }
+    println!("-- mirrored molecules (derived oracle = R for all 8) --");
+    for &(smiles, atom_idx, case_id) in ROWS {
+        let mirrored = mirror_smiles(smiles);
+        let results = run_gate(&mirrored, atom_idx, case_id, CipCode::R);
+        for name in names {
+            if results.get(name).copied().flatten() == Some(CipCode::R) {
+                *mirror_scores.entry(name).or_insert(0) += 1;
+            }
+        }
+    }
+
+    println!("\nSummary (original/8, mirrored/8):");
+    for name in names {
+        println!(
+            "  {name}: {}/8, {}/8",
+            orig_scores.get(name).copied().unwrap_or(0),
+            mirror_scores.get(name).copied().unwrap_or(0)
+        );
+    }
+    println!(
+        "\nA correct, invariant convention scores 8/8 on BOTH lines. 4/4 (mid) is \
+         invariant but still wrong; 8/0 or 0/8 is the absolute-rule failure mode."
+    );
+}

--- a/crates/chematic-cip/examples/rule4b_pair_sequence.rs
+++ b/crates/chematic-cip/examples/rule4b_pair_sequence.rs
@@ -1,0 +1,418 @@
+//! Milestone 4B-1, phase 2: extends `rule4b_aux_sign.rs`'s single-reference gate (which
+//! found 0/8 discriminating -- both branches' *first* embedded reference always carries
+//! the same auxiliary sign) to a genuine ordered *sequence* of paired auxiliary
+//! descriptors per branch, one level deeper each step via
+//! [`CipDigraph::new_with_artificial_ancestor`].
+//!
+//! **Result: 8/8 match the oracle.** At the first sequence position where the two
+//! branches' auxiliary signs differ, S precedes R decides the outer tied atom's own
+//! R/S -- note the orientation: this is the *opposite* convention from
+//! `assign::assign_one_with_rule5`'s "R precedes S" (Rule 5 compares an outer atom's
+//! own resolution directly against 2 embedded references at a single position; this is
+//! a different comparison -- the first *differing* position in a nested pair
+//! sequence -- and empirically needs the opposite orientation to reproduce the
+//! oracle). Found by trying "R precedes S" first (uniform 8/8 wrong-direction
+//! mismatch, all at sequence position 1) and then testing the flipped orientation,
+//! not assumed from either convention.
+//!
+//! This is still a diagnostic/validation script, not production wiring -- the natural
+//! next step, if this direction is confirmed to generalize, is a real
+//! `DescriptorPairList`-shaped implementation wired into `assign.rs` (Milestone 4B-2),
+//! not this script itself.
+//!
+//! Usage: cargo run -p chematic-cip --release --example rule4b_pair_sequence
+
+use std::collections::{HashMap, HashSet};
+
+use chematic_cip::{CipBudget, CipDigraph, CipNodeKind, CompareContext, NodeId, rank_children};
+use chematic_core::{AtomIdx, Chirality, CipCode, Molecule, STEREO_H_SENTINEL};
+
+/// Same 8 `rule4_candidate` rows as `examples/rule4_diagnose.rs`/`rule4b_aux_sign.rs`.
+/// Oracle (`modern`) is `S` for all 8.
+const ROWS: &[(&str, u32, &str)] = &[
+    (
+        "O=C(O[C@@H]1C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@@H](OC(=O)c2cc(O)c(O)c(O)c2)[C@H]1OC(=O)c1cc(O)c(O)c(O)c1)c1cc(O)c(O)c(O)c1",
+        5,
+        "tri-galloyl-a",
+    ),
+    (
+        "O=C(O[C@@H]1C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@@H](OC(=O)c2cc(O)c(O)c(O)c2)[C@H]1OC(=O)c1cc(O)c(O)c(O)c1)c1cc(O)c(O)c(O)c1",
+        35,
+        "tri-galloyl-b",
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](O)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        3,
+        "quinic-a",
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](O)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        7,
+        "quinic-b",
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        3,
+        "mono-galloyl-a",
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        7,
+        "mono-galloyl-b",
+    ),
+    (
+        "O=C(Oc1c(O)cc(C(=O)O[C@H]2[C@H](OC(=O)c3cc(O)c(O)c(O)c3)C[C@](O)(C(=O)O)C[C@H]2OC(=O)c2cc(O)c(O)c(O)c2)cc1O)c1cc(O)c(O)c(O)c1",
+        11,
+        "tetra-galloyl-a",
+    ),
+    (
+        "O=C(Oc1c(O)cc(C(=O)O[C@H]2[C@H](OC(=O)c3cc(O)c(O)c(O)c3)C[C@](O)(C(=O)O)C[C@H]2OC(=O)c2cc(O)c(O)c(O)c2)cc1O)c1cc(O)c(O)c(O)c1",
+        26,
+        "tetra-galloyl-b",
+    ),
+];
+
+const MAX_PAIR_DEPTH: usize = 4;
+
+fn position_node_ids_generalized(
+    graph: &CipDigraph,
+    root_children: &[NodeId],
+    stereo_order: &[u32],
+) -> Option<Vec<NodeId>> {
+    let mut result = Vec::with_capacity(stereo_order.len());
+    for &pos_val in stereo_order {
+        let node_id = if pos_val == STEREO_H_SENTINEL {
+            root_children
+                .iter()
+                .copied()
+                .find(|&id| matches!(graph.node(id).kind, CipNodeKind::ImplicitHydrogen))?
+        } else {
+            let atom_idx = AtomIdx(pos_val);
+            root_children
+                .iter()
+                .copied()
+                .find(|&id| match graph.node(id).kind {
+                    CipNodeKind::Atom { atom_idx: a } => a == atom_idx,
+                    CipNodeKind::RingDuplicate { closure_atom, .. } => closure_atom == atom_idx,
+                    _ => false,
+                })?
+        };
+        result.push(node_id);
+    }
+    Some(result)
+}
+
+fn resolve_is_r_from_groups(
+    groups: &[Vec<NodeId>],
+    position_nodes: &[NodeId],
+    chirality: Chirality,
+) -> Option<bool> {
+    let n = groups.len() as u8;
+    let mut rank_of: HashMap<NodeId, u8> = HashMap::new();
+    for (group_idx, group) in groups.iter().enumerate() {
+        for &node in group {
+            rank_of.insert(node, n - group_idx as u8);
+        }
+    }
+
+    let raw_ranks: Vec<u8> = position_nodes.iter().map(|node| rank_of[node]).collect();
+    let mut distinct_ranks = raw_ranks.clone();
+    distinct_ranks.sort_unstable();
+    distinct_ranks.dedup();
+    let ranks: Vec<u8> = raw_ranks
+        .iter()
+        .map(|&r| distinct_ranks.iter().position(|&x| x == r).unwrap() as u8 + 1)
+        .collect();
+
+    let lowest_pos = ranks.iter().position(|&r| r == 1)?;
+    let parity_odd = lowest_pos % 2 == 1;
+    let smiles_cw = chirality == Chirality::Clockwise;
+    let cw_from_lowest = smiles_cw ^ parity_odd;
+
+    let remaining_ranks: Vec<u8> = (0..4usize)
+        .filter(|&i| i != lowest_pos)
+        .map(|i| ranks[i])
+        .collect();
+    let remaining_swaps_odd = swap_parity(&remaining_ranks)?;
+
+    Some(cw_from_lowest ^ remaining_swaps_odd)
+}
+
+fn swap_parity(remaining_ranks: &[u8]) -> Option<bool> {
+    let mut r = remaining_ranks.to_vec();
+    let target = [2u8, 3, 4];
+    let mut swaps = 0usize;
+    for i in 0..3 {
+        if r[i] != target[i] {
+            let j_rel = r[i + 1..].iter().position(|&x| x == target[i])?;
+            r.swap(i, j_rel + i + 1);
+            swaps += 1;
+        }
+    }
+    Some(swaps % 2 == 1)
+}
+
+/// Search `frontier` outward, level by level, for the nearest atom with
+/// `chirality != None`. Returns `(embedded_atom, arrival_atom, node_id)` --
+/// `arrival_atom` is the real atom immediately preceding it on this path (the seed
+/// [`CipDigraph::new_with_artificial_ancestor`] needs), `node_id` is its own position
+/// in `graph` (so the caller can continue the search *beyond* it via
+/// [`CipDigraph::expand_children`]). `None` if ambiguous (2+ distinct atoms at the
+/// nearest level) or the frontier is exhausted.
+fn search_nearest_embedded(
+    graph: &mut CipDigraph,
+    mol: &Molecule,
+    frontier: Vec<NodeId>,
+) -> Option<(AtomIdx, AtomIdx, NodeId)> {
+    let mut frontier = frontier;
+    while !frontier.is_empty() {
+        let mut found_this_level: Option<(AtomIdx, NodeId)> = None;
+        let mut next_frontier = Vec::new();
+        for &current in &frontier {
+            if let CipNodeKind::Atom { atom_idx } = graph.node(current).kind
+                && mol.atom(atom_idx).chirality != Chirality::None
+            {
+                match found_this_level {
+                    None => found_this_level = Some((atom_idx, current)),
+                    Some((existing, _)) if existing == atom_idx => {}
+                    Some(_) => return None,
+                }
+            }
+            next_frontier.extend(graph.expand_children(current).ok()?);
+        }
+        if let Some((embedded_atom, node_id)) = found_this_level {
+            let parent_id = graph.node(node_id).parent?;
+            let arrival_atom = match graph.node(parent_id).kind {
+                CipNodeKind::Atom { atom_idx } => atom_idx,
+                _ => return None,
+            };
+            return Some((embedded_atom, arrival_atom, node_id));
+        }
+        frontier = next_frontier;
+    }
+    None
+}
+
+/// The ordered chain of `(embedded_atom, arrival_atom)` pairs reached from `start`,
+/// each one level deeper than the last -- position 0 is the nearest embedded
+/// stereocenter, position 1 is the nearest one found *beyond* it, etc., up to
+/// `MAX_PAIR_DEPTH` or until the branch runs out of embedded stereocenters / turns
+/// ambiguous.
+fn embedded_reference_chain(
+    graph: &mut CipDigraph,
+    mol: &Molecule,
+    start: NodeId,
+) -> Vec<(AtomIdx, AtomIdx)> {
+    let mut chain = Vec::new();
+    let mut frontier = vec![start];
+    for _ in 0..MAX_PAIR_DEPTH {
+        let Some((embedded_atom, arrival_atom, node_id)) =
+            search_nearest_embedded(graph, mol, frontier)
+        else {
+            break;
+        };
+        chain.push((embedded_atom, arrival_atom));
+        frontier = match graph.expand_children(node_id) {
+            Ok(children) => children,
+            Err(_) => break,
+        };
+    }
+    chain
+}
+
+fn auxiliary_sign(
+    mol: &Molecule,
+    embedded_atom: AtomIdx,
+    arrival_atom: AtomIdx,
+    budget: CipBudget,
+) -> Option<bool> {
+    let mut graph =
+        CipDigraph::new_with_artificial_ancestor(mol, embedded_atom, arrival_atom, budget).ok()?;
+    let root = graph.root();
+    let root_children = graph.expand_children(root).ok()?;
+    let stereo_order = mol.stereo_neighbor_order(embedded_atom)?;
+    let position_nodes = position_node_ids_generalized(&graph, &root_children, stereo_order)?;
+    let mut ctx = CompareContext::new();
+    let groups = rank_children(&mut graph, &root_children, &mut ctx).ok()?;
+    resolve_is_r_from_groups(&groups, &position_nodes, mol.atom(embedded_atom).chirality)
+}
+
+fn atom_of(graph: &CipDigraph, node: NodeId) -> AtomIdx {
+    match graph.node(node).kind {
+        CipNodeKind::Atom { atom_idx } => atom_idx,
+        other => panic!("expected a physical Atom node, got {other:?}"),
+    }
+}
+
+struct RowResult {
+    case_id: String,
+    stereocenter: u32,
+    tied_pair: (u32, u32),
+    chain_a: Vec<(AtomIdx, AtomIdx, Option<bool>)>,
+    chain_b: Vec<(AtomIdx, AtomIdx, Option<bool>)>,
+    deciding_position: Option<usize>,
+    predicted: Option<CipCode>,
+}
+
+fn diagnose_and_resolve(smiles: &str, atom_idx: u32, case_id: &str) -> RowResult {
+    let mol = chematic_smiles::parse(smiles).expect("valid SMILES");
+    let idx = AtomIdx(atom_idx);
+    let budget = CipBudget::default_budget();
+
+    let mut graph = CipDigraph::new(&mol, idx, budget).expect("digraph builds");
+    let root = graph.root();
+    let root_children = graph.expand_children(root).expect("root expands");
+    let stereo_order = mol
+        .stereo_neighbor_order(idx)
+        .expect("stereocenter has stereo_neighbor_order");
+    let position_nodes = position_node_ids_generalized(&graph, &root_children, stereo_order)
+        .expect("all 4 physical positions resolve to root children");
+
+    let mut ctx = CompareContext::new();
+    let groups = rank_children(&mut graph, &root_children, &mut ctx).expect("root children rank");
+
+    let position_set: HashSet<NodeId> = position_nodes.iter().copied().collect();
+    let mut tied_group_idx = None;
+    let mut tied_pair_nodes = None;
+    for (gi, group) in groups.iter().enumerate() {
+        let physical: Vec<NodeId> = group
+            .iter()
+            .copied()
+            .filter(|n| position_set.contains(n))
+            .collect();
+        if physical.len() == 2 {
+            tied_group_idx = Some(gi);
+            tied_pair_nodes = Some((physical[0], physical[1]));
+        } else if physical.len() > 2 {
+            panic!("{case_id}: 3+-way physical tie, outside this validation's scope");
+        }
+    }
+    let tied_group_idx =
+        tied_group_idx.unwrap_or_else(|| panic!("{case_id}: expected exactly one physical tie"));
+    let (pos_a, pos_b) = tied_pair_nodes.unwrap();
+    let atom_a = atom_of(&graph, pos_a);
+    let atom_b = atom_of(&graph, pos_b);
+
+    let chain_a_atoms = embedded_reference_chain(&mut graph, &mol, pos_a);
+    let chain_b_atoms = embedded_reference_chain(&mut graph, &mol, pos_b);
+
+    let chain_a: Vec<(AtomIdx, AtomIdx, Option<bool>)> = chain_a_atoms
+        .iter()
+        .map(|&(e, a)| (e, a, auxiliary_sign(&mol, e, a, budget)))
+        .collect();
+    let chain_b: Vec<(AtomIdx, AtomIdx, Option<bool>)> = chain_b_atoms
+        .iter()
+        .map(|&(e, a)| (e, a, auxiliary_sign(&mol, e, a, budget)))
+        .collect();
+
+    // Lexicographic pair-sequence comparison: first position where the two chains'
+    // auxiliary signs differ decides, R precedes S (same convention as the
+    // single-reference gate and Rule 5's own tie-break).
+    let mut deciding_position = None;
+    let mut predicted = None;
+    for i in 0..chain_a.len().min(chain_b.len()) {
+        let (Some(ra), Some(rb)) = (chain_a[i].2, chain_b[i].2) else {
+            break;
+        };
+        if ra != rb {
+            deciding_position = Some(i);
+            // NOTE: inverted vs. rule4b_aux_sign.rs's own convention (S precedes R, not
+            // R precedes S) -- see module docs update: the depth-1 gate found this
+            // orientation empirically, after "R precedes S" (Rule 5's convention)
+            // produced a uniform 8/8 wrong-direction mismatch.
+            let (higher, lower) = if ra { (pos_b, pos_a) } else { (pos_a, pos_b) };
+            let mut resolved_groups: Vec<Vec<NodeId>> = Vec::with_capacity(groups.len() + 1);
+            for (gi, group) in groups.iter().enumerate() {
+                if gi == tied_group_idx {
+                    resolved_groups.push(vec![higher]);
+                    let mut lower_group = vec![lower];
+                    lower_group
+                        .extend(group.iter().copied().filter(|&n| n != higher && n != lower));
+                    resolved_groups.push(lower_group);
+                } else {
+                    resolved_groups.push(group.clone());
+                }
+            }
+            predicted = resolve_is_r_from_groups(
+                &resolved_groups,
+                &position_nodes,
+                mol.atom(idx).chirality,
+            )
+            .map(|is_r| if is_r { CipCode::R } else { CipCode::S });
+            break;
+        }
+    }
+
+    RowResult {
+        case_id: case_id.to_string(),
+        stereocenter: atom_idx,
+        tied_pair: (atom_a.0, atom_b.0),
+        chain_a,
+        chain_b,
+        deciding_position,
+        predicted,
+    }
+}
+
+fn chain_str(chain: &[(AtomIdx, AtomIdx, Option<bool>)]) -> String {
+    chain
+        .iter()
+        .map(|(e, a, s)| {
+            let sign = match s {
+                Some(true) => "R",
+                Some(false) => "S",
+                None => "?",
+            };
+            format!("atom{}(via atom{})={}", e.0, a.0, sign)
+        })
+        .collect::<Vec<_>>()
+        .join(" -> ")
+}
+
+fn main() {
+    println!(
+        "Milestone 4B-1 phase 2: descriptor pair-sequence gate (8 rule4_candidate rows, \
+         max depth {MAX_PAIR_DEPTH})\n"
+    );
+
+    let mut matched = 0usize;
+    let mut mismatched = 0usize;
+    let mut inconclusive = 0usize;
+
+    for &(smiles, atom_idx, case_id) in ROWS {
+        let r = diagnose_and_resolve(smiles, atom_idx, case_id);
+
+        println!("case_id: {}", r.case_id);
+        println!("  stereocenter: atom{}", r.stereocenter);
+        println!(
+            "  tied ligand pair: atom{} vs atom{}",
+            r.tied_pair.0, r.tied_pair.1
+        );
+        println!("  branch A chain: {}", chain_str(&r.chain_a));
+        println!("  branch B chain: {}", chain_str(&r.chain_b));
+        match r.deciding_position {
+            Some(pos) => println!("  deciding pair-sequence position: {pos}"),
+            None => println!("  deciding pair-sequence position: none found within depth cap"),
+        }
+        match r.predicted {
+            Some(CipCode::S) => {
+                matched += 1;
+                println!("  predicted: S -- MATCHES oracle (S)");
+            }
+            Some(other) => {
+                mismatched += 1;
+                println!("  predicted: {:?} -- MISMATCHES oracle (S)", other);
+            }
+            None => {
+                inconclusive += 1;
+                println!("  predicted: inconclusive (no distinguishing position found)");
+            }
+        }
+        println!();
+    }
+
+    println!(
+        "Summary: {matched}/8 matched oracle, {mismatched}/8 mismatched, {inconclusive}/8 \
+         inconclusive."
+    );
+}

--- a/crates/chematic-cip/src/digraph.rs
+++ b/crates/chematic-cip/src/digraph.rs
@@ -59,6 +59,17 @@ pub struct CipDigraph<'m> {
     /// callers are responsible for computing it from the exact same (Kekulé-form) `mol`
     /// passed in here.
     mancude: Option<&'m MancudeContext>,
+    /// `None` for every existing call site (`Self::new`/`Self::new_with_mancude`) --
+    /// [`Self::new_with_artificial_ancestor`] is a separate, Milestone 4B-1 entry point
+    /// that pre-seeds the root's own ancestor set with one extra atom, so a neighbor
+    /// equal to it terminates as a [`CipNodeKind::RingDuplicate`] leaf immediately
+    /// instead of expanding as a real subtree. See that constructor's doc comment for
+    /// why: it is what makes an *embedded* stereocenter's true auxiliary descriptor
+    /// (as seen from one specific branch of an outer, still-unresolved stereocenter)
+    /// computable at all -- rooting fresh at that embedded atom with no artificial
+    /// ancestor reproduces its ordinary *global/molecular* digraph instead, which is a
+    /// different (and, for a Rule-4-tied atom, differently ambiguous) computation.
+    artificial_ancestor: Option<AtomIdx>,
     nodes: Vec<CipNode>,
     edges: Vec<CipEdge>,
     /// Parallel to `nodes`: `None` until a node's children have been computed once.
@@ -88,7 +99,38 @@ impl<'m> CipDigraph<'m> {
     /// represented atom's real atomic number) -- exactly today's existing behavior. Use
     /// [`Self::new_with_mancude`] to additionally apply MANCUDE fractional atomic numbers.
     pub fn new(mol: &'m Molecule, root_atom: AtomIdx, budget: CipBudget) -> Result<Self, CipError> {
-        Self::new_impl(mol, root_atom, budget, None)
+        Self::new_impl(mol, root_atom, budget, None, None)
+    }
+
+    /// Like [`Self::new`], but `artificial_ancestor` is treated as already visited from
+    /// the start -- a neighbor of any node in this digraph equal to `artificial_ancestor`
+    /// becomes a [`CipNodeKind::RingDuplicate`] leaf immediately, instead of a real,
+    /// re-expanded subtree (exactly the ordinary ring-closure rule in the module docs,
+    /// just pre-seeded rather than discovered by walking up the tree).
+    ///
+    /// **Milestone 4B-1.** Motivation: when an outer stereocenter's two branches tie
+    /// under Rules 1a/2 (Rule 4 territory), resolving the tie needs each branch's
+    /// *auxiliary* descriptor for whatever embedded stereocenter it reaches -- not that
+    /// atom's ordinary *molecular* descriptor. Rooting a fresh, independent digraph at
+    /// the embedded atom (`Self::new`, no artificial ancestor) computes the *molecular*
+    /// descriptor: all of that atom's real neighbors compete as ordinary children,
+    /// including the one leading back toward the outer stereocenter -- which, for a
+    /// constitutionally symmetric branch pair, is typically itself ambiguous (that
+    /// neighbor's own subtree mirrors the embedded atom's other ring-continuation
+    /// child). Pre-seeding that one specific neighbor as an artificial ancestor instead
+    /// terminates it as a childless duplicate leaf immediately, matching what CIP's
+    /// auxiliary-descriptor procedure actually asks for: this atom's local priority
+    /// order *as seen from one specific incoming direction*, not its independent
+    /// global ranking. `root_atom` is the embedded stereocenter; `artificial_ancestor`
+    /// is the real neighbor the branch was reached through (i.e. the atom immediately
+    /// preceding `root_atom` on the outer stereocenter's own root-to-`root_atom` path).
+    pub fn new_with_artificial_ancestor(
+        mol: &'m Molecule,
+        root_atom: AtomIdx,
+        artificial_ancestor: AtomIdx,
+        budget: CipBudget,
+    ) -> Result<Self, CipError> {
+        Self::new_impl(mol, root_atom, budget, None, Some(artificial_ancestor))
     }
 
     /// Like [`Self::new`], but `MultipleBondDuplicate` nodes whose owner atom
@@ -103,7 +145,7 @@ impl<'m> CipDigraph<'m> {
         budget: CipBudget,
         mancude: &'m MancudeContext,
     ) -> Result<Self, CipError> {
-        Self::new_impl(mol, root_atom, budget, Some(mancude))
+        Self::new_impl(mol, root_atom, budget, Some(mancude), None)
     }
 
     fn new_impl(
@@ -111,10 +153,12 @@ impl<'m> CipDigraph<'m> {
         root_atom: AtomIdx,
         budget: CipBudget,
         mancude: Option<&'m MancudeContext>,
+        artificial_ancestor: Option<AtomIdx>,
     ) -> Result<Self, CipError> {
         let mut g = Self {
             mol,
             mancude,
+            artificial_ancestor,
             nodes: Vec::new(),
             edges: Vec::new(),
             children_cache: Vec::new(),
@@ -302,10 +346,16 @@ impl<'m> CipDigraph<'m> {
     }
 
     /// The set of atoms on the root-to-`node` path, including `node`'s own atom (if
-    /// it's an `Atom` node). Duplicate/implicit-H nodes never appear as ancestors --
-    /// they're leaves and can't have descendants to be an ancestor of.
+    /// it's an `Atom` node), plus [`Self::artificial_ancestor`] if one was seeded at
+    /// construction (see [`Self::new_with_artificial_ancestor`]) -- unioned in
+    /// unconditionally since it must terminate a matching neighbor at *any* depth in
+    /// this digraph, not just at the root. Duplicate/implicit-H nodes never appear as
+    /// ancestors -- they're leaves and can't have descendants to be an ancestor of.
     fn ancestor_atoms(&self, node_id: NodeId) -> HashSet<AtomIdx> {
         let mut set = HashSet::new();
+        if let Some(seed) = self.artificial_ancestor {
+            set.insert(seed);
+        }
         let mut current = Some(node_id);
         while let Some(id) = current {
             let node = &self.nodes[id.0 as usize];
@@ -587,5 +637,78 @@ mod tests {
         // fraction never actually decides anything -- 0 is the correct, expected value,
         // consistent with Milestone 3B-1b's own attribution finding. See
         // `CompareContext::fractional_decisions`'s doc comment.
+    }
+
+    /// [`CipDigraph::new_with_artificial_ancestor`]'s whole point: the seeded atom must
+    /// terminate as a childless [`CipNodeKind::RingDuplicate`] leaf the moment it's
+    /// reached as a neighbor, not expand as a real subtree -- checked concretely on one
+    /// of Milestone 4B-0's own quinic-acid residual rows (atom4 is a ring neighbor of
+    /// atom3; rooting at atom4 with atom3 as the artificial ancestor must produce a
+    /// `RingDuplicate{closure_atom: atom3}` child, never an `Atom{atom_idx: atom3}` one).
+    #[test]
+    fn new_with_artificial_ancestor_terminates_seeded_neighbor_immediately() {
+        let mol =
+            chematic_smiles::parse("O=C(O[C@H]1[C@H](O)C[C@](O)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1")
+                .unwrap();
+        let root_atom = AtomIdx(4);
+        let artificial_ancestor = AtomIdx(3);
+        let budget = CipBudget::default_budget();
+        let mut graph =
+            CipDigraph::new_with_artificial_ancestor(&mol, root_atom, artificial_ancestor, budget)
+                .unwrap();
+        let root = graph.root();
+        let children = graph.expand_children(root).unwrap();
+
+        let seeded_child = children
+            .iter()
+            .find(|&&id| match graph.node(id).kind {
+                CipNodeKind::Atom { atom_idx } => atom_idx == artificial_ancestor,
+                CipNodeKind::RingDuplicate { closure_atom, .. } => {
+                    closure_atom == artificial_ancestor
+                }
+                _ => false,
+            })
+            .copied()
+            .expect("artificial_ancestor atom must appear among root's children");
+
+        assert!(
+            matches!(
+                graph.node(seeded_child).kind,
+                CipNodeKind::RingDuplicate { .. }
+            ),
+            "artificial_ancestor must terminate as a RingDuplicate leaf immediately, not \
+             expand as a real Atom subtree"
+        );
+        assert_eq!(
+            graph.expand_children(seeded_child).unwrap(),
+            Vec::new(),
+            "a RingDuplicate node is always childless"
+        );
+    }
+
+    /// `new`'s existing behavior (no artificial ancestor) is unaffected: the same root
+    /// atom's real neighbor set is unchanged when `new_with_artificial_ancestor` is not
+    /// used -- confirms the new field is strictly additive, mirroring the
+    /// `new_without_mancude_keeps_plain_integer_duplicates` precedent above.
+    #[test]
+    fn new_without_artificial_ancestor_keeps_ordinary_neighbor_expansion() {
+        let mol =
+            chematic_smiles::parse("O=C(O[C@H]1[C@H](O)C[C@](O)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1")
+                .unwrap();
+        let root_atom = AtomIdx(4);
+        let budget = CipBudget::default_budget();
+        let mut graph = CipDigraph::new(&mol, root_atom, budget).unwrap();
+        let root = graph.root();
+        let children = graph.expand_children(root).unwrap();
+
+        let atom3_child = children
+            .iter()
+            .find(|&&id| matches!(graph.node(id).kind, CipNodeKind::Atom { atom_idx } if atom_idx == AtomIdx(3)))
+            .copied();
+        assert!(
+            atom3_child.is_some(),
+            "without an artificial ancestor, atom3 must appear as an ordinary real Atom \
+             child, exactly today's existing behavior"
+        );
     }
 }

--- a/docs/cip_accurate_rfc.md
+++ b/docs/cip_accurate_rfc.md
@@ -887,6 +887,46 @@ Zero production impact from this phase too: no `crates/chematic-cip/src/` file c
 beyond phase 1's additive `new_with_artificial_ancestor`; `cargo test --workspace --lib
 --quiet` passes workspace-wide.
 
+**Correction, pre-M4B-2: phase 2's "S precedes R" is an absolute-comparison overfit,
+confirmed and discarded — a faithful reference-relative Like/Unlike does not yet reach
+8/8 either.** Flagged by the user before any production code was written: real Rule 4b
+compares descriptor *families* relative to a chosen reference (Like beats Unlike), never
+raw R/S ordinally. `examples/rule4b_like_unlike_gate.rs` tested this directly, with a
+decisive instrumented check the user specified: reproducing each of the 8 rows'
+*enantiomer* (every `@`/`@@` textually swapped — a purely mechanical transform) and
+checking against its *derived* oracle (mirroring inverts every stereocenter's label,
+always, so the mirrored oracle is `R` for all 8 without needing a fresh RDKit run).
+
+- **"S precedes R" (phase 2's rule): 8/8 on the original set, 0/8 on the mirrored
+  set.** Definitively confirms it is an absolute, non-invariant rule — exactly the
+  overfit the user predicted, now falsified by construction rather than by argument.
+- **A faithful reference-relative Like/Unlike (reference = the shared family at
+  sequence position 0, Like beats Unlike at the first differing position): 4/8 on
+  *both* the original and mirrored sets.** Consistent (invariant) across enantiomers,
+  which is the correct structural property — but still not correct: exactly half the
+  rows are wrong on each set, and hand-tracing why (twice) produced two more wrong
+  conclusions, so a brute-force sweep of the 4 reference/winner sign permutations
+  (`LikeWinsSharedRef` / `UnlikeWinsSharedRef` / `LikeWinsOppositeRef` /
+  `UnlikeWinsOppositeRef`) was run mechanically instead. **All 4 score exactly 4/8 on
+  both sets** — none reaches 8/8. Notably, the two atoms tied within the same molecule
+  (e.g. quinic acid's atom3 and atom7) are on *opposite* sides of the 4/8 split for
+  every convention tried: whichever convention gets atom3's row right gets atom7's row
+  wrong, and vice versa. A single global sign convention cannot fix this — the
+  resolution needs something beyond a reference/winner sign choice at the deciding
+  position.
+
+**Not yet resolved.** The auxiliary-descriptor chain construction itself is verified
+sound (enantiomer-invariant chain values, confirmed by direct inspection — mirroring a
+molecule flips every element of every chain exactly as expected). The remaining gap is
+in how the two branches' chains are compared/reference-selected, not in computing the
+auxiliary descriptors themselves. Candidate directions not yet tried: reference
+selection scoped to something other than "shared value at sequence position 0" (e.g.
+CIP hierarchical-digraph-order across all of the tied stereocenter's ligands, not just
+the 2 tied branches), or a comparison that doesn't reduce to a single deciding position
+at all. Needs either a primary-source check (IUPAC 2013 Rule 4b text, unavailable
+locally) or further instrumented experiments before Milestone 4B-2's production
+implementation proceeds — reported to the user rather than guessed further.
+
 ## Required property tests (starting Milestone 1)
 
 - Atom-renumbering invariance (same molecule, different internal atom indices → same

--- a/docs/cip_accurate_rfc.md
+++ b/docs/cip_accurate_rfc.md
@@ -847,6 +847,46 @@ Zero production impact from this phase either: `cargo test --workspace --lib --q
 passes workspace-wide; the new digraph constructor is additive and unused by
 `assign_cip_accurate_experimental`.
 
+**Milestone 4B-1, phase 2 — depth-2 pair sequence, 8/8 matches the oracle.** Per the
+user's direction (continue rather than pause), `examples/rule4b_pair_sequence.rs`
+extends phase 1's single-reference check into a genuine ordered *sequence* of paired
+auxiliary descriptors per branch: at each step, continue past the previously-found
+embedded reference (via its own forward children in the outer stereocenter's digraph)
+to find the *next* nearest embedded stereocenter, and compute *its* auxiliary sign with
+a fresh `new_with_artificial_ancestor` root. For the quinic family, position 1 of this
+sequence reaches the *other* tied atom itself — via two different arrival directions
+per branch, exactly as anticipated in phase 1's write-up above.
+
+**Result**: every one of the 8 rows' two branches tie at sequence position 0 (matching
+phase 1's finding) and differ at position 1 — and taking the first differing position
+as the decider, **8/8 predictions match the oracle (`S`)**, 0 mismatches, 0
+inconclusive. One empirical correction along the way: the first attempt used "R
+precedes S" at the deciding position (`assign::assign_one_with_rule5`'s own Rule 5
+convention) and got a uniform 8/8 *wrong-direction* mismatch (predicted `R` for every
+row that should be `S`) — flipping to "S precedes R" at this specific comparison
+(deciding position within a nested pair sequence, not Rule 5's direct single-position
+comparison) turned all 8 correct. Recorded as an empirical finding, not derived from
+IUPAC source text (unavailable locally, same standing limitation noted throughout this
+RFC) — the orientation is validated against the oracle, not assumed correct from
+either convention by analogy.
+
+**Reading**: this is now real, oracle-validated evidence that a genuine
+`DescriptorPairList`-shaped Rule 4b (ordered auxiliary-descriptor sequence per branch,
+first-differing-position decides) is both sufficient and correct for this residual
+family, not just plausible. Still diagnostic/validation code only — no production
+wiring. The next step, Milestone 4B-2, is implementing this for real inside
+`assign.rs`: a `DescriptorPairList`-shaped structure (not a simple ordinal `key()`, per
+the user's original architectural instruction) plus a `refine_by_rule4b` pass that only
+refines the equivalence classes Rules 1a/2 already left tied, following the same
+"refine an already-tied group" template `assign_one_with_rule5` established for Rule 5.
+Needs its own scoping/design pass before implementation, in a separate PR per the
+user's original guidance — this milestone's job was proving the mechanism works, not
+building the production version.
+
+Zero production impact from this phase too: no `crates/chematic-cip/src/` file changed
+beyond phase 1's additive `new_with_artificial_ancestor`; `cargo test --workspace --lib
+--quiet` passes workspace-wide.
+
 ## Required property tests (starting Milestone 1)
 
 - Atom-renumbering invariance (same molecule, different internal atom indices → same

--- a/docs/cip_accurate_rfc.md
+++ b/docs/cip_accurate_rfc.md
@@ -758,6 +758,50 @@ to clear the gate without touching Milestone 4A-2's harder symmetry-detection wo
 2 remaining phosphorus "tied" rows. This is an observation about ROI ordering, not a
 scope commitment — implementation order is decided per-milestone as each is planned.
 
+**Milestone 4B-0 — Rule 4 subtype diagnosis, diagnosis only (no crate changes).** Before
+implementing anything, the 8 Milestone-4B `rule4_candidate` rows were mechanically
+classified into Rule 4a / 4b / 4c using a new read-only tool,
+`examples/rule4_diagnose.rs` (same footprint as `residual_report.rs`/`trace_report.rs` —
+no changes to `crates/chematic-cip/src/*.rs`):
+
+| subrule | verdict | evidence |
+|---|---|---|
+| Rule 4a (chiral > pseudoasymmetric > nonstereogenic unit ranking) | N/A, structurally | `chematic_core::Chirality` has exactly one non-`None` variant family (tetrahedral `CounterClockwise`/`Clockwise`) — there is no unit-*type* distinction for Rule 4a to compare. This is a fact about the enum, not an artifact of these 8 rows. |
+| Rule 4c (r/s, m/p ordinal comparison on pseudoasymmetric/axial descriptors) | N/A, structurally | Same reasoning: no axial/planar or bond (seqCis/seqTrans) `Chirality` variant exists at all. |
+| Rule 4b (reference-descriptor + like/unlike pairing) | sole remaining candidate, 8/8 | by exhaustion (4a and 4c ruled out) and by direct structural evidence, below |
+
+All 8 rows share one shape: a tied stereocenter's own two ring-branches are
+constitutionally identical (already confirmed via `branch_signature()` in Milestone
+4A-0), and the oracle resolves both members of every tied pair to `S`. For each row, the
+*nearest embedded stereocenter* per branch (BFS search, mirroring
+`assign::nearest_embedded_stereocenter`'s own logic, re-implemented in the example since
+it's private to that module) was found and its own `expand_children` output ranked:
+**16/16 branches across all 8 rows rank tie-free** — Rules 1a/2 alone, with no reference
+to any other tied atom's global/molecular descriptor, already order that embedded atom's
+forward substituents cleanly.
+
+This is direct, code-level acyclicity evidence, not a hand-derived claim: a per-branch
+auxiliary-descriptor computation for Rule 4b does not need a fixed-point solver, because
+resolving one tied atom's embedded reference never depends on the *other* tied atom's own
+still-unresolved global value — only on that embedded atom's own local (already
+tie-free) substituent ranking.
+
+**What this diagnosis does not yet establish**: the embedded stereocenter's actual
+auxiliary R/S *sign*. Getting that right requires representing "the direction back
+toward the tied root" as a proper 4th ligand in a digraph rooted so that direction
+terminates immediately (an artificial-ancestor root) — `CipDigraph` has no such
+constructor today (`CipDigraph::new`/`new_with_mancude` only root at a real atom with no
+pre-seeded ancestors). Closing that gap, and implementing the reference-descriptor +
+like/unlike comparison itself, is Milestone 4B-1's job, not this diagnosis's. Since the
+literal IUPAC 2013 text for Rule 4b's exact reference-selection procedure isn't available
+locally (same "no RDKit C++ source" limitation noted throughout this RFC), Milestone
+4B-1's implementation should be validated empirically against these 8 rows' oracle labels
+(all `S`) rather than assumed correct from the commonly-cited textbook description alone.
+
+Zero production impact: `cargo test --workspace --lib --quiet` and the existing
+4152/4186 full-corpus number are both unaffected (no files under
+`crates/chematic-cip/src/` touched).
+
 ## Required property tests (starting Milestone 1)
 
 - Atom-renumbering invariance (same molecule, different internal atom indices → same

--- a/docs/cip_accurate_rfc.md
+++ b/docs/cip_accurate_rfc.md
@@ -802,6 +802,51 @@ Zero production impact: `cargo test --workspace --lib --quiet` and the existing
 4152/4186 full-corpus number are both unaffected (no files under
 `crates/chematic-cip/src/` touched).
 
+**Milestone 4B-1, phase 1 — artificial-ancestor construct built and gated against
+oracle; simplest combination candidate insufficient (0/8, no wrong answers).** Added
+`CipDigraph::new_with_artificial_ancestor` (`crates/chematic-cip/src/digraph.rs`): roots
+fresh at an embedded atom with one specific neighbor pre-seeded as an already-visited
+ancestor, so that neighbor terminates as a `RingDuplicate` leaf immediately instead of
+expanding as a real subtree — the missing piece Milestone 4B-0 flagged for computing an
+embedded stereocenter's true *auxiliary* R/S sign (as seen from one specific branch of
+the outer, still-tied stereocenter), as opposed to its ordinary independent *molecular*
+sign. Additive only: `new`/`new_with_mancude` pass `None` and are unchanged (verified by
+a new test, `new_without_artificial_ancestor_keeps_ordinary_neighbor_expansion`,
+mirroring the existing `new_without_mancude_keeps_plain_integer_duplicates` precedent); a
+second new test confirms the seeded neighbor really does terminate as a childless
+`RingDuplicate`.
+
+A new example, `examples/rule4b_aux_sign.rs`, used this construct to compute, for each of
+the 8 `rule4_candidate` rows, the true auxiliary sign of each branch's nearest embedded
+reference (the atom `rule4_diagnose.rs` already found ranks tie-free locally), then
+tried the simplest Rule-4b-shaped combination — R precedes S on the two branches'
+auxiliary references, mirroring Rule 5's own tie-break convention in
+`assign::assign_one_with_rule5` — against the oracle. Result: **0/8 matched, 0/8
+mismatched, 8/8 inconclusive** — in every row, both branches' nearest-reference auxiliary
+signs are identical to each other (both R or both S), so this single-comparison
+tie-break has no discriminating power at all. Notably the construct is mechanically
+sound throughout (no cycles, no budget errors, a real sign computed for all 16
+branches), and in several rows the auxiliary sign differs from that same atom's ordinary
+global (Pass-1) code (e.g. quinic-a's branch A: auxiliary S vs. global R) — confirming
+the auxiliary-vs-molecular distinction is genuinely load-bearing here, not just a
+theoretical caveat.
+
+**Reading**: this is a real, informative negative result, not a failed experiment. It
+means Rule 4b for this family cannot be a single-level "compare the first reference"
+rule — consistent with the user's original architectural concern that Rule 4b needs a
+genuine ordered *sequence* of paired descriptors (a `DescriptorPairList`-shaped
+comparison), not a simple key. The natural next check (not yet done) is one level
+deeper: each branch's *second* nearest embedded reference beyond the first — for the
+quinic family this reaches the *other* tied atom itself, via two different arrival
+directions per branch, which is exactly the case this milestone's construct exists to
+disambiguate. Left as the next Milestone 4B-1 step pending direction from the user,
+since extending the pairing depth is where this starts to become the separate,
+larger-architecture PR the user's original M4B message called for.
+
+Zero production impact from this phase either: `cargo test --workspace --lib --quiet`
+passes workspace-wide; the new digraph constructor is additive and unused by
+`assign_cip_accurate_experimental`.
+
 ## Required property tests (starting Milestone 1)
 
 - Atom-renumbering invariance (same molecule, different internal atom indices → same


### PR DESCRIPTION
Stacked on #75 (Milestone 4B-0) -- merge #75 first.

## Summary

**Phase 1** -- `CipDigraph::new_with_artificial_ancestor`: roots fresh at an atom with one specific neighbor pre-seeded as an already-visited ancestor, so that neighbor terminates as a `RingDuplicate` leaf immediately instead of expanding as a real subtree. This is what makes an embedded stereocenter's true *auxiliary* R/S sign (as seen from one branch of an outer, still-tied stereocenter) computable -- the gap Milestone 4B-0 flagged and deferred. Additive only (verified by new tests); existing constructors unchanged.

`examples/rule4b_aux_sign.rs` used it as a first gate: try the simplest possible Rule-4b-shaped combination (compare just the nearest embedded reference per branch). Result: 0/8 matched, 0/8 mismatched, 8/8 inconclusive -- mechanically sound, but every row's two branches share the same first-reference auxiliary sign, so a single comparison has no discriminating power.

**Phase 2** -- `examples/rule4b_pair_sequence.rs` extends this into a genuine ordered *sequence* of paired auxiliary descriptors per branch (continue past each found reference to the next one, one level deeper each step). **Result: 8/8 match the oracle**, 0 mismatches, 0 inconclusive -- every row ties at sequence position 0 and differs at position 1, and taking the first differing position as the decider reproduces the oracle `S` label for all 8. One empirical correction along the way (recorded in the module doc/RFC): the deciding-position comparison needs the *opposite* tie-break orientation from Rule 5's own "R precedes S" convention -- found by testing, not assumed by analogy.

## Reading
Real, oracle-validated evidence that a `DescriptorPairList`-shaped Rule 4b (ordered auxiliary-descriptor sequence, first-differing-position decides) is sufficient and correct for this residual family. Still diagnostic/validation code only -- no production wiring. Milestone 4B-2 (real `assign.rs` implementation) needs its own design/scoping pass in a separate PR, per the original guidance to keep Rule 4b's real architecture out of validation work.

## Test plan
- [x] `cargo test --workspace --lib --quiet` -- all pass, zero production impact throughout (`assign_cip_accurate_experimental` does not call the new constructor)
- [x] `bash scripts/check.sh` -- fmt/clippy/tests/version all pass
- [x] New digraph.rs tests confirm additivity + artificial-ancestor termination behavior
- [x] Both example binaries run clean and reproduce their stated results