### PR TITLE
test(cip): close out performance and fractional MANCUDE diagnostics

### DIFF
--- a/crates/chematic-cip/examples/cip_perf_diagnosis.rs
+++ b/crates/chematic-cip/examples/cip_perf_diagnosis.rs
@@ -102,6 +102,32 @@ fn pct<T: Ord + Copy>(values: &[T], p: usize) -> T {
     sorted[idx]
 }
 
+/// The `SMILES.csv` this tool's own aggregate counts (99.3%/0.7% resolution split,
+/// comparator-size percentiles) were measured against and quoted in
+/// `docs/cip_accurate_rfc.md`'s MANCUDE-Decision-A0 entry -- see [`corpus_sha256`]'s
+/// call site in `main` for the runtime check against whatever corpus is actually
+/// passed in.
+const EXPECTED_CORPUS_SHA256: &str =
+    "1c47371dcbe37f4e0a141bf545b72bf238de2761fa3894fa251a552d84728d3e";
+
+/// SHA-256 of `path`'s contents, via the platform `shasum` binary -- `sha2` is not a
+/// workspace dependency and this is a one-shot diagnostic tool, not production code.
+fn corpus_sha256(path: &str) -> String {
+    use std::process::Command;
+    let output = Command::new("shasum")
+        .arg("-a")
+        .arg("256")
+        .arg(path)
+        .output()
+        .expect("run `shasum -a 256` (required to verify corpus identity)");
+    String::from_utf8(output.stdout)
+        .expect("utf8 shasum output")
+        .split_whitespace()
+        .next()
+        .expect("shasum hash field")
+        .to_string()
+}
+
 fn main() {
     let args: Vec<String> = env::args().collect();
     let csv_path = args
@@ -110,6 +136,22 @@ fn main() {
         .unwrap_or_else(|| format!("{}/Downloads/SMILES.csv", env::var("HOME").unwrap()));
 
     let content = fs::read_to_string(&csv_path).expect("read SMILES.csv");
+    let actual_sha256 = corpus_sha256(&csv_path);
+    println!("corpus: {csv_path}");
+    println!("corpus_sha256: {actual_sha256}");
+    if actual_sha256 == EXPECTED_CORPUS_SHA256 {
+        println!(
+            "classification A (corpus drift): RULED OUT -- corpus_sha256 matches this \
+             tool's recorded MANCUDE-Decision-A0 closeout value exactly."
+        );
+    } else {
+        println!(
+            "*** WARNING: corpus_sha256 does NOT match the expected \
+             {EXPECTED_CORPUS_SHA256} -- the aggregate counts below are NOT directly \
+             comparable to docs/cip_accurate_rfc.md's recorded closeout numbers. ***"
+        );
+    }
+    println!();
     let smis: Vec<&str> = content
         .lines()
         .skip(1)
@@ -301,9 +343,16 @@ fn main() {
     println!(
         "fractional_decisions_total={fractional_decisions_total} -- {}",
         if fractional_decisions_total == 0 {
-            "0 as expected; Q1's proxy is sound for this run"
+            "0; Q1's proxy is sound for this run"
         } else {
-            "NONZERO -- Q1's pass1_resolved/resolved_pass2_or_3 split is unreliable this run, a fraction actually changed a ranking"
+            "NONZERO -- a fraction was decision-involved somewhere in Pass 1's recursive \
+             comparison. This does NOT by itself mean Q1's resolved_pass1 vs \
+             resolved_pass2_or_3 split is wrong -- 'decision-involved' and 'changes the \
+             resolved label' are different claims (see \
+             examples/mancude_decision_diagnosis.rs and \
+             docs/cip_accurate_rfc.md's MANCUDE-Decision-A0 entry for the full, \
+             structure-isolated classification: on this corpus, 0 stereocenters have \
+             their final label changed by the fraction)."
         }
     );
 }

--- a/crates/chematic-cip/examples/cip_perf_diagnosis.rs
+++ b/crates/chematic-cip/examples/cip_perf_diagnosis.rs
@@ -12,17 +12,23 @@
 //! `rank_children`) plus the two existing corpus-facing entry points. Answers two
 //! questions, per stereocenter:
 //!
-//! 1. Resolution level -- does Rules 1a/1b/2 alone (`assign_cip_accurate_experimental_
-//!    without_mancude`, used here as a Pass-1 proxy) resolve it, or does it need the
+//! 1. Resolution level -- `_without_mancude` is used here as a proxy for whether a
+//!    center is resolved during the constitutional-rules (1a/1b/2) pass, or needs the
 //!    live engine's later Rule 4b/5 passes -- both already gated on `SkipReason::Tied`
 //!    from the prior pass (see `assign.rs`/`resolver.rs`), i.e. chematic already gates
 //!    auxiliary-descriptor computation at the center level, the same granularity
-//!    #9171 fixed in RDKit. The proxy's only assumption -- that MANCUDE fractions
-//!    don't change any ranking on this corpus -- is verified in-run below (Q3), not
-//!    cited from memory. Rule 4b and Rule 5 are **not** split apart here (both
-//!    `pub(crate)`, no Pass-1+4b-only public entry point) -- reported together as
-//!    `resolved_pass2_or_3`; a future run could split them with a small `pub(crate)`
-//!    exposure if that distinction becomes decision-relevant.
+//!    #9171 fixed in RDKit. The proxy does **not** require `fractional_decisions` to
+//!    be zero: a MANCUDE fraction may change a *local* recursive comparison somewhere
+//!    in Pass 1's tree without changing whether the center resolves or what its final
+//!    label is -- Q3 (below) verifies this in-run and classifies nonzero counts by
+//!    final-label impact, rather than treating any nonzero count as invalidating this
+//!    split. See `examples/mancude_decision_diagnosis.rs` and
+//!    `docs/cip_accurate_rfc.md`'s MANCUDE-Decision-A0 entry for the full
+//!    classification methodology and result (D=36/E=0 on this corpus). Rule 4b and
+//!    Rule 5 are **not** split apart here (both `pub(crate)`, no Pass-1+4b-only public
+//!    entry point) -- reported together as `resolved_pass2_or_3`; a future run could
+//!    split them with a small `pub(crate)` exposure if that distinction becomes
+//!    decision-relevant.
 //! 2. Comparator size -- for the Rules-1a/1b/2 ranking itself, how many digraph nodes
 //!    get materialized (and what fraction are `MultipleBondDuplicate`/`RingDuplicate`
 //!    phantom nodes, not real atoms), how many pairwise comparisons `rank_children`
@@ -31,11 +37,12 @@
 //!    its own module docs) -- this measures whether that matrix stays small in
 //!    practice or is a real cost center, split by whether the center turned out to be
 //!    Pass-1-trivial.
-//! 3. MANCUDE-inertness check -- accumulates `CompareContext::fractional_decisions`
+//! 3. Fractional-decision accounting -- accumulates `CompareContext::fractional_decisions`
 //!    (a fraction actually deciding a ranking, not just being present) across every
-//!    Q2 comparison; asserted 0 at the end if the corpus behaves as Milestone 3B-1b
-//!    found. If nonzero, Q1's proxy is unsound for this run and the split is unreliable
-//!    -- printed, not silently trusted.
+//!    Q2 comparison. A nonzero value triggers D/E classification (see
+//!    `mancude_decision_diagnosis.rs`); it does not by itself invalidate Q1's
+//!    resolution-level accounting -- printed here for corpus-scale awareness, not as
+//!    a pass/fail check on this tool's own output.
 //!
 //! elapsed_us is corroborating only, not authoritative -- single-threaded local run,
 //! read alongside the structural counts, not as a regression gate (see this project's
@@ -177,9 +184,10 @@ fn main() {
     let mut worst_pass1: Option<(usize, String, u32)> = None;
     let mut worst_needs_more: Option<(usize, String, u32)> = None;
 
-    // Q3: does a MANCUDE fraction ever actually decide a ranking on this corpus? If
-    // this stays 0, Q1's `_without_mancude` proxy is verified inert for this run, not
-    // assumed from a past milestone's finding.
+    // Q3: does a MANCUDE fraction ever actually decide a ranking on this corpus? A
+    // nonzero value triggers D/E classification; it does not by itself invalidate the
+    // Q1 resolution-level accounting above (see mancude_decision_diagnosis.rs for the
+    // structure-isolated classification that answers whether any final label changes).
     let mut fractional_decisions_total: u64 = 0;
 
     for smi in &smis {
@@ -339,7 +347,7 @@ fn main() {
         println!("worst needs_pass2_or_3 ({c} comparisons): {smi}  atom {atom}");
     }
     println!();
-    println!("=== Q3: MANCUDE-inertness check (verifies Q1's _without_mancude proxy) ===");
+    println!("=== Q3: fractional-decision accounting (does not by itself invalidate Q1) ===");
     println!(
         "fractional_decisions_total={fractional_decisions_total} -- {}",
         if fractional_decisions_total == 0 {

--- a/crates/chematic-cip/examples/cip_perf_diagnosis.rs
+++ b/crates/chematic-cip/examples/cip_perf_diagnosis.rs
@@ -1,0 +1,309 @@
+//! CIP-Perf-A0: diagnosis-only structural profiling of the AccurateExperimental CIP
+//! engine's Rules-1a/1b/2 comparator. Motivated by RDKit PR #9171 ("CIP labeller
+//! performance: Don't calculate auxiliary descriptors unnecessarily", merged
+//! 2026-05-06): RDKit was computing Rule-4b-equivalent auxiliary stereodescriptors
+//! for *every* center, when only centers still tied after the constitutional rules
+//! need them -- PR #9171's own headline case (PDB 4AXM) went 14s -> 0.036s. Verified
+//! against the PR body directly (`gh pr view 9171 --repo rdkit/rdkit`), not paraphrased
+//! secondhand. This diagnostic checks whether chematic has the same bug.
+//!
+//! Ships **no production changes**: every call below is existing `pub` API, the same
+//! combination `trace_report.rs` already exercises (`CipDigraph` + `CompareContext` +
+//! `rank_children`) plus the two existing corpus-facing entry points. Answers two
+//! questions, per stereocenter:
+//!
+//! 1. Resolution level -- does Rules 1a/1b/2 alone (`assign_cip_accurate_experimental_
+//!    without_mancude`, used here as a Pass-1 proxy) resolve it, or does it need the
+//!    live engine's later Rule 4b/5 passes -- both already gated on `SkipReason::Tied`
+//!    from the prior pass (see `assign.rs`/`resolver.rs`), i.e. chematic already gates
+//!    auxiliary-descriptor computation at the center level, the same granularity
+//!    #9171 fixed in RDKit. The proxy's only assumption -- that MANCUDE fractions
+//!    don't change any ranking on this corpus -- is verified in-run below (Q3), not
+//!    cited from memory. Rule 4b and Rule 5 are **not** split apart here (both
+//!    `pub(crate)`, no Pass-1+4b-only public entry point) -- reported together as
+//!    `resolved_pass2_or_3`; a future run could split them with a small `pub(crate)`
+//!    exposure if that distinction becomes decision-relevant.
+//! 2. Comparator size -- for the Rules-1a/1b/2 ranking itself, how many digraph nodes
+//!    get materialized (and what fraction are `MultipleBondDuplicate`/`RingDuplicate`
+//!    phantom nodes, not real atoms), how many pairwise comparisons `rank_children`
+//!    makes, and how deep recursion goes? `rank_children` computes a full pairwise
+//!    matrix up front for every sibling group at every visited depth (by design, see
+//!    its own module docs) -- this measures whether that matrix stays small in
+//!    practice or is a real cost center, split by whether the center turned out to be
+//!    Pass-1-trivial.
+//! 3. MANCUDE-inertness check -- accumulates `CompareContext::fractional_decisions`
+//!    (a fraction actually deciding a ranking, not just being present) across every
+//!    Q2 comparison; asserted 0 at the end if the corpus behaves as Milestone 3B-1b
+//!    found. If nonzero, Q1's proxy is unsound for this run and the split is unreliable
+//!    -- printed, not silently trusted.
+//!
+//! elapsed_us is corroborating only, not authoritative -- single-threaded local run,
+//! read alongside the structural counts, not as a regression gate (see this project's
+//! own criterion-gate pseudo-replication finding, issue #70).
+//!
+//! Usage:
+//!   cargo run -p chematic-cip --release --example cip_perf_diagnosis -- <SMILES.csv>
+
+use std::env;
+use std::fs;
+use std::time::Instant;
+
+use chematic_cip::{
+    CipBudget, CipDigraph, CipNodeKind, CompareContext, ComparisonTrace,
+    assign_cip_accurate_experimental, assign_cip_accurate_experimental_without_mancude,
+    prepare_kekule_form, rank_children,
+};
+use chematic_core::{AtomIdx, Chirality};
+
+#[derive(Default)]
+struct SizeStats {
+    nodes: Vec<usize>,
+    duplicate_nodes: Vec<usize>,
+    comparisons: Vec<usize>,
+    max_depth: Vec<u32>,
+}
+
+impl SizeStats {
+    fn push(&mut self, nodes: usize, duplicate_nodes: usize, comparisons: usize, max_depth: u32) {
+        self.nodes.push(nodes);
+        self.duplicate_nodes.push(duplicate_nodes);
+        self.comparisons.push(comparisons);
+        self.max_depth.push(max_depth);
+    }
+
+    fn summarize(&self, label: &str) {
+        let n = self.nodes.len();
+        if n == 0 {
+            println!("{label}: n=0");
+            return;
+        }
+        let total_nodes: usize = self.nodes.iter().sum();
+        let total_dupes: usize = self.duplicate_nodes.iter().sum();
+        println!(
+            "{label}: n={n}  nodes[median/p95/max]={}/{}/{}  dup_nodes%={:.1}  comparisons[median/p95/max]={}/{}/{}  depth[median/p95/max]={}/{}/{}",
+            pct(&self.nodes, 50),
+            pct(&self.nodes, 95),
+            self.nodes.iter().max().unwrap(),
+            100.0 * total_dupes as f64 / total_nodes.max(1) as f64,
+            pct(&self.comparisons, 50),
+            pct(&self.comparisons, 95),
+            self.comparisons.iter().max().unwrap(),
+            pct(&self.max_depth, 50),
+            pct(&self.max_depth, 95),
+            self.max_depth.iter().max().unwrap(),
+        );
+    }
+}
+
+fn pct<T: Ord + Copy>(values: &[T], p: usize) -> T {
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable();
+    let idx = (sorted.len() * p / 100).min(sorted.len() - 1);
+    sorted[idx]
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let csv_path = args
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| format!("{}/Downloads/SMILES.csv", env::var("HOME").unwrap()));
+
+    let content = fs::read_to_string(&csv_path).expect("read SMILES.csv");
+    let smis: Vec<&str> = content
+        .lines()
+        .skip(1)
+        .filter(|l| !l.trim().is_empty())
+        .collect();
+
+    let budget = CipBudget::default_budget();
+
+    let mut resolved_pass1 = 0usize;
+    let mut resolved_pass2_or_3 = 0usize;
+    let mut still_tied = 0usize;
+    let mut skip_other = 0usize;
+
+    let mut stats_pass1 = SizeStats::default();
+    let mut stats_needs_more = SizeStats::default();
+
+    let mut total_size_pass_nanos: u128 = 0;
+    let mut total_resolution_pass_nanos: u128 = 0;
+
+    // Worst offender by comparison count, tracked separately for the two groups so a
+    // single pathological molecule doesn't hide what the *other* group's tail looks
+    // like.
+    let mut worst_pass1: Option<(usize, String, u32)> = None;
+    let mut worst_needs_more: Option<(usize, String, u32)> = None;
+
+    // Q3: does a MANCUDE fraction ever actually decide a ranking on this corpus? If
+    // this stays 0, Q1's `_without_mancude` proxy is verified inert for this run, not
+    // assumed from a past milestone's finding.
+    let mut fractional_decisions_total: u64 = 0;
+
+    for smi in &smis {
+        let Ok(mol) = chematic_smiles::parse(smi) else {
+            continue;
+        };
+        let has_chirality =
+            (0..mol.atom_count()).any(|i| mol.atom(AtomIdx(i as u32)).chirality != Chirality::None);
+        if !has_chirality {
+            continue;
+        }
+
+        // Question 1: resolution level (whole-molecule calls, existing pub entry points).
+        let start = Instant::now();
+        let pass1 = assign_cip_accurate_experimental_without_mancude(&mol, budget);
+        let final_result = assign_cip_accurate_experimental(&mol, budget);
+        total_resolution_pass_nanos += start.elapsed().as_nanos();
+
+        let (Ok(pass1), Ok(final_result)) = (pass1, final_result) else {
+            continue;
+        };
+        let pass1_resolved: std::collections::HashSet<AtomIdx> =
+            pass1.assignments.iter().map(|(idx, _)| *idx).collect();
+
+        for (idx, _) in &final_result.assignments {
+            if pass1_resolved.contains(idx) {
+                resolved_pass1 += 1;
+            } else {
+                resolved_pass2_or_3 += 1;
+            }
+        }
+        for (idx, reason) in &final_result.skipped {
+            match reason {
+                chematic_cip::SkipReason::Tied => still_tied += 1,
+                _ => {
+                    let _ = idx;
+                    skip_other += 1;
+                }
+            }
+        }
+
+        // Question 2: comparator size, per candidate stereocenter (4-substituent atoms
+        // only -- mirrors assign.rs's own Pass-1 filter).
+        let kekule = prepare_kekule_form(&mol).ok();
+        for i in 0..mol.atom_count() {
+            let idx = AtomIdx(i as u32);
+            if mol.atom(idx).chirality == Chirality::None {
+                continue;
+            }
+            let Some(stereo_order) = mol.stereo_neighbor_order(idx) else {
+                continue;
+            };
+            if stereo_order.len() != 4 {
+                continue;
+            }
+
+            let start = Instant::now();
+            let mut graph = match &kekule {
+                Some((kekule_mol, ctx)) => {
+                    match CipDigraph::new_with_mancude(kekule_mol, idx, budget, ctx) {
+                        Ok(g) => g,
+                        Err(_) => continue,
+                    }
+                }
+                None => match CipDigraph::new(&mol, idx, budget) {
+                    Ok(g) => g,
+                    Err(_) => continue,
+                },
+            };
+            let root = graph.root();
+            let Ok(root_children) = graph.expand_children(root) else {
+                continue;
+            };
+            let mut trace = ComparisonTrace::new(root, root);
+            let mut ctx = CompareContext::with_trace(&mut trace);
+            if rank_children(&mut graph, &root_children, &mut ctx).is_err() {
+                continue;
+            }
+            total_size_pass_nanos += start.elapsed().as_nanos();
+            fractional_decisions_total += ctx.fractional_decisions;
+
+            let node_count = graph.nodes().len();
+            let duplicate_node_count = graph
+                .nodes()
+                .iter()
+                .filter(|n| {
+                    matches!(
+                        n.kind,
+                        CipNodeKind::MultipleBondDuplicate { .. }
+                            | CipNodeKind::RingDuplicate { .. }
+                    )
+                })
+                .count();
+            let comparison_count = trace.decisions.len();
+            let max_depth = trace.decisions.iter().map(|d| d.depth).max().unwrap_or(0);
+
+            if pass1_resolved.contains(&idx) {
+                stats_pass1.push(
+                    node_count,
+                    duplicate_node_count,
+                    comparison_count,
+                    max_depth,
+                );
+                if worst_pass1
+                    .as_ref()
+                    .is_none_or(|(c, _, _)| comparison_count > *c)
+                {
+                    worst_pass1 = Some((comparison_count, smi.to_string(), idx.0));
+                }
+            } else {
+                stats_needs_more.push(
+                    node_count,
+                    duplicate_node_count,
+                    comparison_count,
+                    max_depth,
+                );
+                if worst_needs_more
+                    .as_ref()
+                    .is_none_or(|(c, _, _)| comparison_count > *c)
+                {
+                    worst_needs_more = Some((comparison_count, smi.to_string(), idx.0));
+                }
+            }
+        }
+    }
+
+    let total_candidates = resolved_pass1 + resolved_pass2_or_3 + still_tied;
+    println!(
+        "=== Q1: resolution level (Pass 1 = Rules 1a/1b/2 alone, via _without_mancude proxy) ==="
+    );
+    println!(
+        "resolved_pass1={resolved_pass1} ({:.1}%)  resolved_pass2_or_3={resolved_pass2_or_3} ({:.1}%)  \
+         still_tied_after_all={still_tied} ({:.1}%)  [of {total_candidates} R/S-eligible centers; \
+         skip_other(not4/budget)={skip_other} excluded from this denominator]",
+        100.0 * resolved_pass1 as f64 / total_candidates.max(1) as f64,
+        100.0 * resolved_pass2_or_3 as f64 / total_candidates.max(1) as f64,
+        100.0 * still_tied as f64 / total_candidates.max(1) as f64,
+    );
+    println!(
+        "resolution-pass elapsed: {:.1}ms total (corroborating only, not a gate)",
+        total_resolution_pass_nanos as f64 / 1_000_000.0
+    );
+    println!();
+    println!(
+        "=== Q2: Rules-1a/1b/2 comparator size, split by whether Pass 1 resolved the center ==="
+    );
+    stats_pass1.summarize("pass1_resolved  ");
+    stats_needs_more.summarize("needs_pass2_or_3");
+    println!(
+        "size-pass elapsed: {:.1}ms total (corroborating only, not a gate)",
+        total_size_pass_nanos as f64 / 1_000_000.0
+    );
+    if let Some((c, smi, atom)) = worst_pass1 {
+        println!("worst pass1_resolved   ({c} comparisons): {smi}  atom {atom}");
+    }
+    if let Some((c, smi, atom)) = worst_needs_more {
+        println!("worst needs_pass2_or_3 ({c} comparisons): {smi}  atom {atom}");
+    }
+    println!();
+    println!("=== Q3: MANCUDE-inertness check (verifies Q1's _without_mancude proxy) ===");
+    println!(
+        "fractional_decisions_total={fractional_decisions_total} -- {}",
+        if fractional_decisions_total == 0 {
+            "0 as expected; Q1's proxy is sound for this run"
+        } else {
+            "NONZERO -- Q1's pass1_resolved/resolved_pass2_or_3 split is unreliable this run, a fraction actually changed a ranking"
+        }
+    );
+}

--- a/crates/chematic-cip/examples/mancude_decision_diagnosis.rs
+++ b/crates/chematic-cip/examples/mancude_decision_diagnosis.rs
@@ -1,0 +1,290 @@
+//! MANCUDE-Decision-A0: classify the nonzero `fractional_decisions` count found while
+//! running CIP-Perf-A0 (`cip_perf_diagnosis`) against the frozen `SMILES.csv` corpus
+//! (`corpus_sha256=1c47371d...`, confirmed identical to the corpus
+//! `docs/cip_accurate_rfc.md`'s Milestone 3B-1b closeout used for its "byte-identical,
+//! fractional_decisions expected 0" claim -- see that file, and
+//! `compare.rs`'s own `CompareContext::fractional_decisions` doc comment, which names a
+//! future nonzero value as Milestone 3B-2's own resumption condition #1).
+//!
+//! Ships **no production changes** -- reuses the same existing `pub` API combination
+//! `cip_perf_diagnosis.rs` and `trace_report.rs` already exercise. Breaks the nonzero
+//! count down into the four units requested before any classification (A: corpus
+//! drift -- already ruled out by the SHA match above; B: instrumentation/counter bug;
+//! C: engine evolution since M3B-1b, e.g. Rule 4b/5 reaching new comparisons; D: real
+//! decision, but final-label-inert; E: real decision that changes a final label):
+//!
+//! - comparison events: `fractional_comparisons` / `fractional_decisions` totals
+//!   (the same two counters `cip_perf_diagnosis` already reads, reprinted here for a
+//!   single source of truth on the raw numbers).
+//! - unique stereocenters / unique molecules: how many distinct (molecule, atom_idx)
+//!   pairs and distinct molecules have `fractional_decisions > 0` on their own
+//!   Rules-1a/1b/2 root-children ranking.
+//! - unique `ranking_parent` nodes touched: a **proxy**, not the strict
+//!   `fractional_decisions` count -- counts `DecisionStep`s whose recorded rule string
+//!   contains a `Rational(...)` key (i.e. a MANCUDE fraction was *involved* in the
+//!   decisive comparison, `compare.rs`'s own weaker `fractional_comparisons` notion),
+//!   grouped by `DecisionStep::ranking_parent`. This is a proxy because
+//!   `fractional_decisions` itself has no per-event node identity recorded anywhere
+//!   (a private `u64` counter, incremented deep inside `compare_by_level`) -- adding
+//!   that would be a production change to `compare.rs`, out of scope for a
+//!   diagnosis-only tool. Reported as an upper bound / concentration signal, not an
+//!   exact count.
+//! - final-assignment impact: for stereocenters where Pass 1 (Rules 1a/1b/2, both with
+//!   and without `MancudeContext`) alone resolves the center, does the resolved
+//!   `CipCode` actually differ between `assign_cip_accurate_experimental_without_mancude`
+//!   and `assign_cip_accurate_experimental`? This isolates the fraction's effect from
+//!   Rule 4b/5 ever running at all (which `_without_mancude` never reaches), directly
+//!   answering classification D vs E for the Pass-1-resolved subset.
+//!
+//! elapsed_us is corroborating only, not a gate (see CIP-Perf-A0's own note, and this
+//! project's criterion pseudo-replication finding, issue #70).
+//!
+//! Usage:
+//!   cargo run -p chematic-cip --release --example mancude_decision_diagnosis -- <SMILES.csv>
+
+use std::collections::HashSet;
+use std::env;
+use std::fs;
+
+use chematic_cip::{
+    CipBudget, CipDigraph, CompareContext, ComparisonTrace, assign_cip_accurate_experimental,
+    assign_cip_accurate_experimental_without_mancude, prepare_kekule_form, rank_children,
+};
+use chematic_core::{AtomIdx, Chirality, CipCode};
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let csv_path = args
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| format!("{}/Downloads/SMILES.csv", env::var("HOME").unwrap()));
+
+    let content = fs::read_to_string(&csv_path).expect("read SMILES.csv");
+    let smis: Vec<&str> = content
+        .lines()
+        .skip(1)
+        .filter(|l| !l.trim().is_empty())
+        .collect();
+
+    let budget = CipBudget::default_budget();
+
+    let mut total_fractional_comparisons: u64 = 0;
+    let mut total_fractional_decisions: u64 = 0;
+    let mut centers_with_decisions: usize = 0;
+    let mut molecules_with_decisions: HashSet<usize> = HashSet::new();
+    let mut proxy_ranking_parents_touched: usize = 0;
+
+    let mut pass1_resolved_final_label_changed: usize = 0;
+    let mut pass1_resolved_final_label_same: usize = 0;
+    let mut changed_rows: Vec<(String, u32, CipCode, CipCode, bool)> = Vec::new();
+
+    let mut worst: Option<(u64, String, u32)> = None;
+
+    for (mol_idx, smi) in smis.iter().enumerate() {
+        let Ok(mol) = chematic_smiles::parse(smi) else {
+            continue;
+        };
+        let has_chirality =
+            (0..mol.atom_count()).any(|i| mol.atom(AtomIdx(i as u32)).chirality != Chirality::None);
+        if !has_chirality {
+            continue;
+        }
+
+        let pass1 = assign_cip_accurate_experimental_without_mancude(&mol, budget);
+        let final_result = assign_cip_accurate_experimental(&mol, budget);
+        let (Ok(pass1), Ok(final_result)) = (pass1, final_result) else {
+            continue;
+        };
+        let pass1_codes: std::collections::HashMap<AtomIdx, CipCode> =
+            pass1.assignments.iter().copied().collect();
+        let final_codes: std::collections::HashMap<AtomIdx, CipCode> =
+            final_result.assignments.iter().copied().collect();
+
+        let kekule = prepare_kekule_form(&mol).ok();
+        for i in 0..mol.atom_count() {
+            let idx = AtomIdx(i as u32);
+            if mol.atom(idx).chirality == Chirality::None {
+                continue;
+            }
+            let Some(stereo_order) = mol.stereo_neighbor_order(idx) else {
+                continue;
+            };
+            if stereo_order.len() != 4 {
+                continue;
+            }
+
+            let mut graph = match &kekule {
+                Some((kekule_mol, ctx)) => {
+                    match CipDigraph::new_with_mancude(kekule_mol, idx, budget, ctx) {
+                        Ok(g) => g,
+                        Err(_) => continue,
+                    }
+                }
+                None => match CipDigraph::new(&mol, idx, budget) {
+                    Ok(g) => g,
+                    Err(_) => continue,
+                },
+            };
+            let root = graph.root();
+            let Ok(root_children) = graph.expand_children(root) else {
+                continue;
+            };
+            let mut trace = ComparisonTrace::new(root, root);
+            let mut ctx = CompareContext::with_trace(&mut trace);
+            let Ok(manc_groups) = rank_children(&mut graph, &root_children, &mut ctx) else {
+                continue;
+            };
+
+            total_fractional_comparisons += ctx.fractional_comparisons;
+            total_fractional_decisions += ctx.fractional_decisions;
+
+            if ctx.fractional_decisions > 0 {
+                centers_with_decisions += 1;
+                molecules_with_decisions.insert(mol_idx);
+
+                if ctx.fractional_decisions > worst.as_ref().map(|(c, _, _)| *c).unwrap_or(0) {
+                    worst = Some((ctx.fractional_decisions, smi.to_string(), idx.0));
+                }
+
+                // Proxy: DecisionSteps whose rule string names a Rational key, grouped
+                // by ranking_parent -- see module docs for why this is an upper bound,
+                // not the strict fractional_decisions count.
+                let touched_parents: HashSet<Option<chematic_cip::NodeId>> = trace
+                    .decisions
+                    .iter()
+                    .filter(|d| d.rule.contains("Rational("))
+                    .map(|d| d.ranking_parent)
+                    .collect();
+                proxy_ranking_parents_touched += touched_parents.len();
+
+                // Final-assignment impact, isolated to the Pass-1-resolved subset.
+                if let (Some(&p1_code), Some(&final_code)) =
+                    (pass1_codes.get(&idx), final_codes.get(&idx))
+                {
+                    if p1_code == final_code {
+                        pass1_resolved_final_label_same += 1;
+                    } else {
+                        pass1_resolved_final_label_changed += 1;
+                        // Discriminating test (isolates Pass 1's own mancude effect from
+                        // Rule 4b/5, which `pass1_codes` vs `final_codes` alone conflates
+                        // -- `final_codes` includes atoms Rule 4b/5 resolved, not just
+                        // Pass-1-with-mancude): rebuild a *plain* root digraph (no
+                        // MancudeContext, on the original `mol` -- exactly what
+                        // `_without_mancude` uses internally) and compare its root-child
+                        // group partition against `manc_groups` above, by root-child
+                        // *index* (NodeIds aren't comparable across separate graphs, but
+                        // root-child expansion order is identical on both since the
+                        // structural divergence is deeper in the tree).
+                        let partitions_match = (|| {
+                            let mut plain_graph = CipDigraph::new(&mol, idx, budget).ok()?;
+                            let plain_root = plain_graph.root();
+                            let plain_children = plain_graph.expand_children(plain_root).ok()?;
+                            let mut plain_ctx = CompareContext::new();
+                            let plain_groups =
+                                rank_children(&mut plain_graph, &plain_children, &mut plain_ctx)
+                                    .ok()?;
+
+                            let to_index_partition =
+                                |groups: &[Vec<chematic_cip::NodeId>],
+                                 children: &[chematic_cip::NodeId]|
+                                 -> Vec<Vec<usize>> {
+                                    groups
+                                        .iter()
+                                        .map(|g| {
+                                            g.iter()
+                                                .filter_map(|n| {
+                                                    children.iter().position(|c| c == n)
+                                                })
+                                                .collect()
+                                        })
+                                        .collect()
+                                };
+                            let plain_partition =
+                                to_index_partition(&plain_groups, &plain_children);
+                            let manc_partition = to_index_partition(&manc_groups, &root_children);
+                            Some(plain_partition == manc_partition)
+                        })()
+                        .unwrap_or(false);
+                        changed_rows.push((
+                            smi.to_string(),
+                            idx.0,
+                            p1_code,
+                            final_code,
+                            partitions_match,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    println!("=== MANCUDE-Decision-A0 ===");
+    println!("corpus: {csv_path}");
+    println!(
+        "classification A (corpus drift): RULED OUT -- `shasum -a 256` on this file was \
+         independently verified (outside this tool) to match docs/cip_accurate_rfc.md's \
+         recorded M3B-1b closeout corpus_sha256=1c47371d... exactly."
+    );
+    println!();
+    println!("--- comparison events (strict counters, same as CIP-Perf-A0's Q3) ---");
+    println!("fractional_comparisons_total: {total_fractional_comparisons}");
+    println!("fractional_decisions_total:   {total_fractional_decisions}");
+    println!();
+    println!("--- unique stereocenters / molecules ---");
+    println!("stereocenters_with_decisions: {centers_with_decisions}");
+    println!(
+        "molecules_with_decisions:     {}",
+        molecules_with_decisions.len()
+    );
+    println!();
+    println!("--- unique ranking_parent nodes touched (PROXY, upper bound -- see module docs) ---");
+    println!(
+        "proxy_ranking_parents_touched (summed per affected center): {proxy_ranking_parents_touched}"
+    );
+    println!();
+    println!(
+        "--- final-assignment impact, Pass-1-resolved subset only (classification D vs E) ---"
+    );
+    println!(
+        "pass1_resolved_final_label_same:    {pass1_resolved_final_label_same}  (fraction was decision-involved but final R/S unchanged -> D)"
+    );
+    println!(
+        "pass1_resolved_final_label_changed: {pass1_resolved_final_label_changed}  (fraction actually changed the resolved R/S -> E, needs RDKit-agreement check)"
+    );
+    if let Some((c, smi, atom)) = worst {
+        println!();
+        println!("worst center by fractional_decisions ({c}): {smi}  atom {atom}");
+    }
+    if !changed_rows.is_empty() {
+        println!();
+        println!(
+            "--- rows where without_mancude != final, with the Pass-1-only discriminating test ---"
+        );
+        println!(
+            "partitions_match=true  -> plain-Pass-1 and mancude-Pass-1 rank identically; the \
+             flip is Rule 4b/5's doing, not mancude's -- classification D, not E."
+        );
+        println!(
+            "partitions_match=false -> mancude-Pass-1's OWN ranking differs from plain-Pass-1's \
+             -- classification E stands for this row."
+        );
+        for (smi, atom, p1, fin, partitions_match) in &changed_rows {
+            println!(
+                "{smi}\tatom {atom}\twithout_mancude={}\twith_mancude(final)={}\tpartitions_match={partitions_match}",
+                code_str(*p1),
+                code_str(*fin)
+            );
+        }
+    }
+}
+
+fn code_str(c: CipCode) -> &'static str {
+    match c {
+        CipCode::R => "R",
+        CipCode::S => "S",
+        CipCode::E => "E",
+        CipCode::Z => "Z",
+        CipCode::LowerR => "r",
+        CipCode::LowerS => "s",
+    }
+}

--- a/crates/chematic-cip/examples/mancude_decision_diagnosis.rs
+++ b/crates/chematic-cip/examples/mancude_decision_diagnosis.rs
@@ -58,6 +58,13 @@ use chematic_cip::{
 };
 use chematic_core::{AtomIdx, Chirality, CipCode};
 
+/// The `SMILES.csv` this tool's own aggregate counts (and
+/// `docs/cip_accurate_rfc.md`'s MANCUDE-Decision-A0 entry, which quotes them) were
+/// measured against -- see [`corpus_sha256`]'s call site in `main` for the runtime
+/// check against whatever corpus is actually passed in.
+const EXPECTED_CORPUS_SHA256: &str =
+    "1c47371dcbe37f4e0a141bf545b72bf238de2761fa3894fa251a552d84728d3e";
+
 fn main() {
     let args: Vec<String> = env::args().collect();
     let csv_path = args
@@ -66,6 +73,7 @@ fn main() {
         .unwrap_or_else(|| format!("{}/Downloads/SMILES.csv", env::var("HOME").unwrap()));
 
     let content = fs::read_to_string(&csv_path).expect("read SMILES.csv");
+    let actual_sha256 = corpus_sha256(&csv_path);
     let smis: Vec<&str> = content
         .lines()
         .skip(1)
@@ -259,11 +267,22 @@ fn main() {
 
     println!("=== MANCUDE-Decision-A0 ===");
     println!("corpus: {csv_path}");
-    println!(
-        "classification A (corpus drift): RULED OUT -- `shasum -a 256` on this file was \
-         independently verified (outside this tool) to match docs/cip_accurate_rfc.md's \
-         recorded M3B-1b closeout corpus_sha256=1c47371d... exactly."
-    );
+    println!("corpus_sha256: {actual_sha256}");
+    if actual_sha256 == EXPECTED_CORPUS_SHA256 {
+        println!(
+            "classification A (corpus drift): RULED OUT -- corpus_sha256 matches \
+             docs/cip_accurate_rfc.md's recorded MANCUDE-Decision-A0/M3B-1b closeout \
+             value exactly."
+        );
+    } else {
+        println!(
+            "*** WARNING: corpus_sha256 does NOT match the expected \
+             {EXPECTED_CORPUS_SHA256} -- classification A (corpus drift) is LIVE for \
+             this run. The aggregate counts below are NOT directly comparable to \
+             docs/cip_accurate_rfc.md's recorded MANCUDE-Decision-A0 closeout numbers. \
+             ***"
+        );
+    }
     println!();
     println!("--- comparison events (strict counters, same as CIP-Perf-A0's Q3) ---");
     println!("fractional_comparisons_total: {total_fractional_comparisons}");
@@ -337,4 +356,22 @@ fn code_str(c: CipCode) -> &'static str {
         CipCode::LowerR => "r",
         CipCode::LowerS => "s",
     }
+}
+
+/// SHA-256 of `path`'s contents, via the platform `shasum` binary -- `sha2` is not a
+/// workspace dependency and this is a one-shot diagnostic tool, not production code.
+fn corpus_sha256(path: &str) -> String {
+    use std::process::Command;
+    let output = Command::new("shasum")
+        .arg("-a")
+        .arg("256")
+        .arg(path)
+        .output()
+        .expect("run `shasum -a 256` (required to verify corpus identity)");
+    String::from_utf8(output.stdout)
+        .expect("utf8 shasum output")
+        .split_whitespace()
+        .next()
+        .expect("shasum hash field")
+        .to_string()
 }

--- a/crates/chematic-cip/examples/mancude_decision_diagnosis.rs
+++ b/crates/chematic-cip/examples/mancude_decision_diagnosis.rs
@@ -29,12 +29,18 @@
 //!   that would be a production change to `compare.rs`, out of scope for a
 //!   diagnosis-only tool. Reported as an upper bound / concentration signal, not an
 //!   exact count.
-//! - final-assignment impact: for stereocenters where Pass 1 (Rules 1a/1b/2, both with
-//!   and without `MancudeContext`) alone resolves the center, does the resolved
-//!   `CipCode` actually differ between `assign_cip_accurate_experimental_without_mancude`
-//!   and `assign_cip_accurate_experimental`? This isolates the fraction's effect from
-//!   Rule 4b/5 ever running at all (which `_without_mancude` never reaches), directly
-//!   answering classification D vs E for the Pass-1-resolved subset.
+//! - final-assignment impact, **structure-isolated**: compares
+//!   `assign_cip_accurate_experimental_without_mancude` run on the *Kekule-respelled*
+//!   molecule (no `MancudeContext` attached -- integer atomic numbers, same digraph
+//!   structure the live engine uses) against `assign_cip_accurate_experimental`
+//!   (Kekule-respelled + `MancudeContext` + Rule 4b/5). This is the real D-vs-E
+//!   classification: holding structure fixed and toggling only the fraction. A
+//!   **naive** contrast -- `_without_mancude` on the *original, un-Kekulized* molecule
+//!   vs the live engine -- is also reported, labeled clearly as naive: it bundles
+//!   Kekule-respelling structure with the fraction, and an earlier version of this
+//!   tool used *only* the naive contrast, wrongly classifying 3 centers as E when
+//!   they're D (see `docs/cip_accurate_rfc.md`'s MANCUDE-Decision-A0 entry for the
+//!   full correction). Do not conclude E from the naive numbers alone.
 //!
 //! elapsed_us is corroborating only, not a gate (see CIP-Perf-A0's own note, and this
 //! project's criterion pseudo-replication finding, issue #70).
@@ -76,6 +82,8 @@ fn main() {
 
     let mut pass1_resolved_final_label_changed: usize = 0;
     let mut pass1_resolved_final_label_same: usize = 0;
+    let mut naive_final_label_changed: usize = 0;
+    let mut naive_final_label_same: usize = 0;
     let mut changed_rows: Vec<(String, u32, CipCode, CipCode, bool)> = Vec::new();
 
     let mut worst: Option<(u64, String, u32)> = None;
@@ -90,17 +98,34 @@ fn main() {
             continue;
         }
 
-        let pass1 = assign_cip_accurate_experimental_without_mancude(&mol, budget);
+        let kekule = prepare_kekule_form(&mol).ok();
+
+        // Naive baseline (bundles Kekule-respelling structure with the fraction --
+        // reported for narrative reproducibility only, NOT the classification; see
+        // module docs).
+        let naive_pass1 = assign_cip_accurate_experimental_without_mancude(&mol, budget);
+        // Structure-isolated baseline: same Kekule-respelled molecule the live engine
+        // uses, no MancudeContext attached. This is the real "integer-collapsed
+        // control" -- structure held fixed, only the fraction toggled.
+        let structure_pass1 = match &kekule {
+            Some((kekule_mol, _)) => {
+                assign_cip_accurate_experimental_without_mancude(kekule_mol, budget)
+            }
+            None => assign_cip_accurate_experimental_without_mancude(&mol, budget),
+        };
         let final_result = assign_cip_accurate_experimental(&mol, budget);
-        let (Ok(pass1), Ok(final_result)) = (pass1, final_result) else {
+        let (Ok(naive_pass1), Ok(structure_pass1), Ok(final_result)) =
+            (naive_pass1, structure_pass1, final_result)
+        else {
             continue;
         };
-        let pass1_codes: std::collections::HashMap<AtomIdx, CipCode> =
-            pass1.assignments.iter().copied().collect();
+        let naive_pass1_codes: std::collections::HashMap<AtomIdx, CipCode> =
+            naive_pass1.assignments.iter().copied().collect();
+        let structure_pass1_codes: std::collections::HashMap<AtomIdx, CipCode> =
+            structure_pass1.assignments.iter().copied().collect();
         let final_codes: std::collections::HashMap<AtomIdx, CipCode> =
             final_result.assignments.iter().copied().collect();
 
-        let kekule = prepare_kekule_form(&mol).ok();
         for i in 0..mol.atom_count() {
             let idx = AtomIdx(i as u32);
             if mol.atom(idx).chirality == Chirality::None {
@@ -157,26 +182,40 @@ fn main() {
                     .collect();
                 proxy_ranking_parents_touched += touched_parents.len();
 
-                // Final-assignment impact, isolated to the Pass-1-resolved subset.
-                if let (Some(&p1_code), Some(&final_code)) =
-                    (pass1_codes.get(&idx), final_codes.get(&idx))
+                // Naive final-assignment impact (narrative only -- bundles structure
+                // with fraction, see module docs).
+                if let (Some(&naive_code), Some(&final_code)) =
+                    (naive_pass1_codes.get(&idx), final_codes.get(&idx))
                 {
-                    if p1_code == final_code {
+                    if naive_code == final_code {
+                        naive_final_label_same += 1;
+                    } else {
+                        naive_final_label_changed += 1;
+                    }
+                }
+
+                // Structure-isolated final-assignment impact -- the real D-vs-E
+                // classification. `structure_pass1_codes` and `final_codes` share the
+                // same Kekule-respelled digraph structure; the only thing toggled is
+                // whether a `MancudeContext` is attached.
+                if let (Some(&structure_code), Some(&final_code)) =
+                    (structure_pass1_codes.get(&idx), final_codes.get(&idx))
+                {
+                    if structure_code == final_code {
                         pass1_resolved_final_label_same += 1;
                     } else {
                         pass1_resolved_final_label_changed += 1;
-                        // Discriminating test (isolates Pass 1's own mancude effect from
-                        // Rule 4b/5, which `pass1_codes` vs `final_codes` alone conflates
-                        // -- `final_codes` includes atoms Rule 4b/5 resolved, not just
-                        // Pass-1-with-mancude): rebuild a *plain* root digraph (no
-                        // MancudeContext, on the original `mol` -- exactly what
-                        // `_without_mancude` uses internally) and compare its root-child
-                        // group partition against `manc_groups` above, by root-child
-                        // *index* (NodeIds aren't comparable across separate graphs, but
-                        // root-child expansion order is identical on both since the
-                        // structural divergence is deeper in the tree).
+                        // Corroborating structural check: same comparison at the
+                        // digraph-partition level, not just the resolved label --
+                        // rebuild a plain (no MancudeContext) root digraph on the SAME
+                        // Kekule-respelled molecule `manc_groups` used, and compare
+                        // root-child partitions by index (NodeIds aren't comparable
+                        // across separately-built graphs, but root-child expansion
+                        // order is identical on both since the structural divergence,
+                        // if any, is deeper in the tree).
                         let partitions_match = (|| {
-                            let mut plain_graph = CipDigraph::new(&mol, idx, budget).ok()?;
+                            let (kekule_mol, _) = kekule.as_ref()?;
+                            let mut plain_graph = CipDigraph::new(kekule_mol, idx, budget).ok()?;
                             let plain_root = plain_graph.root();
                             let plain_children = plain_graph.expand_children(plain_root).ok()?;
                             let mut plain_ctx = CompareContext::new();
@@ -208,7 +247,7 @@ fn main() {
                         changed_rows.push((
                             smi.to_string(),
                             idx.0,
-                            p1_code,
+                            structure_code,
                             final_code,
                             partitions_match,
                         ));
@@ -243,13 +282,22 @@ fn main() {
     );
     println!();
     println!(
-        "--- final-assignment impact, Pass-1-resolved subset only (classification D vs E) ---"
+        "--- NAIVE final-assignment impact (narrative only -- un-Kekulized baseline vs live, \
+         bundles structure+fraction, do NOT classify D/E from this) ---"
+    );
+    println!("naive_final_label_same:    {naive_final_label_same}");
+    println!(
+        "naive_final_label_changed: {naive_final_label_changed}  (these differ from the un-Kekulized \
+         baseline -- see the structure-isolated numbers below for why: Kekule-respelling \
+         structure, not the fraction, per docs/cip_accurate_rfc.md's MANCUDE-Decision-A0 entry)"
+    );
+    println!();
+    println!("--- STRUCTURE-ISOLATED final-assignment impact (real classification D vs E) ---");
+    println!(
+        "pass1_resolved_final_label_same:    {pass1_resolved_final_label_same}  (fraction was decision-involved but final R/S unchanged once structure is held fixed -> D)"
     );
     println!(
-        "pass1_resolved_final_label_same:    {pass1_resolved_final_label_same}  (fraction was decision-involved but final R/S unchanged -> D)"
-    );
-    println!(
-        "pass1_resolved_final_label_changed: {pass1_resolved_final_label_changed}  (fraction actually changed the resolved R/S -> E, needs RDKit-agreement check)"
+        "pass1_resolved_final_label_changed: {pass1_resolved_final_label_changed}  (fraction changed the resolved R/S with structure held fixed -> E)"
     );
     if let Some((c, smi, atom)) = worst {
         println!();
@@ -258,20 +306,22 @@ fn main() {
     if !changed_rows.is_empty() {
         println!();
         println!(
-            "--- rows where without_mancude != final, with the Pass-1-only discriminating test ---"
+            "--- structure-isolated rows where structure_pass1 != final (should be empty; if not, re-classify) ---"
         );
         println!(
-            "partitions_match=true  -> plain-Pass-1 and mancude-Pass-1 rank identically; the \
-             flip is Rule 4b/5's doing, not mancude's -- classification D, not E."
+            "partitions_match=true  -> plain (no MancudeContext) and mancude root-child \
+             partitions on the SAME Kekule-respelled structure agree; a label difference here \
+             would need a different explanation than the partition, investigate further."
         );
         println!(
-            "partitions_match=false -> mancude-Pass-1's OWN ranking differs from plain-Pass-1's \
-             -- classification E stands for this row."
+            "partitions_match=false -> the fraction's own root-level partition differs from \
+             the structure-only partition -- classification E, on the SAME Kekule-respelled \
+             structure (not confounded with Kekule-respelling itself)."
         );
-        for (smi, atom, p1, fin, partitions_match) in &changed_rows {
+        for (smi, atom, structure_code, fin, partitions_match) in &changed_rows {
             println!(
-                "{smi}\tatom {atom}\twithout_mancude={}\twith_mancude(final)={}\tpartitions_match={partitions_match}",
-                code_str(*p1),
+                "{smi}\tatom {atom}\tstructure_only(no_mancude)={}\twith_mancude(final)={}\tpartitions_match={partitions_match}",
+                code_str(*structure_code),
                 code_str(*fin)
             );
         }

--- a/crates/chematic-cip/src/compare.rs
+++ b/crates/chematic-cip/src/compare.rs
@@ -202,13 +202,39 @@ pub struct CompareContext<'t> {
     /// produced a different (or tied) result. Deliberately **not** "non-Equal and either
     /// side is Rational": that naive definition fires even when an element difference
     /// alone decides it (e.g. `Rational(6/1)` vs `Integral(8)`, carbon vs oxygen), which
-    /// would misrepresent a fraction as load-bearing when it did nothing. On the frozen
-    /// corpus this is expected to be **0** -- consistent with Milestone 3B-1b's own
-    /// attribution finding (byte-identical output with/without `MancudeContext` attached)
-    /// -- and 0 is the *correct* result here, not a gap to close. A future nonzero value
-    /// is exactly Milestone 3B-2's own resumption condition #1 ("a new corpus exercises a
-    /// case where fractional MANCUDE actually changes a ranking"); see
-    /// `docs/cip_accurate_rfc.md`'s Milestone 3B closeout entry.
+    /// would misrepresent a fraction as load-bearing when it did nothing.
+    ///
+    /// At the Milestone 3B-1b closeout, the RFC asserted this would be zero on the
+    /// frozen corpus, "consistent with" a byte-identical-output finding -- but that
+    /// assertion was only ever checked against a single curated molecule, never
+    /// measured at full-corpus scale. A later full-corpus diagnostic on the same
+    /// corpus (SHA-256: `1c47371d...`) found the real value is 248, across 36
+    /// stereocenters in 21 molecules (Milestone MANCUDE-Decision-A0; see
+    /// `docs/cip_accurate_rfc.md`'s tripwire closeout entry for the full breakdown).
+    ///
+    /// This is **not** a regression, and it does **not** contradict the byte-identical
+    /// finding once fraction is properly isolated from Kekule-respelling structure (the
+    /// naive "with vs without `MancudeContext`" contrast conflates both): for all 36
+    /// affected centers, including the 3 where the naive contrast's *final* Pass-1
+    /// ranking also differs, holding structure fixed (`CipDigraph::new` on the same
+    /// Kekule-respelled molecule, with vs without the attached `MancudeContext`) shows
+    /// **identical** root-child partitions -- the fraction touches individual
+    /// sub-branch comparisons (hence nonzero `fractional_decisions`) without ever
+    /// changing the resolved label. All 36 are classification D ("fraction locally
+    /// load-bearing, final-label-inert"); **zero** are classification E ("fraction
+    /// changes the final label"). The 3 that flip vs the un-Kekulized baseline flip
+    /// because of Kekule-respelling alone, matching modern and legacy RDKit both --
+    /// frozen as regression fixtures in `tests/mancude_decision_regression.rs`.
+    ///
+    /// A nonzero value is therefore a tripwire requiring classification, not evidence
+    /// of a problem by itself:
+    /// - `fractional_decisions > 0` alone -> diagnosis required (is it D or E?).
+    /// - isolate fraction from structure before concluding either way -- a bundled
+    ///   with/without-`MancudeContext` contrast is not sufficient, as this milestone's
+    ///   own first attempt at that contrast found the hard way.
+    /// - a genuine (isolated) fractional-driven final-label change -> oracle
+    ///   classification required.
+    /// - one that *reduces* oracle agreement -> correctness blocker.
     pub fractional_decisions: u64,
 }
 

--- a/crates/chematic-cip/tests/mancude_decision_regression.rs
+++ b/crates/chematic-cip/tests/mancude_decision_regression.rs
@@ -1,0 +1,215 @@
+//! MANCUDE-Decision-A0 regression fixtures.
+//!
+//! Freezes the 3 stereocenters found (full-corpus diagnostic,
+//! `examples/mancude_decision_diagnosis.rs`, `SMILES.csv` sha256 `1c47371d...`) whose
+//! resolved R/S label differs between the un-Kekulized baseline
+//! (`assign_cip_accurate_experimental_without_mancude` on the original, aromatic-form
+//! molecule) and the live production path -- see `compare.rs`'s
+//! `CompareContext::fractional_decisions` doc comment and
+//! `docs/cip_accurate_rfc.md`'s MANCUDE-Decision-A0 tripwire closeout entry. All three
+//! were confirmed to match both RDKit's modern (`rdCIPLabeler`) and legacy
+//! (`_CIPCode`) oracles at diagnosis time (`.venv/bin/python3`, RDKit 2026.03.3) --
+//! frozen here as fixture expectations, not re-verified live against RDKit on every
+//! test run.
+//!
+//! **Classification, isolating structure from fraction (the naive with/without-
+//! `MancudeContext` contrast conflates both -- see the doc comment above for how the
+//! first attempt at this got it wrong):** holding the Kekule-respelled structure fixed
+//! and only toggling the attached `MancudeContext` leaves the root-child partition
+//! (and hence the resolved label) **unchanged** for all 3 -- the fix from the baseline's
+//! `R` to the correct `S` comes entirely from Kekule-respelling (real double-bond
+//! duplicate nodes an aromatic-bond digraph never has), not from the fractional atomic
+//! numbers. These are classification **D** ("fraction locally load-bearing --
+//! `fractional_decisions > 0` -- but final-label-inert"), the same bucket as the other
+//! 33 affected stereocenters this diagnostic found; **zero** stereocenters in this
+//! corpus are classification E ("fraction changes the final label").
+//!
+//! Deliberately does **not** assert that
+//! `assign_cip_accurate_experimental_without_mancude` gives `R` on the *original*
+//! (un-Kekulized) molecule for these atoms: today it does (that's the whole finding),
+//! but locking that in as an expected value would make a future improvement to the
+//! plain, un-Kekulized path that also reaches `S` *fail* this suite for getting more
+//! correct. Only the production path's correctness is frozen here, plus the structural
+//! facts (a load-bearing fractional decision occurs somewhere in Pass 1's recursive
+//! comparison, and the resolved label is structure-driven, not fraction-driven) that
+//! explain why `fractional_decisions > 0` here is expected and benign.
+
+use chematic_cip::digraph_diff::renumber_molecule;
+use chematic_cip::{
+    CipBudget, CipDigraph, CompareContext, NodeId, assign_cip_accurate_experimental,
+    assign_cip_accurate_experimental_without_mancude, prepare_kekule_form, rank_children,
+};
+use chematic_core::{AtomIdx, Chirality, CipCode, Molecule};
+
+struct Fixture {
+    smiles: &'static str,
+    atom_idx: u32,
+    expected: CipCode,
+}
+
+const FIXTURES: &[Fixture] = &[
+    Fixture {
+        smiles: "Oc1cc(C(F)(F)F)c2cc3c(cc2n1)NC[C@@H]1CCCC[C@H]31",
+        atom_idx: 22,
+        expected: CipCode::S,
+    },
+    Fixture {
+        smiles: "Oc1cc(C(F)(F)F)c2cc3c(cc2n1)NC[C@@H]1CCC[C@H]31",
+        atom_idx: 21,
+        expected: CipCode::S,
+    },
+    Fixture {
+        smiles: "Oc1cc(C(F)(F)F)c2cc3c(cc2n1)NC[C@H]1CCCC[C@H]31",
+        atom_idx: 22,
+        expected: CipCode::S,
+    },
+];
+
+#[test]
+fn mancude_decision_a0_fixtures() {
+    for f in FIXTURES {
+        check_fixture(f);
+    }
+}
+
+#[track_caller]
+fn check_fixture(f: &Fixture) {
+    let budget = CipBudget::default_budget();
+    let mol = chematic_smiles::parse(f.smiles).expect("valid SMILES");
+    let idx = AtomIdx(f.atom_idx);
+
+    // 1. The live, production (mancude-aware) engine gives the expected, RDKit-agreeing
+    // label.
+    assert_eq!(
+        live_code(&mol, idx, budget),
+        Some(f.expected),
+        "{}: live engine assignment at atom {}",
+        f.smiles,
+        f.atom_idx
+    );
+
+    // 2. A MANCUDE fraction is load-bearing *somewhere* in this center's Pass-1
+    // comparison (fractional_decisions > 0) -- confirming this fixture actually
+    // exercises the fractional-key path, not dead code.
+    let (kekule_mol, ctx) = prepare_kekule_form(&mol).expect("kekulizable fixture");
+    let fractional_decisions = fractional_decisions_at_root(&kekule_mol, idx, &ctx, budget);
+    assert!(
+        fractional_decisions > 0,
+        "{}: expected a load-bearing fractional decision at atom {}",
+        f.smiles,
+        f.atom_idx
+    );
+
+    // 3. Classification D, not E: holding the Kekule-respelled *structure* fixed and
+    // only toggling the attached MancudeContext leaves the root-child partition (and
+    // therefore the resolved label) unchanged -- the fraction is locally load-bearing
+    // (item 2) but never decides this center's final ranking. Uses the public
+    // `_without_mancude` entry point directly on `kekule_mol` (not the original
+    // aromatic `mol`) for the no-fraction side, since `apply_kekule` preserves
+    // `AtomIdx` (assign.rs's own note) -- this is the properly isolated
+    // "integer-collapsed control", not a with/without-mancude-on-different-structures
+    // contrast.
+    let structure_only_label =
+        assign_cip_accurate_experimental_without_mancude(&kekule_mol, budget)
+            .expect("budget not exceeded")
+            .assignments
+            .iter()
+            .find(|(a, _)| *a == idx)
+            .map(|(_, c)| *c);
+    assert_eq!(
+        structure_only_label,
+        Some(f.expected),
+        "{}: expected the Kekule-respelled structure ALONE (no MancudeContext) to \
+         already resolve atom {} to {:?} -- if this fails, the fraction has become \
+         load-bearing for the final label and this fixture is actually \
+         classification E, not D; re-classify before trusting this test",
+        f.smiles,
+        f.atom_idx,
+        f.expected
+    );
+
+    // 4. Atom-renumbering invariance.
+    let perm: Vec<usize> = (0..mol.atom_count()).rev().collect();
+    let (renumbered, old_to_new) = renumber_molecule(&mol, &perm);
+    let new_idx = AtomIdx(old_to_new[f.atom_idx as usize]);
+    assert_eq!(
+        live_code(&renumbered, new_idx, budget),
+        Some(f.expected),
+        "{}: renumbered assignment (reversed atom order)",
+        f.smiles
+    );
+
+    // 5. Canonical-SMILES round-trip invariance.
+    let canonical = chematic_smiles::canonical_smiles(&mol);
+    let reparsed = chematic_smiles::parse(&canonical).expect("canonical SMILES reparses");
+    let target = locate_by_branch_signature(&mol, idx, &reparsed, budget).unwrap_or_else(|| {
+        panic!(
+            "{}: no unambiguous atom match after canonical round-trip (-> {canonical})",
+            f.smiles
+        )
+    });
+    assert_eq!(
+        live_code(&reparsed, target, budget),
+        Some(f.expected),
+        "{}: canonical round-trip assignment (-> {canonical})",
+        f.smiles
+    );
+}
+
+fn live_code(mol: &Molecule, idx: AtomIdx, budget: CipBudget) -> Option<CipCode> {
+    let result = assign_cip_accurate_experimental(mol, budget)
+        .expect("budget not exceeded for these fixtures");
+    result
+        .assignments
+        .iter()
+        .find(|(a, _)| *a == idx)
+        .map(|(_, c)| *c)
+}
+
+/// `fractional_decisions` for one stereocenter's root-children ranking, on the given
+/// (already Kekule-respelled) molecule and its `MancudeContext`.
+fn fractional_decisions_at_root(
+    kekule_mol: &Molecule,
+    idx: AtomIdx,
+    ctx: &chematic_cip::MancudeContext,
+    budget: CipBudget,
+) -> u64 {
+    let mut graph =
+        CipDigraph::new_with_mancude(kekule_mol, idx, budget, ctx).expect("digraph builds");
+    let root = graph.root();
+    let children = graph.expand_children(root).expect("root expands");
+    let mut cmp_ctx = CompareContext::new();
+    let _groups: Vec<Vec<NodeId>> =
+        rank_children(&mut graph, &children, &mut cmp_ctx).expect("ranking succeeds");
+    cmp_ctx.fractional_decisions
+}
+
+/// Locate "the same" stereocenter in `mol2` via [`CipDigraph::branch_signature`] (a
+/// chirality-independent structural subtree hash -- see its own doc comment). These
+/// fixtures each have 2 structurally-distinct-but-locally-similar stereocenters, so
+/// `digraph_diff::find_atom_by_signature`'s coarser (element/degree/chirality-tagged)
+/// signature is ambiguous here (verified empirically); `branch_signature` disambiguates
+/// uniquely on all 3 fixtures.
+fn locate_by_branch_signature(
+    mol1: &Molecule,
+    atom1: AtomIdx,
+    mol2: &Molecule,
+    budget: CipBudget,
+) -> Option<AtomIdx> {
+    let sig = |m: &Molecule, a: AtomIdx| -> Option<u64> {
+        let mut g = CipDigraph::new(m, a, budget).ok()?;
+        let root = g.root();
+        g.branch_signature(root).ok()
+    };
+    let want = sig(mol1, atom1)?;
+    let mut matches = (0..mol2.atom_count())
+        .map(|i| AtomIdx(i as u32))
+        .filter(|&idx| mol2.atom(idx).chirality != Chirality::None)
+        .filter(|&idx| sig(mol2, idx) == Some(want));
+    let first = matches.next()?;
+    if matches.next().is_some() {
+        None
+    } else {
+        Some(first)
+    }
+}

--- a/docs/cip_accurate_rfc.md
+++ b/docs/cip_accurate_rfc.md
@@ -536,6 +536,15 @@ and two *independently computed* regression counts).
      structurally could not see. Not root-caused or fixed this round (out of this
      closeout's scope; recorded for Milestone 4 to pick up if it recurs there).
 
+     **Partial correction (Milestone MANCUDE-Decision-A0, below):** "unaffected by
+     [MANCUDE] either way" is imprecise. Root-caused later: `candidate` *does* resolve
+     these 3 to the correct `S` (unlike `baseline`), but via Kekule-respelling structure
+     (real double-bond duplicate nodes an aromatic-bond digraph never emits) introduced
+     by Milestone 3B-1b — not via anything "pre-existing." What *is* correctly
+     unaffected is the fractional atomic-number machinery specifically: holding the
+     Kekule-respelled structure fixed and toggling only the attached `MancudeContext`
+     leaves these 3 centers' resolved label unchanged. See the full breakdown below.
+
    Final results, reported as three explicit comparisons rather than one bare percentage:
    ```
    vs FastApproximate (chematic_chem::assign_cip, cip_ground_truth.py): 4031/4186 (96.30%)
@@ -1599,6 +1608,115 @@ milestone — this is the criteria list for a future decision, not a decision):
   decision, not a number this milestone can resolve on its own.
 - Opt-in in production for ≥ 1 release — not yet started; this milestone's numbers are
   the *starting* baseline for that period, not evidence the period has elapsed.
+
+## Milestone MANCUDE-Decision-A0 — tripwire closeout, diagnosis only, no crate changes
+
+Milestone 3B-1b's closeout asserted `CompareContext::fractional_decisions` "is
+expected to be **0**" on the frozen corpus, and named a future nonzero value as
+Milestone 3B-2's own resumption condition #1. That assertion was checked only against
+one curated molecule (`digraph.rs`'s
+`live_path_fires_fractional_nodes_and_comparisons_on_curated_corpus_molecule`), never
+measured at full-corpus scale — a gap surfaced while investigating CIP-Perf-A0
+(below), not this milestone's original purpose. This entry runs that measurement for
+the first time and classifies the result.
+
+**Method.** Two new diagnosis-only tools (no production code touched):
+`examples/cip_perf_diagnosis.rs` and `examples/mancude_decision_diagnosis.rs`, both
+reusing existing `pub` API only (`CipDigraph`, `CompareContext`, `rank_children`,
+`prepare_kekule_form`, the two `assign_cip_accurate_experimental*` entry points) — the
+same combination `examples/trace_report.rs` already exercised.
+
+**Reproducibility.**
+```
+corpus:            SMILES.csv (5,000 rows)
+corpus_sha256:      1c47371dcbe37f4e0a141bf545b72bf238de2761fa3894fa251a552d84728d3e
+                    (matches this RFC's own recorded Milestone 3B closeout value
+                    exactly — classification "corpus drift" ruled out)
+rdkit_version:      2026.03.3 (.venv/bin/python3 — matches the recorded closeout version)
+```
+
+**Raw counts.**
+```
+fractional_comparisons_total: 984,112
+fractional_decisions_total:   248
+stereocenters_with_decisions: 36
+molecules_with_decisions:     21
+```
+
+**Classification.** A naive "with vs without `MancudeContext`" contrast bundles two
+independent changes — aromatic→Kekule-respelled *structure* and integer→fractional
+*value* — and produces a wrong split (an intermediate result of this investigation
+counted 33 D / 3 E using that contrast; **corrected below** once structure and value
+were properly isolated). Isolating them: hold the Kekule-respelled structure fixed
+(`CipDigraph::new` vs `new_with_mancude`, both on the same Kekule-respelled clone) and
+compare only the root-child partition.
+- **All 36** affected stereocenters: partition **unchanged** by attaching
+  `MancudeContext` once structure is held fixed → classification **D** (fraction
+  locally load-bearing — `fractional_decisions > 0` — but final-label-inert).
+- **Zero** are classification **E** (fraction changes the final label).
+
+**The 3 stereocenters that flip vs. the un-Kekulized baseline** (already on record in
+this RFC's Milestone 3B closeout, line ~529, as `baseline=R modern=S`):
+```
+Oc1cc(C(F)(F)F)c2cc3c(cc2n1)NC[C@@H]1CCCC[C@H]31  atom 22
+Oc1cc(C(F)(F)F)c2cc3c(cc2n1)NC[C@@H]1CCC[C@H]31   atom 21
+Oc1cc(C(F)(F)F)c2cc3c(cc2n1)NC[C@H]1CCCC[C@H]31   atom 22
+```
+All three: `assign_cip_accurate_experimental_without_mancude` on the *original*
+aromatic-form molecule gives `R`; `assign_cip_accurate_experimental_without_mancude`
+on the *Kekule-respelled* clone (structure-only, no `MancudeContext` attached) already
+gives `S`; the live production path also gives `S`. Both `S` answers match RDKit
+modern (`rdCIPLabeler`) and legacy (`_CIPCode`) oracles, RDKit 2026.03.3. Fix is
+Kekule-respelling structure, confirmed fraction-independent — consistent with (not
+contradicting) Milestone 3B-1b's original "gain is Kekule-respelling, not the
+fractional values" finding, once the fraction is actually isolated from structure
+rather than assumed inert from a single-molecule spot check. Frozen as regression
+fixtures in `tests/mancude_decision_regression.rs` (production live-engine output +
+structural facts frozen; live RDKit is not a test-time dependency).
+
+**Official accuracy impact: none.** `scripts/cip_accurate_full_corpus_report.py`
+already scores the mancude-aware `assign_cip_accurate_experimental` as `candidate` —
+these 3 rows were already counted correctly in every reported accuracy number,
+including this file's own Milestone 3B closeout figures. No regression, before or
+after this diagnosis.
+
+**Not done, deliberately out of scope this round:** bisecting which commit (if any)
+first made `fractional_decisions` nonzero at these 36 centers — moot for the
+classification (D holds regardless of when it started; a historical check at the
+Milestone 3B closeout commit, `4e78c53`, found `fractional_decisions=12` and the same
+structure-vs-fraction split already present there, so this was never actually zero —
+the "0" in the original closeout was an unverified extrapolation, not a later
+regression).
+
+**Disposition:**
+- **Milestone 3B-2 is not reopened for implementation.** Its resumption condition
+  (`fractional_decisions > 0` on a real corpus) fired, was investigated, and resolved
+  to "no corrective implementation required" — the production path was already
+  correct. Recorded as closed-by-diagnosis, not as new work.
+- `CompareContext::fractional_decisions`'s doc comment corrected in `compare.rs` to
+  state the real value and the D/E classification methodology, rather than "expected
+  0."
+- **CIP-Perf-S1 is closed as unnecessary.** The motivating question (does chematic
+  compute Rule 4b/5-equivalent auxiliary descriptors for every stereocenter
+  unconditionally, RDKit PR #9171's bug) is answered no: `assign.rs`/`resolver.rs`
+  already gate both later passes on `SkipReason::Tied` from the prior pass. Measured
+  directly: of 4,188 R/S-eligible stereocenters, 4,159 (99.3%) resolve at Rules
+  1a/1b/2 alone; only 29 (0.7%) ever reach Rule 4b/5.
+- **CIP-Perf-A1** (separate issue, not started): even among the 99.3% that resolve at
+  Rules 1a/1b/2 alone, `rank_children`'s comparator size has a long tail —
+  ```
+  pass1_resolved:   n=4159  comparisons[median/p95/max]=24/954/89,250   depth[median/p95/max]=3/11/22   dup_nodes%=18.5
+  needs_pass2_or_3: n=29    comparisons[median/p95/max]=2,094/36,198/36,198  depth[median/p95/max]=21/33/33
+  ```
+  Worst `pass1_resolved` case: a fused polyphenolic macrocycle (89,250 comparisons).
+  Worst `needs_pass2_or_3` case: an adamantane-cage amide (36,198 comparisons) — the
+  same cage family Milestone 5B's 17-carbon unresolved bucket already names. Candidate
+  mechanism: `rank_children`'s per-sibling-group pairwise comparison matrix, applied at
+  every visited depth, on highly symmetric/duplicate-heavy digraphs. No implementation
+  started; see the issue for the proposed investigation order and the gate an eventual
+  optimization PR must clear (assignments and skip reasons byte-identical, this
+  milestone's D/E classification unchanged, the 3 regression fixtures above unchanged,
+  oracle agreement unchanged, budget-exceeded count does not increase).
 
 ## Required property tests (starting Milestone 1)
 


### PR DESCRIPTION
## Summary

Two independent diagnosis-only investigations, closed out together. **No production algorithm changes.**

### CIP-Perf-A0 — closed, CIP-Perf-S1 unnecessary
Measured whether chematic has RDKit PR #9171's bug (auxiliary/Rule-4b-equivalent descriptors computed for every stereocenter instead of only tied ones, [gh pr view 9171 --repo rdkit/rdkit](https://github.com/rdkit/rdkit/pull/9171): 14s→0.036s in RDKit once fixed). It doesn't:

- 4,159/4,188 (99.3%) stereocenters resolve at Rules 1a/1b/2 alone
- Only 29/4,188 (0.7%) ever reach Rule 4b/5 — already gated on `SkipReason::Tied` from the prior pass
- **CIP-Perf-S1 closed as unnecessary.**

Surfaced a separate, real cost tail in `rank_children` on symmetric/duplicate-heavy digraphs (median 24 comparisons, p95 954, max 89,250) — tracked as a **follow-up issue (CIP-Perf-A1)**, not implemented here.

### MANCUDE-Decision-A0 — Milestone 3B-2 tripwire fired, investigated, closed without implementation
While measuring CIP-Perf-A0, found `CompareContext::fractional_decisions = 248` on the same frozen corpus (`sha256 1c47371d...`) that Milestone 3B-1b's closeout claimed would be 0. That claim was only ever checked against one curated molecule, never at full-corpus scale.

Classified the nonzero count by isolating Kekule-respelling **structure** from the fractional atomic-number **values** (a naive with/without-`MancudeContext` contrast conflates both — an intermediate result of this investigation got the classification wrong before this isolation was applied and caught):

- **All 36** affected stereocenters are classification **D** (fraction locally load-bearing, final-label-inert)
- **Zero** are classification **E** (fraction changes the final label)
- The 3 stereocenters whose label differs from the un-Kekulized baseline are fixed by **Kekule-respelling alone**, matching both modern (`rdCIPLabeler`) and legacy RDKit oracles (2026.03.3) — not a regression, already reflected in official accuracy numbers
- Verified via a git worktree at the Milestone 3B closeout commit (`4e78c53`): `fractional_decisions=12` there too — the "0" claim was never actually true, not a later regression

**Milestone 3B-2 is not reopened for implementation** — its resumption condition fired, was investigated, and resolved to "no corrective implementation required." Recorded as closed-by-diagnosis in the RFC.

## Changes

- `crates/chematic-cip/examples/cip_perf_diagnosis.rs` (new) — diagnosis-only, existing `pub` API only
- `crates/chematic-cip/examples/mancude_decision_diagnosis.rs` (new) — diagnosis-only, existing `pub` API only
- `crates/chematic-cip/tests/mancude_decision_regression.rs` (new) — freezes the 3 stereocenters' **live-engine** output (not the known-wrong un-Kekulized baseline, so a future fix to that path isn't penalized for improving), invariant under atom renumbering and canonical-SMILES round-trip
- `crates/chematic-cip/src/compare.rs` — corrects `fractional_decisions`'s stale "expected 0" doc comment
- `docs/cip_accurate_rfc.md` — new MANCUDE-Decision-A0 tripwire closeout entry, plus a correction note on the Milestone 3B closeout's now-imprecise "unrelated to MANCUDE" attribution for these same 3 rows

## Test plan

- [x] `bash scripts/check.sh` passes (fmt, clippy, unit + integration tests, deny, publish graph, version consistency)
- [x] `cargo test -p chematic-cip --test mancude_decision_regression --release` passes
- [x] Positive control: flipped one fixture's expected label to `R`, confirmed the test fails with the expected assertion message, reverted
- [x] Diagnostic tools re-run post-format, numbers stable (4159/4188 Pass-1-resolved, 248 fractional_decisions, 36 centers / 21 molecules, D=36/E=0)

Not merging yet — reporting for review first.