### PR TITLE
feat(fp): add fallible RDKit-bit-exact ECFP4 path

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -38,10 +38,13 @@ from RDKit's `license.txt` at the commit above.
 
 `crates/chematic-fp/src/rdkit_morgan_hash.rs` is a source-verified, line-level
 port of RDKit's Morgan fingerprint hash-combine machinery (connectivity
-invariant, bond invariant, per-round environment hash), built as a
-diagnostic-only reference engine for Milestone M4-A0 (see
-`docs/` and the PR description for the design writeup). Not wired into any
-production API.
+invariant, bond invariant, per-round environment hash), originally built as a
+diagnostic-only reference engine for Milestone M4-A0. Its core (`expand_one_pass`,
+`checked_bond_invariant`) is now also reused by the production, fallible
+`rdkit_morgan_ecfp4_experimental` API in `crates/chematic-fp/src/rdkit_morgan_ecfp4.rs`
+(see `validation/README.md`'s Phase B section) — the diagnostic module itself
+remains diagnostics-feature-gated; only the promoted internals are linked into
+production.
 
 Derived from:
 

--- a/crates/chematic-fp/examples/ecfp_regression_snapshot.rs
+++ b/crates/chematic-fp/examples/ecfp_regression_snapshot.rs
@@ -1,12 +1,19 @@
-//! ECFP RDKit-invariant-mode PR: non-regression snapshot, run once before
-//! this PR's `ecfp.rs` `EcfpInvariantMode` refactor and once after. Uses only
-//! stable, pre-existing public API (no `EcfpInvariantMode`/`*_rdkit_invariants`
-//! reference) so the exact same file compiles against both revisions.
+//! Non-regression snapshot for every existing `chematic-fp` Morgan/ECFP
+//! entry point -- run once before a PR touching this crate's internals and
+//! once after; the two runs must be byte-for-byte identical whenever the PR
+//! claims not to change any existing function's output. Originally written
+//! for PR #110's `EcfpInvariantMode` refactor (hence the narrow original
+//! set); extended for Phase B (`rdkit_morgan_ecfp4_experimental`, PR #124
+//! follow-up) to cover every existing public fingerprint function in
+//! `ecfp.rs`, since that PR reuses internals
+//! ([`chematic_fp`]'s own `rdkit_morgan_hash` module) that are adjacent to,
+//! but must not affect, this set.
 //!
-//! Every existing entry point (`ecfp4`, `ecfp6`, `ecfp` with chirality,
-//! `ecfp_with_bitinfo` fp + origins, `morgan_fp_counts`) must be byte-for-byte
-//! identical before/after, since none of these callers changed which
-//! invariant mode they use.
+//! Covers: `ecfp4`, `ecfp6`, `ecfp` with chirality, `ecfp_with_bitinfo` fp +
+//! origins, `morgan_fp_counts`, `ecfp4_rdkit_invariants`,
+//! `ecfp6_rdkit_invariants`, `ecfp4_rdkit_environment_experimental`,
+//! `ecfp6_rdkit_environment_experimental`,
+//! `ecfp_with_bitinfo_rdkit_environment_experimental`.
 //!
 //! Usage:
 //! ```text
@@ -14,7 +21,11 @@
 //!     -- <SMILES.csv> <out.tsv>
 //! ```
 
-use chematic_fp::{EcfpConfig, ecfp, ecfp_with_bitinfo, ecfp4, ecfp6, morgan_fp_counts};
+use chematic_fp::{
+    EcfpConfig, ecfp, ecfp_with_bitinfo, ecfp_with_bitinfo_rdkit_environment_experimental, ecfp4,
+    ecfp4_rdkit_environment_experimental, ecfp4_rdkit_invariants, ecfp6,
+    ecfp6_rdkit_environment_experimental, ecfp6_rdkit_invariants, morgan_fp_counts,
+};
 use chematic_smiles::parse;
 use std::fs;
 use std::io::Write;
@@ -60,14 +71,38 @@ fn row(smi: &str) -> Option<String> {
         .collect::<Vec<_>>()
         .join(",");
 
+    let rdkit_inv4 = ecfp4_rdkit_invariants(&mol);
+    let rdkit_inv6 = ecfp6_rdkit_invariants(&mol);
+    let rdkit_env4 = ecfp4_rdkit_environment_experimental(&mol);
+    let rdkit_env6 = ecfp6_rdkit_environment_experimental(&mol);
+    let (rdkit_env_bi_fp, rdkit_env_bi_info) =
+        ecfp_with_bitinfo_rdkit_environment_experimental(&mol, &EcfpConfig::default());
+    let mut rdkit_env_bi_origins: Vec<(usize, Vec<(u32, u32)>)> =
+        rdkit_env_bi_info.into_iter().collect();
+    rdkit_env_bi_origins.sort_by_key(|(bit, _)| *bit);
+    for (_, envs) in &mut rdkit_env_bi_origins {
+        envs.sort_unstable();
+    }
+    let rdkit_env_bi_origins_str = rdkit_env_bi_origins
+        .iter()
+        .map(|(bit, envs)| format!("{bit}:{envs:?}"))
+        .collect::<Vec<_>>()
+        .join(";");
+
     Some(format!(
-        "{smi}\t{}\t{}\t{}\t{}\t{}\t{}",
+        "{smi}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
         bits_string(&fp4),
         bits_string(&fp6),
         bits_string(&fp4_chiral),
         bits_string(&bi_fp),
         bi_origins_str,
         counts_str,
+        bits_string(&rdkit_inv4),
+        bits_string(&rdkit_inv6),
+        bits_string(&rdkit_env4),
+        bits_string(&rdkit_env6),
+        bits_string(&rdkit_env_bi_fp),
+        rdkit_env_bi_origins_str,
     ))
 }
 

--- a/crates/chematic-fp/examples/rdkit_morgan_ecfp4_benchmark.rs
+++ b/crates/chematic-fp/examples/rdkit_morgan_ecfp4_benchmark.rs
@@ -1,0 +1,195 @@
+//! Phase B performance record (not a gate, not a Criterion-registered
+//! benchmark -- see `feedback_criterion_gate_pseudo_replication` for why this
+//! repo treats the automated Criterion CI gate's samples as non-independent;
+//! this is a one-off, manually-reported measurement, matching
+//! `morgan_suppression_benchmark.rs`'s own precedent). Compares
+//! `rdkit_morgan_ecfp4_experimental` (candidate: RDKit-bit-exact, does its
+//! own kekulization + RDKit-parity aromaticity perception internally every
+//! call) against `ecfp4_rdkit_environment_experimental` (baseline: reads
+//! whatever aromatic flags are already on the input `Molecule`, no
+//! aromaticity engine call of its own) on the same inputs.
+//!
+//! These two functions do genuinely different amounts of preprocessing work
+//! by design (see the module docs on `rdkit_morgan_ecfp4.rs` -- the
+//! bit-exactness guarantee *requires* the candidate's own aromaticity
+//! perception step). A `--split` run reports how much of the candidate's
+//! time is preprocessing (`apply_aromaticity_rdkit_parity_experimental`
+//! alone) vs. the hash expansion itself, so a >2x ratio is attributable
+//! rather than treated as an undifferentiated "regression."
+//!
+//! Usage:
+//! ```text
+//! cargo run -p chematic-fp --release --example rdkit_morgan_ecfp4_benchmark \
+//!     -- <SMILES.csv> [--corpus-only=baseline|candidate|preprocessing]
+//! ```
+//! (`<SMILES.csv>` is optional -- omit to skip the full-corpus pass and only
+//! run the named/synthetic per-molecule cases. `--corpus-only=...` runs one
+//! side only, for external multi-process median/RSS measurement.)
+
+use chematic_core::Molecule;
+use chematic_fp::{ecfp4_rdkit_environment_experimental, rdkit_morgan_ecfp4_experimental};
+use chematic_perception::apply_aromaticity_rdkit_parity_experimental;
+use chematic_smiles::parse;
+use std::time::{Duration, Instant};
+
+fn median(mut durations: Vec<Duration>) -> Duration {
+    durations.sort_unstable();
+    durations[durations.len() / 2]
+}
+
+fn time_calls<F: FnMut()>(mut f: F, reps: usize) -> Duration {
+    for _ in 0..(reps / 10).max(3) {
+        f();
+    }
+    let mut samples = Vec::with_capacity(reps);
+    for _ in 0..reps {
+        let start = Instant::now();
+        f();
+        samples.push(start.elapsed());
+    }
+    median(samples)
+}
+
+fn bench_molecule(label: &str, mol: &Molecule, reps: usize) {
+    let baseline = time_calls(
+        || {
+            ecfp4_rdkit_environment_experimental(mol);
+        },
+        reps,
+    );
+    let preprocessing = time_calls(
+        || {
+            let _ = apply_aromaticity_rdkit_parity_experimental(mol);
+        },
+        reps,
+    );
+    let candidate = time_calls(
+        || {
+            let _ = rdkit_morgan_ecfp4_experimental(mol);
+        },
+        reps,
+    );
+    let ratio = candidate.as_secs_f64() / baseline.as_secs_f64();
+    let preprocessing_share = preprocessing.as_secs_f64() / candidate.as_secs_f64();
+    println!(
+        "{label:32} atoms={:5} baseline={baseline:>12?} candidate={candidate:>12?} \
+         ratio={ratio:.3}x preprocessing={preprocessing:>12?} ({:.0}% of candidate)",
+        mol.atom_count(),
+        preprocessing_share * 100.0,
+    );
+}
+
+fn linear_alkane(n: usize) -> Molecule {
+    parse(&"C".repeat(n)).unwrap()
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let corpus_only = args
+        .iter()
+        .find_map(|a| a.strip_prefix("--corpus-only=").map(str::to_string));
+    let csv_path = args.iter().find(|a| !a.starts_with("--")).cloned();
+
+    if corpus_only.is_none() {
+        println!("=== per-molecule median wall time (Instant-based, not Criterion) ===");
+        bench_molecule(
+            "typical drug-like (aspirin)",
+            &parse("CC(=O)Oc1ccccc1C(=O)O").unwrap(),
+            2000,
+        );
+        bench_molecule(
+            "symmetric ring (benzene)",
+            &parse("c1ccccc1").unwrap(),
+            2000,
+        );
+        bench_molecule(
+            "fused/polycyclic (steroid-like)",
+            &parse("C[C@]12CCC3C(CCC4=CC(=O)CC[C@@]43C3CO3)C1CCC2=O").unwrap(),
+            2000,
+        );
+        bench_molecule("~100-atom (linear alkane C100)", &linear_alkane(100), 500);
+        bench_molecule("~200-atom (linear alkane C200)", &linear_alkane(200), 200);
+    }
+
+    if let Some(csv_path) = csv_path {
+        let content =
+            std::fs::read_to_string(&csv_path).unwrap_or_else(|e| panic!("read {csv_path}: {e}"));
+        let mols: Vec<Molecule> = content
+            .lines()
+            .filter_map(|l| {
+                let smi = l.trim();
+                if smi.is_empty() {
+                    None
+                } else {
+                    parse(smi).ok()
+                }
+            })
+            .collect();
+
+        match corpus_only.as_deref() {
+            Some("baseline") => {
+                let start = Instant::now();
+                for m in &mols {
+                    ecfp4_rdkit_environment_experimental(m);
+                }
+                println!("baseline_total={:?} n={}", start.elapsed(), mols.len());
+            }
+            Some("candidate") => {
+                let start = Instant::now();
+                let mut errors = 0usize;
+                for m in &mols {
+                    if rdkit_morgan_ecfp4_experimental(m).is_err() {
+                        errors += 1;
+                    }
+                }
+                println!(
+                    "candidate_total={:?} n={} errors={errors}",
+                    start.elapsed(),
+                    mols.len()
+                );
+            }
+            Some("preprocessing") => {
+                let start = Instant::now();
+                for m in &mols {
+                    let _ = apply_aromaticity_rdkit_parity_experimental(m);
+                }
+                println!("preprocessing_total={:?} n={}", start.elapsed(), mols.len());
+            }
+            _ => {
+                println!(
+                    "\n=== full corpus ({} molecules), single in-process pass ===",
+                    mols.len()
+                );
+                let start = Instant::now();
+                for m in &mols {
+                    ecfp4_rdkit_environment_experimental(m);
+                }
+                let baseline_total = start.elapsed();
+
+                let start = Instant::now();
+                for m in &mols {
+                    let _ = apply_aromaticity_rdkit_parity_experimental(m);
+                }
+                let preprocessing_total = start.elapsed();
+
+                let start = Instant::now();
+                let mut errors = 0usize;
+                for m in &mols {
+                    if rdkit_morgan_ecfp4_experimental(m).is_err() {
+                        errors += 1;
+                    }
+                }
+                let candidate_total = start.elapsed();
+
+                let ratio = candidate_total.as_secs_f64() / baseline_total.as_secs_f64();
+                let preprocessing_share =
+                    preprocessing_total.as_secs_f64() / candidate_total.as_secs_f64();
+                println!(
+                    "baseline_total={baseline_total:?} candidate_total={candidate_total:?} ratio={ratio:.3}x \
+                     preprocessing_total={preprocessing_total:?} ({:.0}% of candidate) errors={errors}",
+                    preprocessing_share * 100.0,
+                );
+            }
+        }
+    }
+}

--- a/crates/chematic-fp/examples/rdkit_morgan_ecfp4_dump.rs
+++ b/crates/chematic-fp/examples/rdkit_morgan_ecfp4_dump.rs
@@ -1,0 +1,148 @@
+//! Phase B acceptance-gate dump: `rdkit_morgan_ecfp4_experimental`'s real
+//! output on the M4-A0 5,048-input corpus, for comparison against the same
+//! RDKit oracle rows M4-A0 itself validated against
+//! (`scripts/gen_ecfp_rdkit_environment_oracle.py`'s `default`
+//! (`includeRedundantEnvironments=false`) lifecycle -- the only lifecycle
+//! this production API ever computes).
+//!
+//! Every row is tagged with an explicit `status`, mirroring
+//! `rdkit_morgan_hash_dump_aromaticity_variant`'s established taxonomy --
+//! no fallback, no pooling a different status into `"success"`. Denominator
+//! discipline for the comparator: only `status == "success"` rows enter the
+//! exact-match rate.
+//!
+//! Usage:
+//! ```text
+//! cargo run -p chematic-fp --release --example rdkit_morgan_ecfp4_dump \
+//!     -- <SMILES.csv> <out.jsonl>
+//! ```
+
+use chematic_fp::{RdkitMorganError, rdkit_morgan_ecfp4_experimental};
+use chematic_perception::AromaticityError;
+use chematic_smiles::parse;
+use serde_json::json;
+use std::fs;
+use std::io::Write;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let csv_path = args
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| panic!("usage: rdkit_morgan_ecfp4_dump <SMILES.csv> <out.jsonl>"));
+    let out_path = args
+        .get(2)
+        .cloned()
+        .unwrap_or_else(|| "rdkit_morgan_ecfp4_dump.jsonl".to_string());
+
+    let content = fs::read_to_string(&csv_path).unwrap_or_else(|e| panic!("read {csv_path}: {e}"));
+    let mut f = fs::File::create(&out_path).unwrap_or_else(|e| panic!("create {out_path}: {e}"));
+
+    let mut rows = 0usize;
+    let mut status_counts = std::collections::BTreeMap::<&'static str, usize>::new();
+
+    for line in content.lines() {
+        let smi = line.trim();
+        if smi.is_empty() {
+            continue;
+        }
+        let row_id = rows;
+
+        let mol = match parse(smi) {
+            Ok(m) => m,
+            Err(e) => {
+                *status_counts.entry("parse_failed").or_default() += 1;
+                writeln!(
+                    f,
+                    "{}",
+                    json!({
+                        "row_id": row_id,
+                        "smiles": smi,
+                        "parse_ok": false,
+                        "status": "parse_failed",
+                        "error": e.to_string(),
+                    })
+                )
+                .unwrap();
+                rows += 1;
+                continue;
+            }
+        };
+
+        match rdkit_morgan_ecfp4_experimental(&mol) {
+            Ok(r) => {
+                *status_counts.entry("success").or_default() += 1;
+
+                let mut default_pairs: Vec<(u32, u32, u32)> = r
+                    .raw_bit_info
+                    .iter()
+                    .flat_map(|(&raw_id, envs)| envs.iter().map(move |&(a, rad)| (a, rad, raw_id)))
+                    .collect();
+                default_pairs.sort_unstable();
+
+                let mut sparse_counts: Vec<(u32, u32)> = r.sparse_counts.into_iter().collect();
+                sparse_counts.sort_unstable();
+
+                let mut folded_on_bits: Vec<usize> =
+                    (0..2048usize).filter(|&b| r.fingerprint.get(b)).collect();
+                folded_on_bits.sort_unstable();
+
+                let mut folded_bit_info: Vec<(usize, Vec<(u32, u32)>)> = r
+                    .folded_bit_info
+                    .into_iter()
+                    .map(|(bit, mut envs)| {
+                        envs.sort_unstable();
+                        (bit, envs)
+                    })
+                    .collect();
+                folded_bit_info.sort_unstable_by_key(|(bit, _)| *bit);
+
+                writeln!(
+                    f,
+                    "{}",
+                    json!({
+                        "row_id": row_id,
+                        "smiles": smi,
+                        "parse_ok": true,
+                        "status": "success",
+                        "default_pairs": default_pairs,
+                        "sparse_counts": sparse_counts,
+                        "folded_on_bits": folded_on_bits,
+                        "folded_bit_info": folded_bit_info,
+                    })
+                )
+                .unwrap();
+            }
+            Err(err) => {
+                let status = match &err {
+                    RdkitMorganError::Aromaticity(AromaticityError::KekulizationFailed {
+                        ..
+                    }) => "rdkit_parity_kekulization_failed",
+                    RdkitMorganError::Aromaticity(
+                        AromaticityError::InternalInvariantViolation { .. },
+                    ) => "rdkit_parity_internal_error",
+                    RdkitMorganError::UnsupportedBondOrder { .. } => "unsupported_bond_order",
+                    RdkitMorganError::InternalInvariantViolation { .. } => {
+                        "internal_invariant_violation"
+                    }
+                };
+                *status_counts.entry(status).or_default() += 1;
+                writeln!(
+                    f,
+                    "{}",
+                    json!({
+                        "row_id": row_id,
+                        "smiles": smi,
+                        "parse_ok": true,
+                        "status": status,
+                        "error": err.to_string(),
+                    })
+                )
+                .unwrap();
+            }
+        }
+        rows += 1;
+    }
+
+    eprintln!("rows={rows} status_counts={status_counts:?} out={out_path}");
+}

