### PR TITLE
docs: trim README badges, drop stale WASM size badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,9 @@
 [![crates.io](https://img.shields.io/crates/v/chematic?logo=rust)](https://crates.io/crates/chematic)
 [![npm](https://img.shields.io/npm/v/@kent-tokyo/chematic?logo=npm)](https://www.npmjs.com/package/@kent-tokyo/chematic)
 [![docs.rs](https://docs.rs/chematic/badge.svg)](https://docs.rs/chematic)
-
-![Pure Rust](https://img.shields.io/badge/Pure%20Rust-zero%20C%2B%2B-orange?logo=rust)
-![WASM](https://img.shields.io/badge/WASM-504%20KB-blueviolet?logo=webassembly)
-![MCP](https://img.shields.io/badge/MCP-agent%20ready-purple)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](LICENSE-MIT)
-[![Demo](https://img.shields.io/badge/demo-live-brightgreen)](https://kent-tokyo.github.io/chematic/playground/)
-[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/kent-tokyo/chematic/blob/main/notebooks/quickstart.ipynb)
+
+[Open in Colab](https://colab.research.google.com/github/kent-tokyo/chematic/blob/main/notebooks/quickstart.ipynb)
 
 [日本語](README_ja.md) | [中文](README_zh.md)
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -7,13 +7,9 @@
 [![crates.io](https://img.shields.io/crates/v/chematic?logo=rust)](https://crates.io/crates/chematic)
 [![npm](https://img.shields.io/npm/v/@kent-tokyo/chematic?logo=npm)](https://www.npmjs.com/package/@kent-tokyo/chematic)
 [![docs.rs](https://docs.rs/chematic/badge.svg)](https://docs.rs/chematic)
-
-![Pure Rust](https://img.shields.io/badge/Pure%20Rust-zero%20C%2B%2B-orange?logo=rust)
-![WASM](https://img.shields.io/badge/WASM-719%20KB-blueviolet?logo=webassembly)
-![MCP](https://img.shields.io/badge/MCP-agent%20ready-purple)
 [![ライセンス](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](LICENSE-MIT)
-[![デモ](https://img.shields.io/badge/demo-live-brightgreen)](https://kent-tokyo.github.io/chematic/playground/)
-[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/kent-tokyo/chematic/blob/main/notebooks/quickstart.ipynb)
+
+[Open in Colab](https://colab.research.google.com/github/kent-tokyo/chematic/blob/main/notebooks/quickstart.ipynb)
 
 Python・Rust・ブラウザ向けケモインフォマティクスライブラリ。
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -7,13 +7,9 @@
 [![crates.io](https://img.shields.io/crates/v/chematic?logo=rust)](https://crates.io/crates/chematic)
 [![npm](https://img.shields.io/npm/v/@kent-tokyo/chematic?logo=npm)](https://www.npmjs.com/package/@kent-tokyo/chematic)
 [![docs.rs](https://docs.rs/chematic/badge.svg)](https://docs.rs/chematic)
-
-![Pure Rust](https://img.shields.io/badge/Pure%20Rust-zero%20C%2B%2B-orange?logo=rust)
-![WASM](https://img.shields.io/badge/WASM-719%20KB-blueviolet?logo=webassembly)
-![MCP](https://img.shields.io/badge/MCP-agent%20ready-purple)
 [![许可证](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](LICENSE-MIT)
-[![演示](https://img.shields.io/badge/demo-live-brightgreen)](https://kent-tokyo.github.io/chematic/playground/)
-[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/kent-tokyo/chematic/blob/main/notebooks/quickstart.ipynb)
+
+[Open in Colab](https://colab.research.google.com/github/kent-tokyo/chematic/blob/main/notebooks/quickstart.ipynb)
 
 面向 Python、Rust 和浏览器的化学信息学库。
 


### PR DESCRIPTION
## Summary
- Removed the decorative "Pure Rust" and "MCP" static badges (no dynamic content, redundant with prose already stating both elsewhere).
- Removed the "WASM 504 KB" badge — stale (already fixed to 719 KB elsewhere in these files during the benchmark refresh), and per feedback, not needed as a badge at all.
- Converted Demo/Colab badge-style images to plain markdown links; removed the duplicate Live Demo link each file already had inline in its tagline.
- Applied consistently across README.md, README_ja.md, README_zh.md.

Kept: CI, PyPI, crates.io, npm, docs.rs, License — all either dynamic (auto-reflect the published version) or standard/expected for a crates.io+PyPI+npm project.

## Test plan
- [x] Visual check of the trimmed badge block in all 3 files
- [ ] CI green (Test, Clippy, Format Check, Build Check) — docs-only change, should be a no-op for these