### PR TITLE
fix(iupac): heavy-atom coverage check must exclude explicit-H atoms

### DIFF
--- a/crates/chematic-iupac/src/rings.rs
+++ b/crates/chematic-iupac/src/rings.rs
@@ -62,6 +62,20 @@ impl SimpleBenzeneSubstituent {
     }
 }
 
+/// Count of non-hydrogen atoms in `mol`. `Molecule::atom_count()` is
+/// `self.atoms.len()`, which includes explicit bracket-`[H]` atoms as real
+/// entries (e.g. `Cc1ccc(cc1)O[H]` parses to 9 atoms, not 8) -- a coverage
+/// check using `atom_count()` directly would wrongly reject a substituent
+/// that `classify_simple_benzene_substituent` correctly classified via its
+/// own explicit-H-aware `total_h` count, since the ring+substituent heavy-
+/// atom total (8) would never match `atom_count()` (9). This must be used
+/// for any "does the name account for every atom" check in this module.
+fn heavy_atom_count(mol: &Molecule) -> usize {
+    mol.atoms()
+        .filter(|(_, a)| a.element.atomic_number() != 1)
+        .count()
+}
+
 /// Classify the substituent hanging off ring atom `attach`, accepting ONLY
 /// the exact shapes listed on [`SimpleBenzeneSubstituent`] -- methyl,
 /// hydroxy, amino, or a single halogen, each a lone neutral non-aromatic
