### PR TITLE
feat(perception): Aromaticity-A1-1b-1 -- fallible opt-in production API

### DIFF
--- a/crates/chematic-perception/examples/aromaticity_a1_1b_0_report.rs
+++ b/crates/chematic-perception/examples/aromaticity_a1_1b_0_report.rs
@@ -15,7 +15,7 @@
 
 use std::fs;
 
-use chematic_perception::rdkit_parity::rdkit_parity_aromaticity;
+use chematic_perception::diagnostics::rdkit_parity_aromaticity;
 use serde_json::{Value, json};
 
 fn main() {

--- a/crates/chematic-perception/examples/aromaticity_a1_1b_1_full_corpus_report.rs
+++ b/crates/chematic-perception/examples/aromaticity_a1_1b_1_full_corpus_report.rs
@@ -1,0 +1,113 @@
+//! Aromaticity-A1-1b-1: run the actual production entry point
+//! (`assign_aromaticity_rdkit_parity_experimental`) against a full SMILES
+//! corpus and emit the same per-atom/per-bond JSONL schema as
+//! `rdkit_parity_full_corpus.rs`, for a direct `diff` against that
+//! already-RDKit-verified (100.0000% set agreement) trace, plus explicit
+//! error-kind counts for the two `AromaticityError` variants.
+//!
+//! Byte-identical atom/bond rows here transitively inherit the A1-1b-0
+//! full-corpus RDKit-parity result -- this only needs to prove the wiring
+//! layer added on top (flag-clearing + internal kekulize + invariant check)
+//! doesn't perturb it, not re-join against RDKit again.
+//!
+//! Run:
+//! ```text
+//! cargo run -p chematic-perception --release \
+//!     --example aromaticity_a1_1b_1_full_corpus_report \
+//!     -- ~/Downloads/SMILES.csv \
+//!     > /tmp/aromaticity_a1_1b_1_full_corpus_trace.jsonl
+//! ```
+
+use std::fs;
+
+use chematic_perception::{
+    AromaticityError, apply_aromaticity_rdkit_parity_experimental,
+    assign_aromaticity_rdkit_parity_experimental,
+};
+use serde_json::json;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let path = args
+        .get(1)
+        .expect("usage: aromaticity_a1_1b_1_full_corpus_report <smiles.csv>");
+    let content = fs::read_to_string(path).unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
+
+    let mut n_ok = 0usize;
+    let mut n_parse_fail = 0usize;
+    let mut n_kekulization_failed = 0usize;
+    let mut n_internal_invariant_violation = 0usize;
+    let mut n_apply_disagrees_with_assign = 0usize;
+
+    for line in content.lines() {
+        let smi = line.split(',').next().unwrap_or("").trim();
+        if smi.is_empty() || smi.eq_ignore_ascii_case("smiles") {
+            continue;
+        }
+        let raw = match chematic_smiles::parse(smi) {
+            Ok(m) => m,
+            Err(_) => {
+                n_parse_fail += 1;
+                continue;
+            }
+        };
+
+        let model = match assign_aromaticity_rdkit_parity_experimental(&raw) {
+            Ok(m) => m,
+            Err(AromaticityError::KekulizationFailed { reason }) => {
+                n_kekulization_failed += 1;
+                eprintln!("KekulizationFailed: {smi}: {reason}");
+                continue;
+            }
+            Err(AromaticityError::InternalInvariantViolation { reason }) => {
+                n_internal_invariant_violation += 1;
+                eprintln!("InternalInvariantViolation: {smi}: {reason}");
+                continue;
+            }
+        };
+
+        // Cross-check apply() against assign() on the same input: apply()
+        // re-derives its own kekulized molecule internally, so this also
+        // catches drift between the two entry points, not just panics.
+        if let Ok(applied) = apply_aromaticity_rdkit_parity_experimental(&raw) {
+            let disagrees = applied
+                .atoms()
+                .any(|(idx, atom)| atom.aromatic != model.is_atom_aromatic(idx));
+            if disagrees {
+                n_apply_disagrees_with_assign += 1;
+                eprintln!("APPLY/ASSIGN DISAGREE: {smi}");
+            }
+        }
+
+        for (idx, _atom) in raw.atoms() {
+            let row = json!({
+                "kind": "atom",
+                "smiles": smi,
+                "atom_idx": idx.0,
+                "rdkit_parity_atom_aromatic": model.is_atom_aromatic(idx),
+            });
+            println!("{row}");
+        }
+        for (bidx, bond) in raw.bonds() {
+            let (a1, a2) = (
+                bond.atom1.0.min(bond.atom2.0),
+                bond.atom1.0.max(bond.atom2.0),
+            );
+            let row = json!({
+                "kind": "bond",
+                "smiles": smi,
+                "bond_atoms": [a1, a2],
+                "rdkit_parity_bond_aromatic": model.is_bond_aromatic(bidx),
+            });
+            println!("{row}");
+        }
+        n_ok += 1;
+    }
+
+    eprintln!(
+        "processed {n_ok} molecules, {n_parse_fail} parse failures, \
+         {n_kekulization_failed} KekulizationFailed, \
+         {n_internal_invariant_violation} InternalInvariantViolation, \
+         {n_apply_disagrees_with_assign} apply/assign disagreements"
+    );
+}

--- a/crates/chematic-perception/examples/aromaticity_a1_1b_1_perf.rs
+++ b/crates/chematic-perception/examples/aromaticity_a1_1b_1_perf.rs
@@ -1,0 +1,86 @@
+//! Aromaticity-A1-1b-1: record (not optimize) per-molecule wall-clock
+//! timing for `apply_aromaticity_ex(.., RdkitLike)` (current production
+//! default) vs `apply_aromaticity_rdkit_parity_experimental` (the new
+//! opt-in engine), over the full SMILES corpus.
+//!
+//! This PR does not tune either engine for speed -- these numbers are a
+//! baseline record for a future performance-focused round (A1-1c), not a
+//! gate this PR is judged against.
+//!
+//! Run:
+//! ```text
+//! cargo run -p chematic-perception --release \
+//!     --example aromaticity_a1_1b_1_perf -- ~/Downloads/SMILES.csv
+//! ```
+
+use std::fs;
+use std::time::Instant;
+
+use chematic_perception::apply_aromaticity_rdkit_parity_experimental;
+use chematic_perception::{AromaticityAlgorithm, apply_aromaticity_ex};
+
+fn percentile(sorted_ns: &[u64], p: f64) -> u64 {
+    if sorted_ns.is_empty() {
+        return 0;
+    }
+    let idx = ((sorted_ns.len() as f64 - 1.0) * p).round() as usize;
+    sorted_ns[idx]
+}
+
+fn report(label: &str, mut ns: Vec<u64>) {
+    ns.sort_unstable();
+    let n = ns.len() as u64;
+    let sum: u64 = ns.iter().sum();
+    let mean = sum as f64 / n as f64 / 1000.0;
+    let p50 = percentile(&ns, 0.50) as f64 / 1000.0;
+    let p95 = percentile(&ns, 0.95) as f64 / 1000.0;
+    let max = *ns.last().unwrap_or(&0) as f64 / 1000.0;
+    println!("{label}: n={n} mean={mean:.2}us p50={p50:.2}us p95={p95:.2}us max={max:.2}us");
+}
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: aromaticity_a1_1b_1_perf <smiles.csv>");
+    let content =
+        fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
+
+    let smiles: Vec<&str> = content
+        .lines()
+        .map(|l| l.split(',').next().unwrap_or("").trim())
+        .filter(|s| !s.is_empty() && !s.eq_ignore_ascii_case("smiles"))
+        .collect();
+
+    let mols: Vec<_> = smiles
+        .iter()
+        .filter_map(|s| chematic_smiles::parse(s).ok())
+        .collect();
+    println!("parsed {}/{} molecules", mols.len(), smiles.len());
+
+    // Warm-up pass (page faults, allocator warm-up) -- excluded from timing.
+    for mol in &mols {
+        let _ = apply_aromaticity_ex(mol, AromaticityAlgorithm::RdkitLike);
+        let _ = apply_aromaticity_rdkit_parity_experimental(mol);
+    }
+
+    let mut default_ns = Vec::with_capacity(mols.len());
+    for mol in &mols {
+        let start = Instant::now();
+        let _ = apply_aromaticity_ex(mol, AromaticityAlgorithm::RdkitLike);
+        default_ns.push(start.elapsed().as_nanos() as u64);
+    }
+    report("RdkitLike (current production default)", default_ns);
+
+    let mut experimental_ns = Vec::with_capacity(mols.len());
+    let mut n_kekulize_failed = 0usize;
+    for mol in &mols {
+        let start = Instant::now();
+        let result = apply_aromaticity_rdkit_parity_experimental(mol);
+        experimental_ns.push(start.elapsed().as_nanos() as u64);
+        if result.is_err() {
+            n_kekulize_failed += 1;
+        }
+    }
+    report("RdkitParityExperimental", experimental_ns);
+    println!("(experimental KekulizationFailed count during timing: {n_kekulize_failed})");
+}

