### PR TITLE
docs(mcp): align tool inventory and capability descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,17 +207,23 @@ chematic ships a native **MCP (Model Context Protocol) server** — the first ch
 }
 ```
 
-15 chemistry tools are callable from any MCP-compatible agent:
+20 chemistry tools are callable from any MCP-compatible agent (full list in the
+[`chematic-mcp` README](crates/chematic-mcp/README.md)):
 
 | Tool | What it does |
 |---|---|
-| `name_to_smiles` | Resolve "aspirin", "caffeine", … to SMILES via PubChem |
-| `calc_properties` | MW, LogP, TPSA, HBA/HBD, QED, SA Score, pKa, ADMET |
+| `name_to_smiles` | Resolve "aspirin", "caffeine", … to SMILES via PubChem (the only tool that makes a network call) |
+| `calc_properties` | MW, exact mass, Crippen LogP, TPSA, HBD, HBA, rotatable bonds, QED |
 | `smarts_match` | Substructure search |
 | `pains_check` / `brenk_check` | Flag assay interference or reactive groups |
-| `generate_3d` | 3D coordinates (ETKDG + MMFF94) |
+| `generate_3d` | 3D coordinates via rule-based placement + DREIDING force-field minimization |
 | `find_mcs` | Maximum common substructure |
-| + 9 more | `ecfp4`, `tanimoto`, `canonical_smiles`, `admet_profile`, `boiled_egg`, `sa_score`, `lipinski_check` … |
+| + 13 more | `ecfp4`, `tanimoto`, `canonical_smiles`, `admet_profile`, `boiled_egg`, `sa_score`, `lipinski_check`, `retrosynthesis`, `smiles_to_moljson`, `moljson_to_smiles`, `representation_router`, `molecule_context_pack`, `parse_smiles` |
+
+**Transport**: stdio (JSON-RPC 2.0 over stdin/stdout) only. Runs as a local
+process; there is no hosted Remote MCP endpoint, no authentication, and no
+public service SLA — a remote-ready refactor is under consideration but not
+implemented.
 
 ---
 
@@ -321,7 +327,7 @@ Full history → [benchmarks/](benchmarks/) · Methodology → [validation/](val
 | InChI / InChIKey                             | **Yes** — pure-Rust + **IUPAC-exact** via `native-inchi` | C lib required | C lib required | C lib required |
 | **pKa prediction**                           | **Yes (15 SMARTS rules)**                        | No                  | No             | No                |
 | **ADMET profile** (BBB/Caco-2/hERG/CYP3A4)  | **Yes + BOILED-Egg**                             | Partial             | No             | Partial           |
-| **MCP server (AI agent API)**                | **Yes — 15 tools incl. Name→SMILES**            | No                  | No             | No                |
+| **MCP server (AI agent API)**                | **Yes — 20 tools incl. Name→SMILES (stdio only)** | No                  | No             | No                |
 | IUPAC name generation                        | **Yes (25+ classes)**                            | No                  | No             | Partial           |
 | Name → SMILES (PubChem proxy)                | **Yes** (`name_to_smiles` MCP tool)              | No                  | No             | No                |
 | Maintenance (2026)                           | Active                                           | Active              | Minimal        | Active            |

--- a/README_ja.md
+++ b/README_ja.md
@@ -131,17 +131,19 @@ chematic は **MCP（Model Context Protocol）サーバー**をネイティブ�
 }
 ```
 
-MCP 対応エージェントから呼び出せる 15 の化学ツール：
+MCP 対応エージェントから呼び出せる 20 の化学ツール（全リストは [`chematic-mcp` README](crates/chematic-mcp/README.md) 参照）：
 
 | ツール | 機能 |
 |---|---|
-| `name_to_smiles` | 化合物名（"アスピリン"、"カフェイン"…）を PubChem 経由で SMILES に変換 |
-| `calc_properties` | MW、LogP、TPSA、HBA/HBD、QED、SA Score、pKa、ADMET |
+| `name_to_smiles` | 化合物名（"アスピリン"、"カフェイン"…）を PubChem 経由で SMILES に変換(外部通信を行う唯一のツール) |
+| `calc_properties` | MW、exact mass、Crippen LogP、TPSA、HBD、HBA、rotatable bonds、QED |
 | `smarts_match` | 部分構造検索 |
 | `pains_check` / `brenk_check` | アッセイ干渉・反応性フラグ付け |
-| `generate_3d` | 3D 座標生成（ETKDG + MMFF94） |
+| `generate_3d` | rule-based配置 + DREIDING力場最小化による3D座標生成 |
 | `find_mcs` | 最大共通部分構造 |
-| その他 9 ツール | `ecfp4`、`tanimoto`、`canonical_smiles`、`admet_profile`、`boiled_egg`、`sa_score`、`lipinski_check`… |
+| その他 13 ツール | `ecfp4`、`tanimoto`、`canonical_smiles`、`admet_profile`、`boiled_egg`、`sa_score`、`lipinski_check`、`retrosynthesis`、`smiles_to_moljson`、`moljson_to_smiles`、`representation_router`、`molecule_context_pack`、`parse_smiles` |
+
+**Transport**: stdio（標準入出力経由の JSON-RPC 2.0）のみ。ローカルプロセスとして動作し、公開された Remote MCP エンドポイント・認証・公開サービス SLA は存在しない。remote 対応のリファクタは検討中だが未実装。
 
 ---
 
@@ -203,7 +205,7 @@ npm パッケージ `@kent-tokyo/chematic` は **719 KB gzip** — RDKit.js の�
 | InChI / InChIKey                            | **あり** — 純 Rust（デフォルト）+ **IUPAC 準拠**（`native-inchi`）| C ライブラリ必要 | C ライブラリ必要 | C ライブラリ必要 |
 | **pKa 予測**                                | **あり（15 SMARTS ルール）**               | なし               | なし          | なし             |
 | **ADMET プロファイル + BOILED-Egg**         | **あり**                                   | 一部               | なし          | 一部             |