@@ -335,8 +349,11 @@ impl<'a> Namer<'a> {
         // above, since every substituent atom is on the ring) would still be
         // guarded against by construction, but this makes the invariant
         // explicit and future-proofs against a classifier that stops
-        // requiring direct ring attachment.
-        if mol.atom_count() != ring_atoms.len() + 2 {
+        // requiring direct ring attachment. Must count heavy atoms only (see
+        // heavy_atom_count's doc comment) -- an explicit-H substituent
+        // spelling would otherwise fail this check despite being correctly
+        // classified.
+        if heavy_atom_count(mol) != ring_atoms.len() + 2 {
             return Err(IupacError::NotSupported);
         }
 
@@ -401,7 +418,8 @@ impl<'a> Namer<'a> {
         // exactly the ring atoms plus 3 classified single-heavy-atom
         // substituents -- checked up front so a downgrade below doesn't
         // waste locant/grouping work on a molecule that can never name.
-        if mol.atom_count() != ring_atoms.len() + 3 {
+        // Heavy atoms only (see heavy_atom_count's doc comment).
+        if heavy_atom_count(mol) != ring_atoms.len() + 3 {
             return Err(IupacError::NotSupported);
         }
 

--- a/crates/chematic-iupac/src/tests.rs
+++ b/crates/chematic-iupac/src/tests.rs
@@ -625,3 +625,28 @@ fn test_simple_disubstituted_benzene_table_driven_regression() {
         assert_eq!(name(&mol(smi)).unwrap(), *expected, "smiles: {smi}");
     }
 }
+
+#[test]
+fn test_issue92_explicit_h_substituent_matches_implicit_h_name() {
+    // The heavy-atom coverage check (rings.rs) originally compared against
+    // mol.atom_count(), which counts explicit bracket-[H] atoms as real
+    // entries -- a substituent spelled with an explicit H (e.g. "O[H]"
+    // instead of "O") has a heavy-atom count identical to its implicit
+    // spelling but a DIFFERENT atom_count(), so the coverage check wrongly
+    // rejected an otherwise-correctly-classified substituent. Both spellings
+    // of the same molecule must produce the identical name.
+    assert_eq!(
+        name(&mol("Cc1ccc(cc1)O")).unwrap(),
+        name(&mol("Cc1ccc(cc1)O[H]")).unwrap()
+    );
+    assert_eq!(name(&mol("Cc1ccc(cc1)O[H]")).unwrap(), "4-methylphenol");
+
+    assert_eq!(
+        name(&mol("Cc1ccc(cc1)N")).unwrap(),
+        name(&mol("Cc1ccc(cc1)N([H])[H]")).unwrap()
+    );
+    assert_eq!(
+        name(&mol("Cc1ccc(cc1)N([H])[H]")).unwrap(),
+        "4-methylaniline"
+    );
+}

--- a/scripts/iupac_snapshot_diff.py
+++ b/scripts/iupac_snapshot_diff.py
@@ -34,12 +34,26 @@ EXPECTED_H = {"C": 3, "O": 1, "N": 2, "F": 0, "Cl": 0, "Br": 0, "I": 0}
 
 
 def load(path):
+    """smiles -> (status, name). A duplicate SMILES line would otherwise be
+    silently collapsed to whichever occurrence came last (dict-assignment
+    overwrite) -- this gate's whole premise is "every input SMILES accounted
+    for in exactly one bucket" (see main()'s own assertion), so a duplicate
+    key is a data-integrity problem in the input TSV, not something to paper
+    over by picking one arbitrarily. Fail loudly instead."""
     rows = {}
     with open(path) as f:
-        for line in f:
+        for lineno, line in enumerate(f, start=1):
             parts = line.rstrip("\n").split("\t")
             smi, status = parts[0], parts[1]
             name = parts[2] if len(parts) > 2 else ""
+            if smi in rows:
+                print(
+                    f"FATAL: duplicate SMILES at {path}:{lineno}: {smi!r} "
+                    f"already seen as {rows[smi]!r}, now {status!r}/{name!r} -- "
+                    "refusing to silently overwrite one occurrence with the other",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
             rows[smi] = (status, name)
     return rows
 


### PR DESCRIPTION
Follow-up to PR #111 (merged as a468ebd), addressing review feedback caught after merge.

## Root cause

PR #111's "full heavy-atom coverage" gate compared against `Molecule::atom_count()`
(`self.atoms.len()`), which counts explicit bracket-`[H]` atoms as real entries — not
just heavy atoms. `classify_simple_benzene_substituent` already correctly folds
explicit-H neighbors into its own `total_h` count (so `"O[H]"` and `"O"` both classify
as hydroxy identically), but the coverage check immediately after it compared the
**wrong** count: `"Cc1ccc(cc1)O[H]"` has `atom_count()=9` while `ring_atoms.len()+2=8`,
so the coverage check rejected a substituent the classifier had just correctly accepted.

## Effect

`"Cc1ccc(cc1)O[H]"` (explicit-H p-cresol) and `"Cc1ccc(cc1)N([H])[H]"` (explicit-H
p-methylaniline) returned `Err(NotSupported)` while their implicit-H spellings
(`"Cc1ccc(cc1)O"`, `"Cc1ccc(cc1)N"`) correctly returned `Ok`. Same molecule, different
outcome depending purely on spelling — not a false-name bug, but an inconsistency the
fix's own explicit-H handling in the classifier should have prevented from surfacing at
the coverage-check layer.

## Fix

New `heavy_atom_count(mol)` helper in `rings.rs`, filtering to `atomic_number() != 1`,
used at both coverage-check call sites (`name_disubstituted_benzene`,
`name_trisubstituted_benzene`) instead of `atom_count()`.

## Tests

`test_issue92_explicit_h_substituent_matches_implicit_h_name`: asserts both spellings of
the same molecule (`O` vs `O[H]`, `N` vs `N([H])[H]`) produce the identical name.

## 5,000-molecule corpus audit

0 impact — this corpus contains no explicit-H-spelled benzene substituents, so
before/after are byte-identical (`downgraded=0, newly_ok=0, changed_name=0`). The fix's
effect is only observable via the new targeted regression test, not this corpus — noted
explicitly rather than claiming a corpus number that wouldn't show anything.

## Secondary fix: `scripts/iupac_snapshot_diff.py` duplicate-SMILES silent overwrite

`load()`'s `rows[smi] = (status, name)` silently overwrote a duplicate SMILES key from
the input TSV — a violation of the gate's own stated premise ("every input SMILES
accounted for in exactly one bucket") that could have hidden a real result under an
overwrite without the gate noticing. Now exits non-zero immediately, printing the
file/line and both conflicting values, on any duplicate key.

Positive-controlled: a synthetic 2-line duplicate TSV correctly produces `exit 1` with a
clear message. The real 5,000-molecule corpus has 0 duplicate SMILES (verified via `sort
SMILES.csv | uniq -d`), so this change doesn't alter this round's audit numbers.

## Non-regression

All 56 `chematic-iupac` tests pass (55 existing + 1 new). Full workspace
`cargo test --workspace --lib`: all green. `bash scripts/check.sh`: all checks passed.

## Checks

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p chematic-iupac` (56 passed)
- [x] `cargo test --workspace --lib` (all green)
- [x] `bash scripts/check.sh` (all checks passed)