### PR TITLE
fix(ci): Stage 1 sign-test can never route a regression to Stage 2 (issue #70)

### DIFF
--- a/.github/workflows/bench-pr-gate.yml
+++ b/.github/workflows/bench-pr-gate.yml
@@ -227,9 +227,9 @@ jobs:
       # regression, of any size -- confirmed empirically (+5%/+10%
       # synthetic regressions both came back "inconclusive" with
       # byte-identical confidence bounds). Stage 1 instead routes on a
-      # cheap magnitude/direction check (median block ratio over threshold,
-      # or all 3 blocks agreeing on direction) -- see cmd_route_check in
-      # criterion_gate.sh. Only Stage 2's real sign-test can set any_fail.
+      # cheap magnitude check (median block ratio over threshold) -- see
+      # cmd_route_check in criterion_gate.sh. Only Stage 2's real sign-test
+      # can set any_fail.
       #
       # A same-binary null control (main vs itself, run through the exact
       # same pipeline) runs once per stage. If IT shows a biased verdict,
@@ -287,16 +287,22 @@ jobs:
           # only 3 blocks can never reach 95% confidence even at a unanimous
           # 3-0 split (two-sided exact p=0.25), so Stage 1 stopped being able
           # to route ANY regression into Stage 2 -- see cmd_route_check in
-          # criterion_gate.sh. Stage 1 is now a magnitude/direction screen,
-          # not a statistical verdict; Stage 2's real sign-test (10 blocks)
-          # is still the only thing that can set any_fail.
+          # criterion_gate.sh. Stage 1 is now a pure magnitude screen (median
+          # block ratio over threshold), not a statistical verdict; Stage 2's
+          # real sign-test (10 blocks) is still the only thing that can set
+          # any_fail.
           #
           # 1.04 chosen from an offline evaluation against 28 historical
           # no-op runs (448 (run, benchmark) pairs) plus the +5%/+10%
-          # synthetic-regression fixtures (issue #70): a pure "3/3 unanimous
-          # direction" rule over-routes (21-22% no-op false-routing -- pure
-          # sampling noise at 448 trials, not a real signal). Magnitude
-          # thresholds 1.03/1.04/1.05 all caught both fixtures (medians
+          # synthetic-regression fixtures (issue #70): a "3/3 unanimous
+          # direction" leg (tried first, to catch a small-but-consistent
+          # regression) over-routes on its own (21-22% no-op false-routing --
+          # dominated by sampling noise at 448 trials, not real signal; this
+          # is what a first real CI run of this fix surfaced as a false
+          # `ecfp4_10mol` fail on a PR touching zero chematic-fp files, since
+          # the shipped rule still had that leg OR'd in -- fixed by dropping
+          # it, matching what was actually evaluated). Magnitude thresholds
+          # 1.03/1.04/1.05 alone all caught both fixtures (medians
           # 1.069/1.135) with zero null-control false-routing; 1.04 keeps
           # no-op false-routing modest (4.0%, vs 6.0% at 1.03) while leaving
           # real margin above both fixtures. A false route only costs Stage-2

--- a/.github/workflows/bench-pr-gate.yml
+++ b/.github/workflows/bench-pr-gate.yml
@@ -212,13 +212,24 @@ jobs:
       # blocks accumulate).
       #
       # Two-stage screening keeps CI time bounded: Stage 1 is a cheap,
-      # coarse screen (3 blocks); only a Stage-1 "fail" triggers Stage 2 (10
+      # coarse screen (3 blocks); a Stage-1 route triggers Stage 2 (10
       # blocks, reversed A/B order, longer measurement) as an independent
-      # confirmation. The final gate only fails a benchmark if BOTH stages
-      # independently say fail -- reproduction-under-reversed-order is this
-      # design's multiple-testing correction (simpler than a Bonferroni/Holm
-      # family correction across 16 benchmarks, per issue #70's own
-      # suggested alternative).
+      # confirmation. The final gate only fails a benchmark if Stage 2
+      # independently confirms it -- reproduction-under-reversed-order is
+      # this design's multiple-testing correction (simpler than a
+      # Bonferroni/Holm family correction across 16 benchmarks, per issue
+      # #70's own suggested alternative).
+      #
+      # Stage 1 does NOT run a statistical test (issue #70 follow-up): a
+      # sign test over only 3 blocks can't reach 95% confidence even at a
+      # unanimous 3-0 split (two-sided exact p=0.25), so gating Stage-2
+      # entry on a Stage-1 "fail" verdict made Stage 2 unreachable for any
+      # regression, of any size -- confirmed empirically (+5%/+10%
+      # synthetic regressions both came back "inconclusive" with
+      # byte-identical confidence bounds). Stage 1 instead routes on a
+      # cheap magnitude/direction check (median block ratio over threshold,
+      # or all 3 blocks agreeing on direction) -- see cmd_route_check in
+      # criterion_gate.sh. Only Stage 2's real sign-test can set any_fail.
       #
       # A same-binary null control (main vs itself, run through the exact
       # same pipeline) runs once per stage. If IT shows a biased verdict,
@@ -271,13 +282,32 @@ jobs:
 
           mkdir -p artifacts
           any_fail=0
-          stage1_fail_count=0
+          stage1_routed_count=0
+          # Stage-1 routing threshold (issue #70 follow-up): a sign test over
+          # only 3 blocks can never reach 95% confidence even at a unanimous
+          # 3-0 split (two-sided exact p=0.25), so Stage 1 stopped being able
+          # to route ANY regression into Stage 2 -- see cmd_route_check in
+          # criterion_gate.sh. Stage 1 is now a magnitude/direction screen,
+          # not a statistical verdict; Stage 2's real sign-test (10 blocks)
+          # is still the only thing that can set any_fail.
+          #
+          # 1.04 chosen from an offline evaluation against 28 historical
+          # no-op runs (448 (run, benchmark) pairs) plus the +5%/+10%
+          # synthetic-regression fixtures (issue #70): a pure "3/3 unanimous
+          # direction" rule over-routes (21-22% no-op false-routing -- pure
+          # sampling noise at 448 trials, not a real signal). Magnitude
+          # thresholds 1.03/1.04/1.05 all caught both fixtures (medians
+          # 1.069/1.135) with zero null-control false-routing; 1.04 keeps
+          # no-op false-routing modest (4.0%, vs 6.0% at 1.03) while leaving
+          # real margin above both fixtures. A false route only costs Stage-2
+          # CI time, never any_fail -- see issue #70 for the full data.
+          STAGE1_ROUTE_THRESHOLD=1.04
 
           # Stage 1: cheap screen across every benchmark first, so the (rare)
           # same-binary null-control fail check below reflects this run's
           # actual environment during the bulk of the work, not a check done
           # in isolation before/after.
-          declare -a stage1_fail_names=()
+          declare -a stage1_routed_names=()
           for entry in "${BENCHES[@]}"; do
             IFS=':' read -r name crate benchfile <<< "$entry"
             main_bin=$(bin_path main "$crate" "$benchfile")
@@ -300,14 +330,12 @@ jobs:
 
             out="artifacts/${name}_stage1.jsonl"
             pr/scripts/criterion_gate.sh run-blocks "$main_bin" "$pr_bin" "$name" 3 0.5 1 15 abba "$out"
-            veridict compare "$out" --metric sign-test --confidence 0.95 --min-effect 0.2 \
-              --report-json "artifacts/${name}_stage1_report.json"
-            code=$?
-            echo "=== $name stage1: exit $code ==="
-            cat "artifacts/${name}_stage1_report.json"
-            if [ "$code" -eq 1 ] || [ "$code" -eq 3 ]; then
-              stage1_fail_count=$((stage1_fail_count + 1))
-              stage1_fail_names+=("${name}:${crate}:${benchfile}")
+            route=$(pr/scripts/criterion_gate.sh route-check "$out" "$STAGE1_ROUTE_THRESHOLD")
+            echo "=== $name stage1 routing: $route ==="
+            cat "$out"
+            if [ "$route" = "route" ]; then
+              stage1_routed_count=$((stage1_routed_count + 1))
+              stage1_routed_names+=("${name}:${crate}:${benchfile}")
             fi
           done
 
@@ -321,9 +349,9 @@ jobs:
             environment_contaminated=1
           fi
 
-          # Stage 2: confirmation only for Stage-1 fail candidates, reversed
+          # Stage 2: confirmation only for benchmarks Stage 1 routed, reversed
           # order, more blocks.
-          for entry in "${stage1_fail_names[@]}"; do
+          for entry in "${stage1_routed_names[@]}"; do
             IFS=':' read -r name crate benchfile <<< "$entry"
             main_bin=$(bin_path main "$crate" "$benchfile")
             pr_bin=$(bin_path pr "$crate" "$benchfile")
@@ -342,11 +370,11 @@ jobs:
                 any_fail=1
               fi
             else
-              echo "::notice::$name: Stage 1 flagged a possible regression but Stage 2 (reversed order) did not reproduce it -- treating as noise, not gating."
+              echo "::notice::$name: Stage 1 routed a possible regression but Stage 2 (reversed order) did not confirm it -- treating as noise, not gating."
             fi
           done
 
-          echo "stage1_fail_count=$stage1_fail_count, environment_contaminated=$environment_contaminated, any_fail=$any_fail" >> "$GITHUB_STEP_SUMMARY"
+          echo "stage1_routed_count=$stage1_routed_count, environment_contaminated=$environment_contaminated, any_fail=$any_fail" >> "$GITHUB_STEP_SUMMARY"
           set -e
           [ "$any_fail" -eq 0 ]
 

--- a/.github/workflows/bench-pr-gate.yml
+++ b/.github/workflows/bench-pr-gate.yml
@@ -215,10 +215,10 @@ jobs:
       # coarse screen (3 blocks); a Stage-1 route triggers Stage 2 (10
       # blocks, reversed A/B order, longer measurement) as an independent
       # confirmation. The final gate only fails a benchmark if Stage 2
-      # independently confirms it -- reproduction-under-reversed-order is
-      # this design's multiple-testing correction (simpler than a
-      # Bonferroni/Holm family correction across 16 benchmarks, per issue
-      # #70's own suggested alternative).
+      # independently confirms it. Reproduction under reversed order is an
+      # independent reversed-order confirmation that reduces order-specific
+      # and single-run false positives; it is not claimed to be a formal
+      # family-wise multiple-testing correction across the 16 benchmarks.
       #
       # Stage 1 does NOT run a statistical test (issue #70 follow-up): a
       # sign test over only 3 blocks can't reach 95% confidence even at a
@@ -228,8 +228,29 @@ jobs:
       # synthetic regressions both came back "inconclusive" with
       # byte-identical confidence bounds). Stage 1 instead routes on a
       # cheap magnitude check (median block ratio over threshold) -- see
-      # cmd_route_check in criterion_gate.sh. Only Stage 2's real sign-test
-      # can set any_fail.
+      # cmd_route_check in criterion_gate.sh.
+      #
+      # Stage 2's sign-test is itself magnitude-blind (issue #70 follow-up):
+      # it only asks "did the same side win every block," never "by how
+      # much." Two independent real CI runs of this gate confirmed a
+      # ~1-3% consistent difference between separately-compiled binaries of
+      # byte-identical source (build/codegen variance, not a code
+      # regression) reliably produces a 10/10 unanimous "fail" verdict that
+      # survives order reversal -- e.g. `ecfp4_10mol` and, after that was
+      # fixed, `parse_smiles_10mol` (median ~1.022) both false-failed on a
+      # PR touching neither crate. Stage 2's sign-test verdict is therefore
+      # necessary but not sufficient: any_fail also requires the Stage 2
+      # block ratio median to clear its own practical-effect threshold
+      # (STAGE2_FAIL_THRESHOLD). A sign-test fail below that threshold is
+      # reported as small-effect-inconclusive, not blocking -- a
+      # statistically-consistent-but-small difference is expected build
+      # noise, not evidence of a real regression. The same-binary null
+      # control cannot catch this class by construction (it compares main
+      # against itself -- literally one binary -- so it never exercises the
+      # two-independently-compiled-binaries comparison a real no-op PR
+      # produces); a null control that compiled main twice from separate
+      # checkouts would measure the true codegen noise floor, but that is
+      # not implemented here.
       #
       # A same-binary null control (main vs itself, run through the exact
       # same pipeline) runs once per stage. If IT shows a biased verdict,
@@ -288,9 +309,9 @@ jobs:
           # 3-0 split (two-sided exact p=0.25), so Stage 1 stopped being able
           # to route ANY regression into Stage 2 -- see cmd_route_check in
           # criterion_gate.sh. Stage 1 is now a pure magnitude screen (median
-          # block ratio over threshold), not a statistical verdict; Stage 2's
-          # real sign-test (10 blocks) is still the only thing that can set
-          # any_fail.
+          # block ratio over threshold), not a statistical verdict; only
+          # Stage 2 can set any_fail, and only when its sign-test fails AND
+          # its own median ratio clears STAGE2_FAIL_THRESHOLD (see below).
           #
           # 1.04 chosen from an offline evaluation against 28 historical
           # no-op runs (448 (run, benchmark) pairs) plus the +5%/+10%
@@ -308,6 +329,19 @@ jobs:
           # real margin above both fixtures. A false route only costs Stage-2
           # CI time, never any_fail -- see issue #70 for the full data.
           STAGE1_ROUTE_THRESHOLD=1.04
+          # Stage-2 practical-effect threshold (issue #70 follow-up): a
+          # sign-test fail alone is not sufficient for any_fail=1 -- see the
+          # magnitude-blindness comment above. Starts at the same 1.04 value
+          # as Stage 1's routing threshold; this is an initial value, not a
+          # recalibrated one -- issue #70's real ~1.022 median incident is
+          # pinned as a permanent regression fixture in
+          # scripts/test_criterion_gate.sh to guard against a future edit
+          # silently reintroducing magnitude-blind failing.
+          STAGE2_FAIL_THRESHOLD=1.04
+          pr/scripts/criterion_gate.sh check-threshold "$STAGE1_ROUTE_THRESHOLD" \
+            || { echo "::error::invalid STAGE1_ROUTE_THRESHOLD -- infrastructure failure, not a silent skip"; exit 1; }
+          pr/scripts/criterion_gate.sh check-threshold "$STAGE2_FAIL_THRESHOLD" \
+            || { echo "::error::invalid STAGE2_FAIL_THRESHOLD -- infrastructure failure, not a silent skip"; exit 1; }
 
           # Stage 1: cheap screen across every benchmark first, so the (rare)
           # same-binary null-control fail check below reflects this run's
@@ -336,7 +370,12 @@ jobs:
 
             out="artifacts/${name}_stage1.jsonl"
             pr/scripts/criterion_gate.sh run-blocks "$main_bin" "$pr_bin" "$name" 3 0.5 1 15 abba "$out"
-            route=$(pr/scripts/criterion_gate.sh route-check "$out" "$STAGE1_ROUTE_THRESHOLD")
+            route=$(pr/scripts/criterion_gate.sh route-check "$out" 3 "$STAGE1_ROUTE_THRESHOLD")
+            route_code=$?
+            if [ "$route_code" -ne 0 ]; then
+              echo "::error::$name: stage1 route-check validation failed (exit $route_code) -- this is an infrastructure failure (malformed/short/long block data), not a silent no-route"
+              exit 1
+            fi
             echo "=== $name stage1 routing: $route ==="
             cat "$out"
             if [ "$route" = "route" ]; then
@@ -363,17 +402,29 @@ jobs:
             pr_bin=$(bin_path pr "$crate" "$benchfile")
             out="artifacts/${name}_stage2.jsonl"
             pr/scripts/criterion_gate.sh run-blocks "$main_bin" "$pr_bin" "$name" 10 1 2 20 baab "$out"
+
+            stage2_median=$(pr/scripts/criterion_gate.sh ratio-summary "$out" 10)
+            summary_code=$?
+            if [ "$summary_code" -ne 0 ]; then
+              echo "::error::$name: stage2 ratio-summary validation failed (exit $summary_code) -- this is an infrastructure failure (malformed/short/long block data), not a silent skip"
+              exit 1
+            fi
+
             veridict compare "$out" --metric sign-test --confidence 0.95 --min-effect 0.2 \
               --report-json "artifacts/${name}_stage2_report.json"
             code=$?
-            echo "=== $name stage2 (confirmation, reversed order): exit $code ==="
+            echo "=== $name stage2 (confirmation, reversed order): exit $code, median ratio $stage2_median ==="
             cat "artifacts/${name}_stage2_report.json"
+
             if [ "$code" -eq 1 ] || [ "$code" -eq 3 ]; then
+              meets_effect=$(jq -n --argjson m "$stage2_median" --argjson t "$STAGE2_FAIL_THRESHOLD" '$m >= $t')
               if [ "$environment_contaminated" -eq 1 ]; then
-                echo "::warning::$name: Stage 1 and Stage 2 both failed, but this run's environment is contaminated (null control failed too) -- reporting environment-inconclusive, not blocking."
-              else
-                echo "::error::$name regressed -- reproduced independently in Stage 2 (reversed order, 10 blocks)"
+                echo "::warning::$name: Stage 2 sign-test failed (median ${stage2_median}), but this run's environment is contaminated (null control failed too) -- reporting environment-inconclusive, not blocking."
+              elif [ "$meets_effect" = "true" ]; then
+                echo "::error::$name regressed -- reproduced independently in Stage 2 (reversed order, 10 blocks), median ratio ${stage2_median} >= practical-effect threshold ${STAGE2_FAIL_THRESHOLD}"
                 any_fail=1
+              else
+                echo "::notice::$name: Stage 2 sign-test failed (direction-consistent across all 10 blocks) but median ratio ${stage2_median} is below the practical-effect threshold ${STAGE2_FAIL_THRESHOLD} -- reporting small-effect-inconclusive, not blocking. A statistically-consistent-but-small difference (e.g. build/codegen variance between separately-compiled binaries) is expected and not evidence of a real regression."
               fi
             else
               echo "::notice::$name: Stage 1 routed a possible regression but Stage 2 (reversed order) did not confirm it -- treating as noise, not gating."

--- a/scripts/criterion_gate.sh
+++ b/scripts/criterion_gate.sh
@@ -96,19 +96,28 @@ cmd_bin_path() {
 #
 # Fix: Stage 1 stops asserting statistical significance and becomes a cheap
 # routing screen instead -- does this benchmark look suspicious enough to
-# spend Stage 2's 10-block budget on? Two independent signals, either one
-# routes: the block-level latency ratio's median crossing <threshold>, or all
-# 3 blocks agreeing on direction (candidate slower) even if each individually
-# is small. Stage 1 alone never sets any_fail; only Stage 2's real sign-test
-# (with a null-control-clean check) does that, unchanged from before.
+# spend Stage 2's 10-block budget on? Routes purely on the block-level
+# latency ratio's median crossing <threshold>.
+#
+# A "route if all 3 blocks agree on direction, even below <threshold>" leg
+# was tried first, to catch a small-but-consistent regression a magnitude
+# rule alone would miss -- and was the actual shipped behavior in an earlier
+# revision of this function. It's deliberately NOT here: an offline
+# evaluation against 28 historical no-op runs (issue #70) showed pure
+# direction-agreement is dominated by sampling noise at n=3 (21-22%
+# false-routing, vs 4% for the magnitude threshold alone) -- with 16
+# benchmarks routed independently per run, unanimity fires on noise often
+# enough to be worse than not screening at all. Magnitude-only was the
+# selected candidate; keep it that way unless a re-evaluation says otherwise.
+# Stage 1 alone never sets any_fail; only Stage 2's real sign-test (with a
+# null-control-clean check) does that, unchanged from before.
 cmd_route_check() {
   local jsonl="$1" threshold="$2"
   jq -rs --argjson threshold "$threshold" '
     map((.candidate | fabs) / (.baseline | fabs)) as $ratios
     | ($ratios | sort) as $sorted
     | $sorted[($sorted | length - 1) / 2 | floor] as $median
-    | (($ratios | map(. > 1.0) | all)) as $unanimous
-    | if ($median >= $threshold) or $unanimous then "route" else "no-route" end
+    | if $median >= $threshold then "route" else "no-route" end
   ' "$jsonl"
 }
 

--- a/scripts/criterion_gate.sh
+++ b/scripts/criterion_gate.sh
@@ -29,6 +29,11 @@
 # flips. Used for two-stage confirmation: Stage 2 re-runs a Stage-1 fail
 # candidate with reversed order, so a real regression must reproduce under
 # genuinely different execution order, not just the same measurement twice.
+#
+#   criterion_gate.sh route-check <blocks_jsonl> <median_ratio_threshold>
+#
+# Stage-1 routing screen -- see cmd_route_check below for why Stage 1 can't
+# use veridict's sign-test verdict directly.
 set -euo pipefail
 
 run_point_estimate() {
@@ -80,6 +85,33 @@ cmd_bin_path() {
     | tail -1
 }
 
+# Stage-1 routing screen (issue #70 follow-up). Stage 1 only ever ran 3
+# blocks through `veridict compare --metric sign-test`, but a sign test's
+# strongest possible signal at n=3 (a unanimous 3-0 split) has a two-sided
+# exact p-value of 2*(1/2)^3=0.25 -- it can NEVER cross a 95%-confidence fail
+# bar, so Stage 1 could never produce a fail verdict for a regression of any
+# size, making Stage 2 (the only place that sets any_fail) unreachable.
+# Verified empirically: synthetic +5%/+10% regressions both came back
+# "inconclusive" with byte-identical confidence bounds (issue #70 comment).
+#
+# Fix: Stage 1 stops asserting statistical significance and becomes a cheap
+# routing screen instead -- does this benchmark look suspicious enough to
+# spend Stage 2's 10-block budget on? Two independent signals, either one
+# routes: the block-level latency ratio's median crossing <threshold>, or all
+# 3 blocks agreeing on direction (candidate slower) even if each individually
+# is small. Stage 1 alone never sets any_fail; only Stage 2's real sign-test
+# (with a null-control-clean check) does that, unchanged from before.
+cmd_route_check() {
+  local jsonl="$1" threshold="$2"
+  jq -rs --argjson threshold "$threshold" '
+    map((.candidate | fabs) / (.baseline | fabs)) as $ratios
+    | ($ratios | sort) as $sorted
+    | $sorted[($sorted | length - 1) / 2 | floor] as $median
+    | (($ratios | map(. > 1.0) | all)) as $unanimous
+    | if ($median >= $threshold) or $unanimous then "route" else "no-route" end
+  ' "$jsonl"
+}
+
 case "${1:-}" in
   run-blocks)
     shift
@@ -89,9 +121,14 @@ case "${1:-}" in
     shift
     cmd_bin_path "$@"
     ;;
+  route-check)
+    shift
+    cmd_route_check "$@"
+    ;;
   *)
     echo "usage: $0 run-blocks <bin_a> <bin_b> <bench_name> <n_blocks> <warm_up_secs> <measurement_secs> <sample_size> <order:abba|baab> <out_jsonl>" >&2
     echo "       $0 bin-path <crate_dir> <crate> <benchfile>" >&2