-| **MCP サーバー（AI エージェント API）**     | **あり — 20 ツール（Name→SMILES 含む）**  | なし               | なし          | なし             |
+| **MCP サーバー（AI エージェント API）**     | **あり — 20 ツール（Name→SMILES 含む、stdio のみ）**  | なし               | なし          | なし             |
 | IUPAC 名生成                                | **あり（25+ 化合物クラス）**               | なし               | なし          | 一部             |
 | メンテナンス（2026）                        | アクティブ                                 | アクティブ         | 最小限        | アクティブ       |
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -116,17 +116,19 @@ chematic 是首个内置 **MCP（模型上下文协议）服务器**的化学信
 }
 ```
 
-15 个化学工具可由任意 MCP 兼容代理调用：
+20 个化学工具可由任意 MCP 兼容代理调用（完整列表见 [`chematic-mcp` README](crates/chematic-mcp/README.md)）：
 
 | 工具 | 功能 |
 |---|---|
-| `name_to_smiles` | 通过 PubChem 将化合物名（"阿司匹林"…）解析为 SMILES |
-| `calc_properties` | MW、LogP、TPSA、HBA/HBD、QED、SA Score、pKa、ADMET |
+| `name_to_smiles` | 通过 PubChem 将化合物名（"阿司匹林"…）解析为 SMILES（唯一进行网络通信的工具） |
+| `calc_properties` | MW、exact mass、Crippen LogP、TPSA、HBD、HBA、rotatable bonds、QED |
 | `smarts_match` | 子结构搜索 |
 | `pains_check` / `brenk_check` | 筛查检测干扰或活性基团 |
-| `generate_3d` | 3D 坐标生成（ETKDG + MMFF94） |
+| `generate_3d` | 基于规则的坐标放置 + DREIDING 力场最小化生成 3D 坐标 |
 | `find_mcs` | 最大公共子结构 |
-| 其余 9 个 | `ecfp4`、`tanimoto`、`canonical_smiles`、`admet_profile`、`boiled_egg`、`sa_score`、`lipinski_check`… |
+| 其余 13 个 | `ecfp4`、`tanimoto`、`canonical_smiles`、`admet_profile`、`boiled_egg`、`sa_score`、`lipinski_check`、`retrosynthesis`、`smiles_to_moljson`、`moljson_to_smiles`、`representation_router`、`molecule_context_pack`、`parse_smiles` |
+
+**Transport**：仅 stdio（通过标准输入输出的 JSON-RPC 2.0）。以本地进程方式运行，目前没有已托管的 Remote MCP 端点、身份验证或公开服务 SLA；remote 化的重构正在考虑中，尚未实现。
 
 ---
 
@@ -175,7 +177,7 @@ npm 包 `@kent-tokyo/chematic` 为 **719 KB gzip** — 比 RDKit.js 小约 42 �
 | InChI / InChIKey                             | **有** — 纯 Rust（默认）+ **IUPAC 标准**（`native-inchi`）| 需 C 库 | 需 C 库 | 需 C 库 |
 | **pKa 预测**                                 | **有（15 条 SMARTS 规则）**                  | 无                 | 无            | 无                |
 | **ADMET 简况 + BOILED-Egg**                  | **有**                                       | 部分               | 无            | 部分              |
-| **MCP 服务器（AI Agent API）**               | **有 — 20 个工具（含 Name→SMILES）**        | 无                 | 无            | 无                |
+| **MCP 服务器（AI Agent API）**               | **有 — 20 个工具（含 Name→SMILES，仅 stdio）** | 无                 | 无            | 无                |
 | IUPAC 命名生成                               | **有（25+ 化合物类）**                       | 无                 | 无            | 部分              |
 | 维护状态（2026）                             | 活跃                                         | 活跃               | 最小维护      | 活跃              |
 

--- a/crates/chematic-mcp/README.md
+++ b/crates/chematic-mcp/README.md
@@ -4,8 +4,16 @@ MCP (Model Context Protocol) server for chematic — call cheminformatics tools 
 
 ## Overview
 
-`chematic-mcp` exposes 15 cheminformatics tools via JSON-RPC 2.0 over stdio,
+`chematic-mcp` exposes 20 cheminformatics tools via JSON-RPC 2.0 over stdio,
 making them directly callable by Claude and other MCP-compatible AI agents.
+
+**Transport status**: stdio only. The server runs as a local OS process reading
+newline-delimited JSON-RPC 2.0 from stdin and writing responses to stdout —
+there is no hosted Remote MCP endpoint, no authentication, and no public
+service SLA. A remote-ready refactor (transport-neutral protocol handling, so
+a Streamable HTTP adapter could be added without rewriting tool logic) is
+under consideration but not implemented; nothing here is reachable over the
+network except the one tool noted below.
 
 ```toml
 [dependencies]
@@ -32,9 +40,12 @@ responses to stdout. Add it to your Claude Desktop or Claude Code MCP config:
 }
 ```
 
-## Available tools (15)
+## Available tools (20)
 
 ### Name resolution (requires internet)
+
+This is the **only** tool of the 20 that makes a network call. The other 19
+are pure local computation — see [Network & privacy](#network--privacy) below.
 
 | Tool | Description |
 |------|-------------|
@@ -84,6 +95,21 @@ responses to stdout. Add it to your Claude Desktop or Claude Code MCP config:
 |------|-------------|
 | `generate_3d` | 3D coordinates via rule-based placement + DREIDING minimization (XYZ) |
 
+### Retrosynthesis
+
+| Tool | Description |
+|------|-------------|
+| `retrosynthesis` | One-step BRICS disconnection, all breakable bonds cut individually, ranked by max fragment SA Score |
+
+### Format conversion & LLM integration
+
+| Tool | Description |
+|------|-------------|
+| `smiles_to_moljson` | SMILES → MolJSON (explicit atom/bond JSON representation for LLM consumption) |
+| `moljson_to_smiles` | MolJSON → canonical SMILES |
+| `representation_router` | Route SMILES to the molecular text representation best suited to a given LLM task (MolJSON/CML/InChI/canonical SMILES) |
+| `molecule_context_pack` | Assemble identifiers, properties, drug-likeness, ADMET, and MolJSON into a single LLM/RAG context object (json/markdown/prompt output) |
+
 ## Example call
 
 ```json
@@ -96,8 +122,21 @@ Response:
 {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"{\"gi_absorbed\":true,\"bbb_penetrant\":false,\"logp\":1.316,\"tpsa\":63.6,\"method\":\"BOILED-Egg (Daina & Zoete 2016)\"}"}]}}
 ```
 
+## Network & privacy
+
+- **19 of 20 tools are pure local computation** — no network I/O, no external
+  service dependency, nothing leaves the process.
+- **`name_to_smiles` is the one exception.** The chemical name string you pass
+  it is sent, URL-encoded, to the public PubChem REST API
+  (`pubchem.ncbi.nlm.nih.gov`) over HTTPS with a 10-second timeout. If PubChem
+  is unreachable, slow, or returns an unexpected response, the tool call
+  fails — it does not fall back to local computation, since there is none for
+  name resolution.
+- If you're working with proprietary or privacy-sensitive compound names,
+  be aware `name_to_smiles` is the only tool where your input crosses the
+  network; the other 19 never do.
+
 ## Design
 
-- **Mostly local** — 14 of 15 tools are pure computation with no network I/O. `name_to_smiles` is the exception (PubChem REST, requires internet).
 - **No unsafe code** — `#![forbid(unsafe_code)]` enforced.
 - **WASM-incompatible** — stdio transport requires OS process; use `chematic-wasm` for browser.

