### PR TITLE
chore: bump version 0.4.29 → 0.4.30

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,5 +22,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.4.29
+version: 0.4.30
 date-released: "2026-06-26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.4.29"
+version = "0.4.30"
 edition = "2024"
 rust-version = "1.85"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -184,10 +184,10 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.4.29
+# chematic v0.4.30
 # Python 3.12.x  |  darwin arm64
 #
-# Descriptor accuracy (benchmark 2026-07-17, v0.4.29 vs RDKit 2026.03.3):
+# Descriptor accuracy (benchmark 2026-07-17, v0.4.30 vs RDKit 2026.03.3):
 #   MW / HBA / HBD / ARC  100%   (4,999-mol ChEMBL subset)
 #   TPSA                  100%   within ±0.1 Å²
 #   LogP (Crippen)        100%*  (max Δ = 1.1×10⁻¹³)
@@ -389,7 +389,7 @@ See the [full WASM API reference](https://kent-tokyo.github.io/chematic/) for al
 | `chematic-3d`         | 3D coordinate generation, distance geometry constraints, ETKDG KB (40 torsion patterns, adaptive noise), force-field minimization, shape descriptors, ConformerEnsemble with RMSD pruning, PDB/XYZ; **GETAWAY HATS-matrix** (full 19-dim implementation); **`whim_getaway_combined()`** now 29-dim | 265    |
 | `chematic-rxn`        | Reaction SMILES/SMIRKS, `run_reactants`/`run_reactants_strict`; **`retro_disconnect()`** — 60 retro-SMIRKS templates (AmideBond/Ester/Ether/CNBond/CCBond/CSBond) + SA Score ranking; **parity-aware `@`/`@@` SMIRKS stereo filtering**; **E/Z double-bond stereo filtering** in `run_reactants` (`ez_stereo_outward`, `smirks_ez_stereo_ok`) | 137    |
 | `chematic-inchi`      | InChI/InChIKey: pure-Rust approximation (WASM) **+ IUPAC-standard** via `native-inchi` feature (vendored C lib 1.07.5, bit-exact); **parse_inchi** reader | 96 (+16*)    |
-| `chematic-wasm`       | **130+ WASM exports** — npm: `@kent-tokyo/chematic` v0.4.29 (~1.9 MB, 719 KB gzip); pKa/ADMET/BBB/Caco-2/hERG/CYP3A4; `smiles_to_pdbqt`, `minimize_uff_json` | 211   |
+| `chematic-wasm`       | **130+ WASM exports** — npm: `@kent-tokyo/chematic` v0.4.30 (~1.9 MB, 719 KB gzip); pKa/ADMET/BBB/Caco-2/hERG/CYP3A4; `smiles_to_pdbqt`, `minimize_uff_json` | 211   |
 | `chematic-iupac`      | Local IUPAC name generation — **25+ compound classes**: alkanes, cycloalkanes, alkenes/alkynes, alcohols, amines, halides, aldehydes, ketones, acids, esters, amides, **piperidine, morpholine, piperazine, naphthalene, sulfides** | 47    |
 | `chematic-mcp`        | **MCP (Model Context Protocol) server** — AI agent integration; **20 tools**: parse_smiles, calc_properties, ecfp4, tanimoto, smarts_match, canonical_smiles, find_mcs, generate_3d, pains_check, brenk_check, sa_score, admet_profile, boiled_egg, lipinski_check, name_to_smiles, retrosynthesis, smiles_to_moljson, moljson_to_smiles, representation_router, **molecule_context_pack** | 31    |
 | `chematic-py`         | PyO3 Python bindings (`pip install chematic`); 300+ API endpoints: `from_smiles()`, `Mol.descriptors()`, `Mol.minimize_dreiding()`, `from_cxsmiles()`, `from_rxn_file()`/`to_rxn_file()`, `parse_sdf_with_coords()`, `Mol.ring_families()`, `tanimoto_matrix()`, `iter_sdf()`, `SimilarityIndex`; **`mol.to_pdf()`/`mol.to_eps()`** (depict); **`from_cjson()`/`mol.to_cjson()`** (ChemicalJSON); **`mol.schultz_mti`, `mol.gutman_mti`, `mol.vabc`, `mol.gravitational_index`**; **`bulk.substructure_match(smarts, mols)`** (parallel VF2 on pre-parsed Mol objects); **`mol.describe()`** (LLM/MCP-ready natural-language summary); **`mol.diff(other)`** (element + descriptor diff); Sprint 18–27 coverage | 300+  |
@@ -405,15 +405,19 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +1
 
 ## Recent Development (v0.4.x Era)
 
-**Unreleased** (in progress): **`chematic-cip` — new experimental hierarchical-digraph CIP engine, SMARTS `[rN]` fix**
+**v0.4.30** (2026-07-17): **`chematic-cip` opt-in wired to every surface, SMARTS `[rN]` fix, new RDKit-parity aromaticity engine, 5 stereo-metadata bug fixes**
 - `chematic-smarts`: fixed `[rN]` (ring-size SMARTS, e.g. `[r5]`/`[r6]`) being wrongly aliased to `[kN]`'s any-ring semantics — RDKit's real `[rN]` means "this atom's *smallest* ring is exactly size N", a materially different predicate (confirmed empirically: on a fusion atom shared between a 5-ring and 6-ring, RDKit's `[k6]` matches but `[r6]` doesn't). No ring-model change — `[rN]` now has its own `MinRingSize` primitive computed from chematic's existing SSSR. SMARTS match-set agreement vs RDKit **96.9% → 99.93%** on a 5,000-molecule corpus, 0 regressions; see `docs/rdkit_compat.md`'s "SMARTS-R0"/"SMARTS-R1" entries
 - Milestone 5A: opt-in access to the accurate engine from every public surface — `chematic_chem::assign_cip_with_mode(mol, CipMode::Accurate)` (Rust), `Mol.cip_stereo(mode="accurate")` + `Mol.cip_stereo_unresolved()` (Python), `cip_assignments_accurate_json`/`cip_unresolved_json` (WASM). Every default (`assign_cip()`, `cip_stereo()`, the un-suffixed WASM functions) is unchanged — this is additive only, not a default switch; see `docs/cip_accurate_rfc.md`'s Milestone 5A entry for the merge semantics (accurate tetrahedral R/S + legacy E/Z, since the accurate engine doesn't compute bond stereo) and the "never guess" contract (ties/budget-outs surface explicitly, never silently backfilled)
 - Milestone 4 gate closed: 99.64% oracle-stable agreement (raw 99.38%, 4160/4186) on a full-corpus, representation-stability-stratified score — the last residual (11 phosphorus cyclophosphazene rows) turned out to be an oracle instability (RDKit's own labels change under a chemically-neutral Kekulé respelling of the identical molecule), not a chematic defect; the 15-row Rule 5 cage family remains deferred, unaffected by this gate
-- The accurate engine is available through opt-in APIs (see Milestone 5A above) but is not yet the default implementation behind `assign_cip()`: a provenance-carrying, sphere-by-sphere digraph comparator (Rules 1a/1b/2) plus RDKit-compatible MANCUDE fractional atomic numbers for aromatic ring stereocenters
-- Full-corpus accuracy on this experimental engine 96.68% → 99.19% vs modern RDKit `rdCIPLabeler` (4047/4186 → 4152/4186, 0 regressions) — see `docs/cip_accurate_rfc.md` for the milestone history and honest attribution (the gain is mostly the Kekulé-respelling structural effect, not the fractional values, which are correct but measured inert on this corpus)
+- The accurate engine (a provenance-carrying, sphere-by-sphere digraph comparator — Rules 1a/1b/2 — plus RDKit-compatible MANCUDE fractional atomic numbers for aromatic ring stereocenters) is available through the opt-in APIs above but is not yet the default implementation behind `assign_cip()`
 - Found and fixed a real ~10-14x perf regression (SSSR misused for a boolean ring-bond check, replaced with an O(V+E) bridge-edge DFS); CI Criterion-gate bootstrap fix; a Criterion-gate reliability finding (pseudo-replication, [#70](https://github.com/kent-tokyo/chematic/issues/70)) — process-level redesign (independent process-run observations, two-stage screening, same-binary null control) landed, gate stays non-required until calibration completes
 - Milestone 4A: `CipCode::LowerR`/`LowerS` — Rule 5 (pseudoasymmetry), scoped to 2 verified-independent rows; a three-armed symmetric-cage family (15 rows) was found to be provably unreachable by this pairwise architecture and deferred as Milestone 4A-2 (needs symmetry/automorphism detection)
 - Milestone 4A-0: re-froze the residual fresh at 34 rows and mechanically classified 100% of it (0 unexplained) — 15 Rule 5/pseudoasymmetry (the 4A-2 cage family), 8 Rule 4 candidate (positively confirmed via a structural-identity check, not inferred), 11 phosphorus (9 comparator-bug "wrong" + 2 genuinely-tied)
+- `chematic-perception`: new opt-in `assign_aromaticity_rdkit_parity_experimental`/`apply_aromaticity_rdkit_parity_experimental` — a source-verified port of RDKit's actual aromaticity algorithm, **100.0000% atom/bond agreement** with real RDKit on 4,999/5,000 comparable molecules. Not wired into the default path (`RdkitLike`/`Huckel` unchanged); default-promotion is blocked on a pre-existing, unrelated canonical-SMILES-writer sensitivity, not this engine
+- Fixed 5 instances of the same missing-metadata-copy bug (a `MoleculeBuilder` rebuild not calling `copy_stereo_groups_from`/`copy_stereo_from`/`copy_bond_directions_from`), each silently dropping `stereo_neighbor_order` or worse: `apply_kekule` (P0), `enumerate_stereoisomers` (could silently flip a newly-assigned stereocenter's CIP code), `transfer_hydrogen_aromatic`/`clone_mol` (now deleted, replaced by `Molecule::clone`), `transfer_hydrogen`, and `invert_stereocenter` (which turned out to be a functional no-op on plain `@`/`@@` SMILES input, a separate and more severe bug)
+- `chematic-smiles`: consolidated aromatic bond-direction stashing across all 3 parser bond-creation paths (chain-edge/ring-closure/branch-attachment) into one shared helper — fixes a canonical-round-trip representation instability (4,994/5,000 → 5,000/5,000 stable); does not fix `assign_ez`'s pre-existing blindness to this side channel (tracked as follow-up)
+- Full-corpus accuracy on the experimental CIP engine 96.68% → 99.38% raw / 99.64% oracle-stable vs modern RDKit `rdCIPLabeler` (0 regressions) — see `docs/cip_accurate_rfc.md` for the full milestone history
+- Benchmarks refreshed (`benchmarks/2026-07-17.md`, Apple M4): the previous ECFP4 throughput headline (3.6 µs/mol, 5–14× vs RDKit) does not reproduce on a clean remeasurement — updated to today's measured numbers (~78 µs/mol / 2–3× on a diverse corpus) throughout this README and `docs/`; descriptor accuracy numbers reproduce cleanly
 
 **v0.4.29** (2026-07-10): **Kabsch rotation bug fix + SDF V3000/CDXML write, Avalon FP, O3A**
 - `chematic-3d`: fixed `align_coords`'s Kabsch rotation computed in the wrong direction — was giving grossly inflated RMSD for any non-pure-translation alignment (live on v0.4.28 across crates.io/PyPI/npm before this patch); `correspondence_search` for O3A atom correspondence
@@ -543,7 +547,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v0.4.29)
+├── Cargo.toml                    workspace root (v0.4.30)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)
@@ -596,7 +600,7 @@ If you use chematic in academic or research work, please cite:
   author    = {kent-tokyo},
   title     = {chematic: A pure-Rust cheminformatics toolkit},
   url       = {https://github.com/kent-tokyo/chematic},
-  version   = {0.4.29},
+  version   = {0.4.30},
   year      = {2026},
 }
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -110,10 +110,10 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.4.29
+# chematic v0.4.30
 # Python 3.12.x  |  darwin arm64
 #
-# Descriptor accuracy (benchmark 2026-06, v0.4.29 vs RDKit 2026.03.3):
+# Descriptor accuracy (benchmark 2026-06, v0.4.30 vs RDKit 2026.03.3):
 #   MW / HBA / HBD / ARC  100%   (4,999-mol ChEMBL subset)
 #   TPSA                  98.1%
 #   LogP (Crippen)        ~99%
@@ -266,7 +266,7 @@ const picks = JSON.parse(maxmin_picks_ecfp4_json('["CC","c1ccccc1","CCO","CCCC"]
 | `chematic-3d`          | 3D 座標生成、ETKDG KB (40 パターン、adaptive noise)、力場最小化、形状記述子、ConformerEnsemble、PDB/XYZ | 265     |
 | `chematic-rxn`         | 反応 SMILES/SMIRKS、`run_reactants`/`run_reactants_strict`；**`retro_disconnect()`** — 60 retro-SMIRKS テンプレート (AmideBond/Ester/Ether/CNBond/CCBond/CSBond) + SA Score ランク付き | 137      |
 | `chematic-inchi`       | InChI/InChIKey：純 Rust 近似（WASM 対応）**+ `native-inchi` feature で IUPAC 標準準拠**（C ライブラリ 1.07.5 vendored、ビット完全一致）；**parse_inchi** 読み込み | 96 (+16*)   |
-| `chematic-wasm`        | **130+ WASM エクスポート** — npm: `@kent-tokyo/chematic` v0.4.29（719 KB gzip）；**pKa/ADMET/BBB/Caco-2/hERG/CYP3A4** WASM API | 211     |
+| `chematic-wasm`        | **130+ WASM エクスポート** — npm: `@kent-tokyo/chematic` v0.4.30（719 KB gzip）；**pKa/ADMET/BBB/Caco-2/hERG/CYP3A4** WASM API | 211     |
 | `chematic-iupac`       | ローカル IUPAC 命名（Pure Rust・オフライン）— **25+ 化合物クラス**：アルカン、シクロアルカン、アルコール、アミン、ハロアルカン、ケトン、酸、エステル、アミド、**ピペリジン、モルホリン、ピペラジン、ナフタレン、スルフィド** | 47      |
 | `chematic-mcp`         | **MCP (Model Context Protocol) サーバー** — AI エージェント統合；**20 ツール**：parse_smiles, calc_properties, ecfp4, tanimoto, smarts_match, canonical_smiles, find_mcs, generate_3d, pains_check, brenk_check, sa_score, admet_profile, boiled_egg, lipinski_check, name_to_smiles, retrosynthesis, smiles_to_moljson, moljson_to_smiles, representation_router, molecule_context_pack | 31      |
 | `chematic`             | フィーチャーフラグ付きアンブレラクレート（統合クレート）                                                                                                  | 1       |

--- a/README_zh.md
+++ b/README_zh.md
@@ -234,7 +234,7 @@ const picks = JSON.parse(maxmin_picks_ecfp4_json('["CC","c1ccccc1","CCO","CCCC"]
 | `chematic-3d`         | 3D 坐标生成、ETKDG KB（40 种模式，自适应噪声）、力场最小化、形状描述符、ConformerEnsemble、PDB/XYZ | 265    |
 | `chematic-rxn`        | 反应 SMILES/SMIRKS、`run_reactants`/`run_reactants_strict`；**`retro_disconnect()`** — 60 个 retro-SMIRKS 模板（AmideBond/Ester/Ether/CNBond/CCBond/CSBond）+ SA 分数排序 | 137     |
 | `chematic-inchi`      | InChI/InChIKey：纯 Rust 近似（WASM 兼容）**+ `native-inchi` feature 提供 IUPAC 标准**（vendored C 库 1.07.5，逐位一致）；**parse_inchi** 读取 | 96 (+16*)   |
-| `chematic-wasm`       | **130+ WASM 导出** — npm：`@kent-tokyo/chematic` v0.4.29（719 KB gzip）；**pKa/ADMET/BBB/Caco-2/hERG/CYP3A4** WASM API | 211    |
+| `chematic-wasm`       | **130+ WASM 导出** — npm：`@kent-tokyo/chematic` v0.4.30（719 KB gzip）；**pKa/ADMET/BBB/Caco-2/hERG/CYP3A4** WASM API | 211    |
 | `chematic-iupac`      | 本地 IUPAC 命名（纯 Rust·离线）— **25+ 化合物类**：烷烃、环烷烃、醇、胺、卤代烃、酮、酸、酯、酰胺、**哌啶、吗啉、哌嗪、萘、硫醚** | 47     |
 | `chematic-mcp`        | **MCP（模型上下文协议）服务器** — AI 代理集成；**20 个工具**：parse_smiles, calc_properties, ecfp4, tanimoto, smarts_match, canonical_smiles, find_mcs, generate_3d, pains_check, brenk_check, sa_score, admet_profile, boiled_egg, lipinski_check, name_to_smiles, retrosynthesis, smiles_to_moljson, moljson_to_smiles, representation_router, molecule_context_pack | 31     |
 | `chematic`            | 带功能标志的伞形 crate                                                                                   | 1      |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.4.29 | Yes | Current release — active support |
+| v0.4.30 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.4.29) receives all security updates.  
+**Active Support**: Latest release (v0.4.30) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -16,12 +16,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.4.29" }
-chematic-perception = { path = "../chematic-perception", version = "0.4.29" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.4.29" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.4.29" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.4.29" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.29" }
+chematic-core       = { path = "../chematic-core",       version = "0.4.30" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.30" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.4.30" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.4.30" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.4.30" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.30" }
 
 [dev-dependencies]
-chematic-smiles = { path = "../chematic-smiles", version = "0.4.29" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.4.30" }

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -16,14 +16,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.4.29" }
+chematic-core       = { path = "../chematic-core",       version = "0.4.30" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.4.29" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.29" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.29" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.4.29" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.4.29" }
-chematic-cip        = { path = "../chematic-cip",        version = "0.4.29" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.30" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.30" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.30" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.4.30" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.4.30" }
+chematic-cip        = { path = "../chematic-cip",        version = "0.4.30" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -12,12 +12,12 @@ categories = ["science", "science::computational-chemistry::cheminformatics"]
 publish = false
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.4.29" }
-chematic-perception = { path = "../chematic-perception", version = "0.4.29" }
+chematic-core       = { path = "../chematic-core",       version = "0.4.30" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.30" }
 
 [dev-dependencies]
-chematic-chem   = { path = "../chematic-chem",   version = "0.4.29" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.4.29" }
+chematic-chem   = { path = "../chematic-chem",   version = "0.4.30" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.4.30" }
 serde_json      = "1.0"
 criterion       = { version = "0.8", features = ["html_reports"] }
 

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -22,10 +22,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.4.29" }
-chematic-perception = { path = "../chematic-perception", version = "0.4.29" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.4.29" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.4.29" }
+chematic-core = { path = "../chematic-core", version = "0.4.30" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.30" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.4.30" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.4.30" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.4.29" }
+chematic-core = { path = "../chematic-core", version = "0.4.30" }
 rustfft = "6.4"
 
 [dev-dependencies]
-chematic-3d = { path = "../chematic-3d", version = "0.4.29" }
+chematic-3d = { path = "../chematic-3d", version = "0.4.30" }

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.4.29" }
-chematic-perception = { path = "../chematic-perception", version = "0.4.29" }
+chematic-core       = { path = "../chematic-core",       version = "0.4.30" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.30" }
 
 [dev-dependencies]
-chematic-smiles = { path = "../chematic-smiles", version = "0.4.29" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.4.30" }

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -16,13 +16,13 @@ documentation = "https://docs.rs/chematic-fp"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.4.29" }
+chematic-core = { path = "../chematic-core", version = "0.4.30" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.4.29" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.4.29" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.4.29" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.4.29" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.30" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.4.30" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.4.30" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.4.30" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -18,10 +18,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.4.29", path = "../chematic-core" }
-chematic-smiles = { version = "0.4.29", path = "../chematic-smiles" }
-chematic-chem = { version = "0.4.29", path = "../chematic-chem" }
-chematic-rxn = { version = "0.4.29", path = "../chematic-rxn" }
+chematic-core = { version = "0.4.30", path = "../chematic-core" }
+chematic-smiles = { version = "0.4.30", path = "../chematic-smiles" }
+chematic-chem = { version = "0.4.30", path = "../chematic-chem" }
+chematic-rxn = { version = "0.4.30", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.4.29" }
-chematic-perception = { path = "../chematic-perception", version = "0.4.29" }
+chematic-core       = { path = "../chematic-core",       version = "0.4.30" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.30" }
 
 [dev-dependencies]
-chematic-smiles = { path = "../chematic-smiles", version = "0.4.29" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.4.30" }

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -17,12 +17,12 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.4.29" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.29" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.4.29", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.4.29" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.29" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.4.29" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.4.29" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.4.29" }
-chematic-perception = { path = "../chematic-perception", version = "0.4.29" }
+chematic-core       = { path = "../chematic-core",       version = "0.4.30" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.30" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.4.30", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.4.30" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.30" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.4.30" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.4.30" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.4.30" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.30" }

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -16,10 +16,10 @@ documentation = "https://docs.rs/chematic-mol"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.4.29" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.4.29" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.4.29" }
+chematic-core        = { path = "../chematic-core",        version = "0.4.30" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.4.30" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.4.30" }
 serde_json           = "1.0"
 
 [dev-dependencies]
-chematic-smiles = { path = "../chematic-smiles", version = "0.4.29" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.4.30" }

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -21,11 +21,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.4.29" }
+chematic-core = { path = "../chematic-core", version = "0.4.30" }
 rustc-hash = "2"
 
 [dev-dependencies]
-chematic-smiles = { path = "../chematic-smiles", version = "0.4.29" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.4.30" }
 criterion = { version = "0.8", features = ["html_reports"] }
 serde_json = "1.0"
 

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,16 +25,16 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.4.29" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.29" }
-chematic-perception = { path = "../chematic-perception", version = "0.4.29" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.4.29" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.4.29" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.4.29", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.4.29" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.29" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.4.29" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.4.29" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.4.29" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.4.29" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.4.29" }
+chematic-core       = { path = "../chematic-core",       version = "0.4.30" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.30" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.30" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.4.30" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.4.30" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.4.30", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.4.30" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.30" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.4.30" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.4.30" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.4.30" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.4.30" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.4.30" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-rxn"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.4.29" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.4.29" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.4.29" }
+chematic-core   = { path = "../chematic-core",   version = "0.4.30" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.4.30" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.4.30" }
 rustc-hash = "2"

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.4.29" }
-chematic-perception = { path = "../chematic-perception", version = "0.4.29" }
+chematic-core = { path = "../chematic-core", version = "0.4.30" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.30" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.4.29" }
+chematic-core = { path = "../chematic-core", version = "0.4.30" }
 
 [dev-dependencies]
 # Test-only: re-aromatizing after an explicit kekulize+apply_kekule round
@@ -25,7 +25,7 @@ chematic-core = { path = "../chematic-core", version = "0.4.29" }
 # dev-dependencies pull in chematic-smiles the same way -- Cargo supports
 # this dev-dependency cycle since it never affects either crate's published
 # library dependency graph, only test binaries.
-chematic-perception = { path = "../chematic-perception", version = "0.4.29" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.30" }
 criterion = { version = "0.8", features = ["html_reports"] }
 
 [[bench]]

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -25,16 +25,16 @@ crate-type = ["cdylib", "rlib"]
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["console"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.4.29" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.29" }
-chematic-perception = { path = "../chematic-perception", version = "0.4.29" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.4.29", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.4.29" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.4.29", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.4.29" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.29" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.4.29" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.4.29" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.4.29" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.4.29" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.4.29" }
+chematic-core       = { path = "../chematic-core",       version = "0.4.30" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.30" }
+chematic-perception = { path = "../chematic-perception", version = "0.4.30" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.4.30", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.4.30" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.4.30", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.4.30" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.30" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.4.30" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.4.30" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.4.30" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.4.30" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.4.30" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -33,15 +33,15 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.4.29", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.29", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.4.29", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.4.29", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.4.29", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.4.29", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.4.29", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.29", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.4.29", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.4.29", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.4.29", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.4.29", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.4.30", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.4.30", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.4.30", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.4.30", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.4.30", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.4.30", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.4.30", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.4.30", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.4.30", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.4.30", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.4.30", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.4.30", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,6 +1,6 @@
 # Benchmark
 
-Measured environment: Python 3.13.6, Apple M4, chematic v0.4.29, RDKit 2026.03.3.
+Measured environment: Python 3.13.6, Apple M4, chematic v0.4.30, RDKit 2026.03.3.
 Full methodology and raw numbers: [`benchmarks/2026-07-17.md`](../benchmarks/2026-07-17.md).
 
 ---

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -2,7 +2,7 @@
 
 Summary of descriptor accuracy against RDKit on a ChEMBL-derived corpus.
 
-**Environment:** Python 3.12, Apple M-series, chematic v0.4.29, RDKit 2026.03.3
+**Environment:** Python 3.12, Apple M-series, chematic v0.4.30, RDKit 2026.03.3
 
 ---
 


### PR DESCRIPTION
## Summary
- Version bump only (`workspace.package.version` 0.4.29 → 0.4.30, synced via `scripts/bump_version.py`), releasing everything merged since the last 0.4.29 crates.io publish (2026-07-09): chematic-cip Milestone 4B/4C/5A/5B, SMARTS `[rN]` fix, new opt-in RDKit-parity aromaticity engine, 5 stereo-metadata bug fixes (#94–#100), and the benchmark/CHANGELOG/docs refresh (#101).
- `README.md`'s "Recent Development" section gets a proper **v0.4.30** entry, replacing the stale "Unreleased (in progress)" placeholder that predated several of the fixes above.
- `bash scripts/check.sh` passes clean (no version-consistency warning).

## Test plan
- [x] `bash scripts/check.sh` — version consistency + full check suite pass
- [ ] CI green (Test, Clippy, Format Check, Build Check)

Next: after merge, `cargo publish` the workspace crates (in dependency order) at 0.4.30 — 0.4.29 is already live on crates.io, so this bump is required before any of this cycle's work can ship there.