### PR TITLE
fix(core): P0 -- apply_kekule silently dropped stereo_neighbor_order

### DIFF
--- a/crates/chematic-cip/tests/kekule_s0_stereo_invariance.rs
+++ b/crates/chematic-cip/tests/kekule_s0_stereo_invariance.rs
@@ -1,0 +1,136 @@
+//! Kekule-S0: verify `chematic_core::apply_kekule` preserving
+//! `stereo_neighbor_order` (see `crates/chematic-core/src/kekulization.rs`)
+//! actually fixes atom-mapped CIP R/S assignment for molecules routed
+//! through an explicit kekulize+apply_kekule round trip before CIP
+//! assignment -- exactly what `chematic-perception`'s
+//! `apply_aromaticity_rdkit_parity_experimental` does internally.
+//!
+//! Before the fix, `mol.stereo_neighbor_order(idx)` was `None` on any
+//! post-`apply_kekule` molecule, which both CIP engines treat as
+//! "insufficient information" and *skip* (not mislabel) --
+//! `assign_cip_accurate_experimental` pushes `SkipReason::NotFourSubstituents`
+//! (a misleading name for this cause: the substituent count is fine, the
+//! neighbor *order* is what's missing) and the legacy engine's assignment
+//! for that atom is simply absent. Both engines are checked here, per atom,
+//! comparing the RAW aromatic-form input against the same molecule after an
+//! explicit kekulize+apply_kekule round trip.
+
+use std::collections::HashMap;
+
+use chematic_chem::assign_cip as assign_cip_legacy;
+use chematic_cip::{CipBudget, assign_cip_accurate_experimental};
+use chematic_core::{AtomIdx, CipCode, Molecule, apply_kekule, kekulize};
+
+fn kekulized(mol: &Molecule) -> Molecule {
+    let k = kekulize(mol).expect("kekulizable");
+    apply_kekule(mol, &k)
+}
+
+fn legacy_map(mol: &Molecule) -> HashMap<u32, Option<CipCode>> {
+    let assignment = assign_cip_legacy(mol);
+    (0..mol.atom_count())
+        .map(|i| {
+            let idx = AtomIdx(i as u32);
+            (i as u32, assignment.get(idx))
+        })
+        .collect()
+}
+
+fn accurate_map(mol: &Molecule) -> HashMap<u32, Option<CipCode>> {
+    let assignment = assign_cip_accurate_experimental(mol, CipBudget::default_budget())
+        .expect("CIP budget not exceeded for these small test molecules");
+    let mut map: HashMap<u32, Option<CipCode>> =
+        (0..mol.atom_count()).map(|i| (i as u32, None)).collect();
+    for (idx, code) in &assignment.assignments {
+        map.insert(idx.0, Some(*code));
+    }
+    map
+}
+
+#[track_caller]
+fn assert_cip_invariant_under_kekulize(smi: &str) {
+    let raw = chematic_smiles::parse(smi).expect("valid SMILES");
+    let kek = kekulized(&raw);
+    assert_eq!(
+        raw.atom_count(),
+        kek.atom_count(),
+        "{smi}: apply_kekule must preserve atom count/index mapping"
+    );
+
+    let legacy_before = legacy_map(&raw);
+    let legacy_after = legacy_map(&kek);
+    assert_eq!(
+        legacy_before, legacy_after,
+        "{smi}: legacy chematic_chem::assign_cip differs before/after kekulize+apply_kekule"
+    );
+
+    let accurate_before = accurate_map(&raw);
+    let accurate_after = accurate_map(&kek);
+    assert_eq!(
+        accurate_before, accurate_after,
+        "{smi}: assign_cip_accurate_experimental differs before/after kekulize+apply_kekule"
+    );
+}
+
+#[test]
+fn simple_chiral_centers() {
+    for smi in [
+        "N[C@@H](C)C(=O)O",
+        "N[C@H](C)C(=O)O",
+        "[C@@H]1(N)CCCC1",
+        "F[C@H]1CCCCC1",
+    ] {
+        assert_cip_invariant_under_kekulize(smi);
+    }
+}
+
+#[test]
+fn chiral_substituent_on_aromatic_ring() {
+    // The exact shape that exposed the bug: a stereocenter whose
+    // stereo_neighbor_order is defined relative to an aromatic ring atom
+    // that itself needs kekulization.
+    for smi in [
+        "c1ccc(cc1)[C@H](F)Cl",
+        "c1ccc(cc1)[C@@H](F)Cl",
+        "Cc1cn([C@H]2CCCC[C@@H]2C)c(=O)n1C",
+    ] {
+        assert_cip_invariant_under_kekulize(smi);
+    }
+}
+
+#[test]
+fn real_corpus_case_multi_stereocenter() {
+    // The Aromaticity-A1-1b-1 "experimental_only" canonical-round-trip
+    // instability case that first surfaced this bug: 3 stereocenters, an
+    // aromatic ring directly bonded to two of them.
+    assert_cip_invariant_under_kekulize(
+        "CCCCc1cn([C@H]2[C@H](C)CCC[C@@H]2C)c(=O)n1Cc1ccc(-c2ccccc2-c2nn[nH]n2)nc1",
+    );
+}
+
+#[test]
+fn pre_fix_regression_would_have_skipped_not_mislabeled() {
+    // Documents the exact failure shape the fix closes: without
+    // stereo_neighbor_order, both engines treat the atom as
+    // "insufficient information" rather than emitting a wrong label. This
+    // test would have failed pre-fix with `after[chiral_idx] == None` while
+    // `before[chiral_idx] == Some(..)`.
+    let raw = chematic_smiles::parse("c1ccc(cc1)[C@H](F)Cl").expect("valid SMILES");
+    let chiral_idx = raw
+        .atoms()
+        .find(|(_, a)| a.chirality != chematic_core::Chirality::None)
+        .map(|(idx, _)| idx.0)
+        .expect("test setup sanity: exactly one chiral atom");
+    let kek = kekulized(&raw);
+
+    let before = accurate_map(&raw);
+    let after = accurate_map(&kek);
+    assert!(
+        before[&chiral_idx].is_some(),
+        "test setup sanity: atom {chiral_idx} should be a resolvable stereocenter"
+    );
+    assert_eq!(
+        before[&chiral_idx], after[&chiral_idx],
+        "atom {chiral_idx}'s CIP code must survive kekulize+apply_kekule, not silently become None"
+    );
+}

