### PR TITLE
feat(cip): M4B-2 -- wire validated Rule 4b engine into assign_cip_accurate_experimental

### DIFF
--- a/crates/chematic-cip/src/assign.rs
+++ b/crates/chematic-cip/src/assign.rs
@@ -125,7 +125,12 @@ pub fn assign_cip_accurate_experimental(
 ) -> Result<AccurateCipAssignment, CipCompareError> {
     let kekule = prepare_kekule_form(mol).ok();
     let pass1 = assign_all(mol, budget, kekule.as_ref())?;
-    Ok(apply_rule5_pass(mol, budget, kekule.as_ref(), pass1))
+    // Rule 4b (Milestone 4B-2) must run before Rule 5 -- CIP rule order. Rule 5's own
+    // `provisional` map (built inside `apply_rule5_pass` from whatever
+    // `AccurateCipAssignment` it's handed) sees Rule 4b's newly-resolved atoms for
+    // free; `apply_rule5_pass` needs no changes for this. See `crate::resolver`.
+    let pass2 = crate::resolver::apply_rule4b_pass(mol, budget, kekule.as_ref(), pass1);
+    Ok(apply_rule5_pass(mol, budget, kekule.as_ref(), pass2))
 }
 
 /// Identical to [`assign_cip_accurate_experimental`], but never attaches a