--- a/crates/chematic-mcp/src/lib.rs
+++ b/crates/chematic-mcp/src/lib.rs
@@ -23,17 +23,10 @@
 //!
 //! ## Available tools
 //!
-//! | Tool | Description |
-//! |------|-------------|
-//! | `parse_smiles` | Parse SMILES → atoms, bonds, MW |
-//! | `calc_properties` | LogP, TPSA, MW, HBD, HBA, QED |
-//! | `ecfp4` | ECFP4 fingerprint (2048-bit hex) |
-//! | `tanimoto` | ECFP4 Tanimoto similarity |
-//! | `smarts_match` | Substructure search |
-//! | `canonical_smiles` | Canonicalize SMILES |
-//! | `find_mcs` | Maximum common substructure |
-//! | `generate_3d` | 3D coordinates (XYZ) |
-//! | `retrosynthesis` | One-step BRICS disconnection, ranked by SA Score |
+//! 20 tools total; see `crates/chematic-mcp/README.md` for the full,
+//! categorized list with descriptions (kept there, not duplicated here, so
+//! there is exactly one place to update when a tool is added or changed).
+//! `tools::list_tools()` is the actual runtime source of truth.
 
 #![forbid(unsafe_code)]
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -197,7 +197,7 @@ python scripts/bench5k.py path/to/SMILES.csv --detail
 |---------|----------|-------|
 | pKa prediction | Built-in (15 SMARTS rules) | External tool required |
 | ADMET profile (BBB, Caco-2, hERG, CYP3A4) | Built-in | External tool required |
-| MCP server (AI agent integration) | 15 tools | Not available |
+| MCP server (AI agent integration) | 20 tools (stdio only) | Not available |
 | LSH approximate nearest-neighbour index | Built-in | Not available |
 | IUPAC name generation | Built-in (offline) | Not available |
 | Browser / WASM deployment | Yes (719 KB) | No |