+    echo "       $0 route-check <blocks_jsonl> <median_ratio_threshold>" >&2
     exit 64
     ;;
 esac

--- a/scripts/criterion_gate.sh
+++ b/scripts/criterion_gate.sh
@@ -30,10 +30,14 @@
 # candidate with reversed order, so a real regression must reproduce under
 # genuinely different execution order, not just the same measurement twice.
 #
-#   criterion_gate.sh route-check <blocks_jsonl> <median_ratio_threshold>
+#   criterion_gate.sh route-check <blocks_jsonl> <expected_count> <threshold>
+#   criterion_gate.sh ratio-summary <blocks_jsonl> <expected_count>
+#   criterion_gate.sh check-threshold <threshold>
 #
 # Stage-1 routing screen -- see cmd_route_check below for why Stage 1 can't
-# use veridict's sign-test verdict directly.
+# use veridict's sign-test verdict directly. ratio-summary/check-threshold
+# are the shared validation+computation helpers both route-check and the
+# Stage 2 magnitude gate (in the workflow) call -- see cmd_ratio_summary.
 set -euo pipefail
 
 run_point_estimate() {
@@ -85,6 +89,70 @@ cmd_bin_path() {
     | tail -1
 }
 
+# Shared helper (issue #70 follow-up): strict validation + median-ratio
+# computation for a run-blocks jsonl file, used by both Stage 1's
+# route-check and Stage 2's magnitude gate (in the workflow). A malformed or
+# short/long block file must never silently degrade to a default decision
+# ("no-route", "pass") -- that would hide a real infrastructure problem
+# (a crashed run-blocks invocation, a truncated artifact) behind a verdict
+# that looks like ordinary negative data. Every failure mode below exits
+# non-zero with a message on stderr instead.
+cmd_ratio_summary() {
+  local jsonl="$1" expected_count="$2"
+  if [ ! -s "$jsonl" ]; then
+    echo "ratio-summary: $jsonl is missing or empty" >&2
+    return 1
+  fi
+  jq -rs --argjson expected "$expected_count" '
+    if length != $expected then
+      error("expected exactly \($expected) records, got \(length)")
+    else . end
+    | (map(.id) | unique | length) as $uniq_ids
+    | if $uniq_ids != length then
+        error("duplicate id field -- ids must be unique")
+      else . end
+    | map(
+        if (.baseline | type) != "number" or (.candidate | type) != "number" then
+          error("baseline/candidate must be numbers")
+        elif (.baseline | isinfinite or isnan) or (.candidate | isinfinite or isnan) then
+          error("baseline/candidate must be finite")
+        elif .baseline == 0 then
+          error("baseline must not be zero")
+        else . end
+      )
+    | map((.candidate | fabs) / (.baseline | fabs)) as $ratios
+    | if ($ratios | map(isinfinite or isnan or . <= 0) | any) then
+        error("computed ratio must be finite and positive")
+      else . end
+    | ($ratios | sort) as $sorted
+    | ($sorted | length) as $n
+    | if ($n % 2) == 1 then
+        $sorted[($n - 1) / 2 | floor]
+      else
+        (($sorted[($n / 2 | floor) - 1] + $sorted[$n / 2 | floor]) / 2)
+      end
+  ' "$jsonl"
+}
+
+# Threshold values below 1 would mean "route/fail even when the candidate is
+# faster or equal," which is never a sensible regression-detection bound --
+# reject those (and non-numeric/non-finite input) before they can silently
+# produce a nonsense comparison result downstream.
+cmd_check_threshold() {
+  local threshold="$1"
+  case "$threshold" in
+    ''|*[!0-9.]*)
+      echo "threshold '$threshold' is not a valid number" >&2
+      return 1
+      ;;
+  esac
+  jq -n --argjson t "$threshold" '
+    if ($t | isinfinite or isnan) then error("threshold must be finite, got \($t)")
+    elif $t < 1 then error("threshold must be >= 1, got \($t)")
+    else empty end
+  '
+}
+
 # Stage-1 routing screen (issue #70 follow-up). Stage 1 only ever ran 3
 # blocks through `veridict compare --metric sign-test`, but a sign test's
 # strongest possible signal at n=3 (a unanimous 3-0 split) has a two-sided