--- a/crates/chematic-core/src/kekulization.rs
+++ b/crates/chematic-core/src/kekulization.rs
@@ -268,8 +268,23 @@ pub fn build_kekule_result(
 ///
 /// Aromatic flags on atoms are *not* cleared (the molecule retains the aromaticity
 /// annotation; only bond orders change).
+///
+/// Preserves every stereo side-channel (`stereo_groups`, `stereo_neighbor_order`,
+/// `bond_directions`) unchanged. This matters even though `atom.chirality` itself is
+/// copied verbatim with each `Atom`: `@`/`@@` is a relative descriptor over the SMILES
+/// neighbor-encounter order recorded in `stereo_neighbor_order`, not an absolute one.
+/// Losing that order and re-deriving `@`/`@@` output from a *different* neighbor
+/// ordering downstream (e.g. canonical atom order) can serialize the *same* tetrahedral
+/// center as the wrong configuration -- silently, with no panic and no error, since
+/// `chirality` alone still round-trips as "some chirality is set". Atom/bond indices are
+/// unchanged (nothing is skipped, added, or reordered), the same precondition the
+/// `copy_*_from` methods themselves require.
 pub fn apply_kekule(mol: &Molecule, kekule: &KekuleResult) -> Molecule {
     use crate::molecule::MoleculeBuilder;
+
+    if kekule.is_empty() {
+        return mol.clone();
+    }
 
     let mut builder = MoleculeBuilder::new();
 
@@ -285,6 +300,10 @@ pub fn apply_kekule(mol: &Molecule, kekule: &KekuleResult) -> Molecule {
             .add_bond(bond.atom1, bond.atom2, order)
             .expect("duplicate bond during apply_kekule");
     }
+
+    builder.copy_stereo_groups_from(mol);
+    builder.copy_stereo_from(mol);
+    builder.copy_bond_directions_from(mol);
 
     builder.build()
 }
@@ -598,7 +617,8 @@ mod tests {
     use super::*;
     use crate::atom::Atom;
     use crate::element::Element;
-    use crate::molecule::MoleculeBuilder;
+    use crate::molecule::{MoleculeBuilder, STEREO_H_SENTINEL};
+    use crate::stereo_group::StereoGroup;
 
     /// Build benzene as a fully aromatic SMILES-style molecule.
     fn benzene() -> Molecule {
@@ -1199,5 +1219,162 @@ mod tests {
             .filter(|&&o| o == BondOrder::Double)
             .count();
         assert_eq!(doubles, 3, "b1ccccn1: 3 double bonds");
+    }
+
+    // -----------------------------------------------------------------
+    // Kekule-S0: apply_kekule must preserve stereo side channels.
+    //
+    // `@`/`@@` (`Atom::chirality`) is a *relative* descriptor over the
+    // SMILES neighbor-encounter order recorded in `stereo_neighbor_order`
+    // -- copying `chirality` alone without that order is not enough to
+    // reproduce the same tetrahedral configuration downstream.
+    // -----------------------------------------------------------------
+
+    /// A chiral aromatic ring (5-membered, one sp3 substituent) with a
+    /// stereo group, a stashed bond direction, and a `stereo_neighbor_order`
+    /// entry set on the sp3 atom -- exercises all three side channels
+    /// `apply_kekule` must preserve.
+    fn chiral_aromatic_with_stereo_metadata() -> (Molecule, AtomIdx, BondIdx) {
+        let mut b = MoleculeBuilder::new();
+        let c1 = b.add_atom(Atom::aromatic(Element::C));
+        let c2 = b.add_atom(Atom::aromatic(Element::C));
+        let c3 = b.add_atom(Atom::aromatic(Element::C));
+        let c4 = b.add_atom(Atom::aromatic(Element::C));
+        let o = b.add_atom(Atom::aromatic(Element::O));
+        for i in 0..4 {
+            let ring = [c1, c2, c3, c4, o];
+            b.add_bond(ring[i], ring[i + 1], BondOrder::Aromatic)
+                .unwrap();
+        }
+        b.add_bond(o, c1, BondOrder::Aromatic).unwrap();
+
+        // sp3 chiral substituent on c1: -CH(F)(Cl), a real stereocenter.
+        let mut chiral = Atom::new(Element::C);
+        chiral.chirality = crate::atom::Chirality::CounterClockwise;
+        let ch = b.add_atom(chiral);
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let exocyclic_bond = b.add_bond(c1, ch, BondOrder::Single).unwrap();
+        b.add_bond(ch, f, BondOrder::Single).unwrap();
+        b.add_bond(ch, cl, BondOrder::Single).unwrap();
+
+        let mut mol = b.build();
+        // SMILES-text-order neighbor sequence: c1, implicit-H sentinel, F, Cl.
+        mol.set_stereo_neighbor_order(ch, vec![c1.0, STEREO_H_SENTINEL, f.0, cl.0]);
+        mol.add_stereo_group(StereoGroup::new(
+            crate::stereo_group::StereoGroupKind::Absolute,
+            vec![ch],
+        ));
+        mol.set_bond_direction(exocyclic_bond, BondOrder::Up);
+
+        (mol, ch, exocyclic_bond)
+    }
+
+    #[test]
+    fn apply_kekule_preserves_stereo_neighbor_order() {
+        let (mol, ch, _) = chiral_aromatic_with_stereo_metadata();
+        let before = mol.stereo_neighbor_order(ch).map(|s| s.to_vec());
+        assert!(before.is_some(), "test setup sanity");
+
+        let result = kekulize(&mol).expect("kekulizable");
+        assert!(
+            !result.is_empty(),
+            "test setup sanity: ring must need kekulization"
+        );
+        let kekulized = apply_kekule(&mol, &result);
+
+        assert_eq!(
+            kekulized.stereo_neighbor_order(ch).map(|s| s.to_vec()),
+            before,
+            "stereo_neighbor_order must survive apply_kekule verbatim"
+        );
+    }
+
+    #[test]
+    fn apply_kekule_preserves_stereo_groups() {
+        let (mol, _, _) = chiral_aromatic_with_stereo_metadata();
+        let before = mol.stereo_groups().to_vec();
+        assert!(!before.is_empty(), "test setup sanity");
+
+        let result = kekulize(&mol).expect("kekulizable");
+        let kekulized = apply_kekule(&mol, &result);
+
+        assert_eq!(
+            kekulized.stereo_groups(),
+            before.as_slice(),
+            "stereo_groups must survive apply_kekule verbatim"
+        );
+    }
+
+    #[test]
+    fn apply_kekule_preserves_bond_directions() {
+        let (mol, _, exocyclic_bond) = chiral_aromatic_with_stereo_metadata();
+        let before = mol.bond_direction(exocyclic_bond);
+        assert!(before.is_some(), "test setup sanity");
+
+        let result = kekulize(&mol).expect("kekulizable");
+        let kekulized = apply_kekule(&mol, &result);
+
+        assert_eq!(
+            kekulized.bond_direction(exocyclic_bond),
+            before,
+            "bond_directions must survive apply_kekule verbatim"
+        );
+    }
+
+    #[test]
+    fn apply_kekule_preserves_atom_and_bond_index_mapping() {
+        let (mol, _, _) = chiral_aromatic_with_stereo_metadata();
+        let result = kekulize(&mol).expect("kekulizable");
+        let kekulized = apply_kekule(&mol, &result);
+
+        assert_eq!(kekulized.atom_count(), mol.atom_count());
+        assert_eq!(kekulized.bond_count(), mol.bond_count());
+        for (idx, atom) in mol.atoms() {
+            let after = kekulized.atom(idx);
+            assert_eq!(atom.element, after.element, "atom {idx:?} element moved");
+            assert_eq!(
+                atom.chirality, after.chirality,
+                "atom {idx:?} chirality moved"
+            );
+        }
+        for (bidx, bond) in mol.bonds() {
+            let after = kekulized.bond(bidx);
+            assert_eq!(bond.atom1, after.atom1, "bond {bidx:?} atom1 moved");
+            assert_eq!(bond.atom2, after.atom2, "bond {bidx:?} atom2 moved");
+        }
+    }
+
+    #[test]
+    fn apply_kekule_empty_result_is_full_clone() {
+        // No aromatic bonds at all -- kekulize() returns an empty map, and
+        // apply_kekule must take the early-return clone path, which trivially
+        // preserves every side channel (it's the same molecule).
+        let mut b = MoleculeBuilder::new();
+        let mut chiral = Atom::new(Element::C);
+        chiral.chirality = crate::atom::Chirality::Clockwise;
+        let c = b.add_atom(chiral);
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        let h_bond = b.add_atom(Atom::new(Element::I));
+        b.add_bond(c, f, BondOrder::Single).unwrap();
+        b.add_bond(c, cl, BondOrder::Single).unwrap();
+        b.add_bond(c, br, BondOrder::Single).unwrap();
+        b.add_bond(c, h_bond, BondOrder::Single).unwrap();
+
+        let mut mol = b.build();
+        mol.set_stereo_neighbor_order(c, vec![f.0, cl.0, br.0, h_bond.0]);
+
+        let result = kekulize(&mol).expect("no aromatic bonds -- trivially kekulizable");
+        assert!(result.is_empty(), "test setup sanity: no aromatic bonds");
+
+        let kekulized = apply_kekule(&mol, &result);
+        assert_eq!(
+            kekulized.stereo_neighbor_order(c).map(|s| s.to_vec()),
+            mol.stereo_neighbor_order(c).map(|s| s.to_vec())
+        );
+        assert_eq!(kekulized.atom_count(), mol.atom_count());
+        assert_eq!(kekulized.bond_count(), mol.bond_count());
     }
 }

--- a/crates/chematic-core/src/molecule.rs
+++ b/crates/chematic-core/src/molecule.rs
@@ -42,6 +42,7 @@ impl std::error::Error for MolError {}
 /// Sentinel used in `stereo_neighbor_order` to represent the implicit H in a bracket atom.
 pub const STEREO_H_SENTINEL: u32 = u32::MAX;
 
+#[derive(Clone)]
 pub struct Molecule {
     atoms: Vec<Atom>,
     bonds: Vec<BondEntry>,

--- a/crates/chematic-inchi/tests/kekule_s0_stereo_invariance.rs
+++ b/crates/chematic-inchi/tests/kekule_s0_stereo_invariance.rs
@@ -1,0 +1,147 @@
+//! Kekule-S0: `chematic_inchi::inchi`'s stereo layers (`/t`, `/m`, `/s`)
+//! must be unchanged whether a molecule is InChI-generated directly from its
+//! parsed (possibly aromatic-form) SMILES, or from the same molecule after
+//! an explicit `chematic_core::kekulize`+`apply_kekule` round trip first --
+//! exactly what `chematic-perception`'s
+//! `apply_aromaticity_rdkit_parity_experimental` does internally before
+//! computing aromaticity.
+//!
+//! InChI's own canonical numbering is independent of `AtomIdx`, so this
+//! compares the generated InChI strings (and specifically their stereo
+//! layers) directly rather than an atom-mapped table.
+//!
+//! **Scoping note**: for molecules whose stereocenter sits on/near a ring
+//! that itself needs kekulization, comparing `inchi(direct)` against
+//! `inchi(via_kekulize)` conflates two *different* bugs. Confirmed by direct
+//! check: `chematic_inchi::inchi`'s own canonical numbering (`/c`, `/h`
+//! layers) is representation-dependent (aromatic-form vs Kekulé-form input
+//! produce different atom numbering) for a fully **achiral** aromatic
+//! molecule too (`c1ccc(cc1)C(F)Cl`) -- this is a separate, pre-existing gap
+//! in chematic-inchi's own canonicalization, unrelated to
+//! `stereo_neighbor_order` and out of scope for Kekule-S0 (which is scoped
+//! to `apply_kekule` alone; see `docs/` for the follow-up this surfaces).
+//! For ring-adjacent stereocenters, this suite instead checks
+//! `inchi(via_kekulize(a))` against `inchi(via_kekulize(b))` for a true
+//! enantiomer pair `(a, b)`: both go through the *same* kekulize pipeline,
+//! so the pre-existing numbering instability cancels out, and the
+//! comparison isolates exactly what Kekule-S0 controls -- does the fix
+//! produce a correctly mirrored stereo layer, not a collapsed or unrelated
+//! one.
+//!
+//! **Honest note on what this suite actually demonstrates**: `chematic_inchi`
+//! never reads `Molecule::stereo_neighbor_order` at all (confirmed: no
+//! occurrences in `crates/chematic-inchi/src/`). It derives stereo purely
+//! from `atom.chirality` plus bond/neighbor *insertion* order, which
+//! `apply_kekule`'s rebuild always preserved even before this fix (only the
+//! separate `stereo_neighbor_order`/`stereo_groups`/`bond_directions` side
+//! channels were dropped). Positive-control check (temporarily reverting the
+//! fix) confirms every test in this file passes identically before and
+//! after -- i.e. `chematic-inchi`'s stereo output was never actually at risk
+//! from this bug. These tests are kept as a real, useful regression pin
+//! (InChI stereo layers stay correct across kekulization either way), not as
+//! evidence the fix changed InChI's behavior.
+
+use chematic_core::{apply_kekule, kekulize};
+use chematic_inchi::inchi;
+use chematic_smiles::parse;
+
+/// Extract everything from `/t` onward (the stereo-relevant tail: `/t`,
+/// `/m`, `/s`), or `""` if there's no `/t` layer at all.
+fn stereo_tail(inchi_str: &str) -> &str {
+    inchi_str.find("/t").map_or("", |i| &inchi_str[i..])
+}
+
+#[track_caller]
+fn assert_inchi_stereo_invariant(smi: &str) {
+    let raw = parse(smi).expect("valid SMILES");
+    let k = kekulize(&raw).expect("kekulizable");
+    let kekulized = apply_kekule(&raw, &k);
+
+    let direct = inchi(&raw);
+    let via_kekulize = inchi(&kekulized);
+
+    assert_eq!(
+        stereo_tail(&direct),
+        stereo_tail(&via_kekulize),
+        "{smi}: InChI stereo layer differs before/after kekulize+apply_kekule\n\
+         direct:       {direct}\n\
+         via_kekulize: {via_kekulize}"
+    );
+}
+
+#[test]
+fn simple_stereocenters_no_ring_kekulization_needed() {
+    for smi in [
+        "N[C@@H](C)C(=O)O",         // L-alanine, single stereocenter (/t + /s1, no /m)
+        "N[C@H](C)C(=O)O",          // D-alanine
+        "C[C@H](O)[C@@H](O)C(=O)O", // tartaric acid, two stereocenters (/t + /m + /s1)
+        "[C@@H]1(N)CCCC1",
+        "F[C@H]1CCCCC1",
+    ] {
+        assert_inchi_stereo_invariant(smi);
+    }
+}
+
+#[test]
+fn stereo_tail_present_where_expected() {
+    // Sanity check on the helper itself, and that these test molecules
+    // actually exercise the /t (and for 2+ stereocenters, /m) layers --
+    // guards against the invariance test above passing vacuously because
+    // neither side has a stereo layer at all.
+    let single = inchi(&parse("N[C@@H](C)C(=O)O").unwrap());
+    assert!(stereo_tail(&single).starts_with("/t"), "{single}");
+    assert!(!stereo_tail(&single).contains("/m"), "{single}");
+
+    let double = inchi(&parse("C[C@H](O)[C@@H](O)C(=O)O").unwrap());
+    assert!(stereo_tail(&double).contains("/m"), "{double}");
+}
+
+/// For ring-adjacent stereocenters (where `direct` and `via_kekulize` can't
+/// be fairly string-compared -- see module docs), verify instead that
+/// routing a true enantiomer pair through the *same* kekulize+apply_kekule
+/// pipeline produces InChI output with identical connectivity/H layers
+/// (same molecule, same pre-stereo numbering) and a correctly mirrored
+/// stereo tail (`/t` signs flipped, or `/m` flipped) -- not collapsed to the
+/// same string, and not diverging into an unrelated one.
+#[test]
+fn ring_adjacent_enantiomer_pairs_mirror_correctly_via_kekulize() {
+    let pairs: &[(&str, &str)] = &[
+        ("c1ccc(cc1)[C@H](F)Cl", "c1ccc(cc1)[C@@H](F)Cl"),
+        (
+            "Cc1cn([C@H]2CCCC[C@@H]2C)c(=O)n1C",
+            "Cc1cn([C@@H]2CCCC[C@H]2C)c(=O)n1C",
+        ),
+    ];
+
+    fn via_kekulize(smi: &str) -> String {
+        let raw = parse(smi).expect("valid SMILES");
+        let k = kekulize(&raw).expect("kekulizable");
+        inchi(&apply_kekule(&raw, &k))
+    }
+
+    fn non_stereo_layers(inchi_str: &str) -> &str {
+        inchi_str.find("/t").map_or(inchi_str, |i| &inchi_str[..i])
+    }
+
+    for (a, b) in pairs {
+        let ia = via_kekulize(a);
+        let ib = via_kekulize(b);
+
+        assert_eq!(
+            non_stereo_layers(&ia),
+            non_stereo_layers(&ib),
+            "{a} vs {b}: connectivity/H layers should match for a true enantiomer pair\n\
+             a: {ia}\nb: {ib}"
+        );
+        assert_ne!(
+            stereo_tail(&ia),
+            stereo_tail(&ib),
+            "{a} vs {b}: stereo tail must differ (mirror images), not collapse to the same value\n\
+             a: {ia}\nb: {ib}"
+        );
+        assert!(
+            !stereo_tail(&ia).is_empty() && !stereo_tail(&ib).is_empty(),
+            "{a} vs {b}: both should have a non-empty stereo tail\na: {ia}\nb: {ib}"
+        );
+    }
+}

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -19,6 +19,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 chematic-core = { path = "../chematic-core", version = "0.4.29" }
 
 [dev-dependencies]
+# Test-only: re-aromatizing after an explicit kekulize+apply_kekule round
+# trip needs perception-level Huckel logic to get back to a fairly
+# comparable (aromatic-form) canonical string. chematic-perception's own
+# dev-dependencies pull in chematic-smiles the same way -- Cargo supports
+# this dev-dependency cycle since it never affects either crate's published
+# library dependency graph, only test binaries.
+chematic-perception = { path = "../chematic-perception", version = "0.4.29" }
 criterion = { version = "0.8", features = ["html_reports"] }
 
 [[bench]]

--- a/crates/chematic-smiles/tests/kekule_s0_stereo_invariance.rs
+++ b/crates/chematic-smiles/tests/kekule_s0_stereo_invariance.rs
@@ -1,0 +1,154 @@
+//! Kekule-S0: `chematic_core::apply_kekule` must not change a molecule's
+//! represented stereochemistry.
+//!
+//! Root cause (found while validating Aromaticity-A1-1b-1's canonical
+//! round-trip numbers): `apply_kekule` rebuilt its output via
+//! `MoleculeBuilder` without copying `stereo_neighbor_order` (the
+//! SMILES-text-order neighbor sequence `@`/`@@` is defined relative to).
+//! `atom.chirality` alone survived the rebuild, but without the neighbor
+//! order to interpret it against, downstream canonical-SMILES writing could
+//! serialize the same tetrahedral center with the wrong `@`/`@@` — silently,
+//! since `chirality` itself never became `None`.
+//!
+//! These tests check *chemical* invariance (same molecule, before vs after
+//! an explicit `kekulize`+`apply_kekule` round trip produces the *same*
+//! canonical SMILES), not merely that `@`/`@@` characters appear somewhere.
+//! The direct-vs-kekulize-then-rearomatize comparisons need
+//! `chematic_perception::apply_aromaticity` (Huckel re-perception) purely so
+//! both sides land back in aromatic-form notation before being compared as
+//! strings -- kekulize/apply_kekule themselves only ever change bond-order
+//! *representation*, never aromaticity perception, so this is a fair,
+//! notation-neutral comparison, not a different claim about a different
+//! function.
+
+use chematic_core::{apply_kekule, kekulize};
+use chematic_perception::apply_aromaticity;
+use chematic_smiles::{canonical_smiles, parse};
+
+/// Canonicalize `smi` directly, and again after routing it through an
+/// explicit `kekulize` -> `apply_kekule` -> re-aromatize round trip. Both
+/// must produce the identical canonical string -- kekulization only changes
+/// bond-order representation, never the molecule's stereochemistry, and
+/// re-aromatizing returns both sides to the same (aromatic-form) notation
+/// for a fair string comparison.
+fn check_kekulize_invariant(smi: &str) -> Result<(), String> {
+    let mol = parse(smi).map_err(|e| format!("PARSE_FAIL '{smi}': {e}"))?;
+    let direct = canonical_smiles(&mol);
+
+    let k = kekulize(&mol).map_err(|e| format!("KEKULIZE_FAIL '{smi}': {e}"))?;
+    let kekulized = apply_kekule(&mol, &k);
+    let reperceived = apply_aromaticity(&kekulized);
+    let via_kekulize = canonical_smiles(&reperceived);
+
+    if direct != via_kekulize {
+        Err(format!(
+            "KEKULE_STEREO_DRIFT '{smi}': direct='{direct}' via_kekulize='{via_kekulize}'"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+#[track_caller]
+fn assert_all_kekulize_invariant(cases: &[&str]) {
+    let failures: Vec<_> = cases
+        .iter()
+        .filter_map(|s| check_kekulize_invariant(s).err())
+        .collect();
+    assert!(
+        failures.is_empty(),
+        "kekulize stereo invariance failures:\n{}",
+        failures.join("\n")
+    );
+}
+
+#[test]
+fn simple_chiral_centers_survive_kekulization() {
+    assert_all_kekulize_invariant(&[
+        "N[C@@H](C)C(=O)O",   // L-alanine
+        "N[C@H](C)C(=O)O",    // D-alanine
+        "[C@@H]1(N)CCCC1",    // aminocyclopentane
+        "F[C@H]1CCCCC1",      // fluorocyclohexane
+        "C[C@H](O)c1ccccc1",  // 1-phenylethanol
+        "C[C@@H](O)c1ccccc1", // its enantiomer
+    ]);
+}
+
+#[test]
+fn chiral_substituent_on_aromatic_ring_survives_kekulization() {
+    // A stereocenter directly exocyclic to an aromatic ring -- exactly the
+    // shape that exposed the bug: the ring needs kekulization, the
+    // substituent's stereo descriptor is defined relative to
+    // stereo_neighbor_order recorded when the substituent was parsed.
+    assert_all_kekulize_invariant(&[
+        "c1ccc(cc1)[C@H](F)Cl",
+        "c1ccc(cc1)[C@@H](F)Cl",
+        "Cc1cn([C@H]2CCCC[C@@H]2C)c(=O)n1C",
+    ]);
+}
+
+#[test]
+fn real_corpus_case_survives_kekulization() {
+    // One of the 25 "experimental_only" A1-1b-1 canonical-round-trip
+    // instability cases -- three stereocenters, an aromatic ring directly
+    // bonded to two of them. Confirmed via direct inspection (before this
+    // fix) that stereo_neighbor_order was `None` for all three centers
+    // immediately after `apply_kekule`, and canonical SMILES flipped
+    // `@`/`@@` between the direct and kekulize-first paths.
+    assert_all_kekulize_invariant(&[
+        "CCCCc1cn([C@H]2[C@H](C)CCC[C@@H]2C)c(=O)n1Cc1ccc(-c2ccccc2-c2nn[nH]n2)nc1",
+    ]);
+}
+
+#[test]
+fn enantiomer_pairs_remain_mirror_images_after_kekulization() {
+    // For a true enantiomer pair (every `@`/`@@` swapped, topology
+    // identical), routing both through kekulize+apply_kekule and
+    // canonicalizing must still produce a string pair that is the same
+    // mirror-image relationship: identical modulo `@`<->`@@` swaps, not
+    // collapsed to the same string or diverging into an unrelated one. Both
+    // sides stay in Kekule-form notation here (no re-aromatization needed)
+    // since the comparison is symmetric -- kekule-form-a vs kekule-form-b.
+    //
+    // NOTE: the real_corpus_case_survives_kekulization molecule (3
+    // stereocenters on a ring whose substitution pattern is constitutionally
+    // symmetric -- A-Me-CH2-CH2-CH2-Me-A reads the same both directions) is
+    // deliberately NOT used as a pair here: flipping all 3 centers coincides
+    // with that ring's own topological automorphism, so naively-constructed
+    // "flip every @" does not produce a distinguishable enantiomer for it
+    // (confirmed: even the *direct*, no-kekulize-at-all canonicalization
+    // collapses both spellings to the same string -- a canonicalizer/graph-
+    // symmetry property unrelated to apply_kekule). Use asymmetric
+    // stereocenters here instead, where "flip every @" is unambiguous.
+    let pairs: &[(&str, &str)] = &[
+        ("C[C@H](O)c1ccccc1", "C[C@@H](O)c1ccccc1"),
+        ("N[C@@H](C)C(=O)O", "N[C@H](C)C(=O)O"),
+        ("c1ccc(cc1)[C@H](F)Cl", "c1ccc(cc1)[C@@H](F)Cl"),
+    ];
+
+    fn via_kekulize(smi: &str) -> String {
+        let mol = parse(smi).expect("valid SMILES");
+        let k = kekulize(&mol).expect("kekulizable");
+        canonical_smiles(&apply_kekule(&mol, &k))
+    }
+
+    /// Swap every `@`/`@@` in a canonical SMILES string. `@@` must be
+    /// handled before lone `@` or the second `@` of `@@` gets treated as a
+    /// separate lone `@`.
+    fn swap_at_symbols(s: &str) -> String {
+        s.replace("@@", "\u{0}")
+            .replace('@', "@@")
+            .replace('\u{0}', "@")
+    }
+
+    for (a, b) in pairs {
+        let ca = via_kekulize(a);
+        let cb = via_kekulize(b);
+        assert_eq!(
+            swap_at_symbols(&ca),
+            cb,
+            "enantiomer pair diverged from a clean mirror relationship: \
+             {a} -> {ca}, {b} -> {cb}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

**P0 stereochemistry correctness bug**, found while diagnosing
Aromaticity-A1-1b-1's canonical round-trip instability (94-case corpus,
see the follow-up H0 investigation). `chematic_core::apply_kekule()`
rebuilt its output `Molecule` via `MoleculeBuilder` -- re-adding every
atom and bond from the input -- but never called
`copy_stereo_groups_from`/`copy_stereo_from`/`copy_bond_directions_from`.

`atom.chirality` (`@`/`@@`) is a *relative* descriptor over
`stereo_neighbor_order` (the SMILES-text-order neighbor sequence), a
separate Molecule-level side channel, not a field on `Atom`. Losing it
without losing `chirality` itself means downstream code that infers
`@`/`@@` from a *different* neighbor order (canonical atom rank, CIP
digraph position) can silently serialize the same tetrahedral center as
the wrong configuration -- no panic, no error.

`chematic-perception`'s `build_molecule_from_model` already had this
exact bug, already fixed (with a comment saying so) in an earlier round.
`apply_kekule` itself never got the same fix -- until now.

## Fix

```rust
pub fn apply_kekule(mol: &Molecule, kekule: &KekuleResult) -> Molecule {
    if kekule.is_empty() {
        return mol.clone();  // needs Molecule: Clone (added -- all fields already derive it)
    }
    let mut builder = MoleculeBuilder::new();
    // ...re-add atoms/bonds...
    builder.copy_stereo_groups_from(mol);
    builder.copy_stereo_from(mol);
    builder.copy_bond_directions_from(mol);
    builder.build()
}
```

## Verification (positive-controlled)

Every cross-crate test below was confirmed to **fail** when the fix is
temporarily reverted, then pass once restored -- not just passing
incidentally:

- **`chematic-core`** (6 new unit tests): `stereo_neighbor_order`/
  `stereo_groups`/`bond_directions` preserved verbatim; atom/bond index
  mapping unchanged; empty `KekuleResult` takes the clone fast path.
- **`chematic-smiles`**: canonical SMILES represents the same
  stereochemistry whether generated directly or via an explicit
  kekulize+apply_kekule+re-aromatize round trip; enantiomer pairs stay
  proper mirror images.
- **`chematic-cip`**: atom-mapped R/S unchanged before/after
  kekulize+apply_kekule for both `chematic_chem::assign_cip` (legacy) and
  `assign_cip_accurate_experimental`. Pre-fix, the Accurate engine didn't
  *mislabel* affected stereocenters -- it silently *skipped* them
  (`SkipReason::NotFourSubstituents`, a misleading name; the real cause is
  missing `stereo_neighbor_order`, not substituent count). Same
  no-panic/no-error failure shape as canonical SMILES.
- **`chematic-inchi`**: InChI stereo layers (`/t`, `/m`, `/s`) checked the
  same way. Honest finding: `chematic_inchi` never reads
  `stereo_neighbor_order` at all (confirmed by grep and by positive
  control -- these tests pass identically with the fix reverted), so InChI
  generation was never actually at risk from *this* bug; kept as a real
  regression pin, not evidence the fix changed InChI's output. Separately
  found (and documented as out-of-scope, in the test file): InChI's own
  canonical numbering (`/c`, `/h`) is representation-dependent
  (aromatic-form vs Kekulé-form input) for a fully **achiral** molecule
  too -- a distinct, pre-existing bug unrelated to this one.

## Gate checklist (from review)

1. ✅ `apply_kekule` before/after: all stereo side channels match
2. ⏳ 32 stereo cases from the A1-1b-1 corpus re-evaluated -- follow-up PR
   (H0), paused specifically to land this fix first
3. ✅ Atom-mapped CIP/InChI stereo regression: 0
4. ✅ `chematic-cip` regression: 0 (full workspace suite)
5. ✅ `chematic-inchi` regression: 0 (full workspace suite)
6. ✅ Aromaticity full-corpus (4,999/4,999 comparable molecules, atoms +
   bonds): re-ran `apply_aromaticity_rdkit_parity_experimental` post-fix --
   byte-identical to the pre-fix PR #93 trace (this fix touches only
   stereo side channels, never bond order/aromaticity assignment)
7. ✅ SMARTS ≥99.93% maintained: the existing 80,000-pair corpus uses 16
   patterns, none stereo-specific (`[OH]`, `c`, `[#7]`, `C=O`, ring-size
   predicates, etc.) -- mathematically unaffected by this fix; full Rust
   workspace SMARTS suite is 0 regressions. (`chematic-smarts` *does* have
   separate chirality-aware SMARTS matching that reads
   `stereo_neighbor_order` -- not covered by the 80k corpus either way,
   and benefits from this same fix, but not separately re-measured at
   scale in this PR.)
8. ✅ Canonical structural loss: 0 (atom/bond counts checked directly in
   both the core unit tests and the chematic-smiles integration tests)
9. ✅ `cargo test --workspace --tests`: 0 failures. `cargo clippy
   --workspace --all-targets -- -D warnings`: clean. `bash
   scripts/check.sh`: all green.

## Repo-wide audit (complete)

Read-only audit of every other `MoleculeBuilder::new()` rebuild-from-
existing-`Molecule` site for the same missing-`copy_*_from` pattern.
**3 more live instances found, all in `chematic-chem`, none touched by
this PR** (scoped to `apply_kekule` only, per review):

- `crates/chematic-chem/src/stereo.rs`: `enumerate_stereoisomers` --
  builds each output stereoisomer via a passthrough atom/bond rebuild,
  never copies `stereo_neighbor_order`/`stereo_groups`/
  `bond_directions`. Highest risk of the three: this function's whole
  purpose is generating molecules with specific stereo configurations,
  and it calls `canonical_smiles` on its own output immediately after
  the rebuild -- every call is affected, not just chiral edge cases.
- `crates/chematic-chem/src/tautomer.rs`: `transfer_hydrogen_aromatic`
  and `clone_mol` -- same passthrough-rebuild-missing-3-copies pattern.
  `clone_mol` in particular is now fully redundant with `Molecule::clone`
  (added by this PR) and could be deleted outright in a follow-up rather
  than fixed in place.

Confirmed correctly-implemented elsewhere: `chematic-perception`'s
`build_molecule_from_model` and `rdkit_parity.rs`'s
`clear_aromatic_flags` (both already call all three `copy_*_from`
methods), and `chematic-cip`'s test-only `permute_molecule` helper.

Not fixed here -- a same-shaped follow-up PR (mechanical 3-line fix per
site, same pattern as this PR, no refactor) is the natural next step;
raised to the user for prioritization rather than silently expanding
this PR's scope.

## Not in this PR

No large refactor into a shared `finalize_rebuild_preserving_metadata`
helper (explicitly deferred to a follow-up per review). No changes to the
94-case H0 corpus investigation (resumes in a separate PR once this
lands). No changes to any other function's behavior.