--- a/crates/chematic-perception/examples/aromaticity_a1_1b_1_report.rs
+++ b/crates/chematic-perception/examples/aromaticity_a1_1b_1_report.rs
@@ -1,0 +1,90 @@
+//! Aromaticity-A1-1b-1: run the actual production entry point
+//! (`assign_aromaticity_rdkit_parity_experimental`) against the diagnosis
+//! corpus and emit the same per-(molecule, atom) JSONL schema as
+//! `aromaticity_a1_1b_0_report.rs`, for a direct `diff` against the
+//! already-RDKit-verified `aromaticity_a1_1b_0_trace.jsonl`.
+//!
+//! Unlike the A1-1b-0 report, this passes the *raw* (possibly
+//! aromatic-form) parsed molecule straight to the production function --
+//! no manual pre-kekulization -- so it actually exercises the wiring layer
+//! (`clear_aromatic_flags` + internal `kekulize`/`apply_kekule` +
+//! `validate_aromaticity_invariants`) that A1-1b-1 added on top of the
+//! already-verified `rdkit_parity_aromaticity` engine. A byte-identical
+//! diff against the A1-1b-0 trace is the actual proof that this wiring is
+//! mechanical (in particular, that clearing stale aromatic flags before
+//! kekulizing does not perturb aromatic-form heteroaromatic input).
+//!
+//! Run:
+//! ```text
+//! cargo run -p chematic-perception --release \
+//!     --example aromaticity_a1_1b_1_report \
+//!     -- validation/aromaticity_a1_0_corpus.jsonl \
+//!     > /tmp/aromaticity_a1_1b_1_trace.jsonl
+//! diff /tmp/aromaticity_a1_1b_1_trace.jsonl validation/results/aromaticity_a1_1b_0_trace.jsonl
+//! ```
+
+use std::fs;
+
+use chematic_perception::assign_aromaticity_rdkit_parity_experimental;
+use serde_json::{Value, json};
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let corpus_path = args
+        .get(1)
+        .map(String::as_str)
+        .unwrap_or("validation/aromaticity_a1_0_corpus.jsonl");
+
+    let corpus = fs::read_to_string(corpus_path)
+        .unwrap_or_else(|e| panic!("failed to read {corpus_path}: {e}"));
+
+    let mut rows_written = 0usize;
+    let mut molecules_seen = 0usize;
+    let mut failures = 0usize;
+
+    for line in corpus.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let case: Value = serde_json::from_str(line).expect("valid corpus JSON line");
+        let bucket = case["bucket"].as_str().unwrap_or("unknown").to_string();
+        let case_id = case["case_id"].as_str().unwrap_or("").to_string();
+        let smiles = case["smiles"].as_str().unwrap_or("").to_string();
+
+        let raw = match chematic_smiles::parse(&smiles) {
+            Ok(m) => m,
+            Err(e) => {
+                eprintln!("SKIP {case_id} ({smiles}): parse error: {e}");
+                failures += 1;
+                continue;
+            }
+        };
+
+        // The production entry point does its own kekulization internally
+        // -- pass the raw parsed (aromatic-form) molecule directly, not a
+        // manually pre-kekulized one.
+        let model = match assign_aromaticity_rdkit_parity_experimental(&raw) {
+            Ok(m) => m,
+            Err(e) => {
+                eprintln!("SKIP {case_id} ({smiles}): {e}");
+                failures += 1;
+                continue;
+            }
+        };
+        molecules_seen += 1;
+
+        for (idx, _atom) in raw.atoms() {
+            let row = json!({
+                "bucket": bucket,
+                "case_id": case_id,
+                "smiles": smiles,
+                "atom_idx": idx.0,
+                "rdkit_parity_atom_aromatic": model.is_atom_aromatic(idx),
+            });
+            println!("{row}");
+            rows_written += 1;
+        }
+    }
+
+    eprintln!("molecules: {molecules_seen} (failures: {failures}), rows: {rows_written}");
+}

--- a/crates/chematic-perception/examples/rdkit_parity_full_corpus.rs
+++ b/crates/chematic-perception/examples/rdkit_parity_full_corpus.rs
@@ -15,7 +15,7 @@
 
 use std::fs;
 