--- a/docs/mcp/tool-inventory.md
+++ b/docs/mcp/tool-inventory.md
@@ -1,0 +1,198 @@
+# chematic-mcp tool inventory
+
+**This is a manually maintained snapshot, not a generated artifact.** It is
+not the single source of truth for `chematic-mcp`'s tool catalog — that
+remains `crates/chematic-mcp/src/tools.rs` (`list_tools()` / `call_tool()`)
+until a PR 2 registry refactor can generate this document (or replace it)
+from a single typed definition. If this file and `tools.rs` ever disagree,
+`tools.rs` is correct.
+
+## Classification axes
+
+Adapted from the remote-readiness design discussion (not yet implemented as
+Rust types — this document uses them as prose labels only):
+
+- **Determinism**: `Deterministic` (same input → same output, always) /
+  `Stochastic` (uses randomization) / `ExternalDependent` (result depends on
+  a third-party service's state at call time).
+- **Result method**: `Algorithmic` (exact computation over the input
+  structure) / `RuleBasedEstimate` (empirical/heuristic model — screening
+  estimate, not a measurement) / `HeuristicSearch` (explores a solution
+  space without a completeness guarantee).
+- **Completeness**: `Complete` (always runs to a definitive result) /
+  `TimeoutLimited` (may return a truncated/non-optimal result under a time
+  budget) / `BestEffort` (may fail outright — network dependency, or a
+  heuristic that doesn't guarantee it found anything).
+
+No tool in this inventory uses randomization — verified by grepping
+`chematic-3d`, `chematic-chem`, and `chematic-smarts` for `rand::`/
+`thread_rng`/`StdRng`/`SmallRng` (no hits). `generate_3d`'s "rule-based
+placement + DREIDING minimization" and `find_mcs`'s search are both
+deterministic per-run given identical input, not randomized.
+
+## Tools
+
+### `parse_smiles`
+- Description: Parse a SMILES string → atom count, bond count, molecular weight.
+- Local/network: local
+- Determinism: Deterministic — Result method: Algorithmic — Completeness: Complete
+- High cost: No
+- Explicit limits: none
+- Caveats: no SMILES length limit; unbounded input size.
+
+### `calc_properties`
+- Description: MW, exact mass, Crippen LogP, TPSA, HBD, HBA, rotatable bond count, heavy atom count, QED.
+- Local/network: local
+- Determinism: Deterministic — Result method: **mixed** (MW/exact mass/TPSA/HBD/HBA/rotatable bonds/heavy atom count are exact structural computations; LogP (Crippen atom-contribution) and QED (weighted composite) are empirical `RuleBasedEstimate`) — Completeness: Complete
+- High cost: No
+- Explicit limits: none
+- Caveats: bundles exact counts and empirical estimates in one JSON object without a field-level distinction — a caller cannot currently tell which of the 9 fields are exact vs. modeled without reading this document.
+
+### `ecfp4`
+- Description: ECFP4 (Morgan radius-2) circular fingerprint, 2048-bit hex + popcount.
+- Local/network: local
+- Determinism: Deterministic (within chematic's own implementation) — Result method: Algorithmic — Completeness: Complete
+- High cost: No
+- Explicit limits: none
+- Caveats: deterministic and reproducible within chematic, but **not** guaranteed RDKit bit-exact by default — chematic's ECFP4 invariant includes aromaticity, RDKit's default does not (see `ecfp4_agreement_methodology` in project history).
+
+### `tanimoto`
+- Description: Tanimoto (Jaccard) similarity between two molecules' ECFP4 fingerprints.
+- Local/network: local
+- Determinism: Deterministic — Result method: Algorithmic — Completeness: Complete
+- High cost: No
+- Explicit limits: none
+- Caveats: inherits `ecfp4`'s non-RDKit-bit-exact caveat.
+
+### `smarts_match`
+- Description: SMARTS substructure search — match count + atom index maps.
+- Local/network: local
+- Determinism: Deterministic — Result method: Algorithmic (VF2-based exact isomorphism) — Completeness: Complete (exhaustive match enumeration)
+- High cost: **Potentially** — subgraph isomorphism is worst-case exponential; no timeout guard exists for this tool (unlike `find_mcs`).
+- Explicit limits: none
+- Caveats: an adversarial SMARTS/molecule pair could run long with no internal cutoff.
+
+### `canonical_smiles`
+- Description: Canonical SMILES representation.
+- Local/network: local
+- Determinism: Deterministic — Result method: Algorithmic — Completeness: Complete
+- High cost: No
+- Explicit limits: none
+- Caveats: deterministic and reproducible within chematic, but the canonical **string** is chematic's own canonical form — not necessarily identical to RDKit's canonical SMILES for the same molecule (different canonicalization algorithms, both valid).
+
+### `find_mcs`
+- Description: Maximum common substructure across 2–20 molecules.
+- Local/network: local
+- Determinism: Deterministic — Result method: Algorithmic — Completeness: **TimeoutLimited** (internal 5000ms budget; a run that hits the budget returns the best substructure found so far, not necessarily the true maximum)
+- High cost: Yes — MCS is NP-hard in general; this is one of two tools with an internal timeout for exactly that reason.
+- Explicit limits: 2–20 molecules, ≤200 atoms per molecule, 5000ms internal search timeout.
+- Caveats: do not describe this tool's result as "the" MCS without qualification — under the timeout it is a best-effort lower bound.
+
+### `generate_3d`
+- Description: 3D coordinates via rule-based placement + DREIDING force-field minimization (XYZ).
+- Local/network: local
+- Determinism: Deterministic (verified: no RNG anywhere in `chematic-3d`) — Result method: HeuristicSearch (DREIDING minimization is a local energy optimization from a heuristic starting geometry, not a guaranteed global minimum) — Completeness: Complete for normal inputs (iteration/convergence behavior on pathological inputs not independently verified in this audit)
+- High cost: **Yes, and unguarded** — no atom-count limit exists for this tool at all, unlike `find_mcs`/`retrosynthesis`.
+- Explicit limits: **none** (known gap — see the audit's resource-risk findings)
+- Caveats: single deterministic conformer, not an ensemble or global-minimum search; DREIDING is an approximate universal force field, not a high-accuracy method.
+
+### `pains_check`
+- Description: PAINS (Pan-Assay Interference Compounds) structural alerts.
+- Local/network: local
+- Determinism: Deterministic (SMARTS pattern matching against a fixed alert list is deterministic execution) — Result method: RuleBasedEstimate (the alert list itself is a curated empirical correlation, Baell & Holloway 2010, not a physical law) — Completeness: Complete
+- High cost: No
+- Explicit limits: none
+- Caveats: a match indicates historical association with assay interference in specific HTS contexts, not a guarantee of interference in any given assay; absence of alerts is not a guarantee of clean behavior.
+
+### `brenk_check`
+- Description: Brenk structural alerts (toxicity / metabolic instability / reactivity).
+- Local/network: local
+- Determinism: Deterministic — Result method: RuleBasedEstimate (Brenk et al. 2008 empirical alert list) — Completeness: Complete
+- High cost: No
+- Explicit limits: none
+- Caveats: same as `pains_check` — empirical alert list, not a predictive toxicology model.
+
+### `sa_score`
+- Description: Synthetic accessibility score (Ertl & Schuffenhauer 2009), 1 (easy) to 10 (hard).
+- Local/network: local
+- Determinism: Deterministic — Result method: RuleBasedEstimate (fragment-contribution empirical scoring) — Completeness: Complete
+- High cost: No
+- Explicit limits: none
+- Caveats: an empirical estimate correlated with fragment frequency in known compounds, not a retrosynthetic feasibility proof.
+
+### `admet_profile`
+- Description: BBB, Caco-2, hERG, CYP3A4, AMES, PPB, hepatic clearance.
+- Local/network: local
+- Determinism: Deterministic — Result method: RuleBasedEstimate — Completeness: Complete
+- High cost: No
+- Explicit limits: none
+- Caveats: **every field is a rule-based/QSAR-style screening estimate, not an experimental measurement or clinical/regulatory conclusion.** This is the clearest case in the catalog where the current tool description ("Full ADMET profile") risks reading as more authoritative than the underlying method supports.
+
+### `boiled_egg`
+- Description: BOILED-Egg (Daina & Zoete 2016) — GI absorption + BBB zone prediction from LogP/TPSA thresholds.
+- Local/network: local
+- Determinism: Deterministic — Result method: RuleBasedEstimate (threshold-based empirical classification) — Completeness: Complete
+- High cost: No
+- Explicit limits: none
+- Caveats: threshold classification, not a mechanistic permeability simulation.
+
+### `lipinski_check`
+- Description: Lipinski's Rule of Five with per-rule breakdown.
+- Local/network: local
+- Determinism: Deterministic — Result method: RuleBasedEstimate — Completeness: Complete
+- High cost: No
+- Explicit limits: none
+- Caveats: a heuristic screening rule with well-known exceptions (many approved oral drugs violate Ro5); pass/fail is not a bioavailability guarantee in either direction.
+
+### `name_to_smiles`
+- Description: Chemical name → isomeric SMILES via the PubChem REST API.
+- Local/network: **network** — the only tool in the catalog that makes an external call.
+- Determinism: **ExternalDependent** (result depends on PubChem's database content and availability at call time, not solely on chematic's own code) — Result method: Algorithmic (direct lookup, not a computed estimate) — Completeness: **BestEffort** (fails outright on network/PubChem issues; no local fallback)
+- High cost: No (bounded by a 10-second HTTP timeout)
+- Explicit limits: name ≤500 characters, 10s HTTP timeout.
+- Caveats: input name is sent, URL-encoded, to `pubchem.ncbi.nlm.nih.gov`; see `crates/chematic-mcp/README.md`'s Network & privacy section. Result depends on PubChem's database being current and correct.
+
+### `retrosynthesis`
+- Description: One-step BRICS disconnection, all breakable bonds cut individually, ranked by max fragment SA Score.
+- Local/network: local
+- Determinism: Deterministic — Result method: **HeuristicSearch** — Completeness: **BestEffort** (a single-step rule-based disconnection proposal, not a complete or exhaustive retrosynthetic search)
+- High cost: Potentially, near the atom-count ceiling (BRICS enumeration + per-bond BFS + 2× SA-score per breakable bond).
+- Explicit limits: ≤500 atoms, single connected component required.
+- Caveats: do not describe this as "the" retrosynthesis or a validated route — it is a rule-based (BRICS) one-step disconnection proposal that does not account for reagent availability, reaction feasibility, or stereochemistry, and does not search beyond one disconnection step.
+
+### `smiles_to_moljson`
+- Description: SMILES → MolJSON.
+- Local/network: local
+- Determinism: Deterministic — Result method: Algorithmic — Completeness: Complete
+- High cost: No
+- Explicit limits: none
+
+### `moljson_to_smiles`
+- Description: MolJSON → canonical SMILES.
+- Local/network: local
+- Determinism: Deterministic — Result method: Algorithmic — Completeness: Complete
+- High cost: No
+- Explicit limits: **none** — no length cap on the input `json` string.
+
+### `representation_router`
+- Description: Route SMILES to the molecular text representation (MolJSON/CML/InChI/canonical SMILES) best suited to a given LLM task.
+- Local/network: local
+- Determinism: Deterministic — Result method: **mixed** (the underlying format conversions are Algorithmic/exact; the task→representation mapping itself is a heuristic recommendation from one specific paper (arXiv 2026), not a universal standard) — Completeness: Complete
+- High cost: No
+- Explicit limits: none
+- Caveats: the "best" representation choice reflects one paper's recommendation, not a guarantee that it is optimal for every downstream LLM/task.
+
+### `molecule_context_pack`
+- Description: Identifiers, physicochemical properties, drug-likeness flags, ADMET profile, structural alerts, and MolJSON in one object (json/markdown/prompt output).
+- Local/network: local
+- Determinism: Deterministic — Result method: **mixed** (bundles exact identifiers/MolJSON with empirical LogP/QED/SA/ADMET/PAINS/Brenk estimates) — Completeness: Complete
+- High cost: No (aggregates several already-covered lighter calls; no single expensive step)
+- Explicit limits: none
+- Caveats: the most heavily mixed tool in the catalog — inherits every caveat listed above for the individual estimates it bundles (Crippen LogP, QED, `sa_score`, `admet_profile`, PAINS/Brenk), none of which are distinguished from the exact fields in the output.
+
+## Known cross-cutting gaps (see the PR 1 audit for full detail)
+
+- No tool declares `readOnlyHint`/`destructiveHint` (all 20 are in fact read-only/non-destructive, but this isn't machine-declared).
+- No tool declares the network-access / determinism / completeness axes above as structured metadata — this document is the only place they exist today.
+- Only `find_mcs`, `retrosynthesis`, and `name_to_smiles` have any explicit input/size limit; the other 17 are unbounded.
+- `generate_3d` is both high-cost and has no limit at all — the largest concrete resource-risk gap in the catalog.

--- a/docs/mcp/tool-inventory.md
+++ b/docs/mcp/tool-inventory.md
@@ -12,13 +12,19 @@ from a single typed definition. If this file and `tools.rs` ever disagree,
 Adapted from the remote-readiness design discussion (not yet implemented as
 Rust types — this document uses them as prose labels only):
 
-- **Determinism**: `Deterministic` (same input → same output, always) /
-  `Stochastic` (uses randomization) / `ExternalDependent` (result depends on
-  a third-party service's state at call time).
+- **Determinism**: `DeterministicByDesign` (no intentional random sampling is
+  used) / `Stochastic` (uses randomization) / `ExternalDependent` (result
+  depends on a third-party service's state at call time). `DeterministicByDesign`
+  is **not**, by itself, a guarantee of byte-identical results across
+  processes, platforms, hash seeds, or timeout-limited executions — it only
+  means no `rand`/RNG call is in the path. `HashMap`/`HashSet` iteration
+  order, floating-point results across platforms, and timeout-limited search
+  cutoffs can all still vary without any randomization being involved.
 - **Result method**: `Algorithmic` (exact computation over the input
   structure) / `RuleBasedEstimate` (empirical/heuristic model — screening
   estimate, not a measurement) / `HeuristicSearch` (explores a solution
-  space without a completeness guarantee).
+  space without a completeness guarantee) / `ExternalLookup` (retrieves a
+  value from a third-party database rather than computing one).
 - **Completeness**: `Complete` (always runs to a definitive result) /
   `TimeoutLimited` (may return a truncated/non-optimal result under a time
   budget) / `BestEffort` (may fail outright — network dependency, or a
@@ -26,16 +32,18 @@ Rust types — this document uses them as prose labels only):
 
 No tool in this inventory uses randomization — verified by grepping
 `chematic-3d`, `chematic-chem`, and `chematic-smarts` for `rand::`/
-`thread_rng`/`StdRng`/`SmallRng` (no hits). `generate_3d`'s "rule-based
-placement + DREIDING minimization" and `find_mcs`'s search are both
-deterministic per-run given identical input, not randomized.
+`thread_rng`/`StdRng`/`SmallRng` (no hits). That rules out *stochastic*
+sampling as a source of variation for `generate_3d` and `find_mcs`; it does
+not by itself establish byte-identical output across runs, machines, or
+timeout-affected executions — see each tool's own entry below for what is
+and isn't established.
 
 ## Tools
 
 ### `parse_smiles`
 - Description: Parse a SMILES string → atom count, bond count, molecular weight.
 - Local/network: local
-- Determinism: Deterministic — Result method: Algorithmic — Completeness: Complete
+- Determinism: DeterministicByDesign — Result method: Algorithmic — Completeness: Complete
 - High cost: No
 - Explicit limits: none
 - Caveats: no SMILES length limit; unbounded input size.
@@ -43,7 +51,7 @@ deterministic per-run given identical input, not randomized.
 ### `calc_properties`
 - Description: MW, exact mass, Crippen LogP, TPSA, HBD, HBA, rotatable bond count, heavy atom count, QED.
 - Local/network: local
-- Determinism: Deterministic — Result method: **mixed** (MW/exact mass/TPSA/HBD/HBA/rotatable bonds/heavy atom count are exact structural computations; LogP (Crippen atom-contribution) and QED (weighted composite) are empirical `RuleBasedEstimate`) — Completeness: Complete
+- Determinism: DeterministicByDesign — Result method: **mixed** (MW/exact mass/TPSA/HBD/HBA/rotatable bonds/heavy atom count are exact structural computations; LogP (Crippen atom-contribution) and QED (weighted composite) are empirical `RuleBasedEstimate`) — Completeness: Complete
 - High cost: No
 - Explicit limits: none
 - Caveats: bundles exact counts and empirical estimates in one JSON object without a field-level distinction — a caller cannot currently tell which of the 9 fields are exact vs. modeled without reading this document.
@@ -51,7 +59,7 @@ deterministic per-run given identical input, not randomized.
 ### `ecfp4`
 - Description: ECFP4 (Morgan radius-2) circular fingerprint, 2048-bit hex + popcount.
 - Local/network: local
-- Determinism: Deterministic (within chematic's own implementation) — Result method: Algorithmic — Completeness: Complete
+- Determinism: DeterministicByDesign (within chematic's own implementation) — Result method: Algorithmic — Completeness: Complete
 - High cost: No
 - Explicit limits: none
 - Caveats: deterministic and reproducible within chematic, but **not** guaranteed RDKit bit-exact by default — chematic's ECFP4 invariant includes aromaticity, RDKit's default does not (see `ecfp4_agreement_methodology` in project history).
@@ -59,7 +67,7 @@ deterministic per-run given identical input, not randomized.
 ### `tanimoto`
 - Description: Tanimoto (Jaccard) similarity between two molecules' ECFP4 fingerprints.
 - Local/network: local
-- Determinism: Deterministic — Result method: Algorithmic — Completeness: Complete
+- Determinism: DeterministicByDesign — Result method: Algorithmic — Completeness: Complete
 - High cost: No
 - Explicit limits: none
 - Caveats: inherits `ecfp4`'s non-RDKit-bit-exact caveat.
@@ -67,7 +75,7 @@ deterministic per-run given identical input, not randomized.
 ### `smarts_match`
 - Description: SMARTS substructure search — match count + atom index maps.
 - Local/network: local
-- Determinism: Deterministic — Result method: Algorithmic (VF2-based exact isomorphism) — Completeness: Complete (exhaustive match enumeration)
+- Determinism: DeterministicByDesign — Result method: Algorithmic (VF2-based exact isomorphism) — Completeness: Complete (exhaustive match enumeration)
 - High cost: **Potentially** — subgraph isomorphism is worst-case exponential; no timeout guard exists for this tool (unlike `find_mcs`).
 - Explicit limits: none
 - Caveats: an adversarial SMARTS/molecule pair could run long with no internal cutoff.
@@ -75,7 +83,7 @@ deterministic per-run given identical input, not randomized.
 ### `canonical_smiles`
 - Description: Canonical SMILES representation.
 - Local/network: local
-- Determinism: Deterministic — Result method: Algorithmic — Completeness: Complete
+- Determinism: DeterministicByDesign — Result method: Algorithmic — Completeness: Complete
 - High cost: No
 - Explicit limits: none
 - Caveats: deterministic and reproducible within chematic, but the canonical **string** is chematic's own canonical form — not necessarily identical to RDKit's canonical SMILES for the same molecule (different canonicalization algorithms, both valid).
@@ -83,23 +91,23 @@ deterministic per-run given identical input, not randomized.
 ### `find_mcs`
 - Description: Maximum common substructure across 2–20 molecules.
 - Local/network: local
-- Determinism: Deterministic — Result method: Algorithmic — Completeness: **TimeoutLimited** (internal 5000ms budget; a run that hits the budget returns the best substructure found so far, not necessarily the true maximum)
+- Determinism: Deterministic search procedure, **EnvironmentSensitive outcome under timeout** — the search algorithm itself has no randomization, but the 5000ms wall-clock budget means the same input can hit the cutoff at a different point in the search on a slower machine or a loaded runner, changing the returned result. Not `DeterministicByDesign` without qualification. — Result method: Algorithmic — Completeness: **TimeoutLimited** (internal 5000ms budget; a run that hits the budget returns the best substructure found so far, not necessarily the true maximum)
 - High cost: Yes — MCS is NP-hard in general; this is one of two tools with an internal timeout for exactly that reason.
 - Explicit limits: 2–20 molecules, ≤200 atoms per molecule, 5000ms internal search timeout.
-- Caveats: do not describe this tool's result as "the" MCS without qualification — under the timeout it is a best-effort lower bound.
+- Caveats: do not describe this tool's result as "the" MCS without qualification — under the timeout it is a best-effort lower bound, and the exact result can vary run-to-run on borderline-slow inputs depending on machine speed/load.
 
 ### `generate_3d`
 - Description: 3D coordinates via rule-based placement + DREIDING force-field minimization (XYZ).
 - Local/network: local
-- Determinism: Deterministic (verified: no RNG anywhere in `chematic-3d`) — Result method: HeuristicSearch (DREIDING minimization is a local energy optimization from a heuristic starting geometry, not a guaranteed global minimum) — Completeness: Complete for normal inputs (iteration/convergence behavior on pathological inputs not independently verified in this audit)
+- Determinism: DeterministicByDesign (verified: no RNG anywhere in `chematic-3d`) — Result method: HeuristicSearch (DREIDING minimization is a local energy optimization from a heuristic starting geometry, not a guaranteed global minimum) — Completeness: **BestEffort**
 - High cost: **Yes, and unguarded** — no atom-count limit exists for this tool at all, unlike `find_mcs`/`retrosynthesis`.
 - Explicit limits: **none** (known gap — see the audit's resource-risk findings)
-- Caveats: single deterministic conformer, not an ensemble or global-minimum search; DREIDING is an approximate universal force field, not a high-accuracy method.
+- Caveats: single deterministic conformer, not an ensemble or global-minimum search; DREIDING is an approximate universal force field, not a high-accuracy method. `BestEffort`, not `Complete`, because: coordinate generation or minimization can fail to produce a usable geometry for some inputs; local minimization is not guaranteed to converge to (or even near) the global minimum; convergence has not been proven or tested across the full space of possible inputs; and there is no atom-count or time budget guarding the minimization step, so behavior on large/pathological inputs is unverified.
 
 ### `pains_check`
 - Description: PAINS (Pan-Assay Interference Compounds) structural alerts.
 - Local/network: local
-- Determinism: Deterministic (SMARTS pattern matching against a fixed alert list is deterministic execution) — Result method: RuleBasedEstimate (the alert list itself is a curated empirical correlation, Baell & Holloway 2010, not a physical law) — Completeness: Complete
+- Determinism: DeterministicByDesign (SMARTS pattern matching against a fixed alert list is deterministic execution) — Result method: RuleBasedEstimate (the alert list itself is a curated empirical correlation, Baell & Holloway 2010, not a physical law) — Completeness: Complete
 - High cost: No
 - Explicit limits: none
 - Caveats: a match indicates historical association with assay interference in specific HTS contexts, not a guarantee of interference in any given assay; absence of alerts is not a guarantee of clean behavior.
@@ -107,7 +115,7 @@ deterministic per-run given identical input, not randomized.
 ### `brenk_check`
 - Description: Brenk structural alerts (toxicity / metabolic instability / reactivity).
 - Local/network: local
-- Determinism: Deterministic — Result method: RuleBasedEstimate (Brenk et al. 2008 empirical alert list) — Completeness: Complete
+- Determinism: DeterministicByDesign — Result method: RuleBasedEstimate (Brenk et al. 2008 empirical alert list) — Completeness: Complete
 - High cost: No
 - Explicit limits: none
 - Caveats: same as `pains_check` — empirical alert list, not a predictive toxicology model.
@@ -115,7 +123,7 @@ deterministic per-run given identical input, not randomized.
 ### `sa_score`
 - Description: Synthetic accessibility score (Ertl & Schuffenhauer 2009), 1 (easy) to 10 (hard).
 - Local/network: local
-- Determinism: Deterministic — Result method: RuleBasedEstimate (fragment-contribution empirical scoring) — Completeness: Complete
+- Determinism: DeterministicByDesign — Result method: RuleBasedEstimate (fragment-contribution empirical scoring) — Completeness: Complete
 - High cost: No
 - Explicit limits: none
 - Caveats: an empirical estimate correlated with fragment frequency in known compounds, not a retrosynthetic feasibility proof.
@@ -123,7 +131,7 @@ deterministic per-run given identical input, not randomized.
 ### `admet_profile`
 - Description: BBB, Caco-2, hERG, CYP3A4, AMES, PPB, hepatic clearance.
 - Local/network: local
-- Determinism: Deterministic — Result method: RuleBasedEstimate — Completeness: Complete
+- Determinism: DeterministicByDesign — Result method: RuleBasedEstimate — Completeness: Complete
 - High cost: No
 - Explicit limits: none
 - Caveats: **every field is a rule-based/QSAR-style screening estimate, not an experimental measurement or clinical/regulatory conclusion.** This is the clearest case in the catalog where the current tool description ("Full ADMET profile") risks reading as more authoritative than the underlying method supports.
@@ -131,7 +139,7 @@ deterministic per-run given identical input, not randomized.
 ### `boiled_egg`
 - Description: BOILED-Egg (Daina & Zoete 2016) — GI absorption + BBB zone prediction from LogP/TPSA thresholds.
 - Local/network: local
-- Determinism: Deterministic — Result method: RuleBasedEstimate (threshold-based empirical classification) — Completeness: Complete
+- Determinism: DeterministicByDesign — Result method: RuleBasedEstimate (threshold-based empirical classification) — Completeness: Complete
 - High cost: No
 - Explicit limits: none
 - Caveats: threshold classification, not a mechanistic permeability simulation.
@@ -139,7 +147,7 @@ deterministic per-run given identical input, not randomized.
 ### `lipinski_check`
 - Description: Lipinski's Rule of Five with per-rule breakdown.
 - Local/network: local
-- Determinism: Deterministic — Result method: RuleBasedEstimate — Completeness: Complete
+- Determinism: DeterministicByDesign — Result method: RuleBasedEstimate — Completeness: Complete
 - High cost: No
 - Explicit limits: none
 - Caveats: a heuristic screening rule with well-known exceptions (many approved oral drugs violate Ro5); pass/fail is not a bioavailability guarantee in either direction.
@@ -147,7 +155,7 @@ deterministic per-run given identical input, not randomized.
 ### `name_to_smiles`
 - Description: Chemical name → isomeric SMILES via the PubChem REST API.
 - Local/network: **network** — the only tool in the catalog that makes an external call.
-- Determinism: **ExternalDependent** (result depends on PubChem's database content and availability at call time, not solely on chematic's own code) — Result method: Algorithmic (direct lookup, not a computed estimate) — Completeness: **BestEffort** (fails outright on network/PubChem issues; no local fallback)
+- Determinism: **ExternalDependent** (result depends on PubChem's database content and availability at call time, not solely on chematic's own code) — Result method: **ExternalLookup** (retrieves a value from PubChem's database; this is not chemical-algorithm-driven structure generation — chematic computes nothing here beyond encoding the request and parsing the response) — Completeness: **BestEffort** (fails outright on network/PubChem issues; no local fallback)
 - High cost: No (bounded by a 10-second HTTP timeout)
 - Explicit limits: name ≤500 characters, 10s HTTP timeout.
 - Caveats: input name is sent, URL-encoded, to `pubchem.ncbi.nlm.nih.gov`; see `crates/chematic-mcp/README.md`'s Network & privacy section. Result depends on PubChem's database being current and correct.
@@ -155,7 +163,7 @@ deterministic per-run given identical input, not randomized.
 ### `retrosynthesis`
 - Description: One-step BRICS disconnection, all breakable bonds cut individually, ranked by max fragment SA Score.
 - Local/network: local
-- Determinism: Deterministic — Result method: **HeuristicSearch** — Completeness: **BestEffort** (a single-step rule-based disconnection proposal, not a complete or exhaustive retrosynthetic search)
+- Determinism: DeterministicByDesign — Result method: **HeuristicSearch** — Completeness: **BestEffort** (a single-step rule-based disconnection proposal, not a complete or exhaustive retrosynthetic search)
 - High cost: Potentially, near the atom-count ceiling (BRICS enumeration + per-bond BFS + 2× SA-score per breakable bond).
 - Explicit limits: ≤500 atoms, single connected component required.
 - Caveats: do not describe this as "the" retrosynthesis or a validated route — it is a rule-based (BRICS) one-step disconnection proposal that does not account for reagent availability, reaction feasibility, or stereochemistry, and does not search beyond one disconnection step.
@@ -163,21 +171,21 @@ deterministic per-run given identical input, not randomized.
 ### `smiles_to_moljson`
 - Description: SMILES → MolJSON.
 - Local/network: local
-- Determinism: Deterministic — Result method: Algorithmic — Completeness: Complete
+- Determinism: DeterministicByDesign — Result method: Algorithmic — Completeness: Complete
 - High cost: No
 - Explicit limits: none
 
 ### `moljson_to_smiles`
 - Description: MolJSON → canonical SMILES.
 - Local/network: local
-- Determinism: Deterministic — Result method: Algorithmic — Completeness: Complete
+- Determinism: DeterministicByDesign — Result method: Algorithmic — Completeness: Complete
 - High cost: No
 - Explicit limits: **none** — no length cap on the input `json` string.
 
 ### `representation_router`
 - Description: Route SMILES to the molecular text representation (MolJSON/CML/InChI/canonical SMILES) best suited to a given LLM task.
 - Local/network: local
-- Determinism: Deterministic — Result method: **mixed** (the underlying format conversions are Algorithmic/exact; the task→representation mapping itself is a heuristic recommendation from one specific paper (arXiv 2026), not a universal standard) — Completeness: Complete
+- Determinism: DeterministicByDesign — Result method: **mixed** (the underlying format conversions are Algorithmic/exact; the task→representation mapping itself is a heuristic recommendation from one specific paper (arXiv 2026), not a universal standard) — Completeness: Complete
 - High cost: No
 - Explicit limits: none
 - Caveats: the "best" representation choice reflects one paper's recommendation, not a guarantee that it is optimal for every downstream LLM/task.
@@ -185,7 +193,7 @@ deterministic per-run given identical input, not randomized.
 ### `molecule_context_pack`
 - Description: Identifiers, physicochemical properties, drug-likeness flags, ADMET profile, structural alerts, and MolJSON in one object (json/markdown/prompt output).
 - Local/network: local
-- Determinism: Deterministic — Result method: **mixed** (bundles exact identifiers/MolJSON with empirical LogP/QED/SA/ADMET/PAINS/Brenk estimates) — Completeness: Complete
+- Determinism: DeterministicByDesign — Result method: **mixed** (bundles exact identifiers/MolJSON with empirical LogP/QED/SA/ADMET/PAINS/Brenk estimates) — Completeness: Complete
 - High cost: No (aggregates several already-covered lighter calls; no single expensive step)
 - Explicit limits: none
 - Caveats: the most heavily mixed tool in the catalog — inherits every caveat listed above for the individual estimates it bundles (Crippen LogP, QED, `sa_score`, `admet_profile`, PAINS/Brenk), none of which are distinguished from the exact fields in the output.

--- a/docs/rdkit-comparison.md
+++ b/docs/rdkit-comparison.md
@@ -120,7 +120,7 @@ python scripts/benchmark_vs_rdkit.py --rdkit
 | Feature | chematic | RDKit |
 |---|---|---|
 | Native WASM (no Emscripten) | Yes | No |
-| MCP server (AI agent API) | 20 tools | None |
+| MCP server (AI agent API) | 20 tools (stdio only) | None |
 | pKa prediction (built-in) | 15 SMARTS rules | External tool required |
 | ADMET profile (built-in) | BBB / Caco-2 / hERG / CYP3A4 | External tool required |
 | MAP4 fingerprint | Yes (Minervini 2020) | No (external package) |


### PR DESCRIPTION
PR 1 of the `chematic-mcp` remote-readiness groundwork (documentation-only; see the audit report for the full 4-PR plan). Aligns documentation with the actual implementation — no chemistry, protocol, schema, or dispatch behavior changes.

## 1. Actual tool count: 20

`crates/chematic-mcp/src/tools.rs`'s `list_tools()` (schema) and `call_tool()` (dispatch) both enumerate 20 tools; both existing tests (`lib.rs::test_tools_list`, `tools.rs::test_list_tools_count`) already assert `count == 20` and were passing before this PR. The bug was entirely in documentation.

## 2. Root cause of the 15/20/9 mix

`list_tools()` and `call_tool()` are two independently hand-maintained functions with no single source of truth — adding a tool means remembering to update both, plus every doc that separately enumerates tools. In practice this had already broken: the 5 tools added after the "15 tools" era never propagated past the source code:

- `retrosynthesis`
- `smiles_to_moljson`
- `moljson_to_smiles`
- `representation_router`
- `molecule_context_pack`

Found inconsistent in (before this PR): `crates/chematic-mcp/src/lib.rs` (module doc comment listed only 9), `crates/chematic-mcp/README.md` (15), root `README.md` (**15 and 20 simultaneously**, in different sections of the same file), `README_ja.md`/`README_zh.md` (same 15/20 split), `docs/benchmark.md` (15). `docs/rdkit-comparison.md` already said 20 correctly. `CHANGELOG.md` was audited and needs **no change** — its "8 → 14" / "15th tool" entries are dated historical deltas, correct as history, not current-state claims.

## 3–4. Two factual errors found while cross-checking descriptions against `tools.rs`

- `calc_properties` was described (root/ja/zh README intro tables) as returning **SA Score, pKa, ADMET** — it does not. It returns `mw/exact_mass/logp/tpsa/hbd/hba/rotatable_bonds/heavy_atom_count/qed` only; SA Score and ADMET/pKa are separate tools (`sa_score`, `admet_profile`).
- `generate_3d` was described as using **ETKDG + MMFF94** — the actual implementation (`generate_and_minimize_dreiding`) uses rule-based placement + **DREIDING** minimization only. No ETKDG, no MMFF94.

## 5. MCP transport status now stated explicitly

Added to the crate README and (briefly) to the root/ja/zh READMEs: stdio only, runs as a local process, no hosted Remote MCP endpoint, no authentication, no public service SLA. A remote-ready refactor is described as "under consideration," not implied as available or imminent.

## 6. External communication now stated explicitly

Crate README gets a new "Network & privacy" section: `name_to_smiles` is the only one of 20 tools that makes a network call (PubChem REST, URL-encoded input, 10s timeout); the other 19 are pure local computation; PubChem outages/timeouts fail that tool with no local fallback; privacy-sensitive callers should know their input crosses the network only for that one tool.

## 7. stdio-only, Remote MCP not implemented

Covered by item 5 above — stated in the same places, no separate section needed.

## 8. Chemistry/schema/dispatch/response unchanged — verified, not just asserted

- `cargo test -p chematic-mcp`: all 31 tests pass unchanged.
- `cargo test --workspace --lib`: unchanged, passes.
- `bash scripts/check.sh`: passes.
- Byte-level stdio check: piped the same 3-request fixture (`initialize`, `tools/list`, `tools/call parse_smiles`) through the built binary before and after this diff — **stdout is byte-identical**.
- `lib.rs`'s only change is inside a `//!` module doc comment; no executable code touched anywhere in `crates/chematic-mcp/src/`.

## 9. Registry integration deferred to PR 2

Not started here. `docs/mcp/tool-inventory.md` (new) is explicitly labeled a manually maintained snapshot, not a source of truth — `tools.rs` remains authoritative until PR 2 can generate or verify this document from a single typed registry.

## 10. Explicit non-goals (all confirmed not touched)

Registry extraction, protocol/transport refactor, resource limits, typed errors, execution context, observability, chemistry algorithm changes, stdio API changes, any Remote MCP publishing/deployment/OAuth work.

## Metadata classification note

Per review guidance, `docs/mcp/tool-inventory.md` does **not** collapse determinism/method/completeness into one `exact/approximate/heuristic` axis. It uses three separate axes (Determinism / Result method / Completeness) and deliberately avoids known misclassification traps: `find_mcs` is `TimeoutLimited` (5s internal budget), not unconditionally `Complete`; `retrosynthesis` is `BestEffort` `HeuristicSearch`, not a complete search; `admet_profile` is `RuleBasedEstimate`, not a measurement; PAINS/Brenk execution is `Deterministic` even though the underlying alert rules are empirical; `ecfp4`/`canonical_smiles`/`tanimoto` are flagged deterministic-within-chematic but not guaranteed RDKit-bit-exact. No Rust types added yet — this is prose-only, for PR 2 to formalize.

## Testing

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p chematic-mcp
cargo test --workspace --lib
bash scripts/check.sh
```

All pass. No lightweight tool-count-checking script was added — per review guidance, a regex-based README parser would be fragile and easy to defeat with reformatting; PR 2's registry-driven generation is the intended real fix for this class of drift.

**Not merging without review.**