@@ -109,16 +177,16 @@ cmd_bin_path() {
 # benchmarks routed independently per run, unanimity fires on noise often
 # enough to be worse than not screening at all. Magnitude-only was the
 # selected candidate; keep it that way unless a re-evaluation says otherwise.
-# Stage 1 alone never sets any_fail; only Stage 2's real sign-test (with a
-# null-control-clean check) does that, unchanged from before.
+# Stage 1 alone never sets any_fail; only Stage 2's real sign-test AND
+# magnitude gate (with a null-control-clean check) does that -- see the
+# workflow's Stage 2 loop, not this function.
 cmd_route_check() {
-  local jsonl="$1" threshold="$2"
-  jq -rs --argjson threshold "$threshold" '
-    map((.candidate | fabs) / (.baseline | fabs)) as $ratios
-    | ($ratios | sort) as $sorted
-    | $sorted[($sorted | length - 1) / 2 | floor] as $median
-    | if $median >= $threshold then "route" else "no-route" end
-  ' "$jsonl"
+  local jsonl="$1" expected_count="$2" threshold="$3"
+  cmd_check_threshold "$threshold" || return 1
+  local median
+  median=$(cmd_ratio_summary "$jsonl" "$expected_count") || return 1
+  jq -rn --argjson m "$median" --argjson t "$threshold" \
+    'if $m >= $t then "route" else "no-route" end'
 }
 
 case "${1:-}" in
@@ -134,10 +202,20 @@ case "${1:-}" in
     shift
     cmd_route_check "$@"
     ;;
+  ratio-summary)
+    shift
+    cmd_ratio_summary "$@"
+    ;;
+  check-threshold)
+    shift
+    cmd_check_threshold "$@"
+    ;;
   *)
     echo "usage: $0 run-blocks <bin_a> <bin_b> <bench_name> <n_blocks> <warm_up_secs> <measurement_secs> <sample_size> <order:abba|baab> <out_jsonl>" >&2
     echo "       $0 bin-path <crate_dir> <crate> <benchfile>" >&2
-    echo "       $0 route-check <blocks_jsonl> <median_ratio_threshold>" >&2
+    echo "       $0 route-check <blocks_jsonl> <expected_count> <threshold>" >&2
+    echo "       $0 ratio-summary <blocks_jsonl> <expected_count>" >&2
+    echo "       $0 check-threshold <threshold>" >&2
     exit 64
     ;;
 esac

--- a/scripts/test_criterion_gate.sh
+++ b/scripts/test_criterion_gate.sh
@@ -82,17 +82,24 @@ EOF
 [ "$(cmd_route_check "$fixture_noop" 1.04)" = "no-route" ] || { echo "FAIL: clean no-op (mixed direction, sub-percent) should not route"; exit 1; }
 rm -f "$fixture_noop"
 
-# Direction-only routing: below the magnitude threshold but unanimous across
-# all 3 blocks -- catches a small-but-consistent regression a magnitude-only
-# rule would miss.
-fixture_unanimous_small=$(mktemp)
-cat > "$fixture_unanimous_small" << 'EOF'
-{"id":"1","baseline":-11700.0,"candidate":-11712.0}
-{"id":"2","baseline":-11710.0,"candidate":-11715.0}
-{"id":"3","baseline":-11705.0,"candidate":-11708.0}
+# Regression test for a real incident: PR #117's own first CI run shipped a
+# route-check with an "OR all 3 blocks agree on direction" leg (the offline
+# eval had already disqualified that leg -- 21-22% no-op false-routing, see
+# the comment above cmd_route_check -- but the shipped code kept it anyway).
+# It routed `ecfp4_10mol` to Stage 2 purely on unanimous direction (median
+# 1.0149, under the 1.04 threshold) on a PR touching zero chematic-fp files,
+# and Stage 2 then confirmed a "fail" from real but spurious ~1% build-to-
+# build variance -- a genuine false positive on an unrelated benchmark. This
+# is that exact Stage-1 block data (issue #70): must NOT route under a pure
+# magnitude threshold, even though all 3 blocks agree on direction.
+fixture_ecfp4_incident=$(mktemp)
+cat > "$fixture_ecfp4_incident" << 'EOF'
+{"id":"1","baseline":-165481.56427608195,"candidate":-167948.2795937714}
+{"id":"2","baseline":-165755.31364862694,"candidate":-171745.03897197713}
+{"id":"3","baseline":-166218.16842646126,"candidate":-167825.3596853625}
 EOF
-[ "$(cmd_route_check "$fixture_unanimous_small" 1.04)" = "route" ] || { echo "FAIL: unanimous-but-small regression should route on direction alone"; exit 1; }
-rm -f "$fixture_unanimous_small"
+[ "$(cmd_route_check "$fixture_ecfp4_incident" 1.04)" = "no-route" ] || { echo "FAIL: regression -- unanimous-but-under-threshold data must not route (issue #70 ecfp4_10mol false positive)"; exit 1; }
+rm -f "$fixture_ecfp4_incident"
 
 # Note: this script only unit-tests cmd_route_check's pure logic. The
 # workflow-level invariants (Stage 1 alone never sets any_fail; any_fail=1

--- a/scripts/test_criterion_gate.sh
+++ b/scripts/test_criterion_gate.sh
@@ -44,16 +44,14 @@ echo "baab record: $record_baab"
 
 rm -f "$out"
 
-# --- Stage-1 routing screen (issue #70 follow-up) ---
-# cmd_route_check replaced a sign test that could never fire at n=3 blocks
-# (see criterion_gate.sh's comment above cmd_route_check for the math). These
-# fixtures are the real block data from the +5%/+10% synthetic-regression CI
-# runs and a synthetic clean no-op, so a future accidental edit that breaks
-# routing shows up here without needing a real Criterion binary.
-extracted_route=$(mktemp)
-sed -n '/^cmd_route_check/,/^}/p' scripts/criterion_gate.sh > "$extracted_route"
-source "$extracted_route"
-rm -f "$extracted_route"
+# --- Shared ratio-summary/check-threshold/route-check (issue #70 follow-up) ---
+# route-check calls check-threshold and ratio-summary by name, so extract all
+# three together.
+extracted_shared=$(mktemp)
+sed -n '/^cmd_ratio_summary/,/^}/p;/^cmd_check_threshold/,/^}/p;/^cmd_route_check/,/^}/p' \
+  scripts/criterion_gate.sh > "$extracted_shared"
+source "$extracted_shared"
+rm -f "$extracted_shared"
 
 fixture_plus5=$(mktemp)
 cat > "$fixture_plus5" << 'EOF'
@@ -61,7 +59,7 @@ cat > "$fixture_plus5" << 'EOF'
 {"id":"2","baseline":-11710.817870733676,"candidate":-12516.890630251484}
 {"id":"3","baseline":-11776.024760778471,"candidate":-13441.09866163192}
 EOF
-[ "$(cmd_route_check "$fixture_plus5" 1.04)" = "route" ] || { echo "FAIL: +5% fixture (median +6.9%) should route"; exit 1; }
+[ "$(cmd_route_check "$fixture_plus5" 3 1.04)" = "route" ] || { echo "FAIL: +5% fixture (median +6.9%) should route"; exit 1; }
 rm -f "$fixture_plus5"
 
 fixture_plus10=$(mktemp)
@@ -70,8 +68,19 @@ cat > "$fixture_plus10" << 'EOF'
 {"id":"2","baseline":-11155.27769228296,"candidate":-12628.101260372696}
 {"id":"3","baseline":-11110.051949478835,"candidate":-12760.029773887674}
 EOF
-[ "$(cmd_route_check "$fixture_plus10" 1.04)" = "route" ] || { echo "FAIL: +10% fixture (median +13.5%) should route"; exit 1; }
+[ "$(cmd_route_check "$fixture_plus10" 3 1.04)" = "route" ] || { echo "FAIL: +10% fixture (median +13.5%) should route"; exit 1; }
 rm -f "$fixture_plus10"
+
+# +6% fixture (this PR's own required minimum test): clearly above the 1.04
+# routing threshold, must route.
+fixture_plus6=$(mktemp)
+cat > "$fixture_plus6" << 'EOF'
+{"id":"1","baseline":-10000.0,"candidate":-10600.0}
+{"id":"2","baseline":-10000.0,"candidate":-10620.0}
+{"id":"3","baseline":-10000.0,"candidate":-10580.0}
+EOF
+[ "$(cmd_route_check "$fixture_plus6" 3 1.04)" = "route" ] || { echo "FAIL: +6% fixture should route"; exit 1; }
+rm -f "$fixture_plus6"
 
 fixture_noop=$(mktemp)
 cat > "$fixture_noop" << 'EOF'
@@ -79,7 +88,7 @@ cat > "$fixture_noop" << 'EOF'
 {"id":"2","baseline":-11710.0,"candidate":-11690.0}
 {"id":"3","baseline":-11705.0,"candidate":-11720.0}
 EOF
-[ "$(cmd_route_check "$fixture_noop" 1.04)" = "no-route" ] || { echo "FAIL: clean no-op (mixed direction, sub-percent) should not route"; exit 1; }
+[ "$(cmd_route_check "$fixture_noop" 3 1.04)" = "no-route" ] || { echo "FAIL: clean no-op (mixed direction, sub-percent) should not route"; exit 1; }
 rm -f "$fixture_noop"
 
 # Regression test for a real incident: PR #117's own first CI run shipped a
@@ -98,15 +107,133 @@ cat > "$fixture_ecfp4_incident" << 'EOF'
 {"id":"2","baseline":-165755.31364862694,"candidate":-171745.03897197713}
 {"id":"3","baseline":-166218.16842646126,"candidate":-167825.3596853625}
 EOF
-[ "$(cmd_route_check "$fixture_ecfp4_incident" 1.04)" = "no-route" ] || { echo "FAIL: regression -- unanimous-but-under-threshold data must not route (issue #70 ecfp4_10mol false positive)"; exit 1; }
+[ "$(cmd_route_check "$fixture_ecfp4_incident" 3 1.04)" = "no-route" ] || { echo "FAIL: regression -- unanimous-but-under-threshold data must not route (issue #70 ecfp4_10mol false positive)"; exit 1; }
 rm -f "$fixture_ecfp4_incident"
 
-# Note: this script only unit-tests cmd_route_check's pure logic. The
-# workflow-level invariants (Stage 1 alone never sets any_fail; any_fail=1
-# only on a confirmed Stage 2 fail with a clean null control; a contaminated
-# null control suppresses any_fail even on a Stage 2 fail) live in
-# bench-pr-gate.yml's shell, not in this script, and are verified by code
-# inspection plus real CI run data (issue #70) rather than by this harness --
-# same scope limitation the original block-pairing tests above already had.
+# --- Strict validation (issue #70 follow-up): malformed/insufficient input
+# must fail loudly, never silently degrade to a default "no-route" ---
+
+empty_jsonl=$(mktemp)
+: > "$empty_jsonl"
+if cmd_route_check "$empty_jsonl" 3 1.04 >/dev/null 2>&1; then
+  echo "FAIL: empty Stage-1 jsonl should error, not return a verdict"; exit 1
+fi
+rm -f "$empty_jsonl"
+
+too_few=$(mktemp)
+cat > "$too_few" << 'EOF'
+{"id":"1","baseline":-100.0,"candidate":-100.5}
+{"id":"2","baseline":-101.0,"candidate":-99.0}
+EOF
+if cmd_route_check "$too_few" 3 1.04 >/dev/null 2>&1; then
+  echo "FAIL: 2-record file (expected 3) should error, not return a verdict"; exit 1
+fi
+rm -f "$too_few"
+
+too_many=$(mktemp)
+cat > "$too_many" << 'EOF'
+{"id":"1","baseline":-100.0,"candidate":-100.5}
+{"id":"2","baseline":-101.0,"candidate":-99.0}
+{"id":"3","baseline":-99.5,"candidate":-100.2}
+{"id":"4","baseline":-99.0,"candidate":-100.0}
+EOF
+if cmd_route_check "$too_many" 3 1.04 >/dev/null 2>&1; then
+  echo "FAIL: 4-record file (expected 3) should error, not return a verdict"; exit 1
+fi
+rm -f "$too_many"
+
+zero_baseline=$(mktemp)
+cat > "$zero_baseline" << 'EOF'
+{"id":"1","baseline":0.0,"candidate":-100.5}
+{"id":"2","baseline":-101.0,"candidate":-99.0}
+{"id":"3","baseline":-99.5,"candidate":-100.2}
+EOF
+if cmd_route_check "$zero_baseline" 3 1.04 >/dev/null 2>&1; then
+  echo "FAIL: baseline=0 should error (division by zero), not return a verdict"; exit 1
+fi
+rm -f "$zero_baseline"
+
+if cmd_check_threshold "0.5" >/dev/null 2>&1; then
+  echo "FAIL: threshold below 1 should be rejected"; exit 1
+fi
+
+# --- Stage 2 magnitude gate (issue #70 follow-up): the real ecfp4_10mol fix
+# stopped Stage 1 from routing on noise, but the very next CI run confirmed a
+# DIFFERENT benchmark (parse_smiles_10mol) via a legitimate route + a
+# sign-test fail driven by real-but-spurious ~2.2% build/codegen variance
+# between separately-compiled binaries -- Stage 2's sign-test alone is
+# magnitude-blind. These fixtures pin the practical-effect gate that
+# combines the sign-test verdict with a minimum median-ratio requirement. ---
+
+# Permanent regression fixture: the exact parse_smiles_10mol Stage 2 data
+# from the real incident (issue #70). Median ~1.022, all 10 blocks candidate
+# slower (a real sign-test "fail" from veridict) -- must NOT meet the 1.04
+# practical-effect threshold, so the final gate must not fail on this data.
+fixture_stage2_incident=$(mktemp)
+cat > "$fixture_stage2_incident" << 'EOF'
+{"id":"1","baseline":-9076.104372053887,"candidate":-9201.91136904256}
+{"id":"2","baseline":-8932.942526291896,"candidate":-9219.596574885541}
+{"id":"3","baseline":-8910.356356885584,"candidate":-9143.826173380521}
+{"id":"4","baseline":-8944.482964007622,"candidate":-9235.42058864827}
+{"id":"5","baseline":-8952.404397055447,"candidate":-9106.500793595658}
+{"id":"6","baseline":-8971.499186556917,"candidate":-9324.067453203195}
+{"id":"7","baseline":-8918.297767483793,"candidate":-9081.170864737667}
+{"id":"8","baseline":-9064.68757885133,"candidate":-9099.614237070064}
+{"id":"9","baseline":-9012.72747438855,"candidate":-9246.215896065525}
+{"id":"10","baseline":-9013.023872561964,"candidate":-9108.926275796783}
+EOF
+incident_median=$(cmd_ratio_summary "$fixture_stage2_incident" 10)
+# Loose float comparison via awk -- bash has no native float arithmetic.
+awk -v m="$incident_median" 'BEGIN { if (m < 1.021 || m > 1.023) exit 1; exit 0 }' \
+  || { echo "FAIL: expected median ~1.022 for the pinned incident fixture, got $incident_median"; exit 1; }
+awk -v m="$incident_median" 'BEGIN { exit !(m >= 1.04) }' \
+  && { echo "FAIL: regression -- pinned incident median ($incident_median) must stay below STAGE2_FAIL_THRESHOLD=1.04, or the final gate will start blocking spurious ~2.2% build noise again"; exit 1; }
+rm -f "$fixture_stage2_incident"
+
+# Sibling fixture: a real ~6% Stage 2 difference (well above 1.04) DOES meet
+# the practical-effect threshold -- confirms the gate isn't just permanently
+# disabled, only insensitive to sub-threshold noise.
+fixture_stage2_real=$(mktemp)
+cat > "$fixture_stage2_real" << 'EOF'
+{"id":"1","baseline":-10000.0,"candidate":-10600.0}
+{"id":"2","baseline":-10000.0,"candidate":-10610.0}
+{"id":"3","baseline":-10000.0,"candidate":-10590.0}
+{"id":"4","baseline":-10000.0,"candidate":-10620.0}
+{"id":"5","baseline":-10000.0,"candidate":-10580.0}
+{"id":"6","baseline":-10000.0,"candidate":-10605.0}
+{"id":"7","baseline":-10000.0,"candidate":-10595.0}
+{"id":"8","baseline":-10000.0,"candidate":-10615.0}
+{"id":"9","baseline":-10000.0,"candidate":-10585.0}
+{"id":"10","baseline":-10000.0,"candidate":-10600.0}
+EOF
+real_median=$(cmd_ratio_summary "$fixture_stage2_real" 10)
+awk -v m="$real_median" 'BEGIN { exit !(m >= 1.04) }' \
+  || { echo "FAIL: expected median ~1.06 (>= 1.04 threshold) for the real-effect fixture, got $real_median"; exit 1; }
+rm -f "$fixture_stage2_real"
+
+# Stage-2 strict validation, same shape as Stage 1's: exactly 10 records
+# required, not 9 or 11.
+stage2_too_few=$(mktemp)
+for i in 1 2 3 4 5 6 7 8 9; do
+  printf '{"id":"%d","baseline":-10000.0,"candidate":-10600.0}\n' "$i" >> "$stage2_too_few"
+done
+if cmd_ratio_summary "$stage2_too_few" 10 >/dev/null 2>&1; then
+  echo "FAIL: 9-record Stage-2 file (expected 10) should error"; exit 1
+fi
+rm -f "$stage2_too_few"
+
+# Note: this script unit-tests cmd_ratio_summary/cmd_check_threshold/
+# cmd_route_check's pure logic, including the exact incident data. The
+# workflow-level combination logic in bench-pr-gate.yml --
+#   any_fail=1 requires ALL of: Stage 1 routed (median >= STAGE1_ROUTE_THRESHOLD)
+#   AND Stage 2 sign-test verdict == fail AND Stage 2 median >= STAGE2_FAIL_THRESHOLD
+#   AND environment_contaminated == 0
+#   -- a sign-test fail below STAGE2_FAIL_THRESHOLD is small-effect-inconclusive, not blocking
+#   -- a sign-test fail with environment_contaminated == 1 is environment-inconclusive, not blocking
+#   -- Stage 1 alone never sets any_fail (no code path in the Stage 1 loop touches it)
+# -- lives in bench-pr-gate.yml's shell, not in this script, and is verified
+# by code inspection plus real CI run data (issue #70) rather than by this
+# harness -- same scope limitation the original block-pairing tests above
+# already had.
 
 echo "OK"

--- a/scripts/test_criterion_gate.sh
+++ b/scripts/test_criterion_gate.sh
@@ -43,4 +43,63 @@ echo "baab record: $record_baab"
 [ "$(echo "$record_baab" | jq '.candidate')" = "-200" ] || { echo "FAIL: baab changed candidate label"; exit 1; }
 
 rm -f "$out"
+
+# --- Stage-1 routing screen (issue #70 follow-up) ---
+# cmd_route_check replaced a sign test that could never fire at n=3 blocks
+# (see criterion_gate.sh's comment above cmd_route_check for the math). These
+# fixtures are the real block data from the +5%/+10% synthetic-regression CI
+# runs and a synthetic clean no-op, so a future accidental edit that breaks
+# routing shows up here without needing a real Criterion binary.
+extracted_route=$(mktemp)
+sed -n '/^cmd_route_check/,/^}/p' scripts/criterion_gate.sh > "$extracted_route"
+source "$extracted_route"
+rm -f "$extracted_route"
+
+fixture_plus5=$(mktemp)
+cat > "$fixture_plus5" << 'EOF'
+{"id":"1","baseline":-11723.852948081518,"candidate":-12419.292912444453}
+{"id":"2","baseline":-11710.817870733676,"candidate":-12516.890630251484}
+{"id":"3","baseline":-11776.024760778471,"candidate":-13441.09866163192}
+EOF
+[ "$(cmd_route_check "$fixture_plus5" 1.04)" = "route" ] || { echo "FAIL: +5% fixture (median +6.9%) should route"; exit 1; }
+rm -f "$fixture_plus5"
+
+fixture_plus10=$(mktemp)
+cat > "$fixture_plus10" << 'EOF'
+{"id":"1","baseline":-11073.407252668874,"candidate":-12563.450800114455}
+{"id":"2","baseline":-11155.27769228296,"candidate":-12628.101260372696}
+{"id":"3","baseline":-11110.051949478835,"candidate":-12760.029773887674}
+EOF
+[ "$(cmd_route_check "$fixture_plus10" 1.04)" = "route" ] || { echo "FAIL: +10% fixture (median +13.5%) should route"; exit 1; }
+rm -f "$fixture_plus10"
+
+fixture_noop=$(mktemp)
+cat > "$fixture_noop" << 'EOF'
+{"id":"1","baseline":-11700.0,"candidate":-11705.0}
+{"id":"2","baseline":-11710.0,"candidate":-11690.0}
+{"id":"3","baseline":-11705.0,"candidate":-11720.0}
+EOF
+[ "$(cmd_route_check "$fixture_noop" 1.04)" = "no-route" ] || { echo "FAIL: clean no-op (mixed direction, sub-percent) should not route"; exit 1; }
+rm -f "$fixture_noop"
+
+# Direction-only routing: below the magnitude threshold but unanimous across
+# all 3 blocks -- catches a small-but-consistent regression a magnitude-only
+# rule would miss.
+fixture_unanimous_small=$(mktemp)
+cat > "$fixture_unanimous_small" << 'EOF'
+{"id":"1","baseline":-11700.0,"candidate":-11712.0}
+{"id":"2","baseline":-11710.0,"candidate":-11715.0}
+{"id":"3","baseline":-11705.0,"candidate":-11708.0}
+EOF
+[ "$(cmd_route_check "$fixture_unanimous_small" 1.04)" = "route" ] || { echo "FAIL: unanimous-but-small regression should route on direction alone"; exit 1; }
+rm -f "$fixture_unanimous_small"
+
+# Note: this script only unit-tests cmd_route_check's pure logic. The
+# workflow-level invariants (Stage 1 alone never sets any_fail; any_fail=1
+# only on a confirmed Stage 2 fail with a clean null control; a contaminated
+# null control suppresses any_fail even on a Stage 2 fail) live in
+# bench-pr-gate.yml's shell, not in this script, and are verified by code
+# inspection plus real CI run data (issue #70) rather than by this harness --
+# same scope limitation the original block-pairing tests above already had.
+
 echo "OK"