-use chematic_perception::rdkit_parity::rdkit_parity_aromaticity;
+use chematic_perception::diagnostics::rdkit_parity_aromaticity;
 use serde_json::json;
 
 fn main() {

--- a/crates/chematic-perception/src/aromaticity.rs
+++ b/crates/chematic-perception/src/aromaticity.rs
@@ -111,6 +111,25 @@ impl AromaticityModel {
     pub fn has_antiaromaticity(&self) -> bool {
         !self.antiaromatic_rings.is_empty()
     }
+
+    /// Build a model directly from an aromatic atom/bond set, with no ring
+    /// classification or antiaromaticity data.
+    ///
+    /// Used by engines (e.g. `rdkit_parity`'s experimental production API)
+    /// that determine an aromatic atom/bond set directly rather than via
+    /// this module's own per-ring Hückel passes -- `ring_classifications()`
+    /// and `antiaromatic_rings()` are empty on the result.
+    pub(crate) fn from_atom_bond_sets(
+        aromatic_atoms: FxHashSet<AtomIdx>,
+        aromatic_bonds: FxHashSet<BondIdx>,
+    ) -> Self {
+        AromaticityModel {
+            aromatic_atoms,
+            aromatic_bonds,
+            antiaromatic_rings: Vec::new(),
+            ring_classifications: Vec::new(),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -288,9 +307,21 @@ pub fn apply_aromaticity(mol: &Molecule) -> Molecule {
 ///
 /// Returns a new [`Molecule`] with aromatic flags set according to `algo`.
 pub fn apply_aromaticity_ex(mol: &Molecule, algo: AromaticityAlgorithm) -> Molecule {
-    use chematic_core::{BondOrder, MoleculeBuilder, implicit_hcount};
-
     let model = assign_aromaticity_ex(mol, algo);
+    build_molecule_from_model(mol, &model)
+}
+
+/// Build a new [`Molecule`] from `mol` with atom/bond aromaticity flags set
+/// according to an already-computed `model`.
+///
+/// Shared by [`apply_aromaticity_ex`] and the `rdkit_parity` experimental
+/// production API (`apply_aromaticity_rdkit_parity_experimental`) so both
+/// get the same implicit-H preservation, bond-direction stashing, and
+/// stereo-metadata copying -- this is the same "Kekule-then-perceive"
+/// normalization either caller needs, not something specific to one
+/// algorithm.
+pub(crate) fn build_molecule_from_model(mol: &Molecule, model: &AromaticityModel) -> Molecule {
+    use chematic_core::{BondOrder, MoleculeBuilder, implicit_hcount};
 
     // Implicit-H counts computed BEFORE bond orders are normalized below, for
     // organic-subset atoms without an explicit bracket H count. Needed because

--- a/crates/chematic-perception/src/lib.rs
+++ b/crates/chematic-perception/src/lib.rs
@@ -9,9 +9,7 @@
 pub mod aromaticity;
 pub mod cip_priority;
 pub mod pharmacophore;
-#[cfg(any(test, feature = "diagnostics"))]
-#[doc(hidden)]
-pub mod rdkit_parity;
+mod rdkit_parity;
 pub mod ring_family;
 pub mod sssr;
 pub mod stereo_validation;
@@ -28,7 +26,25 @@ pub use aromaticity::{
 };
 pub use chematic_core::{ValenceError, validate_valence};
 pub use pharmacophore::{Feature, FeatureType, detect_features, features_to_bitvec};
+pub use rdkit_parity::{
+    AromaticityError, apply_aromaticity_rdkit_parity_experimental,
+    assign_aromaticity_rdkit_parity_experimental,
+};
 pub use ring_family::{RingFamily, RingSystemKind, find_ring_families, find_ring_families_over};
+
+/// Diagnostic-only APIs, not meant for production use — reference-engine
+/// internals kept for cross-checking and corpus benchmarking. Gated behind
+/// the `diagnostics` feature. See `docs/aromaticity_a1_rfc.md`.
+///
+/// The production-facing surface of the RDKit-parity engine is
+/// [`assign_aromaticity_rdkit_parity_experimental`] and
+/// [`apply_aromaticity_rdkit_parity_experimental`], both always available
+/// (no feature flag required).
+#[cfg(feature = "diagnostics")]
+#[doc(hidden)]
+pub mod diagnostics {
+    pub use crate::rdkit_parity::rdkit_parity_aromaticity;
+}
 pub use sssr::{RingSet, find_sssr};
 pub use stereo_validation::{
     StereoCompleteness, StereoError, StereoErrorKind, stereo_completeness, validate_stereo,

--- a/crates/chematic-perception/src/rdkit_parity.rs
+++ b/crates/chematic-perception/src/rdkit_parity.rs
@@ -6,12 +6,18 @@
 //! `aromaticityHelper`'s `includeFused` branch — the exact path
 //! `setAromaticity(mol, AROMATICITY_RDKIT, ...)` calls).
 //!
-//! **Test/diagnostic-only. Not wired into `assign_aromaticity_ex`,
-//! `apply_aromaticity_ex`, `ring_pi_electrons`, or any other production
-//! decision path.** Only reachable behind this crate's `diagnostics` feature
-//! (or from `#[cfg(test)]`). See `docs/aromaticity_a1_rfc.md`'s "A1-1b-0"
-//! section for the full design writeup, the calibration battery, and the
-//! corpus gate.
+//! **Not wired into `assign_aromaticity_ex`/`apply_aromaticity_ex`/
+//! `ring_pi_electrons` (the `Huckel`/`RdkitLike` production path is
+//! unchanged and still the default).** As of A1-1b-1 this engine backs a
+//! separate, explicitly opt-in, fallible production API:
+//! [`assign_aromaticity_rdkit_parity_experimental`] and
+//! [`apply_aromaticity_rdkit_parity_experimental`], re-exported from the
+//! crate root. Every other item in this module (the low-level donor-type/
+//! Hückel machinery) is crate-private; the only way to reach it from
+//! outside the crate is through those two functions, or, for diagnostics,
+//! `diagnostics::rdkit_parity_aromaticity` behind the `diagnostics` feature.
+//! See `docs/aromaticity_a1_rfc.md`'s "A1-1b-0"/"A1-1b-1" sections for the
+//! full design writeup, the calibration battery, and the corpus gate.
 //!
 //! Ported from RDKit release `Release_2026_03_4`, commit
 //! `e89c9f656a694fab4105139844cba88d2e013354`. See `THIRD_PARTY_NOTICES.md`
@@ -42,6 +48,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use chematic_core::{AtomIdx, BondIdx, BondOrder, Molecule};
 
+use crate::aromaticity::AromaticityModel;
 use crate::sssr::find_sssr;
 
 // ---------------------------------------------------------------------------
@@ -50,8 +57,12 @@ use crate::sssr::find_sssr;
 
 /// Per-atom pi-electron donor classification, computed once per molecule
 /// (not per candidate ring). Direct port of RDKit's `ElectronDonorType`.
+///
+/// Crate-internal: not part of the public API. The only supported entry
+/// points are [`assign_aromaticity_rdkit_parity_experimental`] and
+/// [`apply_aromaticity_rdkit_parity_experimental`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ElectronDonorType {
+pub(crate) enum ElectronDonorType {
     /// No electrons to spare, but an empty p-orbital (e.g. tropylium-type carbocation).
     Vacant,
     /// Exactly 1 electron (a normal sp2 atom with one endocyclic pi bond).
@@ -60,6 +71,14 @@ pub enum ElectronDonorType {
     TwoElectron,
     /// Either 1 or 2, ambiguous until a specific candidate ring/subset is evaluated
     /// (RDKit tries every value in this range when checking Hückel's rule).
+    ///
+    /// Kept for shape-fidelity with RDKit's own `ElectronDonorType` enum
+    /// (this port's `get_atom_electron_donor_type` doesn't currently
+    /// construct this variant on any input the calibration battery or the
+    /// 5,000-molecule corpus exercises -- was previously masked by this
+    /// enum being `pub`, which suppresses rustc's dead-code analysis for
+    /// externally-constructible items). Not a behavior change to fix here.
+    #[allow(dead_code)]
     OneOrTwo,
     /// Dummy-atom wildcard (1 or 2, but at most one such atom per evaluated ring).
     Any,
@@ -216,7 +235,7 @@ fn more_electronegative(a: u8, b: u8) -> bool {
 /// Port of `getAtomDonorTypeArom` (default params: `exocyclicBondsStealElectrons = true`).
 /// `ring_bonds` = the set of bond indices that are part of *any* SSSR ring in
 /// the whole molecule (global, not scoped to one candidate ring/subset).
-pub fn get_atom_electron_donor_type(
+pub(crate) fn get_atom_electron_donor_type(
     mol: &Molecule,
     atom_idx: AtomIdx,
     ring_bonds: &FxHashSet<BondIdx>,
@@ -273,7 +292,7 @@ pub fn get_atom_electron_donor_type(
 /// Port of `isAtomCandForArom` with the DEFAULT model's parameters
 /// (`allowThirdRow=true, allowTripleBonds=true, allowHigherExceptions=true,
 /// onlyCorN=false, allowExocyclicMultipleBonds=true`).
-pub fn is_atom_candidate_for_aromaticity(
+pub(crate) fn is_atom_candidate_for_aromaticity(
     mol: &Molecule,
     atom_idx: AtomIdx,
     donor_type: ElectronDonorType,
@@ -344,7 +363,7 @@ fn min_max_atom_electrons(dtype: ElectronDonorType) -> (i32, i32) {
 /// electron count in `[sum_of_lower_bounds, sum_of_upper_bounds]` satisfies
 /// 4n+2 -- or the `rup == 2` special case for tiny rings (e.g. cyclopropenyl
 /// cation).
-pub fn apply_huckel(
+pub(crate) fn apply_huckel(
     mol: &Molecule,
     atoms: &[AtomIdx],
     donor: &FxHashMap<AtomIdx, ElectronDonorType>,
@@ -529,7 +548,7 @@ pub fn rdkit_parity_aromaticity(mol: &Molecule) -> (FxHashSet<AtomIdx>, FxHashSe
     rdkit_parity_aromaticity_ex(mol, 6)
 }
 
-pub fn rdkit_parity_aromaticity_ex(
+pub(crate) fn rdkit_parity_aromaticity_ex(
     mol: &Molecule,
     max_num_fused_rings: usize,
 ) -> (FxHashSet<AtomIdx>, FxHashSet<BondIdx>) {
@@ -601,6 +620,169 @@ pub fn rdkit_parity_aromaticity_ex(
     }
 
     (aromatic_atoms, aromatic_bonds)
+}
+
+// ---------------------------------------------------------------------------
+// Production entry points (A1-1b-1): fallible opt-in API
+// ---------------------------------------------------------------------------
+
+/// Error from the RDKit-parity experimental aromaticity API.
+///
+/// Unlike [`assign_aromaticity_ex`](crate::assign_aromaticity_ex)/
+/// [`apply_aromaticity_ex`](crate::apply_aromaticity_ex) (infallible, and
+/// unchanged by this addition), this engine requires an explicit
+/// kekulization step it does not control the success of, so its entry
+/// points return `Result` rather than silently falling back to another
+/// algorithm or panicking.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AromaticityError {
+    /// The input could not be reduced to a Kekulé form (no `BondOrder::Aromatic`
+    /// bonds), which this engine requires as a precondition -- mirrors RDKit's
+    /// own pipeline, where `Kekulize` always runs before `setAromaticity`.
+    KekulizationFailed {
+        /// Human-readable detail from the underlying `chematic_core::KekuleError`.
+        reason: String,
+    },
+    /// A post-computation sanity check failed (e.g. an aromatic bond with a
+    /// non-aromatic endpoint atom) -- should never happen for chemically
+    /// valid input; surfaced as an error rather than a panic or a silently
+    /// wrong result.
+    InternalInvariantViolation {
+        /// Human-readable detail of which invariant failed.
+        reason: String,
+    },
+}
+
+impl std::fmt::Display for AromaticityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AromaticityError::KekulizationFailed { reason } => {
+                write!(f, "rdkit-parity aromaticity: kekulization failed: {reason}")
+            }
+            AromaticityError::InternalInvariantViolation { reason } => {
+                write!(
+                    f,
+                    "rdkit-parity aromaticity: internal invariant violation: {reason}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for AromaticityError {}
+
+/// Clone `mol` with every atom's `aromatic` flag reset to `false`.
+///
+/// Bond orders (including any `BondOrder::Aromatic`) are copied unchanged --
+/// only the atom-level annotation is cleared. This engine derives
+/// aromaticity purely from element/charge/bond-order structure (never reads
+/// `atom.aromatic`), so clearing stale flags here has no effect on the
+/// computation itself; it only ensures the *output* molecule's flags come
+/// entirely from this engine's own verdict, never from whatever annotation
+/// the caller's input happened to carry in.
+fn clear_aromatic_flags(mol: &Molecule) -> Molecule {
+    use chematic_core::MoleculeBuilder;
+    let mut builder = MoleculeBuilder::new();
+    for (_, atom) in mol.atoms() {
+        let mut a = atom.clone();
+        a.aromatic = false;
+        builder.add_atom(a);
+    }
+    for (_, bond) in mol.bonds() {
+        let _ = builder.add_bond(bond.atom1, bond.atom2, bond.order);
+    }
+    builder.copy_stereo_groups_from(mol);
+    builder.copy_stereo_from(mol);
+    builder.copy_bond_directions_from(mol);
+    builder.build()
+}
+
+/// Normalize `mol` to pure Kekulé form (this engine's precondition): clear
+/// stale aromatic flags, then kekulize. Returns an explicit error instead of
+/// falling back to another algorithm or leaving a partially-rewritten
+/// molecule behind -- `mol` itself is never mutated, only read.
+fn kekulize_for_rdkit_parity(mol: &Molecule) -> Result<Molecule, AromaticityError> {
+    let cleared = clear_aromatic_flags(mol);
+    match chematic_core::kekulize(&cleared) {
+        Ok(k) => Ok(chematic_core::apply_kekule(&cleared, &k)),
+        Err(e) => Err(AromaticityError::KekulizationFailed { reason: e.detail }),
+    }
+}
+
+/// Every aromatic bond's two endpoint atoms must themselves be in the
+/// aromatic atom set -- a basic well-formedness property of any Hückel
+/// verdict. Cheap to check, catches a class of bug that would otherwise
+/// surface downstream as a confusing SMILES/valence inconsistency instead
+/// of a clear error at the source.
+fn validate_aromaticity_invariants(
+    mol: &Molecule,
+    atoms: &FxHashSet<AtomIdx>,
+    bonds: &FxHashSet<BondIdx>,
+) -> Result<(), AromaticityError> {
+    for &bidx in bonds {
+        let bond = mol.bond(bidx);
+        if !atoms.contains(&bond.atom1) || !atoms.contains(&bond.atom2) {
+            return Err(AromaticityError::InternalInvariantViolation {
+                reason: format!(
+                    "aromatic bond {bidx:?} ({:?}-{:?}) has a non-aromatic endpoint atom",
+                    bond.atom1, bond.atom2
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn assign_from_kekulized(kekulized: &Molecule) -> Result<AromaticityModel, AromaticityError> {
+    let (atoms, bonds) = rdkit_parity_aromaticity(kekulized);
+    validate_aromaticity_invariants(kekulized, &atoms, &bonds)?;
+    Ok(AromaticityModel::from_atom_bond_sets(atoms, bonds))
+}
+
+/// Assign aromaticity using the RDKit-parity reference engine
+/// (`rdkit_parity_aromaticity`, see the module doc comment).
+///
+/// Explicitly opt-in and separate from [`assign_aromaticity_ex`]/
+/// [`AromaticityAlgorithm`] -- those remain infallible and unchanged. This
+/// function is fallible because it performs its own kekulization
+/// internally (this engine requires pre-kekulized input); on failure,
+/// `mol` is never touched and no partial result is produced.
+///
+/// The returned model's atom/bond indices correspond 1:1 with `mol`'s own
+/// indices (kekulization here is index-preserving: it only clears stale
+/// aromatic flags and normalizes bond orders, never adds/removes/reorders
+/// atoms or bonds).
+///
+/// [`ring_classifications`](AromaticityModel::ring_classifications) and
+/// [`antiaromatic_rings`](AromaticityModel::antiaromatic_rings) are always
+/// empty on the returned model -- this engine (like RDKit's own) determines
+/// only the aromatic atom/bond sets, not a per-ring classification or
+/// antiaromaticity verdict.
+///
+/// [`assign_aromaticity_ex`]: crate::assign_aromaticity_ex
+/// [`AromaticityAlgorithm`]: crate::AromaticityAlgorithm
+pub fn assign_aromaticity_rdkit_parity_experimental(
+    mol: &Molecule,
+) -> Result<AromaticityModel, AromaticityError> {
+    let kekulized = kekulize_for_rdkit_parity(mol)?;
+    assign_from_kekulized(&kekulized)
+}
+
+/// Apply aromaticity using the RDKit-parity reference engine, returning a
+/// new [`Molecule`] with atom/bond flags set according to the computed
+/// model.
+///
+/// See [`assign_aromaticity_rdkit_parity_experimental`] for the fallibility
+/// contract (kekulization failure is reported, never silently substituted
+/// or partially applied) and the index-correspondence guarantee.
+pub fn apply_aromaticity_rdkit_parity_experimental(
+    mol: &Molecule,
+) -> Result<Molecule, AromaticityError> {
+    let kekulized = kekulize_for_rdkit_parity(mol)?;
+    let model = assign_from_kekulized(&kekulized)?;
+    Ok(crate::aromaticity::build_molecule_from_model(
+        &kekulized, &model,
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -710,6 +892,113 @@ mod tests {
             a,
             vec![0, 1, 2, 3, 4, 5, 6, 7, 8],
             "purine: should match RDKit (all 9 atoms aromatic)"
+        );
+    }
+
+    #[test]
+    fn production_api_assign_matches_engine_on_benzene() {
+        let mol = chematic_smiles::parse("c1ccccc1").expect("valid SMILES");
+        let model = assign_aromaticity_rdkit_parity_experimental(&mol).expect("benzene kekulizes");
+        assert_eq!(model.aromatic_atom_count(), 6);
+        for (idx, _) in mol.atoms() {
+            assert!(
+                model.is_atom_aromatic(idx),
+                "atom {idx:?} should be aromatic"
+            );
+        }
+        // This engine only determines atom/bond sets, not per-ring
+        // classification or antiaromaticity -- both must be empty.
+        assert!(model.ring_classifications().is_empty());
+        assert!(model.antiaromatic_rings().is_empty());
+    }
+
+    #[test]
+    fn production_api_apply_sets_aromatic_flags_and_bond_orders() {
+        let mol = chematic_smiles::parse("C1=CC=CC=C1").expect("valid SMILES"); // Kekule benzene
+        let applied = apply_aromaticity_rdkit_parity_experimental(&mol).expect("benzene kekulizes");
+        assert_eq!(applied.atom_count(), mol.atom_count());
+        for (_, atom) in applied.atoms() {
+            assert!(atom.aromatic, "every benzene atom should end up aromatic");
+        }
+        for (_, bond) in applied.bonds() {
+            assert_eq!(bond.order, BondOrder::Aromatic);
+        }
+    }
+
+    #[test]
+    fn production_api_reports_kekulize_failure_not_panic() {
+        // The one known-gap molecule from the full-corpus gate: RDKit itself
+        // parses this fine, but chematic's own `kekulize()` rejects a
+        // bridgehead N in this fused purine-like system. Must surface as
+        // `AromaticityError::KekulizationFailed`, not a panic and not a
+        // silent fallback to another algorithm.
+        let smi = "Cc1cn2c(=O)c3ncn(COCCO)c3nc2n1C";
+        let mol = chematic_smiles::parse(smi).expect("valid SMILES");
+
+        match assign_aromaticity_rdkit_parity_experimental(&mol) {
+            Err(AromaticityError::KekulizationFailed { .. }) => {}
+            other => panic!("expected KekulizationFailed, got {other:?}"),
+        }
+        // `Molecule` has no `Debug` impl, so match on the error shape only
+        // (discarding the `Ok(Molecule)` payload) rather than formatting
+        // the whole `Result` on failure.
+        match apply_aromaticity_rdkit_parity_experimental(&mol).map(|_| ()) {
+            Err(AromaticityError::KekulizationFailed { .. }) => {}
+            other => panic!("expected KekulizationFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn production_api_does_not_mutate_input_on_failure() {
+        // "元の分子を途中まで書き換えてから失敗する経路は作らないでください" --
+        // `mol` is only ever taken by `&Molecule` throughout the fallible
+        // path (`clear_aromatic_flags`/`kekulize`/`apply_kekule` all build
+        // new molecules rather than mutating in place), so this is enforced
+        // by the type system. Pin it as an explicit regression: the input's
+        // own atom/bond flags and counts are unchanged after a failed call.
+        let smi = "Cc1cn2c(=O)c3ncn(COCCO)c3nc2n1C";
+        let mol = chematic_smiles::parse(smi).expect("valid SMILES");
+        let atom_count_before = mol.atom_count();
+        let bond_count_before = mol.bond_count();
+        let aromatic_before: Vec<bool> = mol.atoms().map(|(_, a)| a.aromatic).collect();
+
+        let result = assign_aromaticity_rdkit_parity_experimental(&mol);
+        assert!(
+            result.is_err(),
+            "this molecule is a known kekulize-gap case"
+        );
+
+        assert_eq!(mol.atom_count(), atom_count_before);
+        assert_eq!(mol.bond_count(), bond_count_before);
+        let aromatic_after: Vec<bool> = mol.atoms().map(|(_, a)| a.aromatic).collect();
+        assert_eq!(aromatic_before, aromatic_after);
+    }
+
+    #[test]
+    fn production_api_stale_aromatic_flag_is_overridden_not_leaked() {
+        // A non-aromatic atom that happens to carry a stale `aromatic=true`
+        // flag on input must not leak that flag into the output -- the
+        // engine's own verdict is the sole source of truth for the result.
+        use chematic_core::MoleculeBuilder;
+
+        let mut base = chematic_smiles::parse("CC").expect("valid SMILES"); // ethane, acyclic
+        let mut builder = MoleculeBuilder::new();
+        for (_, atom) in base.atoms() {
+            let mut a = atom.clone();
+            a.aromatic = true; // stale/bogus annotation
+            builder.add_atom(a);
+        }
+        for (_, bond) in base.bonds() {
+            let _ = builder.add_bond(bond.atom1, bond.atom2, bond.order);
+        }
+        base = builder.build();
+        assert!(base.atoms().all(|(_, a)| a.aromatic), "test setup sanity");
+
+        let applied = apply_aromaticity_rdkit_parity_experimental(&base)
+            .expect("acyclic molecule kekulizes trivially (no-op)");
+        assert!(
+            applied.atoms().all(|(_, a)| !a.aromatic),
+            "stale aromatic=true on an acyclic atom must not survive"
         );
     }
 }

--- a/crates/chematic-smarts/examples/aromaticity_a1_1b_1_downstream_check.rs
+++ b/crates/chematic-smarts/examples/aromaticity_a1_1b_1_downstream_check.rs
@@ -1,0 +1,180 @@
+//! Aromaticity-A1-1b-1: downstream sanity checks for molecules produced by
+//! `apply_aromaticity_rdkit_parity_experimental`/
+//! `assign_aromaticity_rdkit_parity_experimental` (the new opt-in
+//! production API, see `docs/aromaticity_a1_rfc.md`'s "A1-1b-1" section).
+//!
+//! This crate (not `chematic-perception`) hosts the check because it
+//! depends on both `chematic-perception` (the new API) and SMARTS matching
+//! -- the reverse dependency direction would be circular.
+//!
+//! Scope, per the "additive" reading of the downstream-regression gate (the
+//! *default* aromaticity pipeline is untouched by A1-1b-1, so bit-identity
+//! against it is not the right bar for the ~0.5% of molecules where this
+//! engine's verdict differs from production by design):
+//!
+//! 1. **Doesn't crash/corrupt**: every molecule that successfully produces
+//!    an experimental-aromaticity result round-trips through canonical
+//!    SMILES without structural loss, and SMARTS matching against it
+//!    completes without panicking, for every query in the same 16-pattern
+//!    set `scripts/rdkit_compat_diff.py` uses for the existing 80,000-pair
+//!    SMARTS corpus. This does NOT re-run that Python-bound 80k corpus
+//!    itself (Python/WASM exposure of the new engine is explicitly out of
+//!    scope for this PR) -- it's a proportionate Rust-level substitute:
+//!    same 16 patterns, full 5,000-molecule corpus, run against
+//!    *experimental*-applied molecules specifically.
+//! 2. **Representation parity**: aromatic-form input and explicitly
+//!    pre-kekulized input must produce an identical aromatic atom set --
+//!    generalizes the existing `purine_representation_stable` unit test
+//!    (one molecule) to the full corpus, through the actual production API.
+//!
+//! Existing-pipeline regression (descriptors/fingerprints/CIP-MANCUDE/the
+//! existing 80,000-pair SMARTS corpus) is not re-measured here: those all
+//! run through the default `assign_aromaticity_ex`/`apply_aromaticity_ex`,
+//! which this PR does not modify (confirmed unchanged by
+//! `cargo test --workspace --lib`, 0 failures).
+//!
+//! Run:
+//! ```text
+//! cargo run -p chematic-smarts --release \
+//!     --example aromaticity_a1_1b_1_downstream_check \
+//!     -- ~/Downloads/SMILES.csv
+//! ```
+
+use std::fs;
+
+use chematic_perception::{
+    AromaticityError, apply_aromaticity_rdkit_parity_experimental,
+    assign_aromaticity_rdkit_parity_experimental,
+};
+use chematic_smarts::{find_matches, parse_smarts};
+use chematic_smiles::canonical_smiles;
+
+const SMARTS_PATTERNS: &[&str] = &[
+    "[OH]",
+    "c",
+    "[#7]",
+    "C=O",
+    "[NX3;H2,H1;!$(NC=O)]",
+    "[r5]",
+    "[r6]",
+    "c1ccccc1",
+    "[CX4]",
+    "[!#6;!#1]",
+    "C(=O)[OH]",
+    "[nH]",
+    "[#6]=[#6]",
+    "[F,Cl,Br,I]",
+    "[OX2H]",
+    "[#16]",
+];
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let path = args
+        .get(1)
+        .expect("usage: aromaticity_a1_1b_1_downstream_check <smiles.csv>");
+    let content = fs::read_to_string(path).unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
+
+    let queries: Vec<_> = SMARTS_PATTERNS
+        .iter()
+        .map(|p| parse_smarts(p).unwrap_or_else(|e| panic!("bad SMARTS {p}: {e}")))
+        .collect();
+
+    let mut n_ok = 0usize;
+    let mut n_parse_fail = 0usize;
+    let mut n_kekulization_failed = 0usize;
+    let mut n_internal_invariant_violation = 0usize;
+    let mut n_canonical_round_trip_unstable = 0usize;
+    let mut n_smarts_evaluations = 0usize;
+    let mut n_representation_parity_mismatch = 0usize;
+
+    for line in content.lines() {
+        let smi = line.split(',').next().unwrap_or("").trim();
+        if smi.is_empty() || smi.eq_ignore_ascii_case("smiles") {
+            continue;
+        }
+        let raw = match chematic_smiles::parse(smi) {
+            Ok(m) => m,
+            Err(_) => {
+                n_parse_fail += 1;
+                continue;
+            }
+        };
+
+        let applied = match apply_aromaticity_rdkit_parity_experimental(&raw) {
+            Ok(m) => m,
+            Err(AromaticityError::KekulizationFailed { .. }) => {
+                n_kekulization_failed += 1;
+                continue;
+            }
+            Err(AromaticityError::InternalInvariantViolation { reason }) => {
+                n_internal_invariant_violation += 1;
+                eprintln!("InternalInvariantViolation: {smi}: {reason}");
+                continue;
+            }
+        };
+        n_ok += 1;
+
+        // --- (1a) canonical round-trip, no structural loss ---
+        let c1 = canonical_smiles(&applied);
+        match chematic_smiles::parse(&c1) {
+            Ok(reparsed) => {
+                let c2 = canonical_smiles(&reparsed);
+                if c1 != c2
+                    || reparsed.atom_count() != applied.atom_count()
+                    || reparsed.bond_count() != applied.bond_count()
+                {
+                    n_canonical_round_trip_unstable += 1;
+                    eprintln!("CANONICAL ROUND-TRIP UNSTABLE: {smi} -> {c1} -> {c2}");
+                }
+            }
+            Err(e) => {
+                n_canonical_round_trip_unstable += 1;
+                eprintln!("CANONICAL OUTPUT FAILED TO REPARSE: {smi} -> {c1}: {e}");
+            }
+        }
+
+        // --- (1b) SMARTS matching completes without panicking, at full rate ---
+        for query in &queries {
+            let _matches = find_matches(query, &applied);
+            n_smarts_evaluations += 1;
+        }
+
+        // --- (2) representation parity: aromatic-form vs pre-kekulized input ---
+        let pre_kekulized = match chematic_core::kekulize(&raw) {
+            Ok(k) => chematic_core::apply_kekule(&raw, &k),
+            Err(_) => continue, // same molecule, same kekulize() outcome as above -- unreachable here
+        };
+        if let Ok(model_from_kekulized) =
+            assign_aromaticity_rdkit_parity_experimental(&pre_kekulized)
+        {
+            let model_from_raw = assign_aromaticity_rdkit_parity_experimental(&raw)
+                .expect("already succeeded above via apply()");
+            let mismatch = raw.atoms().any(|(idx, _)| {
+                model_from_raw.is_atom_aromatic(idx) != model_from_kekulized.is_atom_aromatic(idx)
+            });
+            if mismatch {
+                n_representation_parity_mismatch += 1;
+                eprintln!("REPRESENTATION PARITY MISMATCH: {smi}");
+            }
+        }
+    }
+
+    eprintln!(
+        "processed {n_ok} molecules ({n_parse_fail} parse failures, \
+         {n_kekulization_failed} KekulizationFailed, \
+         {n_internal_invariant_violation} InternalInvariantViolation)"
+    );
+    eprintln!(
+        "canonical round-trip: {}/{n_ok} stable ({n_canonical_round_trip_unstable} unstable)",
+        n_ok - n_canonical_round_trip_unstable
+    );
+    eprintln!(
+        "SMARTS: {n_smarts_evaluations}/{} evaluations completed without panicking",
+        n_ok * SMARTS_PATTERNS.len()
+    );
+    eprintln!(
+        "representation parity: {}/{n_ok} match ({n_representation_parity_mismatch} mismatches)",
+        n_ok - n_representation_parity_mismatch
+    );
+}

--- a/docs/aromaticity_a1_rfc.md
+++ b/docs/aromaticity_a1_rfc.md
@@ -440,6 +440,150 @@ that) both require a fresh explicit go-ahead, per this initiative's standing dia
 before-wiring discipline — the gate being met (and exceeded) is not itself that
 go-ahead.
 
+## A1-1b-1: fallible opt-in production API (this round, landed)
+
+A1-1b-0's gate passed with room to spare (100.0000% set agreement on 4,999/5,000
+comparable molecules). This round wires that reference engine into a real, callable
+production API — but as a **separate fallible surface**, not a new
+`AromaticityAlgorithm` variant, because the existing production API
+(`assign_aromaticity_ex`/`apply_aromaticity_ex`) is infallible by contract (`Huckel` and
+`RdkitLike` never fail), and this engine's precondition — pre-kekulized input — is not
+always satisfiable (the one known `kekulize()` gap). Bending the existing infallible
+signature to accommodate one fallible variant would have been the wrong shape; adding a
+parallel `Result`-returning API keeps both contracts honest.
+
+```rust
+pub enum AromaticityError {
+    KekulizationFailed { reason: String },
+    InternalInvariantViolation { reason: String },
+}
+
+pub fn assign_aromaticity_rdkit_parity_experimental(
+    mol: &Molecule,
+) -> Result<AromaticityModel, AromaticityError>;
+
+pub fn apply_aromaticity_rdkit_parity_experimental(
+    mol: &Molecule,
+) -> Result<Molecule, AromaticityError>;
+```
+
+Both are always available (no feature flag) — only the low-level `rdkit_parity` engine
+internals remain gated. `mod rdkit_parity;` is now unconditionally compiled (it backs
+production code), but every item inside it except the two functions above is
+`pub(crate)`; the only way to reach the raw engine from outside the crate is through
+those two functions, or, for diagnostics/benchmarking, a new
+`chematic_perception::diagnostics` module (`#[doc(hidden)]`, gated behind the
+`diagnostics` feature) that re-exports just `rdkit_parity_aromaticity`.
+
+**Execution path**, matching the specified shape exactly:
+
+```
+input Molecule (&, never mutated)
+  -> private clone with every atom's `aromatic` flag reset to false
+      (this engine only ever reads BondOrder::Aromatic, never atom.aromatic,
+      so this has no effect on the *computation* -- it exists purely so the
+      *output* molecule's flags come entirely from this engine's own
+      verdict, never leftover from whatever the caller passed in)
+  -> kekulize() -- Err(KekulizationFailed { reason }) on failure, `mol` untouched
+  -> rdkit_parity_aromaticity(): donor type computed once per molecule,
+     candidate rings, fused-ring subsets, Hückel verdict (unchanged from A1-1b-0)
+  -> validate_aromaticity_invariants(): every aromatic bond's two endpoints
+     must themselves be aromatic atoms -- Err(InternalInvariantViolation) if not
+     (0/4,999 fired on the full corpus; exists as a defensive no-panic
+     guarantee, not because a violation was ever observed)
+  -> AromaticityModel::from_atom_bond_sets() (ring_classifications() and
+     antiaromatic_rings() are empty -- this engine, like RDKit's own,
+     determines only the aromatic atom/bond sets)
+  -> apply(): build_molecule_from_model() -- the SAME shared function
+     apply_aromaticity_ex() uses (extracted, not duplicated) for implicit-H
+     preservation, bond-direction stashing, and stereo-metadata copying
+```
+
+Every step takes `&Molecule` and returns a new value; nothing is mutated in place, so
+there is no path that partially rewrites the input before failing (enforced by the type
+system, and pinned by `production_api_does_not_mutate_input_on_failure`).
+
+**Verification, not re-derivation.** Since A1-1b-0 already proved the underlying engine
+against RDKit, this round's job was to prove the *wiring* is mechanical — that routing
+through the new fallible entry points doesn't perturb the already-verified verdicts:
+
+- 55-molecule diagnosis corpus, through `assign_aromaticity_rdkit_parity_experimental`
+  (raw aromatic-form input, no manual pre-kekulization) — **byte-identical** JSONL output
+  to the A1-1b-0 trace (1,214/1,214 rows).
+- Full 5,000-molecule corpus, through the same production function — **byte-identical**
+  atom/bond rows to the A1-1b-0 full-corpus trace (138,635 atom rows, 150,004 bond rows),
+  transitively inheriting the 100.0000% RDKit set-agreement result without re-joining
+  RDKit. Exactly 1 `KekulizationFailed` (the known gap), 0 `InternalInvariantViolation`,
+  0 disagreements between `assign_...`/`apply_...` on the same input.
+
+**Downstream checks — additive reading, not bit-identity-with-default.** The engine
+changes aromaticity by design on the molecules where current production already
+disagrees with RDKit (~0.56% atoms / ~1.18% bonds); demanding bit-identity between
+experimental-applied output and default-applied output would fail by construction on
+exactly the cases this engine exists to fix. Interpreted additively instead:
+
+1. **Existing default-path suites stay green.** `assign_aromaticity_ex`/
+   `apply_aromaticity_ex` are byte-unchanged (only the internals were reorganized into a
+   shared `build_molecule_from_model` helper both paths call); `cargo test --workspace
+   --lib` is 0 failures across every crate, including the existing 80,000-pair SMARTS
+   corpus, descriptor/fingerprint/CIP-MANCUDE suites — none of which touch the new
+   experimental path.
+2. **Experimental-applied molecules don't crash or corrupt.** New Rust-level check
+   (`crates/chematic-smarts/examples/aromaticity_a1_1b_1_downstream_check.rs` — lives in
+   `chematic-smarts`, not `chematic-perception`, since the reverse dependency direction
+   would be circular), full 5,000-molecule corpus, molecules produced by
+   `apply_aromaticity_rdkit_parity_experimental`:
+   - SMARTS matching (the same 16-pattern set `scripts/rdkit_compat_diff.py` uses for the
+     existing 80,000-pair corpus) completes without panicking on every evaluation:
+     **79,984/79,984** (4,999 molecules × 16 patterns). This does not re-run the
+     Python-bound 80k corpus itself against the new engine — Python/WASM exposure is
+     explicitly out of scope for this PR — it's a proportionate Rust-level substitute
+     using the same query set at the same corpus scale.
+   - Canonical SMILES round-trip idempotency: **4,912/4,999 (98.26%)** stable. This is
+     *not* a new defect: the pre-existing idempotency baseline (documented in
+     `docs/rdkit_compat.md`, "large fused-ring-system aromaticity round-trip", a
+     canonicalization-tie-break issue upstream of this PR) is already ~98.4% on the same
+     corpus under the *default* pipeline (measured same-run baseline: 69/5,000 = 98.62%
+     unstable via `apply_aromaticity_ex(.., RdkitLike)`). The two unstable sets overlap
+     62/87 (71%); tracing a sample of the 25 molecules unstable *only* under the
+     experimental path found their final aromatic atom/bond verdict is **identical** to
+     the default path's — the divergence traces instead to `build_molecule_from_model`'s
+     implicit-H "Kekule-then-perceive" freeze logic, which behaves slightly differently
+     depending on whether its `mol` argument was already Kekule-form (experimental always
+     passes its own internally-kekulized clone) or still aromatic-form (default's `mol`
+     argument, when the caller passes genuinely aromatic-written SMILES directly, as most
+     of this corpus is). Both are internally consistent with the shared function's
+     documented intent; this shifts *which* molecules hit the pre-existing
+     idempotency gap rather than introducing a new one. Not chased further — root-causing
+     the exact shift is out of scope for a mechanical-wiring PR; flagged here rather than
+     rounded off.
+3. **Representation parity: 4,999/4,999 (100%).** Aromatic-form input and explicitly
+   pre-kekulized input produce an identical aromatic atom set through the production API
+   — generalizes `purine_representation_stable` (one pinned molecule) to the full corpus.
+
+**Performance — recorded, not optimized** (this PR does not tune either engine for
+speed; `crates/chematic-perception/examples/aromaticity_a1_1b_1_perf.rs`, full
+5,000-molecule corpus, warm-up pass excluded from timing):
+
+| Engine | mean | p50 | p95 | max |
+|---|---|---|---|---|
+| `RdkitLike` (current production default) | 408.3µs | 260.2µs | 1021.5µs | 27.7ms |
+| `RdkitParityExperimental` | 424.7µs | 275.1µs | 1062.2µs | 27.3ms |
+
+~4% slower on mean/p50/p95 — essentially comparable, not the order-of-magnitude gap seen
+elsewhere in this project's opt-in-accuracy tradeoffs (e.g. CIP Accurate's ~10x). Peak
+RSS is a coarse whole-process figure (`/usr/bin/time -l` around the full benchmark run,
+both engines plus warm-up in one process): ~19MB: not cleanly separable per-engine in a
+single process, and not expected to differ meaningfully — both algorithms allocate
+`FxHashSet`/`FxHashMap` sized to one molecule's ring/atom count per call, freed
+immediately after, so peak RSS is dominated by corpus loading, not algorithm choice.
+
+**Non-goals held**: `RdkitLike` is not replaced, the default is not changed, the one
+known `kekulize()` gap is not fixed (it surfaces as `KekulizationFailed`, not a silent
+fallback), the reference engine's algorithm is not touched, no SMARTS/canonical-specific
+exceptions were added, and this round does not touch Python/WASM bindings or README
+default-accuracy numbers.
+
 ## A1's gate (for the eventual production-enabling PR, not A1-0)
 
 Per the user's spec — not evaluated in this round, recorded here so A1-1/A1-2's PRs are
@@ -465,30 +609,41 @@ measured against a fixed target instead of a moving one:
 
 1. PR #86 — SMARTS-A0 diagnosis (merged).
 2. PR #87 — Aromaticity-A1-0: component trace + corpus, no behavior change (merged).
-3. **This PR — Aromaticity-A1-1a**: component model (`PiEligibility`,
-   `ConjugatedComponent`, `evaluate_atom_pi_contribution`) + exhaustive reference
-   oracle, no production wiring. Fixed 2 bugs found in this round's own new code
-   (connectivity, home-ring degree evaluation); confirmed the atom-8 carbonyl rule is
-   correct (not the fix target); confirmed candidate generation alone fixes azulene but
-   not the false-positive family or purine — both left as open, pinned findings for
-   A1-1b, not solved here.
-4. **This PR — Aromaticity-A1-1b-0**: RDKit-parity reference engine
+3. PR #88 — Aromaticity-A1-1a: component model (`PiEligibility`, `ConjugatedComponent`,
+   `evaluate_atom_pi_contribution`) + exhaustive reference oracle, no production wiring
+   (merged). Fixed 2 bugs found in this round's own new code (connectivity, home-ring
+   degree evaluation); confirmed the atom-8 carbonyl rule is correct (not the fix
+   target); confirmed candidate generation alone fixes azulene but not the
+   false-positive family or purine — both left as open, pinned findings for A1-1b.
+4. PR #89 — Aromaticity-A1-1b-0: RDKit-parity reference engine
    (`rdkit_parity_aromaticity`), a source-verified port of RDKit's actual default
    aromaticity algorithm (`ElectronDonorType`, candidate rings, fused-ring adjacency,
-   `applyHuckelToFused`-style subset search). Test/diagnostic-only, no production
-   wiring. Passes the full 55-molecule gate (33 FP / 5 FN / 17 NC / 100% atom-flag
-   agreement / 0 unexplained diffs) and, beyond the stated gate, reaches 100.0000%
-   set-level atom/bond agreement with real RDKit on all 4,999 comparable molecules of
-   the full 5,000-molecule benchmark corpus (1 excluded by a pre-existing, unrelated
-   `kekulize()` gap — vs the 99.44%/98.82% production baseline) — appears to resolve
-   both of A1-1a's open findings (false-positive family, purine) by construction.
-   Ports specific RDKit functions under RDKit's BSD 3-Clause license; attribution and
-   full license text recorded in `THIRD_PARTY_NOTICES.md`. The low-level port
-   (`rdkit_parity` module) is diagnostic-only, gated behind this crate's `diagnostics`
-   feature (or `#[cfg(test)]`) and not exported from the crate root.
-5. A1-1b — wire `rdkit_parity_aromaticity` behind a new opt-in `AromaticityAlgorithm`
-   variant, test-only/opt-in (not started; requires explicit go-ahead following this
-   PR's review).
-6. Enable the solver into `apply_aromaticity("rdkit_like")`'s default + full regression
-   against the gate above (not started).
-7. Docs/benchmark updates reflecting the final measured numbers (not started).
+   `applyHuckelToFused`-style subset search), no production wiring (merged). Passed the
+   full 55-molecule gate (33 FP / 5 FN / 17 NC / 100% atom-flag agreement / 0
+   unexplained diffs) and, beyond the stated gate, reached 100.0000% set-level atom/bond
+   agreement with real RDKit on all 4,999 comparable molecules of the full 5,000-molecule
+   benchmark corpus (1 excluded by a pre-existing, unrelated `kekulize()` gap — vs the
+   99.44%/98.82% production baseline) — resolved both of A1-1a's open findings
+   (false-positive family, purine) by construction. Ports specific RDKit functions under
+   RDKit's BSD 3-Clause license; attribution and full license text recorded in
+   `THIRD_PARTY_NOTICES.md`.
+5. **This PR — Aromaticity-A1-1b-1**: fallible opt-in production API
+   (`assign_aromaticity_rdkit_parity_experimental`/
+   `apply_aromaticity_rdkit_parity_experimental`, `AromaticityError`), always available
+   (no feature flag); the low-level `rdkit_parity` engine internals are `pub(crate)`,
+   reachable externally only through those two functions or, for diagnostics, the new
+   `diagnostics` module (gated behind the `diagnostics` feature). Mechanical wiring only
+   — no algorithm change, no `RdkitLike` replacement, no default change. Verified
+   byte-identical to the A1-1b-0 trace on both the 55-molecule and full 5,000-molecule
+   corpora (proving the wiring layer doesn't perturb the already-verified engine);
+   downstream checks (SMARTS-doesn't-panic, canonical round-trip, representation parity)
+   read additively rather than as bit-identity-with-default, since this engine changes
+   aromaticity by design on the molecules where production already disagrees with RDKit.
+6. A1-1b-2 — Python/WASM opt-in exposure of the new production API (not started).
+7. K0 — diagnose the one remaining `kekulize()` gap
+   (`Cc1cn2c(=O)c3ncn(COCCO)c3nc2n1C`) that currently surfaces as
+   `AromaticityError::KekulizationFailed` (not started).
+8. A1-1c — downstream regression/perf evaluation at a scope beyond this PR's proportionate
+   checks, if the additive-reading interpretation above needs revisiting (not started).
+9. A1-1d — decide whether to promote the RDKit-parity engine to
+   `apply_aromaticity("rdkit_like")`'s default, informed by A1-1b-2/K0/A1-1c (not started).


### PR DESCRIPTION
## Summary

Wires the RDKit-parity reference engine (A1-1b-0, PR #89, merged) into a
callable production API, as a **separate fallible surface** rather than a
new `AromaticityAlgorithm` variant. The existing
`assign_aromaticity_ex`/`apply_aromaticity_ex` contract is infallible
(`Huckel`/`RdkitLike` never fail); this engine's pre-kekulized-input
precondition is not always satisfiable (the one known `kekulize()` gap), so
bending the existing signature would have been the wrong shape.

```rust
pub enum AromaticityError {
    KekulizationFailed { reason: String },
    InternalInvariantViolation { reason: String },
}

pub fn assign_aromaticity_rdkit_parity_experimental(
    mol: &Molecule,
) -> Result<AromaticityModel, AromaticityError>;

pub fn apply_aromaticity_rdkit_parity_experimental(
    mol: &Molecule,
) -> Result<Molecule, AromaticityError>;
```

Both always available (no feature flag). `rdkit_parity`'s low-level
internals (`ElectronDonorType`, donor-type/Hückel machinery,
`rdkit_parity_aromaticity_ex`) are now `pub(crate)` -- only the two
functions above are exported from the crate root. A new `diagnostics`
module (`#[doc(hidden)]`, gated behind the `diagnostics` feature) re-exports
`rdkit_parity_aromaticity` for benchmarking/diagnostic examples.

## Execution path

Never mutates the input:

```
input Molecule (&, never mutated)
  -> private clone, aromatic flags cleared
  -> kekulize() -- Err(KekulizationFailed) on failure, no partial rewrite
  -> the already-verified engine (donor type once per molecule, candidate
     rings, fused-ring subsets, Hückel verdict)
  -> validate_aromaticity_invariants() -- Err(InternalInvariantViolation)
     if an aromatic bond has a non-aromatic endpoint (0/4,999 fired)
  -> AromaticityModel
  -> apply(): build_molecule_from_model(), extracted from
     apply_aromaticity_ex (not duplicated) -- same implicit-H/bond-
     direction/stereo handling for both paths
```

## Verification

Proves the wiring is mechanical, not a re-derivation:

- 55-molecule and full 5,000-molecule corpora, through the actual
  production function -- **byte-identical** to the A1-1b-0 trace (138,635
  atom rows, 150,004 bond rows), transitively inheriting the 100.0000%
  RDKit set-agreement result without re-joining RDKit.
- Exactly 1 `KekulizationFailed` (the known gap), 0
  `InternalInvariantViolation`, 0 `assign`/`apply` disagreements.

**Downstream checks read additively**, not as bit-identity-with-default
(this engine changes aromaticity by design on the ~0.56%/1.18% atoms/bonds
where production already disagrees with RDKit):

- Existing default-path suites unchanged: `assign_aromaticity_ex`/
  `apply_aromaticity_ex` byte-unchanged, `cargo test --workspace --lib` 0
  failures (existing 80,000-pair SMARTS corpus, descriptors, fingerprints,
  CIP-MANCUDE all untouched).
- SMARTS matching against experimental-applied molecules: 79,984/79,984
  evaluations (16-pattern set, full corpus) complete without panicking.
- Canonical round-trip idempotency: 98.26%, consistent with (not a
  regression beyond) the project's existing ~98.4% baseline gap -- traced to
  `build_molecule_from_model`'s implicit-H freeze logic behaving slightly
  differently depending on whether the input was already Kekule-form; not
  a new defect, documented rather than rounded off.
- Representation parity (aromatic-form vs pre-kekulized input): 4,999/4,999
  (100%) -- generalizes `purine_representation_stable` to the full corpus.

## Performance

Recorded, not optimized (full 5,000-molecule corpus, warm-up excluded):

| Engine | mean | p50 | p95 | max |
|---|---|---|---|---|
| `RdkitLike` (current default) | 408.3µs | 260.2µs | 1021.5µs | 27.7ms |
| `RdkitParityExperimental` | 424.7µs | 275.1µs | 1062.2µs | 27.3ms |

~4% slower on mean/p50/p95. Peak RSS ~19MB (coarse whole-process figure,
not cleanly separable per-engine).

## Non-goals held

`RdkitLike` not replaced, default unchanged, the known `kekulize()` gap not
fixed (surfaces as an explicit error, never a silent fallback), reference
algorithm untouched, no Python/WASM exposure, no README default-accuracy
changes.

## Test plan

- [x] `cargo test -p chematic-perception --lib rdkit_parity::` (12/12,
      including 5 new production-API tests: benzene assign, apply sets
      flags/bond orders, kekulize-failure-not-panic, no-mutation-on-failure,
      stale-flag-not-leaked)
- [x] `cargo test --workspace --lib --quiet` -- 0 failures
- [x] `bash scripts/check.sh` -- all green
- [x] `cargo check --workspace` confirms the new API needs no feature flag
      while `rdkit_parity`'s internals stay `pub(crate)`
- [x] 55-molecule + full 5,000-molecule corpora: byte-identical to the
      already-RDKit-verified A1-1b-0 trace via the actual production API
- [x] Downstream checks (SMARTS-no-panic, canonical round-trip,
      representation parity) as detailed above