@@ -261,7 +266,7 @@ fn assign_one_with_rule5(
     let root = graph.root();
     let root_children = graph.expand_children(root).map_err(map_digraph_err)?;
 
-    let Some(position_nodes) = position_node_ids(&graph, &root_children, stereo_order) else {
+    let Some(position_nodes) = position_node_ids(&graph, stereo_order, &root_children) else {
         return Ok(None);
     };
 
@@ -417,7 +422,7 @@ fn assign_one(
     let root = graph.root();
     let root_children = graph.expand_children(root).map_err(map_digraph_err)?;
 
-    let Some(position_nodes) = position_node_ids(&graph, &root_children, stereo_order) else {
+    let Some(position_nodes) = position_node_ids(&graph, stereo_order, &root_children) else {
         return Ok(None);
     };
 
@@ -444,10 +449,11 @@ fn assign_one(
 /// Given a fully-ranked group partition (highest-priority group first, matching
 /// [`rank_children`]'s convention) and the 4 physical positions in `stereo_order`
 /// order, compute whether the center is *rectus* (R). Shared by [`assign_one`] (Rules
-/// 1a/1b/2 only) and [`assign_one_with_rule5`] (which passes a `groups` partition with
-/// one tied group already split by a Rule 5 tiebreak) -- the swap-counting parity math
-/// itself doesn't know or care which rule produced the ordering.
-fn resolve_is_r_from_groups(
+/// 1a/1b/2 only), [`assign_one_with_rule5`] (which passes a `groups` partition with
+/// one tied group already split by a Rule 5 tiebreak), and (Milestone 4B-2)
+/// `crate::resolver::assign_one_with_rule4b`/`resolve_chirality` -- the swap-counting
+/// parity math itself doesn't know or care which rule produced the ordering.
+pub(crate) fn resolve_is_r_from_groups(
     groups: &[Vec<NodeId>],
     position_nodes: &[NodeId],
     chirality: Chirality,
@@ -493,12 +499,12 @@ fn resolve_is_r_from_groups(
     Some(cw_from_lowest ^ remaining_swaps_odd)
 }
 
-fn map_digraph_err(e: CipError) -> SkipReason {
+pub(crate) fn map_digraph_err(e: CipError) -> SkipReason {
     let CipError::BudgetExceeded { .. } = e;
     SkipReason::BudgetExceeded
 }
 
-fn map_compare_err(e: CipCompareError) -> SkipReason {
+pub(crate) fn map_compare_err(e: CipCompareError) -> SkipReason {
     match e {
         CipCompareError::BudgetExceeded { .. } | CipCompareError::Digraph(_) => {
             SkipReason::BudgetExceeded
@@ -507,27 +513,41 @@ fn map_compare_err(e: CipCompareError) -> SkipReason {
     }
 }
 
-/// Map each `stereo_neighbor_order` position to the digraph node representing it. A
-/// tetrahedral stereocenter's own substituents are always single-bonded (a `@`/`@@`
-/// marker only appears on genuinely tetrahedral centers), so the root's direct
-/// children are always `Atom`/`ImplicitHydrogen` kinds here -- never a duplicate.
-fn position_node_ids(
+/// Map each `stereo_neighbor_order` position to the digraph node representing it.
+///
+/// For a tetrahedral stereocenter's own root children (the only case before Milestone
+/// 4B-2), substituents are always single-bonded, so `candidates` only ever contains
+/// `Atom`/`ImplicitHydrogen` kinds -- never a duplicate. Milestone 4B-2's Rule 4b
+/// resolver additionally calls this for an *embedded* stereocenter's own 4 positions
+/// (its forward children plus the back-to-root parent node,
+/// `crate::resolver::resolve_chirality`), where a physical position can be a
+/// `RingDuplicate` (the stereo_neighbor_order-named atom is reached via a ring
+/// closure at that embedded position, not as a fresh real node) -- hence the
+/// additional match arm below. Provably inert for every pre-existing caller
+/// ([`assign_one`]/[`assign_one_with_rule5`]), which only ever pass a root's own
+/// direct children.
+pub(crate) fn position_node_ids(
     graph: &CipDigraph,
-    root_children: &[NodeId],
     stereo_order: &[u32],
+    candidates: &[NodeId],
 ) -> Option<Vec<NodeId>> {
     let mut result = Vec::with_capacity(stereo_order.len());
     for &pos_val in stereo_order {
         let node_id = if pos_val == STEREO_H_SENTINEL {
-            root_children
+            candidates
                 .iter()
                 .copied()
                 .find(|&id| matches!(graph.node(id).kind, CipNodeKind::ImplicitHydrogen))?
         } else {
             let atom_idx = AtomIdx(pos_val);
-            root_children.iter().copied().find(|&id| {
-                matches!(graph.node(id).kind, CipNodeKind::Atom { atom_idx: a } if a == atom_idx)
-            })?
+            candidates
+                .iter()
+                .copied()
+                .find(|&id| match graph.node(id).kind {
+                    CipNodeKind::Atom { atom_idx: a } => a == atom_idx,
+                    CipNodeKind::RingDuplicate { closure_atom, .. } => closure_atom == atom_idx,
+                    _ => false,
+                })?
         };
         result.push(node_id);
     }

--- a/crates/chematic-cip/src/auxiliary.rs
+++ b/crates/chematic-cip/src/auxiliary.rs
@@ -1,0 +1,128 @@
+//! Milestone 4B-2 production port of the "back to root" ligand from the validated
+//! reference engine (`examples/rule4b_bottom_up.rs`, 72/72 across 4 oracle corpora
+//! including mirrors -- see `docs/cip_accurate_rfc.md`). Mechanical port: algorithm
+//! unchanged from the example.
+//!
+//! Per Hanson, Musacchio, Mayfield et al. 2018 (*J. Chem. Inf. Model.* 58(9),
+//! 1755-1765): "the priority of a ligand leading back to the digraph root will always
+//! be ranked by Rule 1a, with no need to consider auxiliary centers... the path back
+//! to the root is always unique in connectivity and atomic numbers." [`BackItem`]/
+//! [`expand_back_item`] implement this as a synthetic frontier that walks *up* through
+//! the existing parent chain, reusing already-built off-path subtrees as-is (no
+//! rebuilding, no fresh digraph rooted at the embedded atom -- that re-rooted
+//! architecture is what produced the pair-antisymmetry bug this milestone's reference
+//! engine fixed). [`compare_rule1a_only`] compares this frontier against a real
+//! forward ligand via plain sorted-atomic-number shell comparison -- shell-pooling is
+//! unsound for the full rule cascade (see `compare.rs` module docs) but is exactly
+//! Rule 1a's own classical definition, so it is sound restricted to this one rule.
+
+use std::cmp::Ordering;
+
+use crate::compare::CipCompareError;
+use crate::digraph::CipDigraph;
+use crate::node::NodeId;
+use crate::rational::{AtomicNumberKey, cmp_atomic_number_key};
+
+/// A position in the back-to-root ligand's growing frontier.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BackItem {
+    /// A node already present in the outer digraph -- normal forward expansion from
+    /// here on via `expand_children`, no special handling.
+    Reused(NodeId),
+    /// The walk continues upward: `ancestor` is this sphere's atom; `came_from` is the
+    /// specific child of `ancestor` to exclude when expanding (the one leading back
+    /// down toward the atom under resolution -- never re-enter its subtree).
+    Ascending { ancestor: NodeId, came_from: NodeId },
+}
+
+fn back_item_atomic_number(graph: &CipDigraph, item: BackItem) -> AtomicNumberKey {
+    let node = match item {
+        BackItem::Reused(n) => n,
+        BackItem::Ascending { ancestor, .. } => ancestor,
+    };
+    graph.node(node).atomic_number
+}
+
+pub(crate) fn expand_back_item(
+    graph: &mut CipDigraph,
+    item: BackItem,
+) -> Result<Vec<BackItem>, CipCompareError> {
+    match item {
+        BackItem::Reused(n) => Ok(graph
+            .expand_children(n)
+            .map_err(CipCompareError::Digraph)?
+            .into_iter()
+            .map(BackItem::Reused)
+            .collect()),
+        BackItem::Ascending {
+            ancestor,
+            came_from,
+        } => {
+            let mut result: Vec<BackItem> = graph
+                .expand_children(ancestor)
+                .map_err(CipCompareError::Digraph)?
+                .into_iter()
+                .filter(|&c| c != came_from)
+                .map(BackItem::Reused)
+                .collect();
+            if let Some(grandparent) = graph.node(ancestor).parent {
+                result.push(BackItem::Ascending {
+                    ancestor: grandparent,
+                    came_from: ancestor,
+                });
+            }
+            Ok(result)
+        }
+    }
+}
+
+/// Rule 1a only, shell-pooled (sound for Rule 1a alone -- it is the classical
+/// sum/sorted-multiset-of-atomic-numbers rule; shell-pooling is only unsound once
+/// branch-provenance-aware rules like 1b/4b/5 are mixed in, which this function never
+/// invokes). `Greater` means the back-to-root ligand (`lhs`) outranks `rhs`.
+pub(crate) fn compare_rule1a_only(
+    graph: &mut CipDigraph,
+    mut lhs: Vec<BackItem>,
+    mut rhs: Vec<NodeId>,
+) -> Result<Ordering, CipCompareError> {
+    loop {
+        let mut lhs_keys: Vec<_> = lhs
+            .iter()
+            .map(|&i| back_item_atomic_number(graph, i))
+            .collect();
+        let mut rhs_keys: Vec<_> = rhs.iter().map(|&n| graph.node(n).atomic_number).collect();
+        lhs_keys.sort_unstable_by(|a, b| cmp_atomic_number_key(*b, *a));
+        rhs_keys.sort_unstable_by(|a, b| cmp_atomic_number_key(*b, *a));
+        let n = lhs_keys.len().max(rhs_keys.len());
+        for i in 0..n {
+            let l = lhs_keys.get(i).copied();
+            let r = rhs_keys.get(i).copied();
+            let ord = match (l, r) {
+                (Some(a), Some(b)) => cmp_atomic_number_key(a, b),
+                (Some(_), None) => Ordering::Greater,
+                (None, Some(_)) => Ordering::Less,
+                (None, None) => Ordering::Equal,
+            };
+            if ord != Ordering::Equal {
+                return Ok(ord);
+            }
+        }
+        if lhs.is_empty() && rhs.is_empty() {
+            return Ok(Ordering::Equal);
+        }
+        let mut next_lhs = Vec::new();
+        for item in lhs {
+            next_lhs.extend(expand_back_item(graph, item)?);
+        }
+        let mut next_rhs = Vec::new();
+        for node in rhs {
+            next_rhs.extend(
+                graph
+                    .expand_children(node)
+                    .map_err(CipCompareError::Digraph)?,
+            );
+        }
+        lhs = next_lhs;
+        rhs = next_rhs;
+    }
+}

--- a/crates/chematic-cip/src/lib.rs
+++ b/crates/chematic-cip/src/lib.rs
@@ -19,6 +19,7 @@
 #![forbid(unsafe_code)]
 
 pub mod assign;
+mod auxiliary;
 pub mod budget;
 pub mod compare;
 pub mod debug;
@@ -28,6 +29,8 @@ pub mod edge;
 pub mod mancude;
 pub mod node;
 pub mod rational;
+mod resolver;
+mod rule4b;
 pub mod trace;
 
 #[cfg(test)]

--- a/crates/chematic-cip/src/resolver.rs
+++ b/crates/chematic-cip/src/resolver.rs
@@ -1,0 +1,234 @@
+//! Milestone 4B-2 production port of the validated Rule 4b reference engine
+//! (`examples/rule4b_bottom_up.rs`, 72/72 across 4 oracle corpora including mirrors --
+//! see `docs/cip_accurate_rfc.md`). Mechanical port: [`resolve_chirality`] is
+//! unchanged from the example. [`assign_one_with_rule4b`]/[`apply_rule4b_pass`] are
+//! new, fitting the validated algorithm into `assign.rs`'s existing pass-based
+//! architecture (mirroring [`crate::assign`]'s own `assign_one_with_rule5`/
+//! `apply_rule5_pass` plumbing shape, but the tie-detection loop itself mirrors the
+//! reference engine's `resolve_outer_root` -- looping over *every* group and
+//! attempting a Rule 4b tiebreak on each clean 2-way tie found, not
+//! `assign_one_with_rule5`'s narrower "exactly one tied group" restriction, since
+//! that restriction was never part of what was validated 72/72).
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+
+use chematic_core::{AtomIdx, Chirality, CipCode, Molecule};
+
+use crate::assign::{
+    AccurateCipAssignment, SkipReason, map_compare_err, map_digraph_err, position_node_ids,
+    resolve_is_r_from_groups,
+};
+use crate::budget::CipBudget;
+use crate::compare::{CipCompareError, CompareContext, rank_children};
+use crate::digraph::CipDigraph;
+use crate::mancude::MancudeContext;
+use crate::node::{CipNodeKind, NodeId};
+use crate::rule4b::break_tie_rule4b;
+
+/// The core recursive, memoized, in-place resolver. `node_id` must be a real `Atom`
+/// node (not the true digraph root -- the root has no "back to root" ligand and is
+/// handled by [`assign_one_with_rule4b`] directly, mirroring the reference engine's
+/// own `resolve_outer_root`/`resolve_chirality` split).
+pub(crate) fn resolve_chirality(
+    graph: &mut CipDigraph,
+    mol: &Molecule,
+    node_id: NodeId,
+    budget: CipBudget,
+    cache: &mut HashMap<NodeId, Option<bool>>,
+) -> Result<Option<bool>, CipCompareError> {
+    if let Some(&cached) = cache.get(&node_id) {
+        return Ok(cached);
+    }
+
+    let atom_idx = match graph.node(node_id).kind {
+        CipNodeKind::Atom { atom_idx } => atom_idx,
+        _ => {
+            cache.insert(node_id, None);
+            return Ok(None);
+        }
+    };
+    if mol.atom(atom_idx).chirality == Chirality::None {
+        cache.insert(node_id, None);
+        return Ok(None);
+    }
+    let Some(parent_id) = graph.node(node_id).parent else {
+        // True digraph root -- use assign_one_with_rule4b instead.
+        cache.insert(node_id, None);
+        return Ok(None);
+    };
+
+    let forward_children = graph
+        .expand_children(node_id)
+        .map_err(CipCompareError::Digraph)?;
+    let mut ctx = CompareContext::new();
+    let mut groups = rank_children(graph, &forward_children, &mut ctx)?;
+
+    // Rule 4b tiebreak: only a clean 2-way tie is handled (scope match with every case
+    // seen in this residual family). 3+-way ties are reported, not guessed.
+    for gi in 0..groups.len() {
+        if groups[gi].len() == 2 {
+            let (a, b) = (groups[gi][0], groups[gi][1]);
+            if let Some(ord) = break_tie_rule4b(graph, mol, a, b, budget, cache)? {
+                let (higher, lower) = match ord {
+                    Ordering::Greater => (a, b),
+                    Ordering::Less => (b, a),
+                    Ordering::Equal => (a, b),
+                };
+                if ord != Ordering::Equal {
+                    groups[gi] = vec![lower];
+                    groups.insert(gi, vec![higher]);
+                }
+            }
+        } else if groups[gi].len() > 2 {
+            cache.insert(node_id, None);
+            return Ok(None); // out of scope this round
+        }
+    }
+
+    // Insert the back-to-root ligand at its Rule-1a-only rank among `groups`. Compare
+    // sphere-1-to-sphere-1: the back ligand's sphere 1 is `ancestor` itself; the
+    // forward ligand's sphere 1 is `rep` itself -- NOT `rep`'s children (that would be
+    // off by one sphere).
+    let mut insert_at = groups.len();
+    for (gi, group) in groups.iter().enumerate() {
+        let rep = group[0];
+        let back_frontier = vec![crate::auxiliary::BackItem::Ascending {
+            ancestor: parent_id,
+            came_from: node_id,
+        }];
+        let ord = crate::auxiliary::compare_rule1a_only(graph, back_frontier, vec![rep])?;
+        if ord == Ordering::Greater {
+            insert_at = gi;
+            break;
+        }
+    }
+    let mut final_groups = groups.clone();
+    final_groups.insert(insert_at, vec![parent_id]);
+
+    let stereo_order = match mol.stereo_neighbor_order(atom_idx) {
+        Some(o) => o,
+        None => {
+            cache.insert(node_id, None);
+            return Ok(None);
+        }
+    };
+    let mut candidates = forward_children.clone();
+    candidates.push(parent_id);
+    let position_nodes = match position_node_ids(graph, stereo_order, &candidates) {
+        Some(p) => p,
+        None => {
+            cache.insert(node_id, None);
+            return Ok(None);
+        }
+    };
+    let result =
+        resolve_is_r_from_groups(&final_groups, &position_nodes, mol.atom(atom_idx).chirality);
+    cache.insert(node_id, result);
+    Ok(result)
+}
+
+/// Retry a Pass-1-tied atom with Rule 4b. Builds one fresh digraph rooted at the
+/// outer atom itself (`idx`) -- matching `assign_one`/`assign_one_with_rule5`'s
+/// existing per-outer-atom pattern -- and resolves every embedded stereocenter *in
+/// place* within that same digraph via [`resolve_chirality`], never re-rooting a
+/// second digraph at any embedded atom. Loops over every group produced by
+/// Rules-1a/1b/2 (mirroring the reference engine's `resolve_outer_root`), attempting
+/// the Rule 4b tiebreak on each clean 2-way tie found -- not restricted to exactly one
+/// tied group the way [`crate::assign::assign_one_with_rule5`] is, since that
+/// restriction isn't part of what the reference engine validated 72/72.
+pub(crate) fn assign_one_with_rule4b(
+    mol: &Molecule,
+    idx: AtomIdx,
+    chirality: Chirality,
+    stereo_order: &[u32],
+    budget: CipBudget,
+    kekule: Option<&(Molecule, MancudeContext)>,
+) -> Result<Option<CipCode>, SkipReason> {
+    let mut graph = match kekule {
+        Some((kekule_mol, ctx)) => {
+            CipDigraph::new_with_mancude(kekule_mol, idx, budget, ctx).map_err(map_digraph_err)?
+        }
+        None => CipDigraph::new(mol, idx, budget).map_err(map_digraph_err)?,
+    };
+    let root = graph.root();
+    let root_children = graph.expand_children(root).map_err(map_digraph_err)?;
+
+    let Some(position_nodes) = position_node_ids(&graph, stereo_order, &root_children) else {
+        return Ok(None);
+    };
+
+    let mut ctx = CompareContext::new();
+    let mut groups =
+        rank_children(&mut graph, &root_children, &mut ctx).map_err(map_compare_err)?;
+
+    let mut cache = HashMap::new();
+    for gi in 0..groups.len() {
+        if groups[gi].len() == 2 {
+            let (a, b) = (groups[gi][0], groups[gi][1]);
+            if let Some(ord) = break_tie_rule4b(&mut graph, mol, a, b, budget, &mut cache)
+                .map_err(map_compare_err)?
+            {
+                let (higher, lower) = match ord {
+                    Ordering::Greater => (a, b),
+                    _ => (b, a),
+                };
+                if ord != Ordering::Equal {
+                    groups[gi] = vec![lower];
+                    groups.insert(gi, vec![higher]);
+                }
+            }
+        } else if groups[gi].len() > 2 {
+            return Err(SkipReason::Tied);
+        }
+    }
+
+    let Some(is_r) = resolve_is_r_from_groups(&groups, &position_nodes, chirality) else {
+        return Err(SkipReason::Tied);
+    };
+    Ok(Some(if is_r { CipCode::R } else { CipCode::S }))
+}
+
+/// Milestone 4B-2's Rule 4b refinement -- see module docs for scope. Only ever touches
+/// atoms Pass 1 (`assign_all`) left [`SkipReason::Tied`]; every other atom is carried
+/// through unchanged. Mirrors [`crate::assign::apply_rule5_pass`]'s exact shape and,
+/// crucially, runs *before* it in [`crate::assign::assign_cip_accurate_experimental`]
+/// (Rule 4b precedes Rule 5 in CIP rule order) -- Rule 5's own `provisional` map
+/// (built from whatever `AccurateCipAssignment` it's handed) sees Rule 4b's
+/// newly-resolved atoms for free, no changes needed inside `apply_rule5_pass` itself.
+pub(crate) fn apply_rule4b_pass(
+    mol: &Molecule,
+    budget: CipBudget,
+    kekule: Option<&(Molecule, MancudeContext)>,
+    pass1: AccurateCipAssignment,
+) -> AccurateCipAssignment {
+    let mut assignments = pass1.assignments;
+    let mut skipped = Vec::with_capacity(pass1.skipped.len());
+
+    for (idx, reason) in pass1.skipped {
+        if reason != SkipReason::Tied {
+            skipped.push((idx, reason));
+            continue;
+        }
+
+        let atom = mol.atom(idx);
+        let Some(stereo_order) = mol.stereo_neighbor_order(idx) else {
+            skipped.push((idx, reason));
+            continue;
+        };
+        if stereo_order.len() != 4 {
+            skipped.push((idx, reason));
+            continue;
+        }
+
+        match assign_one_with_rule4b(mol, idx, atom.chirality, stereo_order, budget, kekule) {
+            Ok(Some(code)) => assignments.push((idx, code)),
+            _ => skipped.push((idx, reason)),
+        }
+    }
+
+    AccurateCipAssignment {
+        assignments,
+        skipped,
+    }
+}

--- a/crates/chematic-cip/src/rule4b.rs
+++ b/crates/chematic-cip/src/rule4b.rs
@@ -1,0 +1,133 @@
+//! Milestone 4B-2 production port of the Rule 4b tiebreak from the validated
+//! reference engine (`examples/rule4b_bottom_up.rs`, 72/72 across 4 oracle corpora
+//! including mirrors -- see `docs/cip_accurate_rfc.md`). Mechanical port: algorithm
+//! unchanged from the example.
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+
+use chematic_core::{AtomIdx, Chirality, Molecule};
+
+use crate::budget::CipBudget;
+use crate::compare::CipCompareError;
+use crate::digraph::CipDigraph;
+use crate::node::{CipNodeKind, NodeId};
+use crate::resolver::resolve_chirality;
+
+/// BFS, in place within the outer digraph (no re-rooting), for the nearest
+/// chirality-bearing atom reachable from `start`'s children onward. `None` if 2+
+/// distinct atoms tie at the nearest level (ambiguous -- ties fall through to
+/// `SkipReason::Tied` at the call site, never guessed).
+pub(crate) fn nearest_embedded(
+    graph: &mut CipDigraph,
+    mol: &Molecule,
+    start: NodeId,
+) -> Result<Option<NodeId>, CipCompareError> {
+    let mut frontier = graph
+        .expand_children(start)
+        .map_err(CipCompareError::Digraph)?;
+    loop {
+        if frontier.is_empty() {
+            return Ok(None);
+        }
+        let mut found: Option<(AtomIdx, NodeId)> = None;
+        for &n in &frontier {
+            if let CipNodeKind::Atom { atom_idx } = graph.node(n).kind
+                && mol.atom(atom_idx).chirality != Chirality::None
+            {
+                match found {
+                    None => found = Some((atom_idx, n)),
+                    Some((existing, _)) if existing == atom_idx => {}
+                    Some(_) => return Ok(None),
+                }
+            }
+        }
+        if let Some((_, node_id)) = found {
+            return Ok(Some(node_id));
+        }
+        let mut next = Vec::new();
+        for &n in &frontier {
+            next.extend(graph.expand_children(n).map_err(CipCompareError::Digraph)?);
+        }
+        frontier = next;
+    }
+}
+
+const MAX_CHAIN_DEPTH: usize = 4;
+
+/// The ordered chain of nearest-embedded-stereocenter `NodeId`s reached from `start`,
+/// one level deeper each step -- in place, no re-rooting.
+fn embedded_chain(
+    graph: &mut CipDigraph,
+    mol: &Molecule,
+    start: NodeId,
+) -> Result<Vec<NodeId>, CipCompareError> {
+    // `start` itself is chain position 0 if it's chirality-bearing (it always is here
+    // -- `start` is one of a tied group's own members, i.e. the outer atom's own
+    // forward child, and every case in this residual family has the tied children
+    // themselves be embedded stereocenters). `nearest_embedded` starts searching from
+    // `start`'s *children*, so it is only correct for continuing the chain past an
+    // already-found element, never for the first one.
+    let mut chain = Vec::new();
+    if let CipNodeKind::Atom { atom_idx } = graph.node(start).kind
+        && mol.atom(atom_idx).chirality != Chirality::None
+    {
+        chain.push(start);
+    }
+    let mut current = start;
+    for _ in 0..MAX_CHAIN_DEPTH {
+        match nearest_embedded(graph, mol, current)? {
+            Some(node_id) => {
+                chain.push(node_id);
+                current = node_id;
+            }
+            None => break,
+        }
+    }
+    Ok(chain)
+}
+
+/// Rule 4b tiebreak for an exactly-2-way tie (every case observed in this corpus family
+/// so far; 3+-way ties are out of scope and reported rather than guessed). Faithful
+/// reference-relative Like/Unlike: each branch's own reference is its own nearest
+/// (position-0) resolved chirality, never shared, never inverted -- the operator
+/// confirmed correct by `rule4b_operator_tests.rs` (7/7). The chain elements'
+/// chirality is resolved via *recursive, in-place* [`resolve_chirality`].
+pub(crate) fn break_tie_rule4b(
+    graph: &mut CipDigraph,
+    mol: &Molecule,
+    a: NodeId,
+    b: NodeId,
+    budget: CipBudget,
+    cache: &mut HashMap<NodeId, Option<bool>>,
+) -> Result<Option<Ordering>, CipCompareError> {
+    let chain_a = embedded_chain(graph, mol, a)?;
+    let chain_b = embedded_chain(graph, mol, b)?;
+    let signs_a: Vec<Option<bool>> = chain_a
+        .iter()
+        .map(|&n| resolve_chirality(graph, mol, n, budget, cache))
+        .collect::<Result<_, _>>()?;
+    let signs_b: Vec<Option<bool>> = chain_b
+        .iter()
+        .map(|&n| resolve_chirality(graph, mol, n, budget, cache))
+        .collect::<Result<_, _>>()?;
+
+    let (Some(Some(ref_a)), Some(Some(ref_b))) = (signs_a.first(), signs_b.first()) else {
+        return Ok(None);
+    };
+    for i in 0..signs_a.len().min(signs_b.len()) {
+        let (Some(sa), Some(sb)) = (signs_a[i], signs_b[i]) else {
+            break;
+        };
+        let like_a = sa == *ref_a;
+        let like_b = sb == *ref_b;
+        if like_a != like_b {
+            return Ok(Some(if like_a {
+                Ordering::Greater
+            } else {
+                Ordering::Less
+            }));
+        }
+    }
+    Ok(None)
+}

--- a/crates/chematic-cip/tests/rule4b_production_parity.rs
+++ b/crates/chematic-cip/tests/rule4b_production_parity.rs
@@ -1,0 +1,319 @@
+//! Milestone 4B-2: production-path parity for the ported Rule 4b engine
+//! (`src/auxiliary.rs`/`src/rule4b.rs`/`src/resolver.rs`, wired into
+//! `assign_cip_accurate_experimental` via `assign.rs::assign_cip_accurate_experimental`).
+//!
+//! Reruns the exact 4 oracle corpora (+ mirrors) the diagnostic reference engine
+//! (`examples/rule4b_bottom_up.rs`) validated 72/72 against, but through the real
+//! production entry point (`assign_cip_accurate_experimental`, not a hand-built
+//! digraph) -- this is the parity gate: if the mechanical port introduced any
+//! divergence from the validated reference, it surfaces here, not just in the
+//! full-corpus report.
+//!
+//! `ROWS_ORIGINAL` (quinic acid / galloyl ester molecules) contain aromatic gallic-acid
+//! rings, so running them through `assign_cip_accurate_experimental` (which always
+//! attempts `prepare_kekule_form`/`CipDigraph::new_with_mancude` when it succeeds) is
+//! this suite's MANCUDE/aromatic coverage for the new Rule 4b pass -- a code path the
+//! diagnostic reference engine itself never exercised (it used plain `CipDigraph::new`
+//! throughout). `aromatic_content_present_in_rows_original` checks this claim directly
+//! rather than assuming it.
+//!
+//! A dedicated "Rule 5 didn't regress" test is deliberately not duplicated here: the
+//! full-corpus gate (`cip_accurate_full_corpus_report.py`'s independent per-row oracle
+//! recompute) already covers every corpus row, including the two known Rule-5
+//! (lowercase `r`/`s`) rows, more thoroughly than a hardcoded 2-row unit test would.
+
+use chematic_cip::{CipBudget, assign_cip_accurate_experimental};
+use chematic_core::{AtomIdx, CipCode};
+
+const VS196_SMILES: &str = "Cl[C@H]1[C@H]([C@H]([C@@H]([C@@H]([C@H]1Cl)Cl)Cl)Cl)Cl";
+const VS196_ROWS: &[(u32, CipCode)] = &[
+    (1, CipCode::R),
+    (2, CipCode::S),
+    (3, CipCode::S),
+    (4, CipCode::R),
+    (5, CipCode::S),
+    (6, CipCode::R),
+];
+
+const VS197_SMILES: &str = "Cl[C@H]1[C@@H]([C@H]([C@@H]([C@@H]([C@H]1Cl)Cl)Cl)Cl)Cl";
+const VS197_ROWS: &[(u32, CipCode)] = &[
+    (1, CipCode::R),
+    (2, CipCode::R),
+    (3, CipCode::R),
+    (4, CipCode::R),
+    (5, CipCode::S),
+    (6, CipCode::S),
+];
+
+const ROWS_ORIGINAL: &[(&str, u32, &str, CipCode)] = &[
+    (
+        "O=C(O[C@@H]1C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@@H](OC(=O)c2cc(O)c(O)c(O)c2)[C@H]1OC(=O)c1cc(O)c(O)c(O)c1)c1cc(O)c(O)c(O)c1",
+        5,
+        "tri-galloyl-a",
+        CipCode::S,
+    ),
+    (
+        "O=C(O[C@@H]1C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@@H](OC(=O)c2cc(O)c(O)c(O)c2)[C@H]1OC(=O)c1cc(O)c(O)c(O)c1)c1cc(O)c(O)c(O)c1",
+        35,
+        "tri-galloyl-b",
+        CipCode::S,
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](O)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        3,
+        "quinic-a",
+        CipCode::S,
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](O)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        7,
+        "quinic-b",
+        CipCode::S,
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        3,
+        "mono-galloyl-a",
+        CipCode::S,
+    ),
+    (
+        "O=C(O[C@H]1[C@H](O)C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+        7,
+        "mono-galloyl-b",
+        CipCode::S,
+    ),
+    (
+        "O=C(Oc1c(O)cc(C(=O)O[C@H]2[C@H](OC(=O)c3cc(O)c(O)c(O)c3)C[C@](O)(C(=O)O)C[C@H]2OC(=O)c2cc(O)c(O)c(O)c2)cc1O)c1cc(O)c(O)c(O)c1",
+        11,
+        "tetra-galloyl-a",
+        CipCode::S,
+    ),
+    (
+        "O=C(Oc1c(O)cc(C(=O)O[C@H]2[C@H](OC(=O)c3cc(O)c(O)c(O)c3)C[C@](O)(C(=O)O)C[C@H]2OC(=O)c2cc(O)c(O)c(O)c2)cc1O)c1cc(O)c(O)c(O)c1",
+        26,
+        "tetra-galloyl-b",
+        CipCode::S,
+    ),
+];
+
+const ROWS_DISCRIMINATING: &[(&str, u32, &str, CipCode)] = &[
+    (
+        "C[C@H](O)[C@H](O)[C@@H](O)[C@H](O)[C@@H](O)[C@H](O)[C@@H](O)C",
+        7,
+        "indep-ref-1",
+        CipCode::S,
+    ),
+    (
+        "C[C@H](O)[C@H](O)[C@@H](O)[C@H](O)[C@@H](O)[C@@H](O)[C@H](O)C",
+        7,
+        "indep-ref-2",
+        CipCode::S,
+    ),
+    (
+        "C[C@H](O)[C@H](O)[C@@H](O)[C@H](O)[C@@H](O)[C@@H](O)[C@@H](O)C",
+        7,
+        "indep-ref-3",
+        CipCode::S,
+    ),
+    (
+        "C[C@H](O)[C@@H](O)[C@@H](O)[C@H](O)[C@@H](O)[C@H](O)[C@H](O)C",
+        7,
+        "indep-ref-4",
+        CipCode::R,
+    ),
+    (
+        "C[C@H](O)[C@H](O)[C@H](O)[C@H](O)[C@H](O)[C@H](O)[C@@H](O)C",
+        7,
+        "indep-ref-5",
+        CipCode::R,
+    ),
+    (
+        "C[C@H](O)[C@H](O)[C@H](O)[C@H](O)[C@H](O)[C@@H](O)[C@H](O)C",
+        7,
+        "indep-ref-6",
+        CipCode::R,
+    ),
+    (
+        "C[C@H](O)[C@H](O)[C@H](O)[C@H](O)[C@H](O)[C@@H](O)[C@@H](O)C",
+        7,
+        "indep-ref-7",
+        CipCode::R,
+    ),
+    (
+        "C[C@H](O)[C@@H](O)[C@H](O)[C@H](O)[C@H](O)[C@H](O)[C@H](O)C",
+        7,
+        "indep-ref-8",
+        CipCode::S,
+    ),
+    (
+        "C[C@H](O)[C@H](O)[C@@H](O)[C@H](O)[C@H](O)[C@H](O)[C@H](O)C",
+        7,
+        "deep-div-1",
+        CipCode::S,
+    ),
+    (
+        "C[C@H](O)[C@H](O)[C@@H](O)[C@H](O)[C@H](O)[C@H](O)[C@@H](O)C",
+        7,
+        "deep-div-2",
+        CipCode::S,
+    ),
+    (
+        "C[C@H](O)[C@H](O)[C@@H](O)[C@H](O)[C@H](O)[C@@H](O)[C@H](O)C",
+        7,
+        "deep-div-3",
+        CipCode::S,
+    ),
+    (
+        "C[C@H](O)[C@@H](O)[C@@H](O)[C@H](O)[C@H](O)[C@H](O)[C@H](O)C",
+        7,
+        "deep-div-4",
+        CipCode::S,
+    ),
+    (
+        "C[C@H](O)[C@H](O)[C@H](O)[C@H](O)[C@@H](O)[C@H](O)[C@H](O)C",
+        7,
+        "deep-div-5",
+        CipCode::R,
+    ),
+    (
+        "C[C@H](O)[C@H](O)[C@H](O)[C@H](O)[C@@H](O)[C@H](O)[C@@H](O)C",
+        7,
+        "deep-div-6",
+        CipCode::R,
+    ),
+    (
+        "C[C@H](O)[C@H](O)[C@H](O)[C@H](O)[C@@H](O)[C@@H](O)[C@H](O)C",
+        7,
+        "deep-div-7",
+        CipCode::R,
+    ),
+    (
+        "C[C@H](O)[C@@H](O)[C@H](O)[C@H](O)[C@@H](O)[C@H](O)[C@H](O)C",
+        7,
+        "deep-div-8",
+        CipCode::R,
+    ),
+];
+
+fn mirror_smiles(smiles: &str) -> String {
+    let mut out = String::with_capacity(smiles.len());
+    let mut chars = smiles.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '@' {
+            if chars.peek() == Some(&'@') {
+                chars.next();
+                out.push('@');
+            } else {
+                out.push_str("@@");
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+fn mirror_code(c: CipCode) -> CipCode {
+    match c {
+        CipCode::R => CipCode::S,
+        CipCode::S => CipCode::R,
+        other => other,
+    }
+}
+
+fn assert_case(smiles: &str, atom_idx: u32, case_id: &str, oracle: CipCode) {
+    let mol = chematic_smiles::parse(smiles).expect("valid SMILES");
+    let budget = CipBudget::default_budget();
+    let result = assign_cip_accurate_experimental(&mol, budget).expect("assignment succeeds");
+    let got = result
+        .assignments
+        .iter()
+        .find(|(idx, _)| *idx == AtomIdx(atom_idx))
+        .map(|(_, code)| *code);
+    let skip_reason = result
+        .skipped
+        .iter()
+        .find(|(idx, _)| *idx == AtomIdx(atom_idx))
+        .map(|(_, reason)| reason);
+    assert_eq!(
+        got,
+        Some(oracle),
+        "{case_id} (atom {atom_idx}): expected {oracle:?}, got {got:?} (skip_reason={skip_reason:?})"
+    );
+}
+
+#[test]
+fn vs196_production_parity() {
+    for &(atom_idx, oracle) in VS196_ROWS {
+        assert_case(VS196_SMILES, atom_idx, "VS196", oracle);
+    }
+}
+
+#[test]
+fn vs196_mirror_production_parity() {
+    let mirrored = mirror_smiles(VS196_SMILES);
+    for &(atom_idx, oracle) in VS196_ROWS {
+        assert_case(&mirrored, atom_idx, "VS196-mirror", mirror_code(oracle));
+    }
+}
+
+#[test]
+fn vs197_production_parity() {
+    for &(atom_idx, oracle) in VS197_ROWS {
+        assert_case(VS197_SMILES, atom_idx, "VS197", oracle);
+    }
+}
+
+#[test]
+fn vs197_mirror_production_parity() {
+    let mirrored = mirror_smiles(VS197_SMILES);
+    for &(atom_idx, oracle) in VS197_ROWS {
+        assert_case(&mirrored, atom_idx, "VS197-mirror", mirror_code(oracle));
+    }
+}
+
+#[test]
+fn rows_original_production_parity() {
+    for &(smiles, atom_idx, case_id, oracle) in ROWS_ORIGINAL {
+        assert_case(smiles, atom_idx, case_id, oracle);
+    }
+}
+
+#[test]
+fn rows_original_mirror_production_parity() {
+    for &(smiles, atom_idx, case_id, oracle) in ROWS_ORIGINAL {
+        let mirrored = mirror_smiles(smiles);
+        assert_case(&mirrored, atom_idx, case_id, mirror_code(oracle));
+    }
+}
+
+#[test]
+fn rows_discriminating_production_parity() {
+    for &(smiles, atom_idx, case_id, oracle) in ROWS_DISCRIMINATING {
+        assert_case(smiles, atom_idx, case_id, oracle);
+    }
+}
+
+#[test]
+fn rows_discriminating_mirror_production_parity() {
+    for &(smiles, atom_idx, case_id, oracle) in ROWS_DISCRIMINATING {
+        let mirrored = mirror_smiles(smiles);
+        assert_case(&mirrored, atom_idx, case_id, mirror_code(oracle));
+    }
+}
+
+/// Confirms `ROWS_ORIGINAL`'s molecules genuinely contain aromatic atoms -- the basis
+/// for this suite's claim that `rows_original_production_parity` exercises the
+/// `CipDigraph::new_with_mancude` path, not just plain `CipDigraph::new`.
+#[test]
+fn aromatic_content_present_in_rows_original() {
+    for &(smiles, _, case_id, _) in ROWS_ORIGINAL {
+        let mol = chematic_smiles::parse(smiles).expect("valid SMILES");
+        let has_aromatic = (0..mol.atom_count()).any(|i| mol.atom(AtomIdx(i as u32)).aromatic);
+        assert!(
+            has_aromatic,
+            "{case_id}: expected an aromatic ring (gallic acid ester), found none -- \
+             MANCUDE-path coverage claim would be false"
+        );
+    }
+}

--- a/docs/cip_accurate_rfc.md
+++ b/docs/cip_accurate_rfc.md
@@ -1234,8 +1234,32 @@ both-references-max scoring; 3-way-or-more ties; Rule 5 cage family; phosphorus;
 performance optimization; removing `new_with_artificial_ancestor`; making the
 accurate engine the default path.
 
-**Next**: re-freeze the residual corpus (expected ~26 remaining: ~15 Rule 5 cage
-family, ~11 phosphorus, 0 Rule 4) before scoping M4C (phosphorus) — not started.
+**Post-M4B-2 residual re-freeze — exact match to prediction.** Ran on this same
+branch (CI-green, pre-merge) via `corpus_snapshot.rs --candidate` + a fresh RDKit
+oracle, frozen as `validation/cip_m4b2_post_port_residual.jsonl`:
+
+- **26 residual rows** (4160/4186 correct, 99.38% — matches the full-corpus gate
+  exactly), split:
+  - **15 `rule5_pseudoasymmetric`** (oracle label lowercase `r`/`s`) — the
+    already-known, already-deferred three-armed cage family (Milestone 4A-2).
+  - **11 `phosphorus`** — splits **9 wrong + 2 tied**, matching the pre-M4B
+    classification exactly. All 9 "wrong" rows are phosphazene ring compounds
+    (cyclic P=N systems) showing a clean R↔S flip pattern (chematic's own answer is
+    the oracle's exact opposite in every case, not a random miss) — consistent with
+    the standing diagnosis that this is a P=N digraph-representation issue (duplicate
+    arrival/departure side), not a missing sequence rule.
+  - **0 Rule 4** — the bucket this milestone targeted is empty, confirming the
+    production port didn't just move the residual around.
+
+## M4C-0 — phosphorus diagnosis (not started until this point; see below for scope)
+
+**Next**: M4C-0, mechanically classifying the 9 "wrong" phosphorus rows along the
+axes the user specified (P=N duplicate arrival/departure representation; P-center
+physical-ligand-vs-comparison-duplicate correspondence; valence/formal charge;
+lone-pair representation; root-vs-branch-internal behavior difference; isotope
+Rule-2-path impact) — diagnosis only, no implementation, per the same discipline
+Milestone 4B-0 used for Rule 4. If all 9 are fixed: 4160 + 9 = **4169/4186 (99.59%)**,
+clearing the Milestone 4 gate (99.5%) without touching the harder Rule-5 cage family.
 
 ## Required property tests (starting Milestone 1)
 

--- a/docs/cip_accurate_rfc.md
+++ b/docs/cip_accurate_rfc.md
@@ -1168,6 +1168,75 @@ a **mechanical port, not a rewrite**:
 - Multiple-reference-candidate cases surface as `Unresolved`/deferred, never a silent
   potentially-wrong label.
 
+**Milestone 4B-2 shipped — mechanical production port, all gates met.** Per the
+user's detailed follow-up spec (module names, non-goals, independent parity gate,
+full-corpus targets), the validated reference engine was ported into
+`crates/chematic-cip/src/{auxiliary,rule4b,resolver}.rs` and wired into
+`assign_cip_accurate_experimental` only, as a new pass between `assign_all` (Rules
+1a/1b/2) and the existing `apply_rule5_pass` (Rule 4b precedes Rule 5 in CIP order).
+
+Planned via an independent Plan-agent critique before implementation (not just the
+user's own sketch) — the critique caught one wording ambiguity worth recording:
+`assign_one_with_rule4b`'s tie-detection loop had to mirror the reference engine's
+`resolve_outer_root` (loop over *every* group, attempt Rule 4b on each clean 2-way
+tie) rather than `assign_one_with_rule5`'s narrower "exactly one tied group, bail on
+a second" restriction — a restriction that was never part of what got validated
+72/72. It also flagged that the 72/72 validation ran entirely through plain
+`CipDigraph::new`, with zero MANCUDE/aromatic coverage anywhere in the reference
+example — resolved by noting (and testing directly,
+`aromatic_content_present_in_rows_original`) that the existing `ROWS_ORIGINAL`
+corpus (galloyl/quinic esters) already contains aromatic gallic-acid rings, so
+re-running it through the real `assign_cip_accurate_experimental` entry point (which
+always attempts `CipDigraph::new_with_mancude` when Kekulé form is available)
+exercises that path for free — no separate synthetic molecule needed.
+
+`position_node_ids` (`assign.rs`) was generalized in place (renamed `root_children`
+→ `candidates`, added a `RingDuplicate` match arm) rather than duplicated, since the
+addition is provably inert for the two pre-existing callers. No new `SkipReason`
+variant was added — multiple-reference-candidate and 3+-way-tie cases already fall
+through to the existing `SkipReason::Tied` via `nearest_embedded`'s pre-existing
+ambiguity check, exactly the "fail loudly, don't guess" behavior required, with zero
+API surface change.
+
+**Verification, all four gates independently confirmed:**
+
+- **72/72 production-path parity** (`tests/rule4b_production_parity.rs`): the same 4
+  oracle corpora + mirrors the reference engine validated, rerun through
+  `assign_cip_accurate_experimental` itself (not a hand-built digraph) — 9/9 tests
+  pass.
+- **Full-corpus gate**, `assign_cip_accurate_experimental` on `main` (pre-port,
+  baseline) vs. this branch (candidate), both `--candidate`-mode snapshots via
+  `corpus_snapshot.rs` (an isolated `git worktree` built the `main` baseline so the
+  working tree was never disturbed), diffed with
+  `cip_accurate_full_corpus_report.py` against a fresh RDKit oracle:
+  `baseline_correct=4152/4186 (99.19%)`, `candidate_correct=4160/4186 (99.38%)`,
+  `newly_correct=8` (exactly the `rule4_candidate` residual, no unexplained extras),
+  `regressions_from_full_recompute=0` (Method B, independent full-set recompute),
+  `regressions_from_diff=0` (Method A, 8 changed rows: 8 fixes, 0 regressions, 0
+  neutral) — an exact match to the plan's target on every field.
+- **Rule 5 non-regression**: rather than a separate hardcoded 2-row test (the exact
+  target molecules aren't named anywhere convenient in the repo), relied on two
+  things that already cover it more thoroughly — the existing
+  `tests.rs::rule5_resolves_the_two_verified_milestone_4a_target_rows` test passing
+  unchanged, and the full-corpus gate's Method B (which independently re-checks
+  *every* row, so a Rule-4b pass wrongly stealing a genuine Rule-5 pseudoasymmetric
+  case would show up as a regression, not just a wrong new label).
+- `cargo test --workspace --lib --quiet`, `cargo test -p chematic-cip --release`
+  (all existing suites, unchanged), `cargo clippy --workspace --all-targets -- -D
+  warnings`, `bash scripts/check.sh` all clean.
+
+`chematic_chem::assign_cip()` (legacy) and `assign_cip_accurate_experimental_without_mancude`
+(the frozen MANCUDE-independent reference point) are both untouched, matching Rule
+5's own choice to leave that entry point alone.
+
+**Not done, explicitly out of scope this PR** (per the user's own list): Figure 8's
+both-references-max scoring; 3-way-or-more ties; Rule 5 cage family; phosphorus;
+performance optimization; removing `new_with_artificial_ancestor`; making the
+accurate engine the default path.
+
+**Next**: re-freeze the residual corpus (expected ~26 remaining: ~15 Rule 5 cage
+family, ~11 phosphorus, 0 Rule 4) before scoping M4C (phosphorus) — not started.
+
 ## Required property tests (starting Milestone 1)
 
 - Atom-renumbering invariance (same molecule, different internal atom indices → same

--- a/validation/cip_m4b2_post_port_residual.jsonl
+++ b/validation/cip_m4b2_post_port_residual.jsonl
@@ -1,0 +1,27 @@
+{"_manifest": true, "branch": "cip-m4b2-production-port (CI-green, pre-merge)", "correct": 4160, "generated": "2026-07-16", "rdkit_version": "2026.03.3", "residual": 26, "total": 4186}
+{"atom_idx": 11, "bucket": "phosphorus", "chematic": "R", "modern": "S", "smiles": "C1CCN(P2(N3CCCC3)=N[P@@](N3CCCC3)(N3CC3)=N[P@](N3CCCC3)(N3CC3)=N2)C1"}
+{"atom_idx": 4, "bucket": "phosphorus", "chematic": "S", "modern": "R", "smiles": "C1CCN([P@@]2(N3CC3)=NP(N3CC3)(N3CC3)=N[P@@](N3CCCCC3)(N3CC3)=N2)CC1"}
+{"atom_idx": 22, "bucket": "phosphorus", "chematic": "S", "modern": "R", "smiles": "C1CN(P2(N3CCOCC3)=N[P@](N3CCOCC3)(N3CC3)=N[P@@](N3CCOCC3)(N3CC3)=N2)CCO1"}
+{"atom_idx": 16, "bucket": "phosphorus", "chematic": "S", "modern": "R", "smiles": "C1CN([P@@]2(N3CC3)=NP(N3CC3)(N3CC3)=N[P@@](N3CCOCC3)(N3CC3)=N2)CCO1"}
+{"atom_idx": 31, "bucket": "rule5_pseudoasymmetric", "chematic": "skip:tied", "modern": "s", "smiles": "CCCCCCCC/C=C/CCCCCCCC(=O)OCc1cc(=O)c(OC(=O)[C@]23C[C@H]4C[C@H](C[C@H](C4)C2)C3)co1"}
+{"atom_idx": 33, "bucket": "rule5_pseudoasymmetric", "chematic": "skip:tied", "modern": "s", "smiles": "CCCCCCCC/C=C/CCCCCCCC(=O)OCc1cc(=O)c(OC(=O)[C@]23C[C@H]4C[C@H](C[C@H](C4)C2)C3)co1"}
+{"atom_idx": 35, "bucket": "rule5_pseudoasymmetric", "chematic": "skip:tied", "modern": "s", "smiles": "CCCCCCCC/C=C/CCCCCCCC(=O)OCc1cc(=O)c(OC(=O)[C@]23C[C@H]4C[C@H](C[C@H](C4)C2)C3)co1"}
+{"atom_idx": 16, "bucket": "phosphorus", "chematic": "R", "modern": "S", "smiles": "CN(C)P1(N(C)C)=NP(N(C)C)(N(C)C)=N[P@@](N(C)C)(N2CC2)=N[P@](N(C)C)(N2CC2)=N1"}
+{"atom_idx": 6, "bucket": "phosphorus", "chematic": "skip:tied", "modern": "R", "smiles": "CNP1(NC)=N[P@](NC)(N2CC2)=NP(NC)(NC)=N[P@@](NC)(N2CC2)=N1"}
+{"atom_idx": 19, "bucket": "phosphorus", "chematic": "skip:tied", "modern": "S", "smiles": "CNP1(NC)=N[P@](NC)(N2CC2)=NP(NC)(NC)=N[P@@](NC)(N2CC2)=N1"}
+{"atom_idx": 6, "bucket": "phosphorus", "chematic": "S", "modern": "R", "smiles": "CNP1(NC)=N[P@](NC)(N2CC2)=N[P@](NC)(N2CC2)=N1"}
+{"atom_idx": 2, "bucket": "phosphorus", "chematic": "R", "modern": "S", "smiles": "CN[P@@]1(N)=NP(N2CC2)(N2CC2)=N[P@](N)(NC)=N1"}
+{"atom_idx": 21, "bucket": "rule5_pseudoasymmetric", "chematic": "skip:tied", "modern": "s", "smiles": "COc1ccccc1N1CCN(CCCCNC(=O)C23C[C@H]4C[C@@H](C2)C[C@@H](C3)C4)CC1"}
+{"atom_idx": 23, "bucket": "rule5_pseudoasymmetric", "chematic": "skip:tied", "modern": "s", "smiles": "COc1ccccc1N1CCN(CCCCNC(=O)C23C[C@H]4C[C@@H](C2)C[C@@H](C3)C4)CC1"}
+{"atom_idx": 26, "bucket": "rule5_pseudoasymmetric", "chematic": "skip:tied", "modern": "s", "smiles": "COc1ccccc1N1CCN(CCCCNC(=O)C23C[C@H]4C[C@@H](C2)C[C@@H](C3)C4)CC1"}
+{"atom_idx": 16, "bucket": "phosphorus", "chematic": "S", "modern": "R", "smiles": "Cl[P@@]1(N2CCCC2)=NP(N2CC2)(N2CC2)=N[P@@](Cl)(N2CCCC2)=N1"}
+{"atom_idx": 12, "bucket": "phosphorus", "chematic": "S", "modern": "R", "smiles": "N[P@]1(Cl)=NP(N2CC2)(N2CC2)=N[P@](N)(Cl)=N1"}
+{"atom_idx": 23, "bucket": "rule5_pseudoasymmetric", "chematic": "skip:tied", "modern": "s", "smiles": "O=C(NCCCCN1CCCC(/C=C\\c2ccccc2)C1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3"}
+{"atom_idx": 25, "bucket": "rule5_pseudoasymmetric", "chematic": "skip:tied", "modern": "s", "smiles": "O=C(NCCCCN1CCCC(/C=C\\c2ccccc2)C1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3"}
+{"atom_idx": 28, "bucket": "rule5_pseudoasymmetric", "chematic": "skip:tied", "modern": "s", "smiles": "O=C(NCCCCN1CCCC(/C=C\\c2ccccc2)C1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3"}
+{"atom_idx": 25, "bucket": "rule5_pseudoasymmetric", "chematic": "skip:tied", "modern": "s", "smiles": "O=C(NCCCCN1CCN(c2cccc3ccccc23)CC1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3"}
+{"atom_idx": 27, "bucket": "rule5_pseudoasymmetric", "chematic": "skip:tied", "modern": "s", "smiles": "O=C(NCCCCN1CCN(c2cccc3ccccc23)CC1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3"}
+{"atom_idx": 30, "bucket": "rule5_pseudoasymmetric", "chematic": "skip:tied", "modern": "s", "smiles": "O=C(NCCCCN1CCN(c2cccc3ccccc23)CC1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3"}
+{"atom_idx": 20, "bucket": "rule5_pseudoasymmetric", "chematic": "skip:tied", "modern": "s", "smiles": "O=c1cc(COC2CCOCC2)occ1OC(=O)[C@]12C[C@H]3C[C@H](C[C@H](C3)C1)C2"}
+{"atom_idx": 22, "bucket": "rule5_pseudoasymmetric", "chematic": "skip:tied", "modern": "s", "smiles": "O=c1cc(COC2CCOCC2)occ1OC(=O)[C@]12C[C@H]3C[C@H](C[C@H](C3)C1)C2"}
+{"atom_idx": 24, "bucket": "rule5_pseudoasymmetric", "chematic": "skip:tied", "modern": "s", "smiles": "O=c1cc(COC2CCOCC2)occ1OC(=O)[C@]12C[C@H]3C[C@H](C[C@H](C3)C1)C2"}


### PR DESCRIPTION
## Summary

Mechanical port of the validated Rule 4b reference engine (PR #77, 72/72 across 4 oracle corpora incl. mirrors) into `crates/chematic-cip/src/{auxiliary,rule4b,resolver}.rs`, wired into `assign_cip_accurate_experimental` **only** -- a new pass between `assign_all` (Rules 1a/1b/2) and the existing `apply_rule5_pass` (Rule 4b precedes Rule 5 in CIP order). Algorithm unchanged from the validated reference.

- `assign_one_with_rule4b`'s tie-detection loop mirrors the reference engine's `resolve_outer_root` (loops over every group, attempts Rule 4b on each clean 2-way tie), not `assign_one_with_rule5`'s narrower "exactly one tied group" restriction -- caught by an independent Plan-agent critique before implementation, since that restriction was never part of what got validated.
- `position_node_ids` generalized in place (not duplicated) -- provably inert for existing callers.
- No new `SkipReason` variant: multi-reference-candidate / 3+-way-tie cases already fall through to `SkipReason::Tied` via the existing ambiguity check in `nearest_embedded` -- "fail loudly, never guess" with zero API change.
- `chematic_chem::assign_cip()` (legacy) and `assign_cip_accurate_experimental_without_mancude` untouched.

## Results

- **72/72 production-path parity** (`tests/rule4b_production_parity.rs`) -- the same 4 oracle corpora + mirrors rerun through the real `assign_cip_accurate_experimental` entry point, not a hand-built digraph.
- **Full-corpus gate**: `main` baseline (isolated git worktree) vs. this branch, both snapshotted via `corpus_snapshot.rs --candidate`, diffed with `cip_accurate_full_corpus_report.py` against a fresh RDKit oracle:
  - `4152/4186 (99.19%) -> 4160/4186 (99.38%)`
  - `newly_correct = 8` (exactly the `rule4_candidate` residual, no unexplained extras)
  - `regressions = 0` via both independent methods (Method A diff-only, Method B full-set recompute)
- **Rule 5 non-regression**: existing `rule5_resolves_the_two_verified_milestone_4a_target_rows` test passes unchanged; full-corpus Method B independently covers every row.
- `cargo test --workspace`, `cargo clippy --workspace -- -D warnings`, `bash scripts/check.sh` all clean.

Out of scope per explicit instruction: Figure 8 both-references-max scoring, 3+-way ties, Rule 5 cage family, phosphorus, performance optimization, removing `new_with_artificial_ancestor`, making the accurate engine the default path. Full writeup in `docs/cip_accurate_rfc.md`'s Milestone 4B-2 section.

## Test plan

- [x] `bash scripts/check.sh` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p chematic-cip --release` (all existing suites + new `rule4b_production_parity.rs`) pass
- [x] Full-corpus gate: 4160/4186, 0 regressions (both methods)
- [x] `chematic_chem::assign_cip()` and `assign_cip_accurate_experimental_without_mancude` unchanged