--- a/crates/chematic-fp/src/lib.rs
+++ b/crates/chematic-fp/src/lib.rs
@@ -32,6 +32,7 @@ pub mod path;
 pub mod pattern;
 pub mod pharmacophore_fp;
 mod rdkit_isotope_delta_table;
+mod rdkit_morgan_ecfp4;
 mod rdkit_morgan_hash;
 pub mod reaction_fp;
 pub mod search;
@@ -77,6 +78,7 @@ pub use pattern::{pattern_fp, tanimoto_pattern};
 pub use pharmacophore_fp::{
     pharmacophore_feature_counts, pharmacophore_fp_2d, tanimoto_pharmacophore_2d,
 };
+pub use rdkit_morgan_ecfp4::{RdkitMorganEcfp4, RdkitMorganError, rdkit_morgan_ecfp4_experimental};
 pub use reaction_fp::{
     ReactionFingerprint, ReactionFpConfig, reaction_fp, reaction_fp_ecfp4, reaction_fp_with_config,
     tanimoto_reaction_fp,

--- a/crates/chematic-fp/src/rdkit_morgan_ecfp4.rs
+++ b/crates/chematic-fp/src/rdkit_morgan_ecfp4.rs
@@ -1,0 +1,285 @@
+//! Production, fallible, RDKit-bit-exact ECFP4 path.
+//!
+//! Promotes [`crate::rdkit_morgan_hash`]'s source-verified hash port (Milestone M4-A0, PR #124)
+//! to a real public API, restricted to the single option envelope M4-A0 actually verified
+//! numerically against a live RDKit oracle: radius = 2 (ECFP4), fpSize = 2048,
+//! `includeRedundantEnvironments = false` (RDKit's default, suppressed lifecycle),
+//! `useChirality = false`, `useBondTypes = true`. **Not** ECFP6/radius = 3 — M4-A0 never
+//! compared radius 3 against the oracle, so claiming bit-exactness there would be an
+//! unverified extrapolation.
+//!
+//! Uses [`apply_aromaticity_rdkit_parity_experimental`] internally as a fallible `Result`
+//! step. There is no fallback to production Hückel aromaticity anywhere in this module's
+//! public path — see the project's own
+//! `feedback_fallback_pooling_measurement_error` lesson (M4-A0's original report pooled a
+//! Hückel-fallback result into an "RDKit-parity" success count and had to be corrected): this
+//! module's whole claim is bit-exactness against real RDKit, so silently substituting a
+//! different aromaticity engine on `Err` would silently invalidate that claim on exactly the
+//! inputs where a caller most needs to know it doesn't hold.
+//!
+//! No entry point in this module accepts a pre-aromatized [`Molecule`] — aromaticity
+//! perception always happens internally, via the same RDKit-parity engine every call, so a
+//! caller cannot bypass it with different (possibly Hückel-derived) flags and silently receive
+//! a fingerprint that no longer carries the bit-exactness guarantee.
+
+use chematic_core::{BondIdx, BondOrder, Molecule};
+use chematic_perception::AromaticityError;
+use rustc_hash::FxHashMap;
+
+use crate::bitvec::BitVec2048;
+use crate::rdkit_morgan_hash::{checked_bond_invariant, expand_one_pass};
+
+const ECFP4_RADIUS: u32 = 2;
+const ECFP4_FP_SIZE: usize = 2048;
+
+/// Every RDKit-hash-exact ECFP4 view of a molecule, computed from one shared expansion pass
+/// (RDKit's `includeRedundantEnvironments = false` lifecycle) — not independently recomputed
+/// per field.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RdkitMorganEcfp4 {
+    /// 2048-bit folded fingerprint (`raw_identifier % 2048`, OR-combined).
+    pub fingerprint: BitVec2048,
+    /// Raw (unfolded) identifier → emission count (RDKit's `GetSparseCountFingerprint`
+    /// shape). An identifier's count is how many distinct `(atom, radius)` environments
+    /// emitted it, which can exceed 1 on an accidental hash collision.
+    pub sparse_counts: FxHashMap<u32, u32>,
+    /// Raw identifier → the `(atom_idx, radius)` environments that produced it (RDKit's
+    /// `AdditionalOutput.GetBitInfoMap()`, unfolded).
+    pub raw_bit_info: FxHashMap<u32, Vec<(u32, u32)>>,
+    /// Folded bit (`0..2048`) → the `(atom_idx, radius)` environments that set it (RDKit's
+    /// `AdditionalOutput.GetBitInfoMap()` on the folded fingerprint).
+    pub folded_bit_info: FxHashMap<usize, Vec<(u32, u32)>>,
+}
+
+/// Why [`rdkit_morgan_ecfp4_experimental`] could not produce a result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RdkitMorganError {
+    /// RDKit-parity aromaticity preprocessing failed — see the wrapped
+    /// [`AromaticityError`] for the specific reason (kekulization failure or an internal
+    /// invariant violation). No fallback to another aromaticity engine is ever attempted; see
+    /// the module docs.
+    Aromaticity(AromaticityError),
+    /// `bond_idx`'s `order` has no real RDKit `Bond::BondType` counterpart (only chematic's
+    /// SMARTS-query-only `BondOrder` variants — cannot occur for a SMILES-parsed molecule, but
+    /// is checked explicitly rather than assumed unreachable).
+    UnsupportedBondOrder { bond_idx: BondIdx, order: BondOrder },
+    /// A post-computation sanity check failed that should never happen for chemically valid
+    /// input — surfaced as an error rather than a panic or a silently wrong fingerprint.
+    InternalInvariantViolation { reason: String },
+}
+
+impl std::fmt::Display for RdkitMorganError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RdkitMorganError::Aromaticity(e) => write!(f, "rdkit-exact ecfp4: aromaticity: {e}"),
+            RdkitMorganError::UnsupportedBondOrder { bond_idx, order } => write!(
+                f,
+                "rdkit-exact ecfp4: bond {bond_idx:?} has no RDKit BondType counterpart: {order:?}"
+            ),
+            RdkitMorganError::InternalInvariantViolation { reason } => {
+                write!(
+                    f,
+                    "rdkit-exact ecfp4: internal invariant violation: {reason}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for RdkitMorganError {}
+
+impl From<AromaticityError> for RdkitMorganError {
+    fn from(e: AromaticityError) -> Self {
+        RdkitMorganError::Aromaticity(e)
+    }
+}
+
+/// RDKit-bit-exact ECFP4 (radius = 2, 2048 bits, `includeRedundantEnvironments = false`,
+/// `useChirality = false`, `useBondTypes = true`) — bit-exact against real RDKit for every
+/// input where preprocessing succeeds, verified on the full M4-A0 corpus (5,046/5,046
+/// `rdkit_parity_success` rows, 100% agreement across raw identifiers, sparse counts, folded
+/// bits, and bitInfo). Kekulization/aromaticity failures are reported as `Err`, never silently
+/// degraded to a different, non-exact result — see the module docs.
+pub fn rdkit_morgan_ecfp4_experimental(
+    mol: &Molecule,
+) -> Result<RdkitMorganEcfp4, RdkitMorganError> {
+    let aromatized = chematic_perception::apply_aromaticity_rdkit_parity_experimental(mol)?;
+
+    let mut result = RdkitMorganEcfp4::default();
+    if aromatized.atom_count() == 0 {
+        return Ok(result);
+    }
+
+    let ring_set = chematic_perception::find_sssr(&aromatized);
+    let bond_count = aromatized.bond_count();
+    let mut bond_invariants = Vec::with_capacity(bond_count);
+    for b in 0..bond_count {
+        let bond_idx = BondIdx(b as u32);
+        let order = aromatized.bond(bond_idx).order;
+        let invariant = checked_bond_invariant(order)
+            .ok_or(RdkitMorganError::UnsupportedBondOrder { bond_idx, order })?;
+        bond_invariants.push(invariant);
+    }
+
+    let emitted = expand_one_pass(&aromatized, &ring_set, &bond_invariants, ECFP4_RADIUS, true);
+
+    for ((atom_idx, radius), raw_id) in emitted {
+        let folded = (raw_id as usize) % ECFP4_FP_SIZE;
+        result.fingerprint.set(folded);
+        *result.sparse_counts.entry(raw_id).or_insert(0) += 1;
+        result
+            .raw_bit_info
+            .entry(raw_id)
+            .or_default()
+            .push((atom_idx, radius));
+        result
+            .folded_bit_info
+            .entry(folded)
+            .or_default()
+            .push((atom_idx, radius));
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chematic_core::MoleculeBuilder;
+    use chematic_smiles::parse;
+
+    #[test]
+    fn benzene_matches_rdkit_ground_truth_radius0_and_folds_correctly() {
+        let mol = parse("c1ccccc1").unwrap();
+        let result = rdkit_morgan_ecfp4_experimental(&mol).unwrap();
+        // Radius-0 ground truth pinned in `rdkit_morgan_hash`'s own test module.
+        assert!(result.raw_bit_info.contains_key(&3218693969));
+        for &raw_id in result.raw_bit_info.keys() {
+            let folded = (raw_id as usize) % ECFP4_FP_SIZE;
+            assert!(result.fingerprint.get(folded));
+        }
+    }
+
+    #[test]
+    fn hermetic_equivalence_to_diagnostic_default_lifecycle() {
+        // The production path's raw_bit_info (inverted) must equal
+        // `rdkit_morgan_raw_trace`'s `raw_identifier_default`-Some entries on the same
+        // already-aromatized molecule -- proves the promotion didn't drift from the path
+        // M4-A0 already validated at 5,046/5,046.
+        for smi in ["c1ccncc1", "CC(=O)[O-]", "c1ccc2ccccc2c1", "CC"] {
+            let mol = parse(smi).unwrap();
+            let aromatized =
+                chematic_perception::apply_aromaticity_rdkit_parity_experimental(&mol).unwrap();
+            let result = rdkit_morgan_ecfp4_experimental(&mol).unwrap();
+
+            let trace = crate::rdkit_morgan_hash::rdkit_morgan_raw_trace(&aromatized, 2);
+            let mut expected: Vec<((u32, u32), u32)> = trace
+                .iter()
+                .filter_map(|e| {
+                    e.raw_identifier_default
+                        .map(|rid| ((e.atom_idx, e.radius), rid))
+                })
+                .collect();
+            expected.sort_unstable();
+
+            let mut got: Vec<((u32, u32), u32)> = result
+                .raw_bit_info
+                .iter()
+                .flat_map(|(&raw_id, envs)| envs.iter().map(move |&(a, r)| ((a, r), raw_id)))
+                .collect();
+            got.sort_unstable();
+
+            assert_eq!(got, expected, "mismatch for {smi}");
+        }
+    }
+
+    #[test]
+    fn kekule_pyridinium_reports_kekulization_failed_not_a_fallback_result() {
+        let mol = parse("c1cc[nH+]cc1").unwrap();
+        match rdkit_morgan_ecfp4_experimental(&mol) {
+            Err(RdkitMorganError::Aromaticity(AromaticityError::KekulizationFailed { .. })) => {}
+            other => {
+                panic!("expected Aromaticity(KekulizationFailed) for c1cc[nH+]cc1, got {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn degree_zero_atom_emits_only_its_radius0_identifier() {
+        // Radius 0 is unconditional for every atom (see `rdkit_morgan_hash`'s own
+        // `degree_zero_atom_never_appears_past_radius_zero`) -- only radius >= 1 is suppressed
+        // by degree-0 death.
+        let mol = parse("[Cl-]").unwrap();
+        let result = rdkit_morgan_ecfp4_experimental(&mol).unwrap();
+        assert_eq!(result.sparse_counts.len(), 1);
+        let envs: Vec<_> = result.raw_bit_info.values().flatten().copied().collect();
+        assert_eq!(envs, vec![(0, 0)]);
+    }
+
+    #[test]
+    fn empty_molecule_yields_empty_result_not_an_error() {
+        let mol = MoleculeBuilder::new().build();
+        let result = rdkit_morgan_ecfp4_experimental(&mol).unwrap();
+        assert_eq!(result, RdkitMorganEcfp4::default());
+    }
+
+    /// `BondOrder::Query*` has no real RDKit `Bond::BondType` counterpart (see
+    /// [`checked_bond_invariant`]'s doc comment) and cannot arise from `parse()` -- built
+    /// programmatically here specifically to prove the explicit-`Err` path, not a guessed
+    /// mapping, actually fires.
+    #[test]
+    fn query_bond_order_is_an_explicit_unsupported_bond_order_error_not_a_guess() {
+        use chematic_core::{Atom, Element};
+
+        let mut builder = MoleculeBuilder::new();
+        let a = builder.add_atom(Atom::new(Element::C));
+        let b = builder.add_atom(Atom::new(Element::C));
+        builder.add_bond(a, b, BondOrder::QueryAny).unwrap();
+        let mol = builder.build();
+
+        match rdkit_morgan_ecfp4_experimental(&mol) {
+            Err(RdkitMorganError::UnsupportedBondOrder { bond_idx, order }) => {
+                assert_eq!(bond_idx, BondIdx(0));
+                assert_eq!(order, BondOrder::QueryAny);
+            }
+            other => panic!("expected UnsupportedBondOrder, got {other:?}"),
+        }
+    }
+
+    /// Positive control #9 (Phase B spec): a reintroduced Hückel fallback must be caught by a
+    /// test. Simulated here without editing production code — this test independently proves
+    /// that on the known kekulization-gap molecule, plain (Hückel-based) `apply_aromaticity`
+    /// produces a *different* atom/bond aromaticity outcome than what an `Err` from this
+    /// module's real path implies, so a hypothetical silent fallback substituting the former
+    /// for the latter would be numerically detectable, not just contractually forbidden.
+    #[test]
+    fn hueckel_fallback_would_be_detectable_if_silently_reintroduced() {
+        let smi = "c1cc[nH+]cc1";
+        let mol = parse(smi).unwrap();
+
+        // The real, fallible path must fail -- no result to compare against RDKit at all.
+        let real = rdkit_morgan_ecfp4_experimental(&mol);
+        assert!(matches!(real, Err(RdkitMorganError::Aromaticity(_))));
+
+        // A hypothetical silent fallback would instead run production Hückel aromaticity and
+        // report success. Prove that path is reachable and produces a *different* aromatic-atom
+        // partition than the RDKit-parity engine would have (when the latter succeeds on the
+        // structurally analogous neutral pyridine), so such a substitution is not merely
+        // "different code path" but "numerically distinguishable, and thus catchable" if it
+        // were ever reintroduced.
+        let hueckel_fallback_mol = chematic_perception::apply_aromaticity(&mol);
+        let hueckel_aromatic_atoms: Vec<bool> = (0..hueckel_fallback_mol.atom_count())
+            .map(|i| {
+                hueckel_fallback_mol
+                    .atom(chematic_core::AtomIdx(i as u32))
+                    .aromatic
+            })
+            .collect();
+        // Hückel perceives this ring as fully aromatic (6 aromatic atoms) -- i.e. a silent
+        // fallback would have returned Ok(..) with a full 2048-bit fingerprint here, directly
+        // contradicting the real path's Err. This assertion is what would fail if a fallback
+        // were reintroduced and this test were updated to call the (currently nonexistent)
+        // fallback path instead of the real one.
+        assert_eq!(hueckel_aromatic_atoms, vec![true; 6]);
+    }
+}

--- a/crates/chematic-fp/src/rdkit_morgan_hash.rs
+++ b/crates/chematic-fp/src/rdkit_morgan_hash.rs
@@ -37,17 +37,25 @@
 //!   (`MorganGenerator.cpp`) — the atom-CIP chirality re-fold is likewise out
 //!   of scope (`includeChirality=false` pinned throughout this workstream)
 //!
-//! **Diagnostic reference only.** Deliberately kept structurally separate
-//! from both the FNV-1a production path (`ecfp.rs`) and the Phase B
-//! suppression path (`morgan_environment.rs`), even though it duplicates
-//! some control-flow shape (round loop, degree-0 death, bondset-keyed
-//! suppression) — reusing only genuinely hash-independent infrastructure
+//! Deliberately kept structurally separate from both the FNV-1a production
+//! path (`ecfp.rs`) and the Phase B suppression path
+//! (`morgan_environment.rs`), even though it duplicates some control-flow
+//! shape (round loop, degree-0 death, bondset-keyed suppression) — reusing
+//! only genuinely hash-independent infrastructure
 //! ([`crate::morgan_environment::BondSet`], and `ecfp.rs`'s
 //! `rdkit_total_degree`/`rdkit_total_h_count`/`rdkit_isotope_delta` value
-//! computations) so this module can be promoted to shared core cleanly once
-//! numeric exactness is proven, without having pre-emptively entangled it
-//! with either existing path. **Not wired into any production API** — no
-//! caller outside this module and its diagnostics re-export exists.
+//! computations) so this module was never pre-emptively entangled with
+//! either existing path.
+//!
+//! **Numeric exactness proven (M4-A0), now promoted to a real production
+//! API:** [`crate::rdkit_morgan_ecfp4`]'s `rdkit_morgan_ecfp4_experimental`
+//! reuses this module's [`expand_one_pass`] and [`checked_bond_invariant`]
+//! directly (`pub(crate)`) rather than re-deriving the same hash logic a
+//! second time. The `rdkit_morgan_raw_trace`/`RdkitMorganRawTraceEntry`
+//! diagnostic surface stays diagnostics-feature-gated and computes *both*
+//! RDKit lifecycles at once for comparison purposes — the production path
+//! only ever runs the single `suppress=true` ("default") lifecycle RDKit
+//! itself uses.
 //!
 //! **Caller contract:** [`rdkit_morgan_raw_trace`] expects `mol` to already
 //! have aromaticity perception applied
@@ -159,26 +167,33 @@ fn connectivity_invariant(mol: &Molecule, idx: AtomIdx, ring_set: &RingSet) -> u
 /// kinds with no RDKit `BondType` counterpart at all (not merely
 /// unverified — RDKit's `BondType` enum has no query concept; SMARTS bond
 /// queries are a distinct RDKit type) and cannot appear in a SMILES-parsed
-/// molecule (this diagnostic's entire corpus) — mapped to `u32::MAX`, a
-/// deliberately out-of-band placeholder. A future production API must
-/// treat these (and any other value this function can't map to a real
-/// RDKit `BondType`) as an explicit `Err`, never an implicit/guessed
-/// mapping — see `docs/`'s M4-A0 report for the exact error-type
-/// requirement.
-fn bond_invariant(order: BondOrder) -> u32 {
+/// molecule (this diagnostic's entire corpus) — mapped to `None`. The
+/// production `rdkit_morgan_ecfp4` path (which reuses this function) turns
+/// `None` into an explicit `RdkitMorganError::UnsupportedBondOrder`, never
+/// an implicit/guessed mapping.
+pub(crate) fn checked_bond_invariant(order: BondOrder) -> Option<u32> {
     match order {
-        BondOrder::Single | BondOrder::Up | BondOrder::Down => 1,
-        BondOrder::Double => 2,
-        BondOrder::Triple => 3,
-        BondOrder::Quadruple => 4,
-        BondOrder::Aromatic => 12,
-        BondOrder::Dative => 17,
-        BondOrder::Zero => 21,
+        BondOrder::Single | BondOrder::Up | BondOrder::Down => Some(1),
+        BondOrder::Double => Some(2),
+        BondOrder::Triple => Some(3),
+        BondOrder::Quadruple => Some(4),
+        BondOrder::Aromatic => Some(12),
+        BondOrder::Dative => Some(17),
+        BondOrder::Zero => Some(21),
         BondOrder::QueryAny
         | BondOrder::QuerySingleOrDouble
         | BondOrder::QuerySingleOrAromatic
-        | BondOrder::QueryDoubleOrAromatic => u32::MAX,
+        | BondOrder::QueryDoubleOrAromatic => None,
     }
+}
+
+/// Diagnostic-only wrapper: unsupported bond orders map to `u32::MAX`, a
+/// deliberately out-of-band placeholder, so the diagnostic can still trace
+/// every bond rather than abort — no production caller uses this; the
+/// production path uses [`checked_bond_invariant`] and surfaces an explicit
+/// `Err` instead.
+fn bond_invariant(order: BondOrder) -> u32 {
+    checked_bond_invariant(order).unwrap_or(u32::MAX)
 }
 
 /// One computed `(atom, radius)` combination from [`rdkit_morgan_raw_trace`].
@@ -223,7 +238,7 @@ pub struct RdkitMorganRawTraceEntry {
 /// (degree-0 death, cumulative per-atom `BondSet`, cross-round `seen` set,
 /// one-round invariant grace period) -- only the invariant/hash computation
 /// differs; see the module docs for why that duplication is deliberate.
-fn expand_one_pass(
+pub(crate) fn expand_one_pass(
     mol: &Molecule,
     ring_set: &RingSet,
     bond_invariants: &[u32],

--- a/scripts/ecfp_rdkit_morgan_ecfp4_parity.py
+++ b/scripts/ecfp_rdkit_morgan_ecfp4_parity.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Phase B acceptance gate: `rdkit_morgan_ecfp4_experimental` (the production,
+fallible, RDKit-bit-exact ECFP4 API in `crates/chematic-fp/src/rdkit_morgan_ecfp4.rs`)
+vs the real RDKit oracle (`scripts/gen_ecfp_rdkit_environment_oracle.py`).
+
+Unlike `ecfp_rdkit_raw_identifier_parity.py`'s `classify()`, this script never
+touches RDKit's `includeRedundantEnvironments=True` ("full") lifecycle --
+the production API only ever computes the suppressed ("default") lifecycle,
+which is its entire claim surface. Reuses the oracle-side helpers
+(`rd_default_pairs`/`rd_sparse_counts`/`rd_folded_bit_info`) directly from
+`ecfp_rdkit_raw_identifier_parity.py` so the oracle-reading logic can never
+silently drift between the two scripts.
+
+Denominator discipline (same as `ecfp_rdkit_raw_identifier_parity_aromaticity_variant.py`):
+the exact-match rate is computed ONLY over rows where the chematic dump's own
+`status == "success"`. Error rows are reported separately, never pooled in.
+
+Usage:
+    python scripts/ecfp_rdkit_morgan_ecfp4_parity.py \\
+        --chematic <rdkit_morgan_ecfp4_dump.jsonl> \\
+        --rdkit-oracle <gen_ecfp_rdkit_environment_oracle.py --rows-out output> \\
+        --summary-out <out.json> [--mismatches-out <out.jsonl>]
+
+    python scripts/ecfp_rdkit_morgan_ecfp4_parity.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from ecfp_rdkit_raw_identifier_parity import rd_default_pairs, rd_folded_bit_info, rd_sparse_counts
+
+NBITS = 2048
+
+
+def load_jsonl(path):
+    rows = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def chem_default_pairs(row):
+    return {(a, r): rid for a, r, rid in row["default_pairs"]}
+
+
+def chem_sparse_counts(row):
+    return {rid: count for rid, count in row["sparse_counts"]}
+
+
+def chem_folded_bit_info(row):
+    return {bit: {(a, r) for a, r in envs} for bit, envs in row["folded_bit_info"]}
+
+
+def is_exact_match(chem, rd):
+    """True only if every layer this production API claims (default-lifecycle
+    raw pairs, sparse counts, folded on-bits, folded bitInfo) matches. Only
+    valid for `status == "success"` rows."""
+    if chem_default_pairs(chem) != rd_default_pairs(rd):
+        return False
+    if chem_sparse_counts(chem) != rd_sparse_counts(rd):
+        return False
+    if set(chem["folded_on_bits"]) != set(rd["default"]["folded_on_bits"]):
+        return False
+    if chem_folded_bit_info(chem) != rd_folded_bit_info(rd):
+        return False
+    return True
+
+
+def run(chematic_rows, rdkit_rows):
+    if len(chematic_rows) != len(rdkit_rows):
+        print(
+            f"PIPELINE ERROR: row count mismatch chematic={len(chematic_rows)} rdkit={len(rdkit_rows)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    total_inputs = len(chematic_rows)
+    success_rows = []
+    error_rows = []
+
+    for idx, (chem, rd) in enumerate(zip(chematic_rows, rdkit_rows)):
+        if chem.get("row_id") != idx or rd.get("row_id") != idx:
+            print(f"PIPELINE ERROR at position {idx}: row_id out of sync", file=sys.stderr)
+            sys.exit(1)
+        if chem.get("smiles") != rd.get("smiles"):
+            print(
+                f"PIPELINE ERROR at row {idx}: chematic smiles={chem.get('smiles')!r} "
+                f"!= rdkit smiles={rd.get('smiles')!r}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        if chem.get("status") == "success":
+            success_rows.append((idx, chem, rd))
+        else:
+            error_rows.append({"row_id": idx, "smiles": chem.get("smiles"), "status": chem.get("status")})
+
+    exact = 0
+    non_exact_row_ids = []
+    for idx, chem, rd in success_rows:
+        if is_exact_match(chem, rd):
+            exact += 1
+        else:
+            non_exact_row_ids.append(idx)
+
+    success_count = len(success_rows)
+    exact_pct = round(exact / success_count, 4) if success_count else None
+
+    gate_failures = []
+    if non_exact_row_ids:
+        gate_failures.append(f"{len(non_exact_row_ids)} success row(s) not exact_match: {non_exact_row_ids[:10]}")
+
+    summary = {
+        "total_inputs": total_inputs,
+        "success_count": success_count,
+        "error_count": len(error_rows),
+        "exact_match_among_success": exact,
+        "exact_match_pct_among_success": exact_pct,
+        "non_exact_success_row_ids": non_exact_row_ids,
+        "error_rows": error_rows,
+        "gate_failures": gate_failures,
+        "gate_passed": len(gate_failures) == 0,
+    }
+
+    if gate_failures:
+        print(f"GATE FAILED: {len(gate_failures)} violation(s):", file=sys.stderr)
+        for msg in gate_failures:
+            print(f"  - {msg}", file=sys.stderr)
+
+    return summary, summary["gate_passed"]
+
+
+def run_self_test():
+    checks = []
+
+    def row(default_pairs, sparse_counts=None, folded_bit_info=None, status="success"):
+        sparse_counts = sparse_counts if sparse_counts is not None else {}
+        folded_bit_info = folded_bit_info if folded_bit_info is not None else {}
+        for (_a, _r), rid in {(a, r): rid for a, r, rid in default_pairs}.items():
+            sparse_counts.setdefault(rid, 0)
+            sparse_counts[rid] += 1
+        chem = {
+            "row_id": 0,
+            "smiles": "X",
+            "status": status,
+            "default_pairs": default_pairs,
+            "sparse_counts": list(sparse_counts.items()),
+            "folded_on_bits": sorted({rid % NBITS for _a, _r, rid in default_pairs}),
+            "folded_bit_info": [
+                (bit, sorted(envs)) for bit, envs in (folded_bit_info or _derive_folded_info(default_pairs)).items()
+            ],
+        }
+        rd = {
+            "row_id": 0,
+            "smiles": "X",
+            "default": {
+                "sparse_bit_info": {str(rid): [[a, r] for a, r, rid2 in default_pairs if rid2 == rid] for _a, _r, rid in default_pairs},
+                "sparse_counts": {str(k): v for k, v in sparse_counts.items()},
+                "folded_on_bits": sorted({rid % NBITS for _a, _r, rid in default_pairs}),
+                "folded_bit_info": {
+                    str(bit): [list(e) for e in envs]
+                    for bit, envs in (folded_bit_info or _derive_folded_info(default_pairs)).items()
+                },
+            },
+        }
+        return chem, rd
+
+    def _derive_folded_info(default_pairs):
+        info = {}
+        for a, r, rid in default_pairs:
+            info.setdefault(rid % NBITS, set()).add((a, r))
+        return info
+
+    chem, rd = row([(0, 0, 100), (1, 0, 100)])
+    checks.append(("exact_match", is_exact_match(chem, rd) is True))
+
+    chem, rd = row([(0, 0, 100), (1, 0, 100)])
+    chem["default_pairs"] = [(0, 0, 999), (1, 0, 100)]
+    checks.append(("raw_id_mismatch", is_exact_match(chem, rd) is False))
+
+    chem, rd = row([(0, 0, 100), (1, 0, 100)])
+    chem["sparse_counts"] = [(100, 5)]
+    checks.append(("sparse_count_mismatch", is_exact_match(chem, rd) is False))
+
+    chem, rd = row([(0, 0, 100), (1, 0, 100)])
+    chem["folded_on_bits"] = [999999]
+    checks.append(("folded_bit_mismatch", is_exact_match(chem, rd) is False))
+
+    chem, rd = row([(0, 0, 100), (1, 0, 100)])
+    chem["folded_bit_info"] = [(100, [[0, 0]])]
+    checks.append(("bitinfo_mismatch", is_exact_match(chem, rd) is False))
+
+    ok = True
+    for name, passed in checks:
+        status = "OK" if passed else "FAIL"
+        print(f"  self-test {name}: {status}")
+        ok = ok and passed
+
+    # live gate control: an error row must be excluded from the denominator,
+    # not counted as a mismatch and not counted as a match.
+    chem_success, rd_success = row([(0, 0, 100)])
+    chem_error = {"row_id": 1, "smiles": "Y", "status": "rdkit_parity_kekulization_failed"}
+    rd_error = {"row_id": 1, "smiles": "Y", "default": {"sparse_bit_info": {}, "sparse_counts": {}, "folded_on_bits": [], "folded_bit_info": {}}}
+    summary, gate_passed = run([chem_success, chem_error], [rd_success, rd_error])
+    live_control_ok = (
+        summary["success_count"] == 1
+        and summary["error_count"] == 1
+        and summary["exact_match_among_success"] == 1
+        and gate_passed is True
+    )
+    print(f"  live gate control (error row excluded from denominator): {'OK' if live_control_ok else 'FAIL'}")
+    ok = ok and live_control_ok
+
+    # live gate control: a genuine mismatch in a success row must fail the gate.
+    chem_bad, rd_bad = row([(0, 0, 100), (1, 0, 100)])
+    chem_bad["default_pairs"] = [(0, 0, 999), (1, 0, 100)]
+    _summary2, gate_passed2 = run([chem_bad], [rd_bad])
+    mismatch_gate_ok = gate_passed2 is False
+    print(f"  live gate control (success-row mismatch -> gate fails): {'OK' if mismatch_gate_ok else 'FAIL'}")
+    ok = ok and mismatch_gate_ok
+
+    return ok
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--chematic")
+    p.add_argument("--rdkit-oracle")
+    p.add_argument("--summary-out", default=None)
+    p.add_argument("--self-test", action="store_true")
+    args = p.parse_args()
+
+    if args.self_test:
+        ok = run_self_test()
+        sys.exit(0 if ok else 1)
+
+    if not args.chematic or not args.rdkit_oracle:
+        p.error("--chematic and --rdkit-oracle are required unless --self-test")
+
+    chematic_rows = load_jsonl(args.chematic)
+    rdkit_rows = load_jsonl(args.rdkit_oracle)
+    summary, gate_passed = run(chematic_rows, rdkit_rows)
+
+    print(json.dumps(summary, indent=2))
+    if args.summary_out:
+        with open(args.summary_out, "w") as f:
+            json.dump(summary, f, indent=2, sort_keys=True)
+        print(f"summary written to {args.summary_out}")
+
+    sys.exit(0 if gate_passed else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/README.md
+++ b/validation/README.md
@@ -116,7 +116,8 @@ prior Morgan-parity mode in this crate, which only claims *partition*
 agreement (which atoms are chemically equivalent) and *lifecycle* agreement
 (who wins/dies under suppression), this compares actual 32-bit hash VALUES
 against real RDKit, atom by atom and radius by radius. Not wired into any
-production API; `ecfp4()`/`ecfp6()`/`ecfp4_rdkit_invariants()`/
+production API at the time of this milestone (later promoted to production
+by the "Phase B" section below); `ecfp4()`/`ecfp6()`/`ecfp4_rdkit_invariants()`/
 `ecfp4_rdkit_environment_experimental()` are all unchanged (production
 snapshot verified byte-identical, see Results).
 
@@ -207,18 +208,77 @@ passes and merging by `(atom, radius)` key; regression-pinned in
   --features diagnostics --example rdkit_morgan_hash_dump_aromaticity_variant`
   + `python scripts/ecfp_rdkit_raw_identifier_parity_aromaticity_variant.py`.
 
-**Scope for a future implementation PR** (not started, and explicitly
-constrained by this milestone's findings): promote `rdkit_morgan_hash.rs`'s
-reference engine to a real, RDKit-compatible ECFP4 (radius=2 only -- this
-milestone never compared radius 3, so ECFP6 must not be added yet) API,
-using `apply_aromaticity_rdkit_parity_experimental` internally as a
-fallible `Result` step with **no Hueckel fallback** (matching the measured
-result above: bit-exact where preprocessing succeeds, explicit `Err`
-where it doesn't -- not a blend of the two). Any `BondOrder` this engine
-cannot map to a real RDKit `BondType` (verified this session: SINGLE=1,
-DOUBLE=2, TRIPLE=3, QUADRUPLE=4, AROMATIC=12, DATIVE=17, ZERO=21; only
-chematic's SMARTS-only `Query*` variants have no RDKit equivalent) must
-also be an explicit `Err`, never an implicit/guessed mapping.
+**Implemented as Phase B, same day (2026-07-20)** -- see the section
+immediately below for the production API and its own full corpus results.
+
+### Phase B: `rdkit_morgan_ecfp4_experimental` -- production, fallible, RDKit-bit-exact ECFP4
+
+Promotes M4-A0's reference engine (`crates/chematic-fp/src/rdkit_morgan_hash.rs`)
+to a real public API in `crates/chematic-fp/src/rdkit_morgan_ecfp4.rs`:
+`pub fn rdkit_morgan_ecfp4_experimental(mol: &Molecule) -> Result<RdkitMorganEcfp4, RdkitMorganError>`.
+Scope is intentionally narrow, matching exactly what M4-A0 verified numerically:
+
+- **radius = 2 (ECFP4) only** -- not ECFP6/radius = 3; M4-A0 never compared radius 3
+  against the oracle, so claiming bit-exactness there would be unverified.
+- Uses `apply_aromaticity_rdkit_parity_experimental` internally as a fallible `Result`
+  step -- **no Hueckel fallback anywhere in the public path.** No entry point accepts a
+  pre-aromatized `Molecule` (would let a caller bypass the engine and silently lose the
+  bit-exactness guarantee).
+- `RdkitMorganError`: `Aromaticity(AromaticityError)` (kekulization/internal-invariant
+  failure, wrapping `rdkit_parity.rs`'s own error), `UnsupportedBondOrder { bond_idx, order }`
+  (a `BondOrder` with no real RDKit `Bond::BondType` counterpart -- only chematic's
+  SMARTS-query-only variants, which cannot occur for SMILES-parsed input; confirmed via a
+  programmatically-built `Molecule` test since it can't be reached via `parse()`),
+  `InternalInvariantViolation { reason }`.
+- One shared computation, not independent per-field loops: a single pass over RDKit's
+  `includeRedundantEnvironments=false` ("default") lifecycle populates all four
+  `RdkitMorganEcfp4` fields (`fingerprint`, `sparse_counts`, `raw_bit_info`,
+  `folded_bit_info`) at once.
+
+**Results (same 5,048-input M4-A0 corpus, fresh dump + comparison against the same RDKit
+oracle rows, not re-derived from M4-A0's own numbers):**
+
+| Metric | Result |
+|---|---|
+| Preprocessing succeeded (`status: "success"`) | 5,046/5,048 |
+| Preprocessing failed (`rdkit_parity_kekulization_failed`, the same 2 pinned fixtures as M4-A0) | 2/5,048 |
+| Full exact match (default-lifecycle raw pairs, sparse counts, folded on-bits, folded bitInfo) among the 5,046 successful rows | **5,046/5,046 (100%)** |
+| Hermetic equivalence to `rdkit_morgan_raw_trace`'s already-oracle-validated `raw_identifier_default` output, same already-aromatized molecule | confirmed (unit test, 4 representative fixtures) |
+| Non-regression: `ecfp_regression_snapshot` (10 existing entry points: `ecfp4`, `ecfp6`, `ecfp` chiral, `ecfp_with_bitinfo`, `morgan_fp_counts`, `ecfp4_rdkit_invariants`, `ecfp6_rdkit_invariants`, `ecfp4_rdkit_environment_experimental`, `ecfp6_rdkit_environment_experimental`, `ecfp_with_bitinfo_rdkit_environment_experimental`), full 5,048-input corpus, SHA-256 before/after (git-worktree baseline at the pre-Phase-B commit) | byte-identical, 0 change |
+| Unsupported-bond-order path (`BondOrder::QueryAny`, programmatically built -- cannot arise from `parse()`) | explicit `Err(UnsupportedBondOrder)`, confirmed by test |
+| Positive control: a silently reintroduced Hueckel fallback would be numerically detectable (Hueckel perceives `c1cc[nH+]cc1`'s ring as fully aromatic where the real path correctly errors) | confirmed by test |
+
+**Performance vs. `ecfp4_rdkit_environment_experimental` baseline** (5 independent process
+runs each, full 5,048-corpus, median wall time, `/usr/bin/time -l` for peak RSS -- not a
+Criterion-registered benchmark, see `feedback_criterion_gate_pseudo_replication`):
+
+| | Baseline | Candidate | Ratio |
+|---|---|---|---|
+| Median wall time (5 runs) | 4.862s | 9.734s | **2.00x** |
+| Peak RSS | ~20.2 MB | ~20.4 MB | 1.01x |
+
+The ~2x ratio is fully attributable, not an unexplained regression: the baseline reads
+whatever aromatic flags are already on the input `Molecule` and never calls an aromaticity
+engine, while the candidate performs its own kekulization + RDKit-parity aromaticity
+perception on every call (a per-molecule breakdown shows preprocessing is 46-56% of the
+candidate's time on aromatic-ring-heavy molecules like benzene/aspirin/a steroid-like
+fused system, dropping to 19-20% on large acyclic alkanes with no rings to perceive).
+Per the acceptance-gate policy (stop and explain, don't silently tune), this is reported
+as measured rather than optimized against.
+
+Any `BondOrder` this engine cannot map to a real RDKit `BondType` (verified against
+`Bond.h` during M4-A0: SINGLE=1, DOUBLE=2, TRIPLE=3, QUADRUPLE=4, AROMATIC=12, DATIVE=17,
+ZERO=21; only chematic's SMARTS-only `Query*` variants have no RDKit equivalent) is an
+explicit `Err`, never an implicit/guessed mapping.
+
+- **Files:** `crates/chematic-fp/src/rdkit_morgan_ecfp4.rs`,
+  `crates/chematic-fp/examples/rdkit_morgan_ecfp4_dump.rs`,
+  `crates/chematic-fp/examples/rdkit_morgan_ecfp4_benchmark.rs`,
+  `scripts/ecfp_rdkit_morgan_ecfp4_parity.py`.
+- **How to regenerate:** `cargo run -p chematic-fp --release --example rdkit_morgan_ecfp4_dump
+  -- <SMILES.csv> <out.jsonl>` + `python scripts/ecfp_rdkit_morgan_ecfp4_parity.py --chematic
+  <out.jsonl> --rdkit-oracle <gen_ecfp_rdkit_environment_oracle.py output>`. Self-test:
+  `python scripts/ecfp_rdkit_morgan_ecfp4_parity.py --self-test`.
 
 ## Summary results
 

--- a/validation/ecfp_rdkit_morgan_ecfp4_parity_summary.json
+++ b/validation/ecfp_rdkit_morgan_ecfp4_parity_summary.json
@@ -1,0 +1,22 @@
+{
+  "error_count": 2,
+  "error_rows": [
+    {
+      "row_id": 2150,
+      "smiles": "Cc1cn2c(=O)c3ncn(COCCO)c3nc2n1C",
+      "status": "rdkit_parity_kekulization_failed"
+    },
+    {
+      "row_id": 5010,
+      "smiles": "c1cc[nH+]cc1",
+      "status": "rdkit_parity_kekulization_failed"
+    }
+  ],
+  "exact_match_among_success": 5046,
+  "exact_match_pct_among_success": 1.0,
+  "gate_failures": [],
+  "gate_passed": true,
+  "non_exact_success_row_ids": [],
+  "success_count": 5046,
+  "total_inputs": 5048
+}


### PR DESCRIPTION
## Summary

Promotes Milestone M4-A0's RDKit Morgan hash port (`crates/chematic-fp/src/rdkit_morgan_hash.rs`, PR #124, merged as `7c92ad31eabe4fdfe87602e4b66e929cf4976234`) to a real production API:

```rust
pub fn rdkit_morgan_ecfp4_experimental(mol: &Molecule) -> Result<RdkitMorganEcfp4, RdkitMorganError>
```

Scope is deliberately narrow, matching exactly what M4-A0 verified numerically against a live RDKit oracle — **not** a general RDKit-compatible fingerprint API:

- **radius = 2 (ECFP4) only.** M4-A0 never compared radius 3 against the oracle, so ECFP6 is intentionally not added here.
- Uses `apply_aromaticity_rdkit_parity_experimental` internally as a fallible `Result` step. **No Hueckel fallback anywhere in the public path** — this is the exact discipline the prior PR's own report had to be corrected to follow (see below).
- No entry point accepts a pre-aromatized `Molecule` — a caller can't bypass the engine and silently get a fingerprint that no longer carries the bit-exactness guarantee.
- `RdkitMorganError`: `Aromaticity(AromaticityError)`, `UnsupportedBondOrder { bond_idx, order }` (a `BondOrder` with no real RDKit `Bond::BondType` counterpart — only chematic's SMARTS-query-only variants, unreachable via `parse()` but explicitly tested via a programmatically-built `Molecule`), `InternalInvariantViolation { reason }`. No panics, no string-only errors, no silent unsupported-bond mapping.
- One shared computation populates all four `RdkitMorganEcfp4` fields (`fingerprint`, `sparse_counts`, `raw_bit_info`, `folded_bit_info`) from a single pass over RDKit's `includeRedundantEnvironments=false` lifecycle — not independent per-field loops.

## PR #124 (M4-A0) baseline this builds on

Merged as `7c92ad31eabe4fdfe87602e4b66e929cf4976234`. On the 5,048-input corpus (5,000-mol corpus + 41 + 4 + 3 fixtures):

- RDKit-parity aromaticity preprocessing: **5,046/5,048 succeeded**, 2/5,048 failed (`KekulizationFailed`, both pinned as permanent fixtures: `Cc1cn2c(=O)c3ncn(COCCO)c3nc2n1C`, `c1cc[nH+]cc1`).
- Among the 5,046 successful rows: **100% exact match** across raw identifiers (radius 0-2), representative selection, sparse counts, folded bits, and bitInfo — measured with an honest, non-pooled denominator after a prior draft's Hueckel-fallback pooling bug was found and fixed by the reviewer.
- All 59 production-Hueckel-aromaticity residuals resolved under the RDKit-parity engine (0 not-evaluable, 0 still-mismatching). All 9 of PR #123's representative-selection residuals and its Kekule-pyridine sparse-count-shape mismatch resolved under the real hash alone.

## This PR's own results (fresh full-corpus run, not re-derived from M4-A0's numbers)

New dump (`examples/rdkit_morgan_ecfp4_dump.rs`) + comparator (`scripts/ecfp_rdkit_morgan_ecfp4_parity.py`) against the same RDKit oracle rows:

| Metric | Result |
|---|---|
| Preprocessing succeeded | 5,046/5,048 |
| Preprocessing failed (same 2 pinned fixtures) | 2/5,048 |
| **Full exact match among the 5,046 successful rows** | **5,046/5,046 (100%)** |
| Hermetic equivalence to `rdkit_morgan_raw_trace`'s already-oracle-validated output (same aromatized molecule) | confirmed, unit test |
| Unsupported bond order (`BondOrder::QueryAny`, programmatically built) | explicit `Err(UnsupportedBondOrder)`, confirmed by test |
| Positive control: a reintroduced Hueckel fallback would be numerically detectable | confirmed by test |

**Non-regression:** extended `ecfp_regression_snapshot` to cover all 10 existing `ecfp.rs` entry points (`ecfp4`, `ecfp6`, `ecfp` chiral, `ecfp_with_bitinfo`, `morgan_fp_counts`, `ecfp4_rdkit_invariants`, `ecfp6_rdkit_invariants`, `ecfp4_rdkit_environment_experimental`, `ecfp6_rdkit_environment_experimental`, `ecfp_with_bitinfo_rdkit_environment_experimental`). Full 5,048-input corpus, SHA-256 before/after via a git-worktree baseline at the pre-this-PR commit: **byte-identical, 0 change.**

**Performance vs. `ecfp4_rdkit_environment_experimental` baseline** (5 independent process runs each, full corpus, median wall time, `/usr/bin/time -l` for RSS — not a Criterion-registered benchmark):

| | Baseline | Candidate | Ratio |
|---|---|---|---|
| Median wall time | 4.862s | 9.734s | ~2.00x |
| Peak RSS | ~20.2 MB | ~20.4 MB | 1.01x |

This is attributable, not an unexplained regression: the baseline never calls an aromaticity engine (reads whatever flags are already on the input), while the candidate performs its own kekulization + RDKit-parity aromaticity perception every call. Per-molecule breakdown: preprocessing is 46-56% of candidate time on aromatic-ring-heavy molecules, 19-20% on large acyclic alkanes. Reported as measured, not tuned against.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --exclude chematic-py --all-targets -- -D warnings`
- [x] `cargo clippy -p chematic-fp --all-targets --features diagnostics -- -D warnings`
- [x] `cargo test -p chematic-fp --lib` (245 passed)
- [x] `cargo test -p chematic-perception --lib` (129 passed, 2 ignored)
- [x] `cargo test --workspace --exclude chematic-py --lib --tests` (all green)
- [x] `cargo deny --all-features check` (advisories/bans/licenses/sources ok)
- [x] `python3 scripts/check_publish_graph.py` (OK, 18 publishable crates)
- [x] `bash scripts/check.sh` (full workspace incl. chematic-py: fmt, clippy, test --lib, test --tests, deny, publish graph, version — all green)
- [x] Full-corpus RDKit oracle parity: 5,046/5,046 (100%) among successful rows
- [x] Non-regression snapshot: byte-identical, 0 change, 10 existing entry points

Not merging — stopping here for review, per the same draft-and-stop pattern as PR #124.