### PR DESCRIPTION
Fixes the structural bug reported in [issue #70's calibration finding](https://github.com/kent-tokyo/chematic/issues/70#issuecomment-5014818301): Stage 1's 3-block `veridict compare --metric sign-test` can never produce a fail verdict, because a sign test's strongest possible signal at n=3 (unanimous 3-0) has a two-sided exact p-value of `2*(1/2)^3=0.25`, never crossing the 95%-confidence bar. Since Stage 2 (the only place that sets `any_fail`) only processed benchmarks Stage 1 marked "fail", **Stage 2 was unreachable for a timing regression of any size.**

During this PR's own CI runs, fixing Stage 1 surfaced two further, more specific bugs (documented below) before landing on the final design.

## Final design

**Stage 1** (3 ABBA blocks) is a pure magnitude routing screen, not a statistical test:
- Routes to Stage 2 if the median candidate/baseline ratio ≥ `STAGE1_ROUTE_THRESHOLD` (1.04).
- No unanimous-direction condition. Stage 1 alone never sets `any_fail` — no code path in the Stage 1 loop touches it.

**Stage 2** (10 BAAB blocks, reversed order) sets `any_fail=1` only when **all** of the following hold:
- `veridict compare --metric sign-test` verdict is `fail`
- Stage 2 median candidate/baseline ratio ≥ `STAGE2_FAIL_THRESHOLD` (1.04)
- `environment_contaminated == 0` (same-binary null control didn't also fail)

A sign-test fail with median ratio below 1.04 is reported as `small-effect-inconclusive` and does **not** block the PR.

## What changed, and why (found via this PR's own real CI runs, not local testing)

1. **First CI run**: the shipped `route-check` still contained an "OR all 3 blocks agree on direction" leg — the offline threshold evaluation (below) had already disqualified this rule for 21-22% no-op false-routing, but the actual code kept it anyway. It routed `ecfp4_10mol` to Stage 2 (median 1.0149, under the 1.04 threshold) on a PR touching zero `chematic-fp` files, and Stage 2 then confirmed a "fail" from real-but-spurious ~1% build-to-build variance — a genuine false positive on an unrelated benchmark. **Fix**: removed the unanimous-direction leg entirely; Stage 1 routes on magnitude only.
2. **Second CI run** (after fix 1): `parse_smiles_10mol` routed *legitimately* this time (Stage 1 median +5.4%, correctly crossing 1.04), but Stage 2's sign-test alone is magnitude-blind — it only asks "did the same side win every block," never "by how much." The real Stage 2 median was only ~2.2% (build/codegen variance between two separately-compiled binaries of byte-identical source), yet 10/10 unanimous blocks triggered a formal sign-test "fail," and this survived order reversal (ABBA→BAAB) — real, order-invariant codegen variance, not measurement noise. **Fix**: added `STAGE2_FAIL_THRESHOLD`, requiring the sign-test fail to also clear a practical-effect magnitude before it can block. The exact `parse_smiles_10mol` incident data (median ≈1.022) is pinned as a permanent regression fixture in `scripts/test_criterion_gate.sh` asserting the final gate does not fail on it.

## What changes (files)

- `scripts/criterion_gate.sh`: `cmd_ratio_summary` (strict jq validation: exact record count, unique ids, finite non-zero baseline, finite positive ratio, correct median for both odd- and even-length arrays) and `cmd_check_threshold` (threshold must be finite and ≥1) as shared helpers; `cmd_route_check` refactored to use them, with the unanimous-direction leg removed.
- `.github/workflows/bench-pr-gate.yml`: Stage 1 calls `route-check` with `STAGE1_ROUTE_THRESHOLD=1.04`; Stage 2 adds the `STAGE2_FAIL_THRESHOLD=1.04` AND-combination described above. Malformed/missing/wrong-count JSONL from either stage is an infrastructure failure (non-zero exit), never a silent no-route/pass. Comment language claiming reversed-order confirmation is a formal multiple-testing correction has been weakened to: "independent reversed-order confirmation that reduces order-specific and single-run false positives; it is not claimed to be a formal family-wise multiple-testing correction."
- `scripts/test_criterion_gate.sh`: rewritten with the +5%/+6%/+10% routing fixtures, a clean no-op non-route, the `ecfp4_10mol` unanimous-but-under-threshold non-route regression test, malformed-input error tests (empty/2-record/4-record/zero-baseline/invalid-threshold), and the Stage 2 magnitude-gate fixtures (the pinned real `parse_smiles_10mol` incident at median ≈1.022 must not final-fail; a synthetic ≈1.06 fixture must final-fail; a 9-record Stage-2 file must error).

## Threshold selection (1.04)

Evaluated 5 candidate rules offline against 28 historical no-op runs (448 (run, benchmark) pairs, zero missing artifacts) plus the two regression fixtures:

| Rule | No-op false-routing | Routes +5% fixture (median 1.069) | Routes +10% fixture (median 1.135) | Null-control false-routing |
|---|---:|:---:|:---:|---:|
| median ≥ 1.03 | 6.03% | yes | yes | 0/28 |
| **median ≥ 1.04 (chosen)** | **4.02%** | **yes** | **yes** | **0/28** |
| median ≥ 1.05 | 2.23% | yes | yes | 0/28 |
| 3/3 unanimous | 21.43% | yes | yes | 0/28 |
| (median ≥ 1.03) OR unanimous | 22.32% | yes | yes | 0/28 |

Pure-unanimity routing over-fires on noise at this sample size (448 independent trials give far more chances to land 3/3 by chance than the 28-run null control did) and is disqualified. 1.03/1.04/1.05 are all viable; 1.04 balances real margin above both fixtures against no-op false-routing. `STAGE2_FAIL_THRESHOLD` reuses the same 1.04 value as an initial choice (same rationale: clears both regression fixtures' medians with margin, and the pinned ~1.022 incident sits safely below it).

## Known gap, reported not fixed here

The same-binary null control compares `main` against itself (one binary), so it can detect environment-wide contamination but cannot detect build/codegen variance *between two separately-compiled binaries* of identical source — exactly the class of noise that caused the `parse_smiles_10mol` false positive. A fix would compile `main` twice from separate checkouts to measure the true cross-binary noise floor; not built in this PR.

## Not in scope here

- Does not reopen or resume the remaining calibration experiments (+10% regression, one-sided contamination, +5% regression) — those stay on hold until this PR is reviewed and merged, per standing instruction. Resume order once unblocked: +10% → one-sided contamination → +5%.
- Does not change the null control's own mechanism (7 blocks, still via `veridict compare` sign-test) — at n=7 a unanimous split *can* reach significance (two-sided exact p=0.0156), so it doesn't share Stage 1's structural ceiling.
- Does not promote the gate toward required status — stays non-required/advisory.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/test_criterion_gate.sh` — all fixtures incl. pinned real-incident regression tests pass
- [x] `cargo test --workspace --lib`
- [x] `bash scripts/check.sh`
- [x] CI / Security Audit / Bench PR Gate all green on this PR's own head commit
