### PR TITLE
feat(io): add streaming Daylight TDT reader and writer

### DIFF
--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -19,10 +19,5 @@ rustdoc-args = ["--cfg", "docsrs"]
 chematic-core        = { path = "../chematic-core",        version = "0.4.30" }
 chematic-rxn         = { path = "../chematic-rxn",         version = "0.4.30" }
 chematic-perception  = { path = "../chematic-perception",  version = "0.4.30" }
+chematic-smiles      = { path = "../chematic-smiles",      version = "0.4.30" }
 serde_json           = "1.0"
-
-[dev-dependencies]
-# Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies
-# comment -- a version-pinned dev-dependency must resolve against the
-# registry at `cargo publish` time, which a forward reference can't satisfy.
-chematic-smiles = { path = "../chematic-smiles" }

--- a/crates/chematic-mol/examples/smiles_table_benchmark.rs
+++ b/crates/chematic-mol/examples/smiles_table_benchmark.rs
@@ -1,0 +1,54 @@
+//! IO-1 performance record (not a gate, not a Criterion-registered
+//! benchmark -- see `feedback_criterion_gate_pseudo_replication` for why
+//! this repo treats the automated Criterion CI gate's samples as
+//! non-independent; this is a one-off, manually-reported measurement,
+//! matching the precedent of `morgan_suppression_benchmark.rs`/
+//! `rdkit_morgan_ecfp4_benchmark.rs`). Performance here is purely
+//! informational -- parser correctness is never traded for speed.
+//!
+//! Reports records/sec over a full streaming pass of a 10,000-record
+//! SMILES table file (title line + name column + 2 extra property columns,
+//! ~2% deliberately malformed rows to also measure invalid-record recovery
+//! throughput), using the streaming `SmilesRecordReader` (no
+//! `read_to_string` of the whole file).
+//!
+//! Usage:
+//! ```text
+//! cargo run -p chematic-mol --release --example smiles_table_benchmark -- <10k.smi>
+//! ```
+
+use chematic_mol::{SmilesReaderOptions, SmilesRecordReader};
+use std::io::BufReader;
+use std::time::Instant;
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| panic!("usage: smiles_table_benchmark <10k.smi>"));
+
+    let file = std::fs::File::open(&path).unwrap_or_else(|e| panic!("open {path}: {e}"));
+    let reader = SmilesRecordReader::new(
+        BufReader::new(file),
+        SmilesReaderOptions {
+            title_line: true,
+            ..Default::default()
+        },
+    );
+
+    let start = Instant::now();
+    let mut success = 0usize;
+    let mut errors = 0usize;
+    for result in reader {
+        match result {
+            Ok(_) => success += 1,
+            Err(_) => errors += 1,
+        }
+    }
+    let elapsed = start.elapsed();
+    let total = success + errors;
+    let records_per_sec = total as f64 / elapsed.as_secs_f64();
+
+    println!(
+        "total={total} success={success} errors={errors} elapsed={elapsed:?} records_per_sec={records_per_sec:.0}"
+    );
+}

--- a/crates/chematic-mol/examples/smiles_table_dump.rs
+++ b/crates/chematic-mol/examples/smiles_table_dump.rs
@@ -1,0 +1,123 @@
+//! IO-1 acceptance-gate dump: runs `SmilesRecordReader` over every scenario
+//! file named in `scripts/gen_smiles_table_fixtures.py`'s manifest, using
+//! that scenario's own configured options, and dumps each row's extracted
+//! `(status, name, properties, chematic_canonical_smiles)` as JSONL for
+//! comparison against a real RDKit oracle
+//! (`scripts/gen_rdkit_smiles_table_oracle.py`).
+//!
+//! Usage:
+//! ```text
+//! cargo run -p chematic-mol --release --example smiles_table_dump -- \
+//!     <manifest.json> <fixtures_dir> <out.jsonl>
+//! ```
+
+use chematic_mol::{Delimiter, SmilesReaderOptions, SmilesRecordReader, SmilesTableError};
+use serde_json::{Value, json};
+use std::fs;
+use std::io::{BufReader, Write};
+
+fn parse_delimiter(s: &str) -> Delimiter {
+    match s {
+        " " => Delimiter::Whitespace,
+        "\t" => Delimiter::Tab,
+        "," => Delimiter::Comma,
+        other => {
+            let bytes = other.as_bytes();
+            assert_eq!(
+                bytes.len(),
+                1,
+                "unsupported delimiter in manifest: {other:?}"
+            );
+            Delimiter::Custom(bytes[0])
+        }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let manifest_path = args
+        .get(1)
+        .expect("usage: smiles_table_dump <manifest.json> <fixtures_dir> <out.jsonl>");
+    let fixtures_dir = args
+        .get(2)
+        .expect("usage: smiles_table_dump <manifest.json> <fixtures_dir> <out.jsonl>");
+    let out_path = args
+        .get(3)
+        .expect("usage: smiles_table_dump <manifest.json> <fixtures_dir> <out.jsonl>");
+
+    let manifest_text =
+        fs::read_to_string(manifest_path).unwrap_or_else(|e| panic!("read manifest: {e}"));
+    let manifest: Value =
+        serde_json::from_str(&manifest_text).unwrap_or_else(|e| panic!("parse manifest: {e}"));
+
+    let mut out = fs::File::create(out_path).unwrap_or_else(|e| panic!("create {out_path}: {e}"));
+    let mut total_rows = 0usize;
+
+    let scenarios = manifest["scenarios"].as_object().expect("scenarios object");
+    let mut scenario_names: Vec<&String> = scenarios.keys().collect();
+    scenario_names.sort();
+
+    for name in scenario_names {
+        let scenario = &scenarios[name];
+        let opts = &scenario["options"];
+        let delimiter = parse_delimiter(opts["delimiter"].as_str().unwrap());
+        let smiles_column = opts["smiles_column"].as_u64().unwrap() as usize;
+        let name_column = opts["name_column"].as_u64().map(|v| v as usize);
+        let title_line = opts["title_line"].as_bool().unwrap();
+
+        let file_name = scenario["file"].as_str().unwrap();
+        let path = format!("{fixtures_dir}/{file_name}");
+        let file = fs::File::open(&path).unwrap_or_else(|e| panic!("open {path}: {e}"));
+
+        let known_rows = scenario["rows"].as_array().cloned().unwrap_or_default();
+
+        let reader_options = SmilesReaderOptions {
+            delimiter,
+            smiles_column,
+            name_column,
+            title_line,
+            strict_parsing: false,
+            ..Default::default()
+        };
+        let reader = SmilesRecordReader::new(BufReader::new(file), reader_options);
+
+        for (row_index, result) in reader.enumerate() {
+            let row = match result {
+                Ok(rec) => {
+                    let canonical = chematic_smiles::write(&rec.mol);
+                    let mut props: Vec<(String, String)> = rec.properties;
+                    props.sort_unstable();
+
+                    let self_consistent = known_rows
+                        .get(row_index)
+                        .and_then(|r| r["smiles"].as_str())
+                        .map(|known_smi| match chematic_smiles::parse(known_smi) {
+                            Ok(known_mol) => chematic_smiles::write(&known_mol) == canonical,
+                            Err(_) => false,
+                        });
+
+                    json!({
+                        "scenario": name,
+                        "row_index": row_index,
+                        "status": "success",
+                        "name": rec.name,
+                        "properties": props,
+                        "chematic_canonical_smiles": canonical,
+                        "self_consistent_with_known_smiles": self_consistent,
+                    })
+                }
+                Err(SmilesTableError::Io(msg)) => panic!("unexpected IO error in {name}: {msg}"),
+                Err(e) => json!({
+                    "scenario": name,
+                    "row_index": row_index,
+                    "status": "error",
+                    "error": e.to_string(),
+                }),
+            };
+            writeln!(out, "{row}").unwrap();
+            total_rows += 1;
+        }
+    }
+
+    eprintln!("total_rows={total_rows} out={out_path}");
+}

--- a/crates/chematic-mol/examples/tdt_benchmark.rs
+++ b/crates/chematic-mol/examples/tdt_benchmark.rs
@@ -1,0 +1,42 @@
+//! IO-2 performance record (not a gate, not a Criterion-registered
+//! benchmark -- see `feedback_criterion_gate_pseudo_replication` and the
+//! precedent of `smiles_table_benchmark.rs`). Performance here is purely
+//! informational.
+//!
+//! Reports records/sec over a full streaming pass of a 10,000-record TDT
+//! file (SMI + NAME + one property, ~2% deliberately malformed rows).
+//!
+//! Usage:
+//! ```text
+//! cargo run -p chematic-mol --release --example tdt_benchmark -- <10k.tdt>
+//! ```
+
+use chematic_mol::{TdtReaderOptions, TdtRecordReader};
+use std::io::BufReader;
+use std::time::Instant;
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| panic!("usage: tdt_benchmark <10k.tdt>"));
+
+    let file = std::fs::File::open(&path).unwrap_or_else(|e| panic!("open {path}: {e}"));
+    let reader = TdtRecordReader::new(BufReader::new(file), TdtReaderOptions::default());
+
+    let start = Instant::now();
+    let mut success = 0usize;
+    let mut errors = 0usize;
+    for result in reader {
+        match result {
+            Ok(_) => success += 1,
+            Err(_) => errors += 1,
+        }
+    }
+    let elapsed = start.elapsed();
+    let total = success + errors;
+    let records_per_sec = total as f64 / elapsed.as_secs_f64();
+
+    println!(
+        "total={total} success={success} errors={errors} elapsed={elapsed:?} records_per_sec={records_per_sec:.0}"
+    );
+}

--- a/crates/chematic-mol/examples/tdt_dump.rs
+++ b/crates/chematic-mol/examples/tdt_dump.rs
@@ -1,0 +1,102 @@
+//! IO-2 acceptance-gate dump: runs `TdtRecordReader` over every scenario
+//! file named in `scripts/gen_tdt_fixtures.py`'s manifest and dumps each
+//! row's extracted `(status, name, properties, coordinates)` as JSONL for
+//! comparison against a real RDKit oracle
+//! (`scripts/gen_rdkit_tdt_oracle.py`).
+//!
+//! Usage:
+//! ```text
+//! cargo run -p chematic-mol --release --example tdt_dump -- \
+//!     <manifest.json> <fixtures_dir> <out.jsonl>
+//! ```
+
+use chematic_mol::{TdtError, TdtReaderOptions, TdtRecordReader};
+use serde_json::{Value, json};
+use std::fs;
+use std::io::{BufReader, Write};
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let manifest_path = args
+        .get(1)
+        .expect("usage: tdt_dump <manifest.json> <fixtures_dir> <out.jsonl>");
+    let fixtures_dir = args
+        .get(2)
+        .expect("usage: tdt_dump <manifest.json> <fixtures_dir> <out.jsonl>");
+    let out_path = args
+        .get(3)
+        .expect("usage: tdt_dump <manifest.json> <fixtures_dir> <out.jsonl>");
+
+    let manifest_text =
+        fs::read_to_string(manifest_path).unwrap_or_else(|e| panic!("read manifest: {e}"));
+    let manifest: Value =
+        serde_json::from_str(&manifest_text).unwrap_or_else(|e| panic!("parse manifest: {e}"));
+
+    let mut out = fs::File::create(out_path).unwrap_or_else(|e| panic!("create {out_path}: {e}"));
+    let mut total_rows = 0usize;
+
+    let scenarios = manifest["scenarios"].as_object().expect("scenarios object");
+    let mut scenario_names: Vec<&String> = scenarios.keys().collect();
+    scenario_names.sort();
+
+    for name in scenario_names {
+        let scenario = &scenarios[name];
+        let file_name = scenario["file"].as_str().unwrap();
+        let path = format!("{fixtures_dir}/{file_name}");
+        let file = fs::File::open(&path).unwrap_or_else(|e| panic!("open {path}: {e}"));
+
+        let known_rows = scenario["rows"].as_array().cloned().unwrap_or_default();
+
+        let read_coords = name == "coordinates";
+        let reader_options = TdtReaderOptions {
+            name_tag: Some("NAME".to_string()),
+            read_2d: read_coords,
+            read_3d: read_coords,
+            strict_parsing: false,
+            ..Default::default()
+        };
+        let reader = TdtRecordReader::new(BufReader::new(file), reader_options);
+
+        for (row_index, result) in reader.enumerate() {
+            let row = match result {
+                Ok(rec) => {
+                    let mut props: Vec<(String, String)> = rec.properties;
+                    props.sort_unstable();
+
+                    let self_consistent = known_rows
+                        .get(row_index)
+                        .and_then(|r| r["smiles"].as_str())
+                        .map(|known_smi| match chematic_smiles::parse(known_smi) {
+                            Ok(known_mol) => {
+                                chematic_smiles::write(&known_mol)
+                                    == chematic_smiles::write(&rec.mol)
+                            }
+                            Err(_) => false,
+                        });
+
+                    json!({
+                        "scenario": name,
+                        "row_index": row_index,
+                        "status": "success",
+                        "name": rec.name,
+                        "properties": props,
+                        "coordinates_2d": rec.coordinates_2d,
+                        "coordinates_3d": rec.coordinates_3d,
+                        "self_consistent_with_known_smiles": self_consistent,
+                    })
+                }
+                Err(TdtError::Io(msg)) => panic!("unexpected IO error in {name}: {msg}"),
+                Err(e) => json!({
+                    "scenario": name,
+                    "row_index": row_index,
+                    "status": "error",
+                    "error": e.to_string(),
+                }),
+            };
+            writeln!(out, "{row}").unwrap();
+            total_rows += 1;
+        }
+    }
+
+    eprintln!("total_rows={total_rows} out={out_path}");
+}

--- a/crates/chematic-mol/src/lib.rs
+++ b/crates/chematic-mol/src/lib.rs
@@ -28,8 +28,10 @@ pub mod mol2_tripos;
 pub mod mol3000;
 pub mod moljson;
 pub mod pdbqt;
+pub mod record;
 pub mod rxn;
 pub mod sdf;
+pub mod smiles_table;
 
 // Convenient re-exports at crate root.
 pub use error::MolParseError;
@@ -50,5 +52,10 @@ pub use mol2000::{
 pub use mol3000::{parse_mol_v3000, parse_mol_v3000_with_coords, write_mol_v3000};
 pub use moljson::{MolJsonError, parse_moljson, write_moljson};
 pub use pdbqt::{PdbqtError, autodock_atom_type, parse_pdbqt, write_pdbqt};
+pub use record::MoleculeRecord;
 pub use rxn::{RxnParseError, parse_rxn_file, write_rxn_file};
 pub use sdf::{SdfFileReader, SdfReader, SdfRecord, SdfRecordReader};
+pub use smiles_table::{
+    Delimiter, SmilesReaderOptions, SmilesRecordReader, SmilesRecordWriter, SmilesTableError,
+    SmilesWriterOptions,
+};

--- a/crates/chematic-mol/src/lib.rs
+++ b/crates/chematic-mol/src/lib.rs
@@ -32,6 +32,7 @@ pub mod record;
 pub mod rxn;
 pub mod sdf;
 pub mod smiles_table;
+pub mod tdt;
 
 // Convenient re-exports at crate root.
 pub use error::MolParseError;
@@ -59,3 +60,4 @@ pub use smiles_table::{
     Delimiter, SmilesReaderOptions, SmilesRecordReader, SmilesRecordWriter, SmilesTableError,
     SmilesWriterOptions,
 };
+pub use tdt::{TdtError, TdtReaderOptions, TdtRecordReader, TdtRecordWriter, TdtWriterOptions};

--- a/crates/chematic-mol/src/record.rs
+++ b/crates/chematic-mol/src/record.rs
@@ -1,0 +1,52 @@
+//! [`MoleculeRecord`] — a format-agnostic single-molecule record shared by
+//! streaming readers/writers for record-oriented formats (SMILES table
+//! files, TDT, MRV) that are not MOL/SDF's own Ctab-based `SdfRecord`.
+//!
+//! Properties are an insertion-ordered `Vec`, not a `HashMap` — several
+//! writers in this module family must reproduce the exact column/tag order
+//! a caller configured, and `HashMap` iteration order is not deterministic
+//! across runs, which would make round-trip output non-reproducible.
+
+use chematic_core::Molecule;
+
+/// A single molecule plus its file-format-level metadata: name, arbitrary
+/// key/value properties (in file order), and optional 2D/3D coordinates.
+///
+/// Not every record-oriented format populates every field — e.g. a SMILES
+/// table record never has `coordinates_2d`/`coordinates_3d` (SMILES text
+/// carries no geometry), while a TDT record may have either or both.
+#[derive(Clone)]
+pub struct MoleculeRecord {
+    /// The parsed molecule (heavy atoms only, no explicit H).
+    pub mol: Molecule,
+    /// The record's name/title, or an empty string if the format/record has none.
+    pub name: String,
+    /// Arbitrary key/value properties, in the order they appeared in (or
+    /// should be written to) the file.
+    pub properties: Vec<(String, String)>,
+    /// 2D atom coordinates in file order, one entry per atom, if present.
+    pub coordinates_2d: Option<Vec<[f64; 2]>>,
+    /// 3D atom coordinates in file order, one entry per atom, if present.
+    pub coordinates_3d: Option<Vec<[f64; 3]>>,
+}
+
+impl MoleculeRecord {
+    /// A record with no name, no properties, and no coordinates.
+    pub fn new(mol: Molecule) -> Self {
+        Self {
+            mol,
+            name: String::new(),
+            properties: Vec::new(),
+            coordinates_2d: None,
+            coordinates_3d: None,
+        }
+    }
+
+    /// Look up a property's value by key (first match, in insertion order).
+    pub fn get_property(&self, key: &str) -> Option<&str> {
+        self.properties
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
+}

--- a/crates/chematic-mol/src/smiles_table.rs
+++ b/crates/chematic-mol/src/smiles_table.rs
@@ -552,6 +552,16 @@ impl<W: Write> SmilesRecordWriter<W> {
     pub fn into_inner(self) -> W {
         self.writer
     }
+
+    /// Replace the set (and order) of extra properties written per record.
+    pub fn set_properties(&mut self, properties: Vec<String>) {
+        self.options.properties = properties;
+    }
+
+    /// Flush the underlying writer.
+    pub fn flush(&mut self) -> std::io::Result<()> {
+        self.writer.flush()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/chematic-mol/src/smiles_table.rs
+++ b/crates/chematic-mol/src/smiles_table.rs
@@ -39,6 +39,21 @@
 //!   know a quoted field is unterminated without reading ahead indefinitely;
 //!   rather than silently misparsing or unboundedly buffering, an
 //!   unterminated quote is a [`SmilesTableError::UnterminatedQuote`].
+//!   **RDKit's own `SmilesMolSupplier` has no CSV-quote-awareness at all**
+//!   for its comma-delimiter mode — confirmed against a live RDKit oracle
+//!   this session, not merely inferred from source: a value like
+//!   `"has, a comma"` is split into two raw columns by RDKit's literal
+//!   comma-splitting, corrupting the field. Chematic's quoting support is a
+//!   genuine, deliberate improvement here, not a matched behavior — any
+//!   `.csv` file with an embedded comma or quote will therefore disagree
+//!   between chematic and RDKit by design, in chematic's favor.
+//! - No name column (`name_column: None`, RDKit's `nameColumn=-1`): RDKit's
+//!   `SmilesMolSupplier` falls back to the running *physical line number* as
+//!   `_Name` in this case (source-confirmed and independently reproduced
+//!   against a live RDKit oracle this session, `scripts/gen_rdkit_smiles_table_oracle.py`).
+//!   [`MoleculeRecord::name`] is simply empty in this case instead —
+//!   replicating a line-number-as-name fallback was judged a low-value,
+//!   surprising RDKit implementation detail not worth reproducing.
 
 use std::collections::HashSet;
 use std::io::{BufRead, Write};

--- a/crates/chematic-mol/src/smiles_table.rs
+++ b/crates/chematic-mol/src/smiles_table.rs
@@ -1,0 +1,886 @@
+//! Streaming SMILES table file I/O — `.smi`, `.smiles`, `.csv`, `.tsv`, `.txt`.
+//!
+//! A SMILES table file is one molecule per line, split into columns by a
+//! delimiter; one column holds the SMILES, an optional column holds a name,
+//! and any other columns become molecule properties. This is chematic's
+//! streaming counterpart to RDKit's `SmilesMolSupplier`/`SmilesWriter`
+//! (`Code/GraphMol/FileParsers/SmilesMolSupplier.cpp`/`SmilesWriter.cpp`,
+//! RDKit commit `8afba32ec539dcb2369bc84549d802aca3f7eb39`, the true
+//! resolution of tag `Release_2026_03_4` — see
+//! `docs/` audit notes for the full source-cited findings this module is
+//! built from).
+//!
+//! **Deliberate divergences from RDKit, documented rather than silently
+//! matched or silently different:**
+//! - RDKit's `SmilesMolSupplier` is a lazy, seek-based random-access reader
+//!   (`.length()`/`operator[]` scan-and-cache the whole remaining file).
+//!   [`SmilesRecordReader`] is forward-only (`BufRead`, not `Seek`) — no
+//!   `.length()`/indexed access is offered, intentionally.
+//! - RDKit's delimiter default differs across its own entry points (four
+//!   different values were found across the v1 C++ API, the v2 core struct,
+//!   and the Python binding). Chematic does not attempt to replicate that
+//!   inconsistency; [`Delimiter::default()`] is [`Delimiter::Whitespace`],
+//!   collapsing runs of space/tab into one split point (RDKit's own
+//!   `boost::char_separator` with `keep_empty_tokens` does *not* collapse
+//!   runs, a footgun this module deliberately does not reproduce).
+//! - RDKit's `SmilesMolSupplier` has no strict/lax parsing toggle at all — a
+//!   bad row always returns `None` for that entry while iteration continues
+//!   unconditionally. [`SmilesReaderOptions::strict_parsing`] is a chematic
+//!   addition: `true` still yields `Err` for the bad row but the reader then
+//!   stops (subsequent `next()` calls return `None`); `false` yields the same
+//!   `Err` and continues to the next row, matching RDKit's own behavior.
+//! - CXSMILES: not recognized in the SMILES column (parsed via
+//!   [`chematic_smiles::parse`], which has no CXSMILES support at all) —
+//!   this matches RDKit's *own* default for `SmilesMolSupplier`, which
+//!   explicitly hard-codes `allowCXSMILES=false` for this entry point too.
+//! - CSV quoting: an explicit RFC 4180 *subset* — quoted fields may contain
+//!   the delimiter, embedded quotes (doubled, `""` → `"`), but **may not
+//!   span multiple physical lines**. A line-based `BufRead` reader cannot
+//!   know a quoted field is unterminated without reading ahead indefinitely;
+//!   rather than silently misparsing or unboundedly buffering, an
+//!   unterminated quote is a [`SmilesTableError::UnterminatedQuote`].
+
+use std::collections::HashSet;
+use std::io::{BufRead, Write};
+
+use chematic_core::Molecule;
+use chematic_smiles::SmilesError;
+
+use crate::record::MoleculeRecord;
+
+// ---------------------------------------------------------------------------
+// Delimiter
+// ---------------------------------------------------------------------------
+
+/// How columns are separated on each data line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Delimiter {
+    /// One or more consecutive ASCII space/tab characters, collapsed into a
+    /// single split point (like `str::split_whitespace`, but restricted to
+    /// space/tab — this module strips `\r` from line ends before
+    /// tokenizing, so no other whitespace is ever present to split on).
+    #[default]
+    Whitespace,
+    /// A single literal tab character. Unlike [`Delimiter::Whitespace`],
+    /// consecutive tabs are **not** collapsed — an empty field between two
+    /// tabs is a real, empty column.
+    Tab,
+    /// A single literal comma, with RFC 4180-subset quoting (see the module
+    /// docs).
+    Comma,
+    /// Any other single ASCII byte, treated like [`Delimiter::Tab`] (literal,
+    /// non-collapsing, no quoting).
+    Custom(u8),
+}
+
+/// Split one already-`\r`-stripped line into columns per `delimiter`.
+///
+/// Returns `Err` only for [`Delimiter::Comma`] with an unterminated quoted
+/// field — every other delimiter mode cannot fail (worst case: a very long
+/// single field).
+fn tokenize_line(line: &str, delimiter: Delimiter) -> Result<Vec<String>, ()> {
+    match delimiter {
+        Delimiter::Whitespace => Ok(line
+            .split([' ', '\t'])
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect()),
+        Delimiter::Tab => Ok(line.split('\t').map(str::to_string).collect()),
+        Delimiter::Custom(b) => Ok(line.split(b as char).map(str::to_string).collect()),
+        Delimiter::Comma => tokenize_csv(line),
+    }
+}
+
+/// RFC 4180 *subset* CSV tokenizer (see module docs for the exact subset:
+/// quote-doubling supported, embedded newlines in a quoted field are not).
+fn tokenize_csv(line: &str) -> Result<Vec<String>, ()> {
+    let mut fields = Vec::new();
+    let mut field = String::new();
+    let mut chars = line.chars().peekable();
+    let mut in_quotes = false;
+    let mut quoted_field = false;
+
+    while let Some(c) = chars.next() {
+        if in_quotes {
+            if c == '"' {
+                if chars.peek() == Some(&'"') {
+                    field.push('"');
+                    chars.next();
+                } else {
+                    in_quotes = false;
+                }
+            } else {
+                field.push(c);
+            }
+        } else if c == '"' && field.is_empty() && !quoted_field {
+            in_quotes = true;
+            quoted_field = true;
+        } else if c == ',' {
+            fields.push(std::mem::take(&mut field));
+            quoted_field = false;
+        } else {
+            field.push(c);
+        }
+    }
+    if in_quotes {
+        return Err(());
+    }
+    fields.push(field);
+    Ok(fields)
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+/// Configuration for [`SmilesRecordReader`].
+#[derive(Debug, Clone)]
+pub struct SmilesReaderOptions {
+    pub delimiter: Delimiter,
+    /// 0-indexed column holding the SMILES string.
+    pub smiles_column: usize,
+    /// 0-indexed column holding the record name, or `None` if there is no
+    /// name column (the record's `name` is then always empty).
+    pub name_column: Option<usize>,
+    /// Whether the first non-comment, non-blank line is a header naming the
+    /// extra (non-SMILES, non-name) columns, rather than a data row.
+    pub title_line: bool,
+    /// `true`: a row that fails to parse/sanitize yields one `Err`, then the
+    /// reader stops (subsequent `next()` calls return `None`). `false`: the
+    /// same `Err` is yielded, but the reader continues to the next row.
+    pub strict_parsing: bool,
+    /// Hard cap on a single line's byte length, to bound memory use against
+    /// a pathological or adversarial input; exceeding it is
+    /// [`SmilesTableError::LineTooLong`].
+    pub max_line_bytes: usize,
+}
+
+impl Default for SmilesReaderOptions {
+    fn default() -> Self {
+        Self {
+            delimiter: Delimiter::default(),
+            smiles_column: 0,
+            name_column: Some(1),
+            title_line: false,
+            strict_parsing: false,
+            max_line_bytes: 1 << 20, // 1 MiB
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors from [`SmilesRecordReader`]/[`SmilesRecordWriter`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum SmilesTableError {
+    /// The SMILES column's value could not be parsed as SMILES.
+    InvalidSmiles {
+        line: usize,
+        record_index: usize,
+        detail: SmilesError,
+    },
+    /// The requested SMILES column index does not exist on this line.
+    MissingSmilesColumn {
+        line: usize,
+        record_index: usize,
+        column: usize,
+        columns_found: usize,
+    },
+    /// A quoted CSV field (`Delimiter::Comma`) was never closed on the line
+    /// it started on — see the module docs' RFC 4180-subset note.
+    UnterminatedQuote { line: usize, record_index: usize },
+    /// A line exceeded `max_line_bytes`.
+    LineTooLong {
+        line: usize,
+        record_index: usize,
+        limit: usize,
+    },
+    /// An IO error occurred while reading the input stream.
+    Io(String),
+}
+
+impl std::fmt::Display for SmilesTableError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidSmiles {
+                line,
+                record_index,
+                detail,
+            } => write!(
+                f,
+                "invalid SMILES at line {line} (record {record_index}): {detail}"
+            ),
+            Self::MissingSmilesColumn {
+                line,
+                record_index,
+                column,
+                columns_found,
+            } => write!(
+                f,
+                "line {line} (record {record_index}) has no column {column} \
+                 (only {columns_found} column(s) found)"
+            ),
+            Self::UnterminatedQuote { line, record_index } => write!(
+                f,
+                "unterminated quoted field at line {line} (record {record_index})"
+            ),
+            Self::LineTooLong {
+                line,
+                record_index,
+                limit,
+            } => write!(
+                f,
+                "line {line} (record {record_index}) exceeds the {limit}-byte limit"
+            ),
+            Self::Io(msg) => write!(f, "IO error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for SmilesTableError {}
+
+// ---------------------------------------------------------------------------
+// Reader
+// ---------------------------------------------------------------------------
+
+/// Streaming iterator over a SMILES table file.
+///
+/// Comment lines (first byte is literally `#`, before any trimming — a line
+/// with leading whitespace before `#` is *not* a comment, matching RDKit's
+/// own `SmilesMolSupplier::skipComments` behavior) and blank lines
+/// (whitespace-only) are skipped silently, never counted as a record.
+pub struct SmilesRecordReader<R: BufRead> {
+    reader: R,
+    options: SmilesReaderOptions,
+    header: Option<Vec<String>>,
+    header_read: bool,
+    line_number: usize,
+    record_index: usize,
+    stopped: bool,
+}
+
+impl<R: BufRead> SmilesRecordReader<R> {
+    pub fn new(reader: R, options: SmilesReaderOptions) -> Self {
+        Self {
+            reader,
+            options,
+            header: None,
+            header_read: false,
+            line_number: 0,
+            record_index: 0,
+            stopped: false,
+        }
+    }
+
+    /// Read one raw line (without its line terminator), or `None` at EOF.
+    fn read_line(&mut self) -> Result<Option<String>, SmilesTableError> {
+        let mut buf = String::new();
+        let n = self
+            .reader
+            .read_line(&mut buf)
+            .map_err(|e| SmilesTableError::Io(e.to_string()))?;
+        if n == 0 {
+            return Ok(None);
+        }
+        self.line_number += 1;
+        if buf.len() > self.options.max_line_bytes {
+            return Err(SmilesTableError::LineTooLong {
+                line: self.line_number,
+                record_index: self.record_index,
+                limit: self.options.max_line_bytes,
+            });
+        }
+        while buf.ends_with('\n') || buf.ends_with('\r') {
+            buf.pop();
+        }
+        Ok(Some(buf))
+    }
+
+    /// Read the header line, if configured, populating `self.header`.
+    fn ensure_header(&mut self) -> Result<(), SmilesTableError> {
+        if self.header_read {
+            return Ok(());
+        }
+        self.header_read = true;
+        if !self.options.title_line {
+            return Ok(());
+        }
+        if let Some(line) = self.next_data_line()? {
+            let tokens = tokenize_line(&line, self.options.delimiter).map_err(|_| {
+                SmilesTableError::UnterminatedQuote {
+                    line: self.line_number,
+                    record_index: self.record_index,
+                }
+            })?;
+            self.header = Some(tokens);
+        }
+        Ok(())
+    }
+
+    /// Read the next non-comment, non-blank raw line.
+    fn next_data_line(&mut self) -> Result<Option<String>, SmilesTableError> {
+        loop {
+            match self.read_line()? {
+                None => return Ok(None),
+                Some(line) => {
+                    if line.starts_with('#') || line.trim().is_empty() {
+                        continue;
+                    }
+                    return Ok(Some(line));
+                }
+            }
+        }
+    }
+
+    fn property_name(&self, col: usize) -> String {
+        self.header
+            .as_ref()
+            .and_then(|h| h.get(col))
+            .cloned()
+            .unwrap_or_else(|| format!("column_{col}"))
+    }
+}
+
+impl<R: BufRead> Iterator for SmilesRecordReader<R> {
+    type Item = Result<MoleculeRecord, SmilesTableError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.stopped {
+            return None;
+        }
+        if let Err(e) = self.ensure_header() {
+            self.stopped = true;
+            return Some(Err(e));
+        }
+
+        let line = match self.next_data_line() {
+            Ok(Some(l)) => l,
+            Ok(None) => return None,
+            Err(e) => {
+                self.stopped = true;
+                return Some(Err(e));
+            }
+        };
+
+        let record_line = self.line_number;
+        let record_index = self.record_index;
+        self.record_index += 1;
+
+        let tokens = match tokenize_line(&line, self.options.delimiter) {
+            Ok(t) => t,
+            Err(()) => {
+                let err = SmilesTableError::UnterminatedQuote {
+                    line: record_line,
+                    record_index,
+                };
+                if self.options.strict_parsing {
+                    self.stopped = true;
+                }
+                return Some(Err(err));
+            }
+        };
+
+        let Some(smi) = tokens.get(self.options.smiles_column) else {
+            let err = SmilesTableError::MissingSmilesColumn {
+                line: record_line,
+                record_index,
+                column: self.options.smiles_column,
+                columns_found: tokens.len(),
+            };
+            if self.options.strict_parsing {
+                self.stopped = true;
+            }
+            return Some(Err(err));
+        };
+
+        let mol: Molecule = match chematic_smiles::parse(smi) {
+            Ok(m) => m,
+            Err(detail) => {
+                let err = SmilesTableError::InvalidSmiles {
+                    line: record_line,
+                    record_index,
+                    detail,
+                };
+                if self.options.strict_parsing {
+                    self.stopped = true;
+                }
+                return Some(Err(err));
+            }
+        };
+
+        let mut record = MoleculeRecord::new(mol);
+        record.name = self
+            .options
+            .name_column
+            .and_then(|c| tokens.get(c))
+            .cloned()
+            .unwrap_or_default();
+
+        let skip: HashSet<usize> = [self.options.smiles_column]
+            .into_iter()
+            .chain(self.options.name_column)
+            .collect();
+        for (col, val) in tokens.iter().enumerate() {
+            if skip.contains(&col) {
+                continue;
+            }
+            record
+                .properties
+                .push((self.property_name(col), val.clone()));
+        }
+
+        Some(Ok(record))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Writer
+// ---------------------------------------------------------------------------
+
+/// Configuration for [`SmilesRecordWriter`].
+#[derive(Debug, Clone)]
+pub struct SmilesWriterOptions {
+    pub delimiter: Delimiter,
+    /// Header label for the name column; an empty string suppresses the
+    /// name field entirely (both header and data rows).
+    pub name_header: String,
+    pub include_header: bool,
+    /// Which properties to write, and in what order — an empty slice writes
+    /// no extra properties (chematic's default; matches RDKit's own
+    /// `SmilesWriter` default of writing nothing beyond SMILES + name).
+    pub properties: Vec<String>,
+}
+
+impl Default for SmilesWriterOptions {
+    fn default() -> Self {
+        Self {
+            delimiter: Delimiter::Whitespace,
+            name_header: "Name".to_string(),
+            include_header: true,
+            properties: Vec::new(),
+        }
+    }
+}
+
+fn delimiter_char(d: Delimiter) -> char {
+    match d {
+        Delimiter::Whitespace => ' ',
+        Delimiter::Tab => '\t',
+        Delimiter::Comma => ',',
+        Delimiter::Custom(b) => b as char,
+    }
+}
+
+/// Quote a CSV field per the RFC 4180 subset this module implements, only
+/// if it actually needs quoting (contains the delimiter, a quote, or `\r`/`\n`).
+fn csv_quote_if_needed(field: &str, delim: char) -> String {
+    if field.contains(delim) || field.contains('"') || field.contains(['\r', '\n']) {
+        format!("\"{}\"", field.replace('"', "\"\""))
+    } else {
+        field.to_string()
+    }
+}
+
+fn write_field(delim: Delimiter, field: &str) -> String {
+    if delim == Delimiter::Comma {
+        csv_quote_if_needed(field, ',')
+    } else {
+        field.to_string()
+    }
+}
+
+/// Streaming writer for a SMILES table file.
+pub struct SmilesRecordWriter<W: Write> {
+    writer: W,
+    options: SmilesWriterOptions,
+    header_written: bool,
+}
+
+impl<W: Write> SmilesRecordWriter<W> {
+    pub fn new(writer: W, options: SmilesWriterOptions) -> Self {
+        Self {
+            writer,
+            options,
+            header_written: false,
+        }
+    }
+
+    fn write_header(&mut self) -> std::io::Result<()> {
+        let delim = delimiter_char(self.options.delimiter);
+        write!(self.writer, "SMILES")?;
+        if !self.options.name_header.is_empty() {
+            write!(self.writer, "{delim}{}", self.options.name_header)?;
+        }
+        for p in &self.options.properties {
+            write!(self.writer, "{delim}{p}")?;
+        }
+        writeln!(self.writer)
+    }
+
+    /// Write one record. The molecule is serialized via
+    /// [`chematic_smiles::write`] (canonical, isomeric, aromatic-bond SMILES
+    /// — chematic has no separate Kekule-SMILES writer mode at present).
+    pub fn write_record(&mut self, record: &MoleculeRecord) -> std::io::Result<()> {
+        if self.options.include_header && !self.header_written {
+            self.write_header()?;
+        }
+        self.header_written = true;
+
+        let delim = delimiter_char(self.options.delimiter);
+        let smi = chematic_smiles::write(&record.mol);
+        write!(self.writer, "{}", write_field(self.options.delimiter, &smi))?;
+        if !self.options.name_header.is_empty() {
+            write!(
+                self.writer,
+                "{delim}{}",
+                write_field(self.options.delimiter, &record.name)
+            )?;
+        }
+        for p in &self.options.properties {
+            let val = record.get_property(p).unwrap_or("");
+            write!(
+                self.writer,
+                "{delim}{}",
+                write_field(self.options.delimiter, val)
+            )?;
+        }
+        writeln!(self.writer)
+    }
+
+    pub fn into_inner(self) -> W {
+        self.writer
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufReader, Cursor};
+
+    fn reader_over(
+        input: &str,
+        options: SmilesReaderOptions,
+    ) -> SmilesRecordReader<BufReader<Cursor<Vec<u8>>>> {
+        SmilesRecordReader::new(
+            BufReader::new(Cursor::new(input.as_bytes().to_vec())),
+            options,
+        )
+    }
+
+    #[test]
+    fn whitespace_delimiter_basic() {
+        let input = "CC ethane\nCCO ethanol\n";
+        let recs: Vec<_> = reader_over(input, SmilesReaderOptions::default())
+            .map(|r| r.unwrap())
+            .collect();
+        assert_eq!(recs.len(), 2);
+        assert_eq!(recs[0].mol.atom_count(), 2);
+        assert_eq!(recs[0].name, "ethane");
+        assert_eq!(recs[1].mol.atom_count(), 3);
+        assert_eq!(recs[1].name, "ethanol");
+    }
+
+    #[test]
+    fn tab_delimiter_does_not_collapse_empty_fields() {
+        let opts = SmilesReaderOptions {
+            delimiter: Delimiter::Tab,
+            name_column: Some(1),
+            ..Default::default()
+        };
+        let input = "CC\t\tActivity1\n"; // empty name field between two tabs
+        let rec = reader_over(input, opts).next().unwrap().unwrap();
+        assert_eq!(rec.name, "");
+        assert_eq!(
+            rec.properties,
+            vec![("column_2".to_string(), "Activity1".to_string())]
+        );
+    }
+
+    #[test]
+    fn comma_csv_with_quoted_embedded_comma() {
+        let opts = SmilesReaderOptions {
+            delimiter: Delimiter::Comma,
+            name_column: Some(1),
+            ..Default::default()
+        };
+        let input = "CC,\"a, b\",7.2\n";
+        let rec = reader_over(input, opts).next().unwrap().unwrap();
+        assert_eq!(rec.name, "a, b");
+        assert_eq!(
+            rec.properties,
+            vec![("column_2".to_string(), "7.2".to_string())]
+        );
+    }
+
+    #[test]
+    fn comma_csv_doubled_quote_escape() {
+        let opts = SmilesReaderOptions {
+            delimiter: Delimiter::Comma,
+            name_column: Some(1),
+            ..Default::default()
+        };
+        let input = "CC,\"say \"\"hi\"\"\"\n";
+        let rec = reader_over(input, opts).next().unwrap().unwrap();
+        assert_eq!(rec.name, "say \"hi\"");
+    }
+
+    #[test]
+    fn comma_csv_unterminated_quote_is_lax_recoverable() {
+        let opts = SmilesReaderOptions {
+            delimiter: Delimiter::Comma,
+            strict_parsing: false,
+            ..Default::default()
+        };
+        let input = "CC,\"unterminated\nCCO,ethanol\n";
+        let mut reader = reader_over(input, opts);
+        let first = reader.next().unwrap();
+        assert!(matches!(
+            first,
+            Err(SmilesTableError::UnterminatedQuote { .. })
+        ));
+        let second = reader.next().unwrap().unwrap();
+        assert_eq!(second.mol.atom_count(), 3);
+    }
+
+    #[test]
+    fn strict_parsing_stops_after_first_error() {
+        let opts = SmilesReaderOptions {
+            strict_parsing: true,
+            ..Default::default()
+        };
+        let input = "not(a(smiles\nCCO ethanol\n";
+        let mut reader = reader_over(input, opts);
+        assert!(matches!(
+            reader.next(),
+            Some(Err(SmilesTableError::InvalidSmiles { .. }))
+        ));
+        assert!(reader.next().is_none());
+    }
+
+    #[test]
+    fn lax_parsing_continues_after_error() {
+        let opts = SmilesReaderOptions {
+            strict_parsing: false,
+            ..Default::default()
+        };
+        let input = "not(a(smiles\nCCO ethanol\n";
+        let mut reader = reader_over(input, opts);
+        assert!(matches!(
+            reader.next(),
+            Some(Err(SmilesTableError::InvalidSmiles { .. }))
+        ));
+        let second = reader.next().unwrap().unwrap();
+        assert_eq!(second.mol.atom_count(), 3);
+        assert!(reader.next().is_none());
+    }
+
+    #[test]
+    fn comment_and_blank_lines_skipped() {
+        let input =
+            "# a comment\n\nCC ethane\n  # not a comment, treated as data (leading space)\n";
+        let recs: Vec<_> = reader_over(input, SmilesReaderOptions::default()).collect();
+        // The "leading-space-before-#" line is real data with an invalid SMILES -> Err.
+        assert_eq!(recs.len(), 2);
+        assert!(recs[0].is_ok());
+        assert!(recs[1].is_err());
+    }
+
+    #[test]
+    fn title_line_supplies_property_names() {
+        let opts = SmilesReaderOptions {
+            title_line: true,
+            name_column: Some(1),
+            ..Default::default()
+        };
+        let input = "SMILES Name Activity\nCC ethane 7.2\n";
+        let rec = reader_over(input, opts).next().unwrap().unwrap();
+        assert_eq!(rec.name, "ethane");
+        assert_eq!(
+            rec.properties,
+            vec![("Activity".to_string(), "7.2".to_string())]
+        );
+    }
+
+    #[test]
+    fn no_title_line_uses_stable_column_names() {
+        let opts = SmilesReaderOptions {
+            title_line: false,
+            name_column: Some(1),
+            ..Default::default()
+        };
+        let input = "CC ethane 7.2\n";
+        let rec = reader_over(input, opts).next().unwrap().unwrap();
+        assert_eq!(
+            rec.properties,
+            vec![("column_2".to_string(), "7.2".to_string())]
+        );
+    }
+
+    #[test]
+    fn missing_smiles_column_is_explicit_error() {
+        let opts = SmilesReaderOptions {
+            smiles_column: 5,
+            ..Default::default()
+        };
+        let input = "CC ethane\n";
+        let mut reader = reader_over(input, opts);
+        assert!(matches!(
+            reader.next(),
+            Some(Err(SmilesTableError::MissingSmilesColumn { .. }))
+        ));
+    }
+
+    #[test]
+    fn no_name_column_yields_empty_name() {
+        let opts = SmilesReaderOptions {
+            name_column: None,
+            ..Default::default()
+        };
+        let input = "CC extra1 extra2\n";
+        let rec = reader_over(input, opts).next().unwrap().unwrap();
+        assert_eq!(rec.name, "");
+        assert_eq!(
+            rec.properties,
+            vec![
+                ("column_1".to_string(), "extra1".to_string()),
+                ("column_2".to_string(), "extra2".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn line_too_long_is_explicit_error_not_panic() {
+        let opts = SmilesReaderOptions {
+            max_line_bytes: 8,
+            ..Default::default()
+        };
+        let input = "CC a_very_long_name_field\n";
+        let mut reader = reader_over(input, opts);
+        assert!(matches!(
+            reader.next(),
+            Some(Err(SmilesTableError::LineTooLong { .. }))
+        ));
+    }
+
+    #[test]
+    fn writer_default_roundtrip() {
+        let mol = chematic_smiles::parse("c1ccccc1").unwrap();
+        let mut record = MoleculeRecord::new(mol);
+        record.name = "benzene".to_string();
+
+        let mut out = Vec::new();
+        {
+            let mut writer = SmilesRecordWriter::new(&mut out, SmilesWriterOptions::default());
+            writer.write_record(&record).unwrap();
+        }
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.starts_with("SMILES Name\n") || text.starts_with("SMILES Name \n"));
+
+        let mut reader = reader_over(
+            &text,
+            SmilesReaderOptions {
+                title_line: true,
+                ..Default::default()
+            },
+        );
+        let back = reader.next().unwrap().unwrap();
+        assert_eq!(back.mol.atom_count(), 6);
+        assert_eq!(back.name, "benzene");
+    }
+
+    #[test]
+    fn writer_no_name_header_omits_name_field() {
+        let mol = chematic_smiles::parse("CC").unwrap();
+        let mut record = MoleculeRecord::new(mol);
+        record.name = "ethane".to_string();
+
+        let opts = SmilesWriterOptions {
+            name_header: String::new(),
+            include_header: false,
+            ..Default::default()
+        };
+        let mut out = Vec::new();
+        {
+            let mut writer = SmilesRecordWriter::new(&mut out, opts);
+            writer.write_record(&record).unwrap();
+        }
+        let text = String::from_utf8(out).unwrap();
+        assert_eq!(
+            text.trim_end(),
+            chematic_smiles::write(&chematic_smiles::parse("CC").unwrap())
+        );
+    }
+
+    #[test]
+    fn writer_selected_properties_in_order() {
+        let mol = chematic_smiles::parse("CC").unwrap();
+        let mut record = MoleculeRecord::new(mol);
+        record.name = "ethane".to_string();
+        record.properties = vec![
+            ("MW".to_string(), "30.07".to_string()),
+            ("Activity".to_string(), "7.2".to_string()),
+        ];
+
+        let opts = SmilesWriterOptions {
+            properties: vec!["Activity".to_string(), "MW".to_string()],
+            include_header: false,
+            ..Default::default()
+        };
+        let mut out = Vec::new();
+        {
+            let mut writer = SmilesRecordWriter::new(&mut out, opts);
+            writer.write_record(&record).unwrap();
+        }
+        let text = String::from_utf8(out).unwrap();
+        let smi = chematic_smiles::write(&chematic_smiles::parse("CC").unwrap());
+        assert_eq!(text.trim_end(), format!("{smi} ethane 7.2 30.07"));
+    }
+
+    #[test]
+    fn writer_missing_property_writes_empty_field() {
+        // name_header left at its default ("Name"), so both the (empty) name
+        // field and the missing property field are written as empty fields,
+        // not omitted -- two trailing delimiters, which `trim_end()` would
+        // wrongly swallow, hence `strip_suffix('\n')` here.
+        let mol = chematic_smiles::parse("CC").unwrap();
+        let record = MoleculeRecord::new(mol);
+        let opts = SmilesWriterOptions {
+            properties: vec!["Missing".to_string()],
+            include_header: false,
+            ..Default::default()
+        };
+        let mut out = Vec::new();
+        {
+            let mut writer = SmilesRecordWriter::new(&mut out, opts);
+            writer.write_record(&record).unwrap();
+        }
+        let text = String::from_utf8(out).unwrap();
+        let smi = chematic_smiles::write(&chematic_smiles::parse("CC").unwrap());
+        assert_eq!(text.strip_suffix('\n').unwrap(), format!("{smi}  "));
+    }
+
+    #[test]
+    fn csv_write_quotes_field_containing_comma() {
+        let mol = chematic_smiles::parse("CC").unwrap();
+        let mut record = MoleculeRecord::new(mol);
+        record.name = "a, b".to_string();
+        let opts = SmilesWriterOptions {
+            delimiter: Delimiter::Comma,
+            include_header: false,
+            ..Default::default()
+        };
+        let mut out = Vec::new();
+        {
+            let mut writer = SmilesRecordWriter::new(&mut out, opts);
+            writer.write_record(&record).unwrap();
+        }
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("\"a, b\""));
+    }
+}

--- a/crates/chematic-mol/src/smiles_table.rs
+++ b/crates/chematic-mol/src/smiles_table.rs
@@ -909,3 +909,178 @@ mod tests {
         assert!(text.contains("\"a, b\""));
     }
 }
+
+// ---------------------------------------------------------------------------
+// Adversarial / fuzz-style tests
+// ---------------------------------------------------------------------------
+//
+// No `cargo-fuzz`/libfuzzer harness exists anywhere in this workspace yet,
+// and introducing that toolchain (nightly + a separate fuzz crate) for one
+// module was judged disproportionate to the risk here (a line-based text
+// tokenizer over `BufRead`, not a binary/byte-oriented format). Instead:
+// deterministic adversarial unit tests for every category the acceptance
+// gate requires, plus a small seeded random-mutation corpus. All assert
+// only "no panic, no hang, no OOM, no infinite loop" -- not any particular
+// output -- since the whole point is that malformed/adversarial input must
+// degrade to a clean `Err`, never worse.
+
+#[cfg(test)]
+mod adversarial_tests {
+    use super::*;
+    use std::io::{BufReader, Cursor};
+
+    fn drain(input: &[u8], options: SmilesReaderOptions) -> usize {
+        let reader = SmilesRecordReader::new(BufReader::new(Cursor::new(input.to_vec())), options);
+        reader.count()
+    }
+
+    #[test]
+    fn empty_input_no_panic() {
+        assert_eq!(drain(b"", SmilesReaderOptions::default()), 0);
+    }
+
+    #[test]
+    fn truncated_input_no_trailing_newline_no_panic() {
+        assert_eq!(drain(b"CC ethane", SmilesReaderOptions::default()), 1);
+    }
+
+    #[test]
+    fn truncated_input_mid_quote_no_panic() {
+        let opts = SmilesReaderOptions {
+            delimiter: Delimiter::Comma,
+            ..Default::default()
+        };
+        // Unterminated quote at EOF, no newline at all.
+        assert_eq!(drain(b"CC,\"unterminated", opts), 1);
+    }
+
+    #[test]
+    fn huge_line_is_explicit_error_not_panic_or_oom() {
+        let mut line = b"CC ".to_vec();
+        line.extend(std::iter::repeat_n(b'a', 10_000_000)); // 10MB name field
+        line.push(b'\n');
+        let opts = SmilesReaderOptions {
+            max_line_bytes: 1 << 20,
+            ..Default::default()
+        };
+        let reader = SmilesRecordReader::new(BufReader::new(Cursor::new(line)), opts);
+        let results: Vec<_> = reader.collect();
+        assert_eq!(results.len(), 1);
+        assert!(matches!(
+            results[0],
+            Err(SmilesTableError::LineTooLong { .. })
+        ));
+    }
+
+    #[test]
+    fn huge_property_value_within_limit_does_not_panic() {
+        let mut line = b"CC ethane ".to_vec();
+        line.extend(std::iter::repeat_n(b'x', 500_000));
+        line.push(b'\n');
+        let opts = SmilesReaderOptions {
+            max_line_bytes: 1 << 21, // large enough to admit this line
+            ..Default::default()
+        };
+        let reader = SmilesRecordReader::new(BufReader::new(Cursor::new(line)), opts);
+        let results: Vec<_> = reader.collect();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_ok());
+    }
+
+    #[test]
+    fn invalid_utf8_byte_path_yields_io_error_not_panic() {
+        // 0xFF is never valid UTF-8 in any position.
+        let input: &[u8] = b"CC \xFF\xFE ethane\n";
+        let reader = SmilesRecordReader::new(
+            BufReader::new(Cursor::new(input.to_vec())),
+            SmilesReaderOptions::default(),
+        );
+        let results: Vec<_> = reader.collect();
+        assert_eq!(results.len(), 1);
+        assert!(matches!(results[0], Err(SmilesTableError::Io(_))));
+    }
+
+    #[test]
+    fn excessive_column_count_does_not_panic() {
+        let mut line = String::from("CC");
+        for i in 0..5000 {
+            line.push(' ');
+            line.push_str(&format!("prop{i}"));
+        }
+        line.push('\n');
+        let results: Vec<_> = drain_results(line.as_bytes(), SmilesReaderOptions::default());
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_ok());
+        let rec = results[0].as_ref().unwrap();
+        assert_eq!(rec.properties.len(), 4999); // 5000 extra tokens minus the name column
+    }
+
+    #[test]
+    fn very_large_molecule_smiles_does_not_panic() {
+        // A long linear alkane -- exercises the SMILES parser + tokenizer on
+        // an unusually large single field, not just a large file.
+        let smi = "C".repeat(3000);
+        let line = format!("{smi} big_alkane\n");
+        let results: Vec<_> = drain_results(line.as_bytes(), SmilesReaderOptions::default());
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_ok());
+        assert_eq!(results[0].as_ref().unwrap().mol.atom_count(), 3000);
+    }
+
+    fn drain_results(
+        input: &[u8],
+        options: SmilesReaderOptions,
+    ) -> Vec<Result<MoleculeRecord, SmilesTableError>> {
+        SmilesRecordReader::new(BufReader::new(Cursor::new(input.to_vec())), options).collect()
+    }
+
+    /// Tiny deterministic PRNG (splitmix64) -- no `rand` dependency needed
+    /// for a seeded, reproducible mutation corpus.
+    struct SplitMix64(u64);
+    impl SplitMix64 {
+        fn next(&mut self) -> u64 {
+            self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+            let mut z = self.0;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+            z ^ (z >> 31)
+        }
+    }
+
+    #[test]
+    fn seeded_random_mutation_corpus_never_panics() {
+        let base: &[u8] = b"SMILES,Name,Note\nCC,ethane,\"has, a comma\"\nc1ccccc1,benzene,plain\n";
+        let mut rng = SplitMix64(0xDEADBEEFCAFEF00D);
+
+        for _ in 0..2000 {
+            let mut mutated = base.to_vec();
+            let n_mutations = 1 + (rng.next() % 5) as usize;
+            for _ in 0..n_mutations {
+                if mutated.is_empty() {
+                    break;
+                }
+                let idx = (rng.next() as usize) % mutated.len();
+                let op = rng.next() % 3;
+                match op {
+                    0 => mutated[idx] = (rng.next() % 256) as u8,
+                    1 => {
+                        mutated.insert(idx, (rng.next() % 256) as u8);
+                    }
+                    _ => {
+                        mutated.remove(idx);
+                    }
+                }
+            }
+
+            let opts = SmilesReaderOptions {
+                delimiter: Delimiter::Comma,
+                title_line: true,
+                max_line_bytes: 1 << 16,
+                ..Default::default()
+            };
+            // The only contract under test: this must terminate and never
+            // panic, regardless of how corrupted the byte stream is.
+            let _ = drain(&mutated, opts);
+        }
+    }
+}

--- a/crates/chematic-mol/src/tdt.rs
+++ b/crates/chematic-mol/src/tdt.rs
@@ -1,0 +1,1042 @@
+//! Streaming Daylight TDT (Tagged Data) file I/O — `.tdt`.
+//!
+//! A TDT record is a sequence of `TAGNAME<value>` lines terminated by a line
+//! starting with `|`. This is chematic's counterpart to RDKit's
+//! `TDTMolSupplier`/`TDTWriter`
+//! (`Code/GraphMol/FileParsers/TDTMolSupplier.cpp`/`TDTWriter.cpp`, RDKit
+//! commit `8afba32ec539dcb2369bc84549d802aca3f7eb39`, the true resolution of
+//! tag `Release_2026_03_4`).
+//!
+//! ```text
+//! $SMI<CCO>
+//! NAME<ethanol>
+//! ACTIVITY<7.2>
+//! |
+//! ```
+//!
+//! **Grammar, source-confirmed (not guessed):** a record starts with the
+//! literal 5 characters `$SMI<` at column 0. A generic tag line is
+//! `TAGNAME<value>`: the tag name is the substring before the *first* `<`
+//! (trimmed of leading/trailing space/tab only); the value is the substring
+//! between that first `<` and the *last* `>` on the line — both `<` and `>`
+//! must appear on the same physical line for a generic tag, or it's a parse
+//! error. Only the `2D`/`3D` coordinate tags support multi-line values
+//! (comma-separated numbers terminated by a token containing `;>`). The
+//! record terminator `|` must be the first character of its line; nothing
+//! after it is inspected. There is no escaping mechanism for `<`/`>` inside
+//! a value anywhere in this grammar (RDKit has none either).
+//!
+//! **Deliberate, documented divergences from RDKit, all found via this
+//! session's source audit and confirmed against a live RDKit oracle:**
+//!
+//! - **Coordinate-block parsing bug, fixed, not replicated.** RDKit's own
+//!   `TDTMolSupplier` silently drops the *last* atom's position when
+//!   reading a `2D`/`3D` coordinate tag (its comma-tokenizer treats the
+//!   token containing the trailing `;>` as "found the terminator," and
+//!   never pushes that token's own numeric value) — confirmed against a
+//!   live RDKit 2026.03.3 run, not merely read from source. This chematic
+//!   port parses the full coordinate list correctly. Precision-first
+//!   library, real bug found in the reference implementation, not
+//!   reproduced.
+//! - **Reader/writer name-tag symmetry, fixed, not replicated.** RDKit's
+//!   `TDTWriter` hard-codes its name-tag output as literally `"NAME"`
+//!   (unconfigurable), while `TDTMolSupplier`'s own `nameRecord` parameter
+//!   defaults to `""` (meaning *no* tag populates `_Name`) — so a bare
+//!   `TDTWriter`/`TDTMolSupplier()` round trip silently loses the molecule
+//!   name by default, confirmed empirically against real RDKit. This is a
+//!   genuine, low-value RDKit design wart, not a deliberate feature;
+//!   [`TdtReaderOptions::name_tag`]/[`TdtWriterOptions::name_tag`] both
+//!   default to `Some("NAME")`, so a default reader+writer pair round-trips
+//!   the name correctly out of the box.
+//! - **Malformed-record recovery, hardened, not replicated.** In real
+//!   RDKit, a missing `>` on a generic tag line throws an exception that is
+//!   *not* caught inside `TDTMolSupplier::next()`'s own position-advance
+//!   bookkeeping — confirmed against source and empirically: naively
+//!   retrying `next()` after catching the exception re-seeks to the exact
+//!   same failed record and throws again, indefinitely. This reader instead
+//!   scans forward to the next `$SMI<`/record terminator internally before
+//!   returning `Err` for the broken record, so the *next* call to
+//!   [`Iterator::next`] always makes progress — matching this crate's
+//!   established "malformed input never causes non-termination" discipline
+//!   (see [`crate::smiles_table`]'s own `strict_parsing` design).
+//! - **`2D`/`3D` tags require an explicit opt-in to be interpreted as
+//!   coordinates** ([`TdtReaderOptions::read_2d`]/`read_3d`, both default
+//!   `false`) — matching RDKit's own default of *not* reading a conformer
+//!   (RDKit's Python binding explicitly pins `confId3D=-1` regardless of
+//!   the underlying C++ class's own differing default, a cross-entry-point
+//!   inconsistency this port does not reproduce). When disabled, a `2D`/`3D`
+//!   tag is stored as a generic string property holding the raw,
+//!   unparsed coordinate text — never silently discarded.
+
+use std::io::{BufRead, Write};
+
+use chematic_core::Molecule;
+use chematic_smiles::SmilesError;
+
+use crate::record::MoleculeRecord;
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+/// Configuration for [`TdtRecordReader`].
+#[derive(Debug, Clone)]
+pub struct TdtReaderOptions {
+    /// Which tag's value populates [`MoleculeRecord::name`]. `None` means no
+    /// tag does (RDKit's own `nameRecord=""` sentinel).
+    pub name_tag: Option<String>,
+    /// Interpret a `2D` tag as a 2D coordinate list (see the module docs for
+    /// why this defaults to `false`, matching RDKit's real Python default).
+    pub read_2d: bool,
+    /// Interpret a `3D` tag as a 3D coordinate list.
+    pub read_3d: bool,
+    /// `true`: a malformed record yields one `Err`, then the reader stops.
+    /// `false`: the same `Err` is yielded, but the reader recovers and
+    /// continues to the next record (always, regardless of this flag --
+    /// see the module docs' malformed-record-recovery note -- this flag
+    /// only controls whether the *caller* sees further items afterward).
+    pub strict_parsing: bool,
+    /// Hard cap on a single line's byte length.
+    pub max_line_bytes: usize,
+}
+
+impl Default for TdtReaderOptions {
+    fn default() -> Self {
+        Self {
+            name_tag: Some("NAME".to_string()),
+            read_2d: false,
+            read_3d: false,
+            strict_parsing: false,
+            max_line_bytes: 1 << 20,
+        }
+    }
+}
+
+/// Configuration for [`TdtRecordWriter`].
+#[derive(Debug, Clone)]
+pub struct TdtWriterOptions {
+    /// Tag name under which [`MoleculeRecord::name`] is written, or `None`
+    /// to omit the name entirely. Matches RDKit's `TDTWriter` default of
+    /// writing a `"NAME"` tag when a name is present.
+    pub name_tag: Option<String>,
+    /// Write a `2D` coordinate tag from [`MoleculeRecord::coordinates_2d`],
+    /// if present.
+    pub write_2d: bool,
+    /// Write a `3D` coordinate tag from [`MoleculeRecord::coordinates_3d`],
+    /// if present.
+    pub write_3d: bool,
+    /// Which properties to write, and in what order. `None` writes every
+    /// property on the record (matches RDKit's own `TDTWriter` default of
+    /// writing all non-computed properties); `Some(keys)` restricts to
+    /// exactly those keys, in that order (matches `SetProps`).
+    pub properties: Option<Vec<String>>,
+    /// Number of significant digits for written coordinate values (matches
+    /// `TDTWriter::SetNumDigits`, default 4).
+    pub precision: usize,
+}
+
+impl Default for TdtWriterOptions {
+    fn default() -> Self {
+        Self {
+            name_tag: Some("NAME".to_string()),
+            write_2d: false,
+            write_3d: true, // matches RDKit's TDTWriter default (3D, not 2D)
+            properties: None,
+            precision: 4,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors from [`TdtRecordReader`]/[`TdtRecordWriter`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum TdtError {
+    /// The record did not start with `$SMI<...>`.
+    MissingSmilesTag { line: usize, record_index: usize },
+    /// The `$SMI` tag's value could not be parsed as SMILES.
+    InvalidSmiles {
+        line: usize,
+        record_index: usize,
+        detail: SmilesError,
+    },
+    /// A generic tag line had `<` but no closing `>` on the same line.
+    UnterminatedTag {
+        line: usize,
+        record_index: usize,
+        tag_name: String,
+    },
+    /// A `2D`/`3D` coordinate list could not be parsed as comma-separated
+    /// numbers, or its length didn't match `3 * atom_count`/`2 * atom_count`.
+    MalformedCoordinateList {
+        line: usize,
+        record_index: usize,
+        tag_name: String,
+        detail: String,
+    },
+    /// A line exceeded `max_line_bytes`.
+    LineTooLong {
+        line: usize,
+        record_index: usize,
+        limit: usize,
+    },
+    /// An IO error occurred while reading the input stream.
+    Io(String),
+}
+
+impl std::fmt::Display for TdtError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingSmilesTag { line, record_index } => {
+                write!(
+                    f,
+                    "record {record_index} at line {line}: missing $SMI<...> tag"
+                )
+            }
+            Self::InvalidSmiles {
+                line,
+                record_index,
+                detail,
+            } => write!(
+                f,
+                "invalid SMILES at line {line} (record {record_index}): {detail}"
+            ),
+            Self::UnterminatedTag {
+                line,
+                record_index,
+                tag_name,
+            } => write!(
+                f,
+                "no closing '>' for tag {tag_name:?} at line {line} (record {record_index})"
+            ),
+            Self::MalformedCoordinateList {
+                line,
+                record_index,
+                tag_name,
+                detail,
+            } => write!(
+                f,
+                "malformed {tag_name} coordinate list at line {line} (record {record_index}): {detail}"
+            ),
+            Self::LineTooLong {
+                line,
+                record_index,
+                limit,
+            } => write!(
+                f,
+                "line {line} (record {record_index}) exceeds the {limit}-byte limit"
+            ),
+            Self::Io(msg) => write!(f, "IO error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for TdtError {}
+
+// ---------------------------------------------------------------------------
+// Reader
+// ---------------------------------------------------------------------------
+
+enum RawTag {
+    /// A generic `TAGNAME<value>` tag, fully resolved on one line.
+    Generic { name: String, value: String },
+    /// A `2D`/`3D` coordinate tag, already collected across however many
+    /// physical lines its `;>`-terminated number list spanned.
+    Coordinates { name: String, raw: String },
+}
+
+/// Streaming iterator over a TDT file.
+pub struct TdtRecordReader<R: BufRead> {
+    reader: R,
+    options: TdtReaderOptions,
+    line_number: usize,
+    record_index: usize,
+    stopped: bool,
+    at_eof: bool,
+}
+
+impl<R: BufRead> TdtRecordReader<R> {
+    pub fn new(reader: R, options: TdtReaderOptions) -> Self {
+        Self {
+            reader,
+            options,
+            line_number: 0,
+            record_index: 0,
+            stopped: false,
+            at_eof: false,
+        }
+    }
+
+    fn read_raw_line(&mut self) -> Result<Option<String>, TdtError> {
+        let mut buf = String::new();
+        let n = self
+            .reader
+            .read_line(&mut buf)
+            .map_err(|e| TdtError::Io(e.to_string()))?;
+        if n == 0 {
+            self.at_eof = true;
+            return Ok(None);
+        }
+        self.line_number += 1;
+        if buf.len() > self.options.max_line_bytes {
+            return Err(TdtError::LineTooLong {
+                line: self.line_number,
+                record_index: self.record_index,
+                limit: self.options.max_line_bytes,
+            });
+        }
+        while buf.ends_with('\n') || buf.ends_with('\r') {
+            buf.pop();
+        }
+        Ok(Some(buf))
+    }
+
+    /// Skip forward to (but not past) the next `$SMI<` line, recovering
+    /// from a malformed record. Consumes lines up to and including a `|`
+    /// terminator if one is seen first, or up to (excluding) the next
+    /// `$SMI<` line.
+    fn recover_to_next_record(&mut self) -> Result<(), TdtError> {
+        loop {
+            match self.reader.fill_buf() {
+                Ok([]) => return Ok(()), // EOF
+                Ok(_) => {}
+                Err(e) => return Err(TdtError::Io(e.to_string())),
+            }
+            // Peek one line without consuming past a `$SMI<` boundary.
+            let mut probe = String::new();
+            let consumed = {
+                let buf = self
+                    .reader
+                    .fill_buf()
+                    .map_err(|e| TdtError::Io(e.to_string()))?;
+                let text = String::from_utf8_lossy(buf);
+                if text.starts_with("$SMI<") {
+                    0
+                } else if let Some(nl) = text.find('\n') {
+                    probe.push_str(&text[..=nl]);
+                    nl + 1
+                } else {
+                    let len = text.len();
+                    probe.push_str(&text);
+                    len
+                }
+            };
+            if consumed == 0 {
+                return Ok(());
+            }
+            self.reader.consume(consumed);
+            self.line_number += 1;
+            let is_terminator = probe.trim_end_matches(['\r', '\n']).starts_with('|');
+            if is_terminator {
+                return Ok(());
+            }
+        }
+    }
+
+    fn read_record_tags(&mut self) -> Result<Option<(usize, Vec<RawTag>)>, TdtError> {
+        let start_line = loop {
+            let line = match self.read_raw_line()? {
+                None => return Ok(None),
+                Some(l) => l,
+            };
+            if line.trim().is_empty() {
+                continue;
+            }
+            break line;
+        };
+
+        let record_line = self.line_number;
+
+        if !start_line.starts_with("$SMI<") {
+            // A real record's first non-blank line must be `$SMI<...>`. This
+            // is a malformed record (missing SMILES entirely), not noise to
+            // skip -- recover to the next record boundary so the *next*
+            // `next()` call still makes progress.
+            self.recover_to_next_record()?;
+            return Err(TdtError::MissingSmilesTag {
+                line: record_line,
+                record_index: self.record_index,
+            });
+        }
+
+        let mut tags = Vec::new();
+
+        let smi_value =
+            extract_tag_value(&start_line).ok_or_else(|| TdtError::UnterminatedTag {
+                line: record_line,
+                record_index: self.record_index,
+                tag_name: "$SMI".to_string(),
+            })?;
+        tags.push(RawTag::Generic {
+            name: "$SMI".to_string(),
+            value: smi_value,
+        });
+
+        loop {
+            let line = match self.read_raw_line()? {
+                None => break, // EOF mid-record: return what we have (matches RDKit)
+                Some(l) => l,
+            };
+            if line.starts_with('|') {
+                break;
+            }
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            let tag_name = tag_name_of(&line);
+            if tag_name == "2D" || tag_name == "3D" {
+                let raw = self.read_coordinate_list(&line, &tag_name)?;
+                tags.push(RawTag::Coordinates {
+                    name: tag_name,
+                    raw,
+                });
+            } else {
+                match extract_tag_value(&line) {
+                    Some(value) => tags.push(RawTag::Generic {
+                        name: tag_name,
+                        value,
+                    }),
+                    None => {
+                        self.recover_to_next_record()?;
+                        return Err(TdtError::UnterminatedTag {
+                            line: self.line_number,
+                            record_index: self.record_index,
+                            tag_name,
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(Some((record_line, tags)))
+    }
+
+    /// Read a coordinate tag's value, following continuation lines until a
+    /// token containing `;>` is seen (matches RDKit's real multi-line
+    /// number-list grammar for `2D`/`3D` only).
+    fn read_coordinate_list(
+        &mut self,
+        first_line: &str,
+        tag_name: &str,
+    ) -> Result<String, TdtError> {
+        let start = first_line
+            .find('<')
+            .ok_or_else(|| TdtError::UnterminatedTag {
+                line: self.line_number,
+                record_index: self.record_index,
+                tag_name: tag_name.to_string(),
+            })?;
+        let mut buf = first_line[start + 1..].to_string();
+        while !buf.contains(";>") {
+            match self.read_raw_line()? {
+                None => {
+                    return Err(TdtError::MalformedCoordinateList {
+                        line: self.line_number,
+                        record_index: self.record_index,
+                        tag_name: tag_name.to_string(),
+                        detail: "unterminated coordinate list at EOF".to_string(),
+                    });
+                }
+                Some(more) => {
+                    buf.push(',');
+                    buf.push_str(&more);
+                }
+            }
+        }
+        let end = buf.find(";>").unwrap();
+        Ok(buf[..end].to_string())
+    }
+}
+
+fn tag_name_of(line: &str) -> String {
+    match line.find('<') {
+        Some(pos) => line[..pos].trim().to_string(),
+        None => line.trim().to_string(),
+    }
+}
+
+/// Extract a generic tag's value: substring between the first `<` and the
+/// last `>` on the line. `None` if either delimiter is missing.
+fn extract_tag_value(line: &str) -> Option<String> {
+    let start = line.find('<')?;
+    let end = line.rfind('>')?;
+    if end < start {
+        return None;
+    }
+    Some(line[start + 1..end].to_string())
+}
+
+fn parse_coordinate_list(raw: &str) -> Result<Vec<f64>, String> {
+    raw.split(',')
+        .filter(|s| !s.is_empty())
+        .map(|s| s.trim().parse::<f64>().map_err(|e| e.to_string()))
+        .collect()
+}
+
+impl<R: BufRead> Iterator for TdtRecordReader<R> {
+    type Item = Result<MoleculeRecord, TdtError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.stopped {
+            return None;
+        }
+
+        let (record_line, tags) = match self.read_record_tags() {
+            Ok(None) => return None,
+            Ok(Some(t)) => t,
+            Err(e) => {
+                let record_index = self.record_index;
+                self.record_index += 1;
+                if self.options.strict_parsing {
+                    self.stopped = true;
+                }
+                return Some(Err(match e {
+                    TdtError::UnterminatedTag { line, tag_name, .. } => TdtError::UnterminatedTag {
+                        line,
+                        record_index,
+                        tag_name,
+                    },
+                    other => other,
+                }));
+            }
+        };
+
+        let record_index = self.record_index;
+        self.record_index += 1;
+
+        let mut smi: Option<String> = None;
+        let mut properties: Vec<(String, String)> = Vec::new();
+        let mut name = String::new();
+        let mut coordinates_2d: Option<Vec<[f64; 2]>> = None;
+        let mut coordinates_3d: Option<Vec<[f64; 3]>> = None;
+        let mut raw_2d: Option<String> = None;
+        let mut raw_3d: Option<String> = None;
+
+        for tag in tags {
+            match tag {
+                RawTag::Generic {
+                    name: tag_name,
+                    value,
+                } if tag_name == "$SMI" => {
+                    smi = Some(value);
+                }
+                RawTag::Generic {
+                    name: tag_name,
+                    value,
+                } => {
+                    if self.options.name_tag.as_deref() == Some(tag_name.as_str()) {
+                        name = value.clone();
+                    }
+                    set_property(&mut properties, tag_name, value);
+                }
+                RawTag::Coordinates {
+                    name: tag_name,
+                    raw,
+                } => {
+                    if tag_name == "2D" {
+                        raw_2d = Some(raw);
+                    } else {
+                        raw_3d = Some(raw);
+                    }
+                }
+            }
+        }
+
+        let Some(smi) = smi else {
+            return Some(Err(TdtError::MissingSmilesTag {
+                line: record_line,
+                record_index,
+            }));
+        };
+
+        let mol: Molecule = match chematic_smiles::parse(&smi) {
+            Ok(m) => m,
+            Err(detail) => {
+                let err = TdtError::InvalidSmiles {
+                    line: record_line,
+                    record_index,
+                    detail,
+                };
+                if self.options.strict_parsing {
+                    self.stopped = true;
+                }
+                return Some(Err(err));
+            }
+        };
+
+        if let Some(raw) = raw_2d {
+            if self.options.read_2d {
+                match parse_coordinate_list(&raw) {
+                    Ok(nums) if nums.len() == 2 * mol.atom_count() => {
+                        coordinates_2d = Some(nums.chunks_exact(2).map(|c| [c[0], c[1]]).collect());
+                    }
+                    Ok(nums) => {
+                        return Some(Err(TdtError::MalformedCoordinateList {
+                            line: record_line,
+                            record_index,
+                            tag_name: "2D".to_string(),
+                            detail: format!(
+                                "expected {} numbers (2 * {} atoms), found {}",
+                                2 * mol.atom_count(),
+                                mol.atom_count(),
+                                nums.len()
+                            ),
+                        }));
+                    }
+                    Err(detail) => {
+                        return Some(Err(TdtError::MalformedCoordinateList {
+                            line: record_line,
+                            record_index,
+                            tag_name: "2D".to_string(),
+                            detail,
+                        }));
+                    }
+                }
+            } else {
+                set_property(&mut properties, "2D".to_string(), raw);
+            }
+        }
+        if let Some(raw) = raw_3d {
+            if self.options.read_3d {
+                match parse_coordinate_list(&raw) {
+                    Ok(nums) if nums.len() == 3 * mol.atom_count() => {
+                        coordinates_3d =
+                            Some(nums.chunks_exact(3).map(|c| [c[0], c[1], c[2]]).collect());
+                    }
+                    Ok(nums) => {
+                        return Some(Err(TdtError::MalformedCoordinateList {
+                            line: record_line,
+                            record_index,
+                            tag_name: "3D".to_string(),
+                            detail: format!(
+                                "expected {} numbers (3 * {} atoms), found {}",
+                                3 * mol.atom_count(),
+                                mol.atom_count(),
+                                nums.len()
+                            ),
+                        }));
+                    }
+                    Err(detail) => {
+                        return Some(Err(TdtError::MalformedCoordinateList {
+                            line: record_line,
+                            record_index,
+                            tag_name: "3D".to_string(),
+                            detail,
+                        }));
+                    }
+                }
+            } else {
+                set_property(&mut properties, "3D".to_string(), raw);
+            }
+        }
+
+        Some(Ok(MoleculeRecord {
+            mol,
+            name,
+            properties,
+            coordinates_2d,
+            coordinates_3d,
+        }))
+    }
+}
+
+/// Insert-or-overwrite-in-place, matching RDKit's own `Dict::setVal`
+/// "last wins, same position" semantics for repeated tags.
+fn set_property(properties: &mut Vec<(String, String)>, key: String, value: String) {
+    if let Some(existing) = properties.iter_mut().find(|(k, _)| *k == key) {
+        existing.1 = value;
+    } else {
+        properties.push((key, value));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Writer
+// ---------------------------------------------------------------------------
+
+/// Streaming writer for a TDT file.
+pub struct TdtRecordWriter<W: Write> {
+    writer: W,
+    options: TdtWriterOptions,
+    wrote_any: bool,
+    closed: bool,
+}
+
+impl<W: Write> TdtRecordWriter<W> {
+    pub fn new(writer: W, options: TdtWriterOptions) -> Self {
+        Self {
+            writer,
+            options,
+            wrote_any: false,
+            closed: false,
+        }
+    }
+
+    /// Write one record. The molecule's SMILES is serialized via
+    /// [`chematic_smiles::write`].
+    pub fn write_record(&mut self, record: &MoleculeRecord) -> std::io::Result<()> {
+        if self.wrote_any {
+            writeln!(self.writer, "|")?;
+        }
+        self.wrote_any = true;
+
+        let smi = chematic_smiles::write(&record.mol);
+        writeln!(self.writer, "$SMI<{smi}>")?;
+
+        if let Some(tag) = &self.options.name_tag
+            && !record.name.is_empty()
+        {
+            writeln!(self.writer, "{tag}<{}>", record.name)?;
+        }
+
+        if self.options.write_2d
+            && let Some(coords) = &record.coordinates_2d
+        {
+            self.write_coordinate_tag("2D", coords.iter().flat_map(|c| c.iter().copied()))?;
+        }
+        if self.options.write_3d
+            && let Some(coords) = &record.coordinates_3d
+        {
+            self.write_coordinate_tag("3D", coords.iter().flat_map(|c| c.iter().copied()))?;
+        }
+
+        match &self.options.properties {
+            None => {
+                for (k, v) in &record.properties {
+                    writeln!(self.writer, "{k}<{}>", v.replace('\n', " "))?;
+                }
+            }
+            Some(keys) => {
+                for k in keys {
+                    if let Some(v) = record.get_property(k) {
+                        writeln!(self.writer, "{k}<{}>", v.replace('\n', " "))?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn write_coordinate_tag(
+        &mut self,
+        tag: &str,
+        values: impl Iterator<Item = f64>,
+    ) -> std::io::Result<()> {
+        let precision = self.options.precision;
+        let formatted: Vec<String> = values.map(|v| format!("{v:.precision$}")).collect();
+        writeln!(self.writer, "{tag}<{};>", formatted.join(","))
+    }
+
+    /// Terminate the final record (matches RDKit's `TDTWriter::close`,
+    /// which writes the trailing `|` only on close, not on every `write`).
+    /// Idempotent -- a second call is a no-op, so an explicit `close()`
+    /// followed by `Drop` never double-writes the terminator.
+    pub fn close(&mut self) -> std::io::Result<()> {
+        if self.closed {
+            return Ok(());
+        }
+        self.closed = true;
+        if self.wrote_any {
+            writeln!(self.writer, "|")?;
+        }
+        self.writer.flush()
+    }
+
+    /// Consume the writer, returning the underlying `W` without finalizing
+    /// (call [`Self::close`] first if the trailing `|` terminator matters --
+    /// this writer does not finalize on drop, matching this crate's other
+    /// streaming writers).
+    pub fn into_inner(self) -> W {
+        self.writer
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufReader, Cursor};
+
+    fn reader_over(
+        input: &str,
+        options: TdtReaderOptions,
+    ) -> TdtRecordReader<BufReader<Cursor<Vec<u8>>>> {
+        TdtRecordReader::new(
+            BufReader::new(Cursor::new(input.as_bytes().to_vec())),
+            options,
+        )
+    }
+
+    #[test]
+    fn basic_record_with_name_and_property() {
+        let input = "$SMI<CCO>\nNAME<ethanol>\nACTIVITY<7.2>\n|\n";
+        let rec = reader_over(input, TdtReaderOptions::default())
+            .next()
+            .unwrap()
+            .unwrap();
+        assert_eq!(rec.mol.atom_count(), 3);
+        assert_eq!(rec.name, "ethanol");
+        assert_eq!(rec.get_property("ACTIVITY"), Some("7.2"));
+    }
+
+    #[test]
+    fn multiple_records() {
+        let input = "$SMI<CC>\nNAME<ethane>\n|\n$SMI<CCO>\nNAME<ethanol>\n|\n";
+        let recs: Vec<_> = reader_over(input, TdtReaderOptions::default())
+            .map(|r| r.unwrap())
+            .collect();
+        assert_eq!(recs.len(), 2);
+        assert_eq!(recs[0].name, "ethane");
+        assert_eq!(recs[1].name, "ethanol");
+    }
+
+    #[test]
+    fn missing_smi_tag_is_explicit_error() {
+        let input = "NAME<no_smiles>\n|\n";
+        let mut reader = reader_over(input, TdtReaderOptions::default());
+        assert!(matches!(
+            reader.next(),
+            Some(Err(TdtError::MissingSmilesTag { .. }))
+        ));
+    }
+
+    #[test]
+    fn empty_value_tag_is_stored_as_empty_string() {
+        let input = "$SMI<CC>\nNOTE<>\n|\n";
+        let rec = reader_over(input, TdtReaderOptions::default())
+            .next()
+            .unwrap()
+            .unwrap();
+        assert_eq!(rec.get_property("NOTE"), Some(""));
+    }
+
+    #[test]
+    fn repeated_tag_last_wins_same_position() {
+        let input = "$SMI<CC>\nFOO<first>\nBAR<x>\nFOO<second>\n|\n";
+        let rec = reader_over(input, TdtReaderOptions::default())
+            .next()
+            .unwrap()
+            .unwrap();
+        assert_eq!(rec.get_property("FOO"), Some("second"));
+        assert_eq!(rec.properties[0].0, "FOO"); // position preserved, not moved to end
+    }
+
+    #[test]
+    fn unknown_tags_stored_as_generic_properties() {
+        let input = "$SMI<CC>\nMFCD<12345>\nCAS<64-17-5>\n|\n";
+        let rec = reader_over(input, TdtReaderOptions::default())
+            .next()
+            .unwrap()
+            .unwrap();
+        assert_eq!(rec.get_property("MFCD"), Some("12345"));
+        assert_eq!(rec.get_property("CAS"), Some("64-17-5"));
+    }
+
+    #[test]
+    fn unterminated_generic_tag_recovers_to_next_record() {
+        let input = "$SMI<CC>\nBROKEN<no_close\n|\n$SMI<CCO>\nNAME<ethanol>\n|\n";
+        let mut reader = reader_over(input, TdtReaderOptions::default());
+        assert!(matches!(
+            reader.next(),
+            Some(Err(TdtError::UnterminatedTag { .. }))
+        ));
+        let second = reader.next().unwrap().unwrap();
+        assert_eq!(second.name, "ethanol");
+        assert!(reader.next().is_none());
+    }
+
+    #[test]
+    fn strict_parsing_stops_after_first_error() {
+        let opts = TdtReaderOptions {
+            strict_parsing: true,
+            ..Default::default()
+        };
+        let input = "NAME<no_smiles>\n|\n$SMI<CC>\n|\n";
+        let mut reader = reader_over(input, opts);
+        assert!(matches!(
+            reader.next(),
+            Some(Err(TdtError::MissingSmilesTag { .. }))
+        ));
+        assert!(reader.next().is_none());
+    }
+
+    #[test]
+    fn eof_mid_record_no_terminator_still_succeeds() {
+        let input = "$SMI<CC>\nNAME<ethane>";
+        let rec = reader_over(input, TdtReaderOptions::default())
+            .next()
+            .unwrap()
+            .unwrap();
+        assert_eq!(rec.name, "ethane");
+    }
+
+    #[test]
+    fn coordinate_2d_opt_in_parses_full_list_no_last_atom_drop() {
+        let opts = TdtReaderOptions {
+            read_2d: true,
+            ..Default::default()
+        };
+        // 3-atom molecule: 6 numbers.
+        let input = "$SMI<CCO>\n2D<0.0,0.0,1.0,0.0,2.0,1.0;>\n|\n";
+        let rec = reader_over(input, opts).next().unwrap().unwrap();
+        let coords = rec.coordinates_2d.expect("2D coords present");
+        assert_eq!(coords.len(), 3);
+        assert_eq!(coords[2], [2.0, 1.0]); // last atom NOT dropped (RDKit's own bug, not replicated)
+    }
+
+    #[test]
+    fn coordinate_3d_opt_in_parses_full_list() {
+        let opts = TdtReaderOptions {
+            read_3d: true,
+            ..Default::default()
+        };
+        let input = "$SMI<CCO>\n3D<0.0,0.0,0.0,1.0,0.0,0.0,2.0,1.0,0.5;>\n|\n";
+        let rec = reader_over(input, opts).next().unwrap().unwrap();
+        let coords = rec.coordinates_3d.expect("3D coords present");
+        assert_eq!(coords.len(), 3);
+        assert_eq!(coords[2], [2.0, 1.0, 0.5]);
+    }
+
+    #[test]
+    fn coordinate_tag_without_opt_in_stored_as_raw_property() {
+        let input = "$SMI<CCO>\n2D<0.0,0.0,1.0,0.0,2.0,1.0;>\n|\n";
+        let rec = reader_over(input, TdtReaderOptions::default())
+            .next()
+            .unwrap()
+            .unwrap();
+        assert!(rec.coordinates_2d.is_none());
+        assert_eq!(rec.get_property("2D"), Some("0.0,0.0,1.0,0.0,2.0,1.0"));
+    }
+
+    #[test]
+    fn multiline_coordinate_list_spanning_lines() {
+        let opts = TdtReaderOptions {
+            read_2d: true,
+            ..Default::default()
+        };
+        let input = "$SMI<CCO>\n2D<0.0,0.0,\n1.0,0.0,\n2.0,1.0;>\n|\n";
+        let rec = reader_over(input, opts).next().unwrap().unwrap();
+        let coords = rec.coordinates_2d.expect("2D coords present");
+        assert_eq!(coords, vec![[0.0, 0.0], [1.0, 0.0], [2.0, 1.0]]);
+    }
+
+    #[test]
+    fn writer_default_roundtrip_preserves_name() {
+        let mol = chematic_smiles::parse("CCO").unwrap();
+        let mut record = MoleculeRecord::new(mol);
+        record.name = "ethanol".to_string();
+        record
+            .properties
+            .push(("Activity".to_string(), "7.2".to_string()));
+
+        let mut out = Vec::new();
+        {
+            let mut writer = TdtRecordWriter::new(&mut out, TdtWriterOptions::default());
+            writer.write_record(&record).unwrap();
+            writer.close().unwrap();
+        }
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.starts_with("$SMI<"));
+        assert!(text.contains("NAME<ethanol>"));
+        assert!(text.contains("Activity<7.2>"));
+        assert!(text.trim_end().ends_with('|'));
+
+        let mut reader = reader_over(&text, TdtReaderOptions::default());
+        let back = reader.next().unwrap().unwrap();
+        assert_eq!(back.mol.atom_count(), 3);
+        assert_eq!(back.name, "ethanol"); // default reader+writer round-trips the name
+    }
+
+    #[test]
+    fn writer_multiple_records_terminator_placement() {
+        let mol1 = chematic_smiles::parse("CC").unwrap();
+        let mol2 = chematic_smiles::parse("CCO").unwrap();
+        let mut out = Vec::new();
+        {
+            let mut writer = TdtRecordWriter::new(&mut out, TdtWriterOptions::default());
+            writer.write_record(&MoleculeRecord::new(mol1)).unwrap();
+            writer.write_record(&MoleculeRecord::new(mol2)).unwrap();
+            writer.close().unwrap();
+        }
+        let text = String::from_utf8(out).unwrap();
+        let terminator_count = text.lines().filter(|l| *l == "|").count();
+        assert_eq!(terminator_count, 2);
+    }
+
+    #[test]
+    fn writer_properties_none_writes_all() {
+        let mol = chematic_smiles::parse("CC").unwrap();
+        let mut record = MoleculeRecord::new(mol);
+        record.properties = vec![
+            ("A".to_string(), "1".to_string()),
+            ("B".to_string(), "2".to_string()),
+        ];
+        let mut out = Vec::new();
+        {
+            let mut writer = TdtRecordWriter::new(
+                &mut out,
+                TdtWriterOptions {
+                    name_tag: None,
+                    ..Default::default()
+                },
+            );
+            writer.write_record(&record).unwrap();
+            writer.close().unwrap();
+        }
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("A<1>"));
+        assert!(text.contains("B<2>"));
+    }
+
+    #[test]
+    fn writer_properties_selected_subset_and_order() {
+        let mol = chematic_smiles::parse("CC").unwrap();
+        let mut record = MoleculeRecord::new(mol);
+        record.properties = vec![
+            ("A".to_string(), "1".to_string()),
+            ("B".to_string(), "2".to_string()),
+        ];
+        let mut out = Vec::new();
+        {
+            let mut writer = TdtRecordWriter::new(
+                &mut out,
+                TdtWriterOptions {
+                    name_tag: None,
+                    properties: Some(vec!["B".to_string()]),
+                    ..Default::default()
+                },
+            );
+            writer.write_record(&record).unwrap();
+            writer.close().unwrap();
+        }
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("B<2>"));
+        assert!(!text.contains("A<1>"));
+    }
+
+    #[test]
+    fn writer_embedded_newline_in_property_replaced_with_space() {
+        let mol = chematic_smiles::parse("CC").unwrap();
+        let mut record = MoleculeRecord::new(mol);
+        record
+            .properties
+            .push(("Note".to_string(), "line1\nline2".to_string()));
+        let mut out = Vec::new();
+        {
+            let mut writer = TdtRecordWriter::new(
+                &mut out,
+                TdtWriterOptions {
+                    name_tag: None,
+                    ..Default::default()
+                },
+            );
+            writer.write_record(&record).unwrap();
+            writer.close().unwrap();
+        }
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("Note<line1 line2>"));
+    }
+}

--- a/crates/chematic-mol/src/tdt.rs
+++ b/crates/chematic-mol/src/tdt.rs
@@ -753,6 +753,24 @@ impl<W: Write> TdtRecordWriter<W> {
     pub fn into_inner(self) -> W {
         self.writer
     }
+
+    /// Replace the set (and order) of properties written per record.
+    /// `None` writes every property (RDKit's own `TDTWriter` default).
+    pub fn set_properties(&mut self, properties: Option<Vec<String>>) {
+        self.options.properties = properties;
+    }
+
+    /// Replace the tag under which the record name is written, or `None`
+    /// to omit it entirely (matches `SetWriteNames`).
+    pub fn set_name_tag(&mut self, name_tag: Option<String>) {
+        self.options.name_tag = name_tag;
+    }
+
+    /// Replace the number of significant digits used for written coordinate
+    /// values (matches `SetNumDigits`).
+    pub fn set_precision(&mut self, precision: usize) {
+        self.options.precision = precision;
+    }
 }
 
 #[cfg(test)]

--- a/crates/chematic-mol/src/tdt.rs
+++ b/crates/chematic-mol/src/tdt.rs
@@ -370,14 +370,35 @@ impl<R: BufRead> TdtRecordReader<R> {
             });
         }
 
+        // Any error from here on (malformed tag, oversized line, malformed
+        // coordinate list, IO error mid-record) must recover to the next
+        // record boundary before propagating -- otherwise a leftover
+        // fragment of THIS record (e.g. its `|` terminator, already read
+        // into a buffer that got rejected for being too long) is
+        // misinterpreted as the start of a phantom next record. Centralized
+        // here rather than at each individual error site inside
+        // `read_record_body`, so no future error path can forget it.
+        match self.read_record_body(&start_line, record_line) {
+            Ok(tags) => Ok(Some((record_line, tags))),
+            Err(e) => {
+                self.recover_to_next_record()?;
+                Err(e)
+            }
+        }
+    }
+
+    fn read_record_body(
+        &mut self,
+        start_line: &str,
+        record_line: usize,
+    ) -> Result<Vec<RawTag>, TdtError> {
         let mut tags = Vec::new();
 
-        let smi_value =
-            extract_tag_value(&start_line).ok_or_else(|| TdtError::UnterminatedTag {
-                line: record_line,
-                record_index: self.record_index,
-                tag_name: "$SMI".to_string(),
-            })?;
+        let smi_value = extract_tag_value(start_line).ok_or_else(|| TdtError::UnterminatedTag {
+            line: record_line,
+            record_index: self.record_index,
+            tag_name: "$SMI".to_string(),
+        })?;
         tags.push(RawTag::Generic {
             name: "$SMI".to_string(),
             value: smi_value,
@@ -409,7 +430,6 @@ impl<R: BufRead> TdtRecordReader<R> {
                         value,
                     }),
                     None => {
-                        self.recover_to_next_record()?;
                         return Err(TdtError::UnterminatedTag {
                             line: self.line_number,
                             record_index: self.record_index,
@@ -420,7 +440,7 @@ impl<R: BufRead> TdtRecordReader<R> {
             }
         }
 
-        Ok(Some((record_line, tags)))
+        Ok(tags)
     }
 
     /// Read a coordinate tag's value, following continuation lines until a
@@ -1065,5 +1085,193 @@ mod tests {
         }
         let text = String::from_utf8(out).unwrap();
         assert!(text.contains("Note<line1 line2>"));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Adversarial / fuzz-style tests
+// ---------------------------------------------------------------------------
+//
+// Same rationale as `crate::smiles_table::adversarial_tests`: no
+// cargo-fuzz/libfuzzer harness exists anywhere in this workspace, and
+// introducing one for this module was judged disproportionate. Deterministic
+// adversarial unit tests instead, all asserting only "no panic/hang/OOM".
+
+#[cfg(test)]
+mod adversarial_tests {
+    use super::*;
+    use std::io::{BufReader, Cursor};
+
+    fn drain(input: &[u8], options: TdtReaderOptions) -> usize {
+        TdtRecordReader::new(BufReader::new(Cursor::new(input.to_vec())), options).count()
+    }
+
+    #[test]
+    fn empty_input_no_panic() {
+        assert_eq!(drain(b"", TdtReaderOptions::default()), 0);
+    }
+
+    #[test]
+    fn truncated_input_mid_smi_tag_no_panic() {
+        assert_eq!(drain(b"$SMI<CC", TdtReaderOptions::default()), 1);
+    }
+
+    #[test]
+    fn truncated_input_at_dollar_sign_only_no_panic() {
+        assert_eq!(drain(b"$", TdtReaderOptions::default()), 1);
+    }
+
+    #[test]
+    fn huge_line_is_explicit_error_not_panic_or_oom() {
+        let mut line = b"$SMI<CC>\nNOTE<".to_vec();
+        line.extend(std::iter::repeat_n(b'a', 10_000_000));
+        line.push(b'>');
+        line.push(b'\n');
+        line.extend_from_slice(b"|\n");
+        let opts = TdtReaderOptions {
+            max_line_bytes: 1 << 20,
+            ..Default::default()
+        };
+        let reader = TdtRecordReader::new(BufReader::new(Cursor::new(line)), opts);
+        let results: Vec<_> = reader.collect();
+        assert_eq!(results.len(), 1);
+        assert!(matches!(results[0], Err(TdtError::LineTooLong { .. })));
+    }
+
+    #[test]
+    fn huge_property_value_within_limit_does_not_panic() {
+        let mut line = b"$SMI<CC>\nNOTE<".to_vec();
+        line.extend(std::iter::repeat_n(b'x', 500_000));
+        line.extend_from_slice(b">\n|\n");
+        let opts = TdtReaderOptions {
+            max_line_bytes: 1 << 21,
+            ..Default::default()
+        };
+        let results: Vec<_> =
+            TdtRecordReader::new(BufReader::new(Cursor::new(line)), opts).collect();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_ok());
+    }
+
+    #[test]
+    fn invalid_utf8_byte_path_yields_io_error_not_panic() {
+        let input: &[u8] = b"$SMI<CC>\nNOTE<\xFF\xFE>\n|\n";
+        let results: Vec<_> = TdtRecordReader::new(
+            BufReader::new(Cursor::new(input.to_vec())),
+            TdtReaderOptions::default(),
+        )
+        .collect();
+        assert_eq!(results.len(), 1);
+        assert!(matches!(results[0], Err(TdtError::Io(_))));
+    }
+
+    #[test]
+    fn excessive_property_count_does_not_panic() {
+        let mut line = String::from("$SMI<CC>\n");
+        for i in 0..5000 {
+            line.push_str(&format!("P{i}<v{i}>\n"));
+        }
+        line.push_str("|\n");
+        let results: Vec<_> = TdtRecordReader::new(
+            BufReader::new(Cursor::new(line.into_bytes())),
+            TdtReaderOptions::default(),
+        )
+        .collect();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_ok());
+        assert_eq!(results[0].as_ref().unwrap().properties.len(), 5000);
+    }
+
+    #[test]
+    fn very_large_molecule_smiles_does_not_panic() {
+        let smi = "C".repeat(3000);
+        let line = format!("$SMI<{smi}>\n|\n");
+        let results: Vec<_> = TdtRecordReader::new(
+            BufReader::new(Cursor::new(line.into_bytes())),
+            TdtReaderOptions::default(),
+        )
+        .collect();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_ok());
+        assert_eq!(results[0].as_ref().unwrap().mol.atom_count(), 3000);
+    }
+
+    #[test]
+    fn malformed_coordinate_list_does_not_panic() {
+        let opts = TdtReaderOptions {
+            read_2d: true,
+            ..Default::default()
+        };
+        let input = b"$SMI<CCO>\n2D<not,numbers,here;>\n|\n";
+        let results: Vec<_> =
+            TdtRecordReader::new(BufReader::new(Cursor::new(input.to_vec())), opts).collect();
+        assert_eq!(results.len(), 1);
+        assert!(matches!(
+            results[0],
+            Err(TdtError::MalformedCoordinateList { .. })
+        ));
+    }
+
+    #[test]
+    fn coordinate_list_never_terminated_does_not_hang() {
+        let opts = TdtReaderOptions {
+            read_2d: true,
+            max_line_bytes: 1 << 16,
+            ..Default::default()
+        };
+        // No ";>" anywhere -- must not loop forever waiting for one.
+        let input = "$SMI<CC>\n2D<1.0,2.0,3.0\n".repeat(50) + "|\n";
+        let results: Vec<_> =
+            TdtRecordReader::new(BufReader::new(Cursor::new(input.into_bytes())), opts).collect();
+        // Whatever the outcome, this line finishing at all (not hanging) is the test.
+        assert!(results.len() <= 1);
+    }
+
+    /// Tiny deterministic PRNG (splitmix64), matching
+    /// `crate::smiles_table::adversarial_tests`' own approach -- no `rand`
+    /// dependency needed for a seeded, reproducible mutation corpus.
+    struct SplitMix64(u64);
+    impl SplitMix64 {
+        fn next(&mut self) -> u64 {
+            self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+            let mut z = self.0;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+            z ^ (z >> 31)
+        }
+    }
+
+    #[test]
+    fn seeded_random_mutation_corpus_never_panics() {
+        let base: &[u8] = b"$SMI<CCO>\nNAME<ethanol>\n2D<0.0,0.0,1.0,0.0,2.0,1.0;>\nNOTE<x>\n|\n";
+        let mut rng = SplitMix64(0xC0FFEE1234567890);
+
+        for _ in 0..2000 {
+            let mut mutated = base.to_vec();
+            let n_mutations = 1 + (rng.next() % 5) as usize;
+            for _ in 0..n_mutations {
+                if mutated.is_empty() {
+                    break;
+                }
+                let idx = (rng.next() as usize) % mutated.len();
+                let op = rng.next() % 3;
+                match op {
+                    0 => mutated[idx] = (rng.next() % 256) as u8,
+                    1 => {
+                        mutated.insert(idx, (rng.next() % 256) as u8);
+                    }
+                    _ => {
+                        mutated.remove(idx);
+                    }
+                }
+            }
+
+            let opts = TdtReaderOptions {
+                read_2d: true,
+                max_line_bytes: 1 << 16,
+                ..Default::default()
+            };
+            let _ = drain(&mutated, opts);
+        }
     }
 }

--- a/crates/chematic-mol/src/tdt.rs
+++ b/crates/chematic-mol/src/tdt.rs
@@ -67,6 +67,15 @@
 //!   inconsistency this port does not reproduce). When disabled, a `2D`/`3D`
 //!   tag is stored as a generic string property holding the raw,
 //!   unparsed coordinate text — never silently discarded.
+//! - **A file with no trailing newline drops its final tag line in real
+//!   RDKit, discovered against a live oracle this session (not predicted by
+//!   the initial source audit).** A record whose last generic tag line is
+//!   also the file's last byte, with no trailing `\n`, has that tag line
+//!   silently dropped by RDKit's `TDTMolSupplier` — confirmed empirically
+//!   (`$SMI<CC>\nNAME<ethane>` with no trailing newline yields `_Name == ""`
+//!   in real RDKit, not `"ethane"`). This reader's line-reading loop
+//!   (`BufRead::read_line`) returns a final unterminated line correctly, so
+//!   chematic does not reproduce this gap.
 
 use std::io::{BufRead, Write};
 

--- a/crates/chematic-py/python/chematic/rdkit_compat.py
+++ b/crates/chematic-py/python/chematic/rdkit_compat.py
@@ -41,6 +41,7 @@ __all__ = [
     "MolToMolBlock", "SanitizeMol", "Kekulize", "AddHs", "RemoveHs",
     "MolFromSmarts",
     "SDMolSupplier", "SDWriter", "SmilesMolSupplier", "SmilesWriter",
+    "TDTMolSupplier", "TDTWriter",
     "Descriptors", "rdMolDescriptors", "DataStructs", "pyAvalonTools",
 ]
 
@@ -795,6 +796,105 @@ class SmilesWriter:
         self._writer.close()
 
     def __enter__(self) -> "SmilesWriter":
+        return self
+
+    def __exit__(self, *args) -> None:
+        self.close()
+
+
+# ---------------------------------------------------------------------------
+# TDTMolSupplier / TDTWriter — Daylight Tagged Data file I/O
+# ---------------------------------------------------------------------------
+
+class TDTMolSupplier:
+    """Read molecules from a Daylight TDT file (RDKit-compatible).
+
+    Thin wrapper over :class:`chematic.TDTMolSupplier`. ``nameRecord``
+    defaults to ``"NAME"`` here, not RDKit's own ``""`` default -- see
+    ``chematic.TDTMolSupplier``'s doc comment for why. ``confId2D``/
+    ``confId3D`` >= 0 raise ``NotImplementedError`` (chematic's Python
+    ``Mol`` wrapper has no coordinate-carrying slot yet).
+    """
+
+    def __init__(
+        self,
+        filename: str,
+        nameRecord: str = "NAME",
+        confId2D: int = -1,
+        confId3D: int = -1,
+        sanitize: bool = True,
+    ) -> None:
+        self._filename = filename
+        self._name_record = nameRecord
+        self._conf_id_2d = confId2D
+        self._conf_id_3d = confId3D
+        self._sanitize = sanitize
+
+    def __iter__(self):
+        sup = _ch.TDTMolSupplier(
+            self._filename,
+            nameRecord=self._name_record,
+            confId2D=self._conf_id_2d,
+            confId3D=self._conf_id_3d,
+            sanitize=self._sanitize,
+        )
+        for mol in sup:
+            yield Mol(mol) if mol is not None else None
+
+    def __len__(self) -> int:
+        return sum(1 for _ in self)
+
+    def __getitem__(self, i: int):
+        """Random access by record index (RDKit-compatible).
+
+        .. note:: O(i) -- iterates from the start. Avoid in tight loops.
+        """
+        if i < 0:
+            raise IndexError(i)
+        for j, mol in enumerate(self):
+            if j == i:
+                return mol
+        raise IndexError(i)
+
+
+class TDTWriter:
+    """Write molecules to a Daylight TDT file (RDKit-compatible).
+
+    Thin wrapper over :class:`chematic.TDTWriter`. Only name + properties
+    round-trip through this binding at present -- see
+    ``chematic.TDTWriter``'s doc comment.
+    """
+
+    def __init__(self, filename: str) -> None:
+        self._writer = _ch.TDTWriter(filename)
+
+    def write(self, mol: Mol) -> None:
+        self._writer.write(mol._mol)
+
+    def SetProps(self, props) -> None:
+        """Restrict (and order) which properties are written."""
+        self._writer.SetProps(list(props))
+
+    def SetWriteNames(self, val: bool) -> None:
+        self._writer.SetWriteNames(val)
+
+    def SetWrite2D(self, val: bool) -> None:
+        """No visible effect at present -- see the class doc comment."""
+        self._writer.SetWrite2D(val)
+
+    def SetNumDigits(self, n: int) -> None:
+        self._writer.SetNumDigits(n)
+
+    def NumMols(self) -> int:
+        return self._writer.NumMols()
+
+    def flush(self) -> None:
+        self._writer.flush()
+
+    def close(self) -> None:
+        self._writer.close()
+
+    def __enter__(self) -> "TDTWriter":
         return self
 
     def __exit__(self, *args) -> None:

--- a/crates/chematic-py/python/chematic/rdkit_compat.py
+++ b/crates/chematic-py/python/chematic/rdkit_compat.py
@@ -686,17 +686,27 @@ class SDWriter:
 # ---------------------------------------------------------------------------
 
 class SmilesMolSupplier:
-    """Read molecules from a SMILES file, one record per line (RDKit-compatible).
+    """Read molecules from a SMILES table file (RDKit-compatible).
 
-    Each line is split on *delimiter*; ``smilesColumn`` is parsed as the SMILES
-    and ``nameColumn`` (when present) is stored as the ``_Name`` property.
-    Yields ``Mol | None`` (``None`` on a parse failure), like RDKit.
+    Thin wrapper over :class:`chematic.SmilesMolSupplier`, the Rust-backed
+    streaming reader in ``chematic-mol::smiles_table`` (a source-cited port
+    of RDKit's own ``SmilesMolSupplier`` semantics) -- this class does not
+    implement any parsing itself, unlike an earlier version of this wrapper
+    which loaded the whole file into memory in pure Python.
+
+    Yields ``Mol | None`` (``None`` on a malformed row), like RDKit.
+
+    .. note::
+       ``__len__``/``__getitem__`` perform an O(n) re-scan from the start
+       each time (the underlying reader is forward-only streaming, matching
+       ``chematic-mol``'s own documented divergence from RDKit's seek-based
+       ``SmilesMolSupplier``). Avoid in hot loops.
     """
 
     def __init__(
         self,
         filename: str,
-        delimiter: str = " \t",
+        delimiter: str = " ",
         smilesColumn: int = 0,
         nameColumn: int = 1,
         titleLine: bool = True,
@@ -709,45 +719,26 @@ class SmilesMolSupplier:
         self._title_line = titleLine
         self._sanitize = sanitize
 
-    def _split(self, line: str) -> list:
-        # RDKit treats `delimiter` as a set of separator characters.
-        if len(self._delimiter) == 1:
-            return line.split(self._delimiter)
-        import re
-        return re.split("[" + re.escape(self._delimiter) + "]+", line.strip())
-
-    def _header_and_records(self):
-        with open(self._filename) as f:
-            lines = [ln.rstrip("\n") for ln in f if ln.strip()]
-        header = None
-        if self._title_line and lines:
-            header = self._split(lines[0])
-            lines = lines[1:]
-        return header, lines
-
     def __iter__(self):
-        header, records = self._header_and_records()
-        for line in records:
-            fields = self._split(line)
-            if len(fields) <= self._smiles_col:
-                yield None
-                continue
-            mol = MolFromSmiles(fields[self._smiles_col], sanitize=self._sanitize)
-            if mol is not None:
-                if self._name_col is not None and len(fields) > self._name_col:
-                    mol.SetProp("_Name", fields[self._name_col])
-                # Extra columns become properties, named by the title line when present.
-                for col, value in enumerate(fields):
-                    if col == self._smiles_col or col == self._name_col:
-                        continue
-                    key = header[col] if header and col < len(header) else f"col_{col}"
-                    mol.SetProp(key, value)
-            yield mol
+        sup = _ch.SmilesMolSupplier(
+            self._filename,
+            delimiter=self._delimiter,
+            smilesColumn=self._smiles_col,
+            nameColumn=self._name_col,
+            titleLine=self._title_line,
+            sanitize=self._sanitize,
+        )
+        for mol in sup:
+            yield Mol(mol) if mol is not None else None
 
     def __len__(self) -> int:
-        return len(self._header_and_records()[1])
+        return sum(1 for _ in self)
 
     def __getitem__(self, i: int):
+        """Random access by record index (RDKit-compatible).
+
+        .. note:: O(i) -- iterates from the start. Avoid in tight loops.
+        """
         if i < 0:
             raise IndexError(i)
         for j, mol in enumerate(self):
@@ -761,10 +752,15 @@ class SmilesMolSupplier:
 # ---------------------------------------------------------------------------
 
 class SmilesWriter:
-    """Write molecules as a delimited SMILES file with optional property columns.
+    """Write molecules as a delimited SMILES table file (RDKit-compatible).
 
-    Columns: ``SMILES`` + name + any properties set via ``SetProps``.
-    Supports the context-manager protocol.
+    Thin wrapper over :class:`chematic.SmilesWriter`. Columns: SMILES + name
+    + any properties set via ``SetProps``. Supports the context-manager
+    protocol.
+
+    ``isomericSmiles=False`` and ``kekuleSmiles=True`` raise
+    ``NotImplementedError`` -- chematic has no non-isomeric or Kekule-form
+    SMILES writer at present.
     """
 
     def __init__(
@@ -773,42 +769,30 @@ class SmilesWriter:
         delimiter: str = " ",
         nameHeader: str = "Name",
         includeHeader: bool = True,
+        isomericSmiles: bool = True,
         kekuleSmiles: bool = False,
     ) -> None:
-        self._fh = open(filename, "w")
-        self._delimiter = delimiter
-        self._name_header = nameHeader
-        self._include_header = includeHeader
-        self._props = None
-        self._wrote_header = False
-
-    def SetProps(self, props) -> None:
-        """Restrict which properties are written as extra columns."""
-        self._props = list(props)
-
-    def _header(self, mol: Mol) -> list:
-        cols = ["SMILES", self._name_header]
-        if self._props is not None:
-            cols += self._props
-        return cols
+        self._writer = _ch.SmilesWriter(
+            filename,
+            delimiter=delimiter,
+            nameHeader=nameHeader,
+            includeHeader=includeHeader,
+            isomericSmiles=isomericSmiles,
+            kekuleSmiles=kekuleSmiles,
+        )
 
     def write(self, mol: Mol) -> None:
-        if self._include_header and not self._wrote_header:
-            self._fh.write(self._delimiter.join(self._header(mol)) + "\n")
-            self._wrote_header = True
-        name = mol.GetProp("_Name") if mol.HasProp("_Name") else ""
-        row = [mol._mol.smiles, name]
-        if self._props is not None:
-            for key in self._props:
-                row.append(mol.GetProp(key) if mol.HasProp(key) else "")
-        self._fh.write(self._delimiter.join(row) + "\n")
+        self._writer.write(mol._mol)
+
+    def SetProps(self, props) -> None:
+        """Restrict (and order) which properties are written as extra columns."""
+        self._writer.SetProps(list(props))
 
     def flush(self) -> None:
-        self._fh.flush()
+        self._writer.flush()
 
     def close(self) -> None:
-        if not self._fh.closed:
-            self._fh.close()
+        self._writer.close()
 
     def __enter__(self) -> "SmilesWriter":
         return self

--- a/crates/chematic-py/src/io.rs
+++ b/crates/chematic-py/src/io.rs
@@ -686,6 +686,241 @@ impl PySmilesWriter {
 }
 
 // ---------------------------------------------------------------------------
+// TDTMolSupplier / TDTWriter — RDKit-compatible Daylight TDT I/O
+// ---------------------------------------------------------------------------
+
+/// Streaming reader for Daylight TDT (Tagged Data) files.
+///
+/// RDKit-compatible API:
+///
+///     sup = chematic.TDTMolSupplier("compounds.tdt")
+///     for mol in sup:
+///         if mol is None:
+///             continue  # malformed record
+///         print(mol.smiles, mol.GetProp("_Name"))
+///
+/// ``nameRecord`` defaults to ``"NAME"`` here, **not** RDKit's own default
+/// of ``""`` (meaning no tag populates the name) -- a source-confirmed,
+/// deliberate divergence: RDKit's own `TDTWriter` always writes a `NAME`
+/// tag by default, but its own `TDTMolSupplier` doesn't recognize it back
+/// by default either, so a bare RDKit round trip silently loses the name.
+/// See `chematic_mol::tdt`'s module doc comment for the full citation.
+///
+/// ``confId2D``/``confId3D`` (RDKit's opt-in-to-read-coordinates
+/// convention: `< 0` disables, `>= 0` enables) are accepted, but a
+/// non-negative value raises ``NotImplementedError`` -- chematic's Python
+/// ``Mol`` wrapper has no coordinate-carrying slot yet, so 2D/3D
+/// coordinates from a TDT file cannot be surfaced through this binding at
+/// present (the Rust API, `chematic_mol::tdt::TdtRecordReader`, supports
+/// them fully and is tested against a real coordinate-parsing bug found in
+/// RDKit itself). ``sanitize`` is accepted for API compatibility but is a
+/// no-op.
+#[pyclass(name = "TDTMolSupplier")]
+pub struct PyTdtMolSupplier {
+    inner: chematic_mol::TdtRecordReader<std::io::BufReader<std::fs::File>>,
+}
+
+#[pymethods]
+impl PyTdtMolSupplier {
+    #[new]
+    #[allow(non_snake_case)]
+    #[pyo3(signature = (path, nameRecord="NAME".to_string(), confId2D=-1, confId3D=-1, sanitize=true))]
+    fn new(
+        path: &str,
+        nameRecord: String,
+        confId2D: i32,
+        confId3D: i32,
+        sanitize: bool,
+    ) -> PyResult<Self> {
+        let _ = sanitize;
+        if confId2D >= 0 || confId3D >= 0 {
+            return Err(pyo3::exceptions::PyNotImplementedError::new_err(
+                "chematic's Python Mol wrapper has no coordinate-carrying slot yet; \
+                 confId2D/confId3D >= 0 (requesting coordinate data) is not supported here. \
+                 Use the Rust API (chematic_mol::tdt::TdtRecordReader with read_2d/read_3d) \
+                 for full 2D/3D coordinate support.",
+            ));
+        }
+        let file = std::fs::File::open(path)
+            .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{path}: {e}")))?;
+        let options = chematic_mol::TdtReaderOptions {
+            name_tag: if nameRecord.is_empty() {
+                None
+            } else {
+                Some(nameRecord)
+            },
+            read_2d: false,
+            read_3d: false,
+            strict_parsing: false,
+            ..Default::default()
+        };
+        Ok(PyTdtMolSupplier {
+            inner: chematic_mol::TdtRecordReader::new(std::io::BufReader::new(file), options),
+        })
+    }
+
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(&mut self, py: Python<'_>) -> PyResult<Option<pyo3::Py<pyo3::PyAny>>> {
+        match self.inner.next() {
+            None => Ok(None),
+            Some(Ok(rec)) => {
+                let mut props: std::collections::HashMap<String, String> =
+                    rec.properties.into_iter().collect();
+                if !rec.name.is_empty() {
+                    props.insert("_Name".to_string(), rec.name);
+                }
+                let mol = Mol {
+                    inner: Arc::new(rec.mol),
+                    props,
+                };
+                Ok(Some(pyo3::Py::new(py, mol)?.into_any()))
+            }
+            Some(Err(chematic_mol::TdtError::Io(msg))) => {
+                Err(pyo3::exceptions::PyIOError::new_err(msg))
+            }
+            Some(Err(_)) => Ok(Some(py.None())), // malformed record -> None, matches RDKit
+        }
+    }
+}
+
+/// Streaming writer for Daylight TDT files.
+///
+///     with chematic.TDTWriter("output.tdt") as w:
+///         mol = chematic.from_smiles("c1ccccc1")
+///         mol.SetProp("_Name", "benzene")
+///         w.write(mol)
+///
+/// Only name + properties round-trip through this binding at present --
+/// chematic's Python ``Mol`` wrapper carries no 2D/3D coordinate data to
+/// write (see ``TDTMolSupplier``'s doc comment); ``SetWrite2D`` is accepted
+/// for API compatibility but has no visible effect until `Mol` gains a
+/// coordinate-carrying mechanism.
+#[pyclass(name = "TDTWriter")]
+pub struct PyTdtWriter {
+    writer: Option<chematic_mol::TdtRecordWriter<std::io::BufWriter<std::fs::File>>>,
+    num_mols: usize,
+}
+
+#[pymethods]
+impl PyTdtWriter {
+    #[new]
+    fn new(path: &str) -> PyResult<Self> {
+        let file = std::fs::File::create(path)
+            .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{path}: {e}")))?;
+        Ok(PyTdtWriter {
+            writer: Some(chematic_mol::TdtRecordWriter::new(
+                std::io::BufWriter::new(file),
+                chematic_mol::TdtWriterOptions {
+                    write_2d: false,
+                    write_3d: false,
+                    ..Default::default()
+                },
+            )),
+            num_mols: 0,
+        })
+    }
+
+    fn write(&mut self, mol: &Mol) -> PyResult<()> {
+        let writer = self.writer.as_mut().ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err("TDTWriter is already closed")
+        })?;
+        let name = mol.props.get("_Name").cloned().unwrap_or_default();
+        let mut properties: Vec<(String, String)> = mol
+            .props
+            .iter()
+            .filter(|(k, _)| k.as_str() != "_Name")
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        properties.sort_unstable();
+        let record = chematic_mol::MoleculeRecord {
+            mol: (*mol.inner).clone(),
+            name,
+            properties,
+            coordinates_2d: None,
+            coordinates_3d: None,
+        };
+        writer
+            .write_record(&record)
+            .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+        self.num_mols += 1;
+        Ok(())
+    }
+
+    /// Restrict (and order) which properties are written. Pass `None` to
+    /// reset to RDKit's own `TDTWriter` default (write all).
+    #[pyo3(name = "SetProps")]
+    fn set_props(&mut self, props: Option<Vec<String>>) -> PyResult<()> {
+        let writer = self.writer.as_mut().ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err("TDTWriter is already closed")
+        })?;
+        writer.set_properties(props);
+        Ok(())
+    }
+
+    #[pyo3(name = "SetWriteNames")]
+    fn set_write_names(&mut self, val: bool) -> PyResult<()> {
+        let writer = self.writer.as_mut().ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err("TDTWriter is already closed")
+        })?;
+        writer.set_name_tag(if val { Some("NAME".to_string()) } else { None });
+        Ok(())
+    }
+
+    /// No visible effect at present -- see the class doc comment.
+    #[pyo3(name = "SetWrite2D")]
+    fn set_write_2d(&mut self, _val: bool) {}
+
+    #[pyo3(name = "SetNumDigits")]
+    fn set_num_digits(&mut self, n: usize) -> PyResult<()> {
+        let writer = self.writer.as_mut().ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err("TDTWriter is already closed")
+        })?;
+        writer.set_precision(n);
+        Ok(())
+    }
+
+    #[pyo3(name = "NumMols")]
+    fn num_mols(&self) -> usize {
+        self.num_mols
+    }
+
+    fn flush(&mut self) -> PyResult<()> {
+        if let Some(w) = self.writer.as_mut() {
+            w.close()
+                .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    fn close(&mut self) -> PyResult<()> {
+        if let Some(w) = self.writer.as_mut() {
+            w.close()
+                .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+        }
+        self.writer.take();
+        Ok(())
+    }
+
+    fn __enter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    #[allow(unused_variables)]
+    fn __exit__(
+        &mut self,
+        exc_type: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+        exc_val: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+        exc_tb: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+    ) -> PyResult<bool> {
+        self.close()?;
+        Ok(false)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Register
 // ---------------------------------------------------------------------------
 
@@ -698,6 +933,8 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<SdWriter>()?;
     m.add_class::<PySmilesMolSupplier>()?;
     m.add_class::<PySmilesWriter>()?;
+    m.add_class::<PyTdtMolSupplier>()?;
+    m.add_class::<PyTdtWriter>()?;
     m.add_function(wrap_pyfunction!(iter_sdf, m)?)?;
     m.add_function(wrap_pyfunction!(iter_sdf_str, m)?)?;
     m.add_function(wrap_pyfunction!(iter_sdf_batched, m)?)?;

--- a/crates/chematic-py/src/io.rs
+++ b/crates/chematic-py/src/io.rs
@@ -448,6 +448,244 @@ impl SdWriter {
 }
 
 // ---------------------------------------------------------------------------
+// SmilesMolSupplier / SmilesWriter — RDKit-compatible SMILES table I/O
+// ---------------------------------------------------------------------------
+
+/// Parse an RDKit-style delimiter string into a [`chematic_mol::Delimiter`].
+///
+/// A string consisting only of spaces/tabs (RDKit's own multi-char
+/// delimiter *class* convention, e.g. `" \t"`) maps to
+/// [`chematic_mol::Delimiter::Whitespace`] (runs collapsed) — chematic does
+/// not offer RDKit's non-collapsing `keep_empty_tokens` behavior for a
+/// multi-character class, only for the single-character
+/// [`chematic_mol::Delimiter::Tab`]/[`chematic_mol::Delimiter::Custom`] cases.
+/// Any other multi-character string is rejected explicitly rather than
+/// silently truncated to its first character.
+fn parse_delimiter(s: &str) -> PyResult<chematic_mol::Delimiter> {
+    if !s.is_empty() && s.chars().all(|c| c == ' ' || c == '\t') {
+        return Ok(chematic_mol::Delimiter::Whitespace);
+    }
+    let mut chars = s.chars();
+    match (chars.next(), chars.next()) {
+        (Some(','), None) => Ok(chematic_mol::Delimiter::Comma),
+        (Some('\t'), None) => Ok(chematic_mol::Delimiter::Tab),
+        (Some(c), None) if c.is_ascii() => Ok(chematic_mol::Delimiter::Custom(c as u8)),
+        _ => Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "unsupported delimiter {s:?}: chematic requires a single ASCII byte, or a \
+             space/tab-only string (mapped to whitespace-class splitting)"
+        ))),
+    }
+}
+
+/// Streaming reader for SMILES table files (`.smi`/`.smiles`/`.csv`/`.tsv`/`.txt`).
+///
+/// RDKit-compatible API:
+///
+///     sup = chematic.SmilesMolSupplier("compounds.smi")
+///     for mol in sup:
+///         if mol is None:
+///             continue  # malformed row
+///         print(mol.smiles, mol.GetProp("_Name"))
+///
+/// ``sanitize`` is accepted for API compatibility but is a no-op (chematic's
+/// SMILES parser already applies default aromaticity perception). Unlike
+/// RDKit's own ``SmilesMolSupplier``, this reader is forward-only streaming
+/// (no ``len()``/index access) — see ``chematic_mol::smiles_table``'s module
+/// docs for the full list of deliberate, documented divergences from RDKit.
+#[pyclass(name = "SmilesMolSupplier")]
+pub struct PySmilesMolSupplier {
+    inner: chematic_mol::SmilesRecordReader<std::io::BufReader<std::fs::File>>,
+}
+
+#[pymethods]
+impl PySmilesMolSupplier {
+    #[new]
+    #[allow(non_snake_case)]
+    #[pyo3(signature = (path, delimiter=" ".to_string(), smilesColumn=0, nameColumn=1, titleLine=true, sanitize=true))]
+    fn new(
+        path: &str,
+        delimiter: String,
+        smilesColumn: usize,
+        nameColumn: i64,
+        titleLine: bool,
+        sanitize: bool,
+    ) -> PyResult<Self> {
+        let _ = sanitize; // accepted, no-op (see doc comment)
+        let delim = parse_delimiter(&delimiter)?;
+        let file = std::fs::File::open(path)
+            .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{path}: {e}")))?;
+        let options = chematic_mol::SmilesReaderOptions {
+            delimiter: delim,
+            smiles_column: smilesColumn,
+            name_column: if nameColumn < 0 {
+                None
+            } else {
+                Some(nameColumn as usize)
+            },
+            title_line: titleLine,
+            // RDKit's own SmilesMolSupplier has no strict/lax toggle at all --
+            // it unconditionally returns None for a bad row and continues.
+            // This constructor matches that behavior; chematic's stricter
+            // stop-on-error mode is only reachable via the Rust API.
+            strict_parsing: false,
+            ..Default::default()
+        };
+        Ok(PySmilesMolSupplier {
+            inner: chematic_mol::SmilesRecordReader::new(std::io::BufReader::new(file), options),
+        })
+    }
+
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(&mut self, py: Python<'_>) -> PyResult<Option<pyo3::Py<pyo3::PyAny>>> {
+        match self.inner.next() {
+            None => Ok(None),
+            Some(Ok(rec)) => {
+                let mut props: std::collections::HashMap<String, String> =
+                    rec.properties.into_iter().collect();
+                if !rec.name.is_empty() {
+                    props.insert("_Name".to_string(), rec.name);
+                }
+                let mol = Mol {
+                    inner: Arc::new(rec.mol),
+                    props,
+                };
+                Ok(Some(pyo3::Py::new(py, mol)?.into_any()))
+            }
+            Some(Err(chematic_mol::SmilesTableError::Io(msg))) => {
+                Err(pyo3::exceptions::PyIOError::new_err(msg))
+            }
+            Some(Err(_)) => Ok(Some(py.None())), // malformed row -> None, matches RDKit
+        }
+    }
+}
+
+/// Streaming writer for SMILES table files.
+///
+///     with chematic.SmilesWriter("output.smi") as w:
+///         mol = chematic.from_smiles("c1ccccc1")
+///         mol.SetProp("_Name", "benzene")
+///         w.write(mol)
+///
+/// ``isomericSmiles=False`` and ``kekuleSmiles=True`` raise
+/// ``NotImplementedError`` -- chematic has no non-isomeric or Kekule-form
+/// SMILES writer at present, and this binding does not silently fall back
+/// to the isomeric/aromatic form it can actually produce.
+#[pyclass(name = "SmilesWriter")]
+pub struct PySmilesWriter {
+    writer: Option<chematic_mol::SmilesRecordWriter<std::io::BufWriter<std::fs::File>>>,
+}
+
+#[pymethods]
+impl PySmilesWriter {
+    #[new]
+    #[allow(non_snake_case)]
+    #[pyo3(signature = (path, delimiter=" ".to_string(), nameHeader="Name".to_string(), includeHeader=true, isomericSmiles=true, kekuleSmiles=false))]
+    fn new(
+        path: &str,
+        delimiter: String,
+        nameHeader: String,
+        includeHeader: bool,
+        isomericSmiles: bool,
+        kekuleSmiles: bool,
+    ) -> PyResult<Self> {
+        if !isomericSmiles {
+            return Err(pyo3::exceptions::PyNotImplementedError::new_err(
+                "chematic has no non-isomeric SMILES writer mode; isomericSmiles=False is not supported",
+            ));
+        }
+        if kekuleSmiles {
+            return Err(pyo3::exceptions::PyNotImplementedError::new_err(
+                "chematic has no Kekule-form SMILES writer mode; kekuleSmiles=True is not supported",
+            ));
+        }
+        let delim = parse_delimiter(&delimiter)?;
+        let file = std::fs::File::create(path)
+            .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{path}: {e}")))?;
+        let options = chematic_mol::SmilesWriterOptions {
+            delimiter: delim,
+            name_header: nameHeader,
+            include_header: includeHeader,
+            properties: Vec::new(),
+        };
+        Ok(PySmilesWriter {
+            writer: Some(chematic_mol::SmilesRecordWriter::new(
+                std::io::BufWriter::new(file),
+                options,
+            )),
+        })
+    }
+
+    fn write(&mut self, mol: &Mol) -> PyResult<()> {
+        let writer = self.writer.as_mut().ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err("SmilesWriter is already closed")
+        })?;
+        let name = mol.props.get("_Name").cloned().unwrap_or_default();
+        let mut properties: Vec<(String, String)> = mol
+            .props
+            .iter()
+            .filter(|(k, _)| k.as_str() != "_Name")
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        properties.sort_unstable();
+        let record = chematic_mol::MoleculeRecord {
+            mol: (*mol.inner).clone(),
+            name,
+            properties,
+            coordinates_2d: None,
+            coordinates_3d: None,
+        };
+        writer
+            .write_record(&record)
+            .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))
+    }
+
+    /// Restrict (and order) which properties are written, mirroring RDKit's
+    /// ``SetProps``. Defaults to writing no extra properties beyond
+    /// SMILES + name, matching RDKit's own ``SmilesWriter`` default.
+    #[pyo3(name = "SetProps")]
+    fn set_props(&mut self, props: Vec<String>) -> PyResult<()> {
+        let writer = self.writer.as_mut().ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err("SmilesWriter is already closed")
+        })?;
+        // SmilesRecordWriter doesn't expose a setter for its own options
+        // struct post-construction; rebuild is unnecessary since `properties`
+        // is the only field this method touches -- reach it directly.
+        writer.set_properties(props);
+        Ok(())
+    }
+
+    fn flush(&mut self) -> PyResult<()> {
+        if let Some(w) = self.writer.as_mut() {
+            w.flush()
+                .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    fn close(&mut self) {
+        self.writer.take();
+    }
+
+    fn __enter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    #[allow(unused_variables)]
+    fn __exit__(
+        &mut self,
+        exc_type: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+        exc_val: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+        exc_tb: Option<&pyo3::Bound<'_, pyo3::PyAny>>,
+    ) -> bool {
+        self.close();
+        false
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Register
 // ---------------------------------------------------------------------------
 
@@ -458,6 +696,8 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<SdfBatchIter>()?;
     m.add_class::<SdMolSupplier>()?;
     m.add_class::<SdWriter>()?;
+    m.add_class::<PySmilesMolSupplier>()?;
+    m.add_class::<PySmilesWriter>()?;
     m.add_function(wrap_pyfunction!(iter_sdf, m)?)?;
     m.add_function(wrap_pyfunction!(iter_sdf_str, m)?)?;
     m.add_function(wrap_pyfunction!(iter_sdf_batched, m)?)?;

--- a/crates/chematic-py/tests/test_rdkit_compat.py
+++ b/crates/chematic-py/tests/test_rdkit_compat.py
@@ -927,6 +927,83 @@ def test_smiles_writer_no_name_header_omits_name_column(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# TDTWriter + TDTMolSupplier
+# ---------------------------------------------------------------------------
+
+def test_tdt_writer_supplier_roundtrip(tmp_path):
+    out = tmp_path / "mols.tdt"
+    with Chem.TDTWriter(str(out)) as w:
+        w.SetProps(["activity"])
+        for smi, name, act in [("CCO", "ethanol", "1.2"), ("c1ccccc1", "benzene", "3.4")]:
+            m = Chem.MolFromSmiles(smi)
+            m.SetProp("_Name", name)
+            m.SetProp("activity", act)
+            w.write(m)
+
+    sup = Chem.TDTMolSupplier(str(out))
+    mols = list(sup)
+    assert len(mols) == 2
+    assert mols[0].GetProp("_Name") == "ethanol"
+    assert mols[0].GetProp("activity") == "1.2"
+    assert mols[1].GetProp("_Name") == "benzene"
+
+
+def test_tdt_default_roundtrip_preserves_name_unlike_real_rdkit(tmp_path):
+    # chematic's own deliberate divergence: RDKit's own default
+    # TDTWriter+TDTMolSupplier round trip silently loses the name (writer
+    # hard-codes "NAME", reader's own nameRecord defaults to ""). Chematic's
+    # defaults are reconciled so this round-trips correctly out of the box.
+    out = tmp_path / "x.tdt"
+    with Chem.TDTWriter(str(out)) as w:
+        m = Chem.MolFromSmiles("CC")
+        m.SetProp("_Name", "ethane")
+        w.write(m)
+    mol = next(iter(Chem.TDTMolSupplier(str(out))))
+    assert mol.GetProp("_Name") == "ethane"
+
+
+def test_tdt_supplier_random_access(tmp_path):
+    out = tmp_path / "mols.tdt"
+    with Chem.TDTWriter(str(out)) as w:
+        for smi, name in [("CCO", "a"), ("CCC", "b"), ("CCCC", "c")]:
+            m = Chem.MolFromSmiles(smi)
+            m.SetProp("_Name", name)
+            w.write(m)
+    sup = Chem.TDTMolSupplier(str(out))
+    assert sup[2].GetProp("_Name") == "c"
+    with pytest.raises(IndexError):
+        _ = sup[99]
+
+
+def test_tdt_supplier_bad_record_yields_none(tmp_path):
+    out = tmp_path / "bad.tdt"
+    out.write_text("NAME<no_smiles_here>\n|\n$SMI<CCO>\nNAME<ethanol>\n|\n")
+    mols = list(Chem.TDTMolSupplier(str(out)))
+    assert mols[0] is None
+    assert mols[1] is not None
+
+
+def test_tdt_writer_num_mols(tmp_path):
+    out = tmp_path / "x.tdt"
+    w = Chem.TDTWriter(str(out))
+    w.write(Chem.MolFromSmiles("CC"))
+    w.write(Chem.MolFromSmiles("CCC"))
+    assert w.NumMols() == 2
+    w.close()
+
+
+def test_tdt_supplier_coordinate_request_raises_not_implemented(tmp_path):
+    out = tmp_path / "x.tdt"
+    with Chem.TDTWriter(str(out)) as w:
+        w.write(Chem.MolFromSmiles("CC"))
+    # The rdkit_compat wrapper is lazy (matches SmilesMolSupplier's own
+    # established pattern): construction of the underlying Rust supplier,
+    # and thus the NotImplementedError, happens on iteration.
+    with pytest.raises(NotImplementedError):
+        list(Chem.TDTMolSupplier(str(out), confId3D=0))
+
+
+# ---------------------------------------------------------------------------
 # SDMolSupplier random access + context manager
 # ---------------------------------------------------------------------------
 

--- a/crates/chematic-py/tests/test_rdkit_compat.py
+++ b/crates/chematic-py/tests/test_rdkit_compat.py
@@ -895,6 +895,37 @@ def test_smiles_supplier_bad_line_yields_none(tmp_path):
     assert mols[1] is not None
 
 
+def test_smiles_supplier_csv_delimiter_with_quoted_comma(tmp_path):
+    out = tmp_path / "mols.csv"
+    out.write_text('SMILES,Name,Note\nCC,ethane,"has, a comma"\n')
+    mols = list(Chem.SmilesMolSupplier(str(out), delimiter=","))
+    assert len(mols) == 1
+    assert mols[0].GetProp("_Name") == "ethane"
+    assert mols[0].GetProp("Note") == "has, a comma"
+
+
+def test_smiles_writer_isomeric_false_raises_not_implemented(tmp_path):
+    out = tmp_path / "x.smi"
+    with pytest.raises(NotImplementedError):
+        Chem.SmilesWriter(str(out), isomericSmiles=False)
+
+
+def test_smiles_writer_kekule_true_raises_not_implemented(tmp_path):
+    out = tmp_path / "x.smi"
+    with pytest.raises(NotImplementedError):
+        Chem.SmilesWriter(str(out), kekuleSmiles=True)
+
+
+def test_smiles_writer_no_name_header_omits_name_column(tmp_path):
+    out = tmp_path / "x.smi"
+    with Chem.SmilesWriter(str(out), nameHeader="", includeHeader=False) as w:
+        m = Chem.MolFromSmiles("CC")
+        m.SetProp("_Name", "ethane")
+        w.write(m)
+    text = out.read_text()
+    assert "ethane" not in text
+
+
 # ---------------------------------------------------------------------------
 # SDMolSupplier random access + context manager
 # ---------------------------------------------------------------------------

--- a/scripts/gen_rdkit_smiles_table_oracle.py
+++ b/scripts/gen_rdkit_smiles_table_oracle.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Real RDKit oracle for the IO-1 (SMILES table) acceptance gate.
+
+Runs RDKit's actual `Chem.SmilesMolSupplier` over every scenario file named
+in `gen_smiles_table_fixtures.py`'s manifest, using that scenario's own
+configured options, and dumps each row's extracted
+`(status, name, properties, rdkit_canonical_smiles)` as JSONL, in the same
+row order as `smiles_table_dump.rs`'s chematic-side dump.
+
+Also computes, for every successfully-parsed row, a *self-consistency*
+check against the manifest's own known ground-truth SMILES for that row:
+does `Chem.MolToSmiles(Chem.MolFromSmiles(known_smiles))` equal
+`Chem.MolToSmiles(mol_from_supplier)`? This validates RDKit's own
+tokenization extracted the right substring, using ONLY RDKit's own
+canonicalizer -- never compared against chematic's canonical output (see
+`scripts/smiles_table_io_parity.py`'s module docs for why: chematic/RDKit
+canonical-SMILES divergence is a known, separately-tracked, unrelated
+issue -- this oracle is not evidence about it, and must not be misread as
+such).
+
+Usage:
+    python scripts/gen_rdkit_smiles_table_oracle.py --manifest <manifest.json> \\
+        --fixtures-dir <dir> --out <out.jsonl>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from rdkit import Chem
+
+
+def rdkit_style_split(line, delimiter):
+    """RDKit's own tokenization rule (see the IO-1 source audit): a
+    space/tab delimiter string is a CHARACTER CLASS (any char in it is an
+    independent separator, `boost::keep_empty_tokens` -- consecutive
+    delimiters yield empty tokens), a comma or other single character is
+    a literal split with no quoting logic in RDKit's own tokenizer (RDKit's
+    SmilesMolSupplier has no CSV-quote awareness at all)."""
+    if all(c in " \t" for c in delimiter):
+        out, cur = [], ""
+        for ch in line:
+            if ch in " \t":
+                out.append(cur)
+                cur = ""
+            else:
+                cur += ch
+        out.append(cur)
+        return out
+    return line.split(delimiter)
+
+
+def run_scenario(name, scenario, fixtures_dir):
+    opts = scenario["options"]
+    delimiter = opts["delimiter"]
+    smiles_column = opts["smiles_column"]
+    name_column = opts["name_column"]
+    title_line = opts["title_line"]
+
+    path = f"{fixtures_dir}/{scenario['file']}"
+
+    # RDKit's SmilesMolSupplier delimiter kwarg: pass through verbatim; a
+    # multi-char whitespace-only class (unused here, kept single-char to
+    # avoid RDKit's own cross-entry-point delimiter-default inconsistency
+    # noted in the IO-1 source audit) works the same as a plain " ".
+    sup = Chem.SmilesMolSupplier(
+        path,
+        delimiter=delimiter,
+        smilesColumn=smiles_column,
+        nameColumn=name_column if name_column is not None else -1,
+        titleLine=title_line,
+        sanitize=True,
+    )
+
+    known_rows = scenario["rows"]
+    rows_out = []
+    for row_index, mol in enumerate(sup):
+        if mol is None:
+            rows_out.append({"scenario": name, "row_index": row_index, "status": "error", "error": "rdkit_returned_none"})
+            continue
+
+        # Dump RDKit's raw property dict as-is, under whatever key RDKit
+        # itself used (the manifest's own authored key when a title line
+        # named the column, "Column_N" 0-indexed-over-the-full-row when not
+        # -- reconciling the two tools' differing fallback-name CONVENTIONS
+        # is the comparator's job, done once in one place rather than
+        # duplicated across both oracle-generating scripts). `GetProp` (not
+        # `GetPropsAsDict`, which opportunistically coerces numeric-looking
+        # strings to float/int) is used deliberately -- chematic's own
+        # property store never does that type inference (source-confirmed:
+        # SmilesMolSupplier stores every extra column as a plain string),
+        # so comparing against RDKit's *raw* string avoids a false mismatch
+        # that's really just a Python-API-layer type-coercion difference.
+        props = [
+            [k, mol.GetProp(k)]
+            for k in mol.GetPropNames(includePrivate=False, includeComputed=False)
+            if k != "_Name" and not k.startswith("__")
+        ]
+        props.sort()
+
+        rdkit_name = mol.GetProp("_Name") if mol.HasProp("_Name") else ""
+        rdkit_canonical = Chem.MolToSmiles(mol)
+
+        self_consistent = None
+        if row_index < len(known_rows):
+            known_smi = known_rows[row_index]["smiles"]
+            known_mol = Chem.MolFromSmiles(known_smi)
+            if known_mol is not None:
+                self_consistent = Chem.MolToSmiles(known_mol) == rdkit_canonical
+
+        rows_out.append(
+            {
+                "scenario": name,
+                "row_index": row_index,
+                "status": "success",
+                "name": rdkit_name,
+                "properties": props,
+                "rdkit_canonical_smiles": rdkit_canonical,
+                "self_consistent_with_known_smiles": self_consistent,
+            }
+        )
+    return rows_out
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--manifest", required=True)
+    p.add_argument("--fixtures-dir", required=True)
+    p.add_argument("--out", required=True)
+    args = p.parse_args()
+
+    with open(args.manifest) as f:
+        manifest = json.load(f)
+
+    total = 0
+    with open(args.out, "w") as out:
+        for name in sorted(manifest["scenarios"].keys()):
+            scenario = manifest["scenarios"][name]
+            for row in run_scenario(name, scenario, args.fixtures_dir):
+                out.write(json.dumps(row) + "\n")
+                total += 1
+
+    print(f"total_rows={total} rdkit_version={Chem.rdBase.rdkitVersion} out={args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gen_rdkit_tdt_oracle.py
+++ b/scripts/gen_rdkit_tdt_oracle.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Real RDKit oracle for the IO-2 (TDT) acceptance gate.
+
+Runs RDKit's actual `Chem.TDTMolSupplier` over every scenario file named in
+`gen_tdt_fixtures.py`'s manifest, using `nameRecord="NAME"` explicitly
+(matching what the fixtures actually write, and what chematic's own
+TdtReaderOptions default now recognizes -- see `chematic_mol::tdt`'s module
+doc comment for why RDKit's OWN default of `nameRecord=""` would silently
+fail to recognize it). Dumps each row's extracted
+`(status, name, properties, coordinates)` as JSONL, same row order as
+`tdt_dump.rs`'s chematic-side dump.
+
+Also computes each successfully-parsed row's self-consistency against the
+manifest's own known ground-truth SMILES -- see
+`scripts/smiles_table_io_parity.py`'s module docs for why this project never
+compares chematic-canonical vs. RDKit-canonical SMILES directly.
+
+Usage:
+    python scripts/gen_rdkit_tdt_oracle.py --manifest <manifest.json> \\
+        --fixtures-dir <dir> --out <out.jsonl>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from rdkit import Chem
+
+
+def run_scenario(name, scenario, fixtures_dir):
+    path = f"{fixtures_dir}/{scenario['file']}"
+    read_coords = name == "coordinates"
+
+    # Distinct conformer IDs for 2D vs 3D -- using the SAME id for both would
+    # make RDKit's own addConformer(id=0, assignId=False) calls collide.
+    sup = Chem.TDTMolSupplier(
+        path,
+        nameRecord="NAME",
+        confId2D=0 if read_coords else -1,
+        confId3D=1 if read_coords else -1,
+        sanitize=True,
+    )
+
+    known_rows = scenario["rows"]
+    rows_out = []
+    # Index-based access, not a plain `for mol in sup` loop: RDKit's own
+    # TDTMolSupplier has a confirmed recovery-hazard bug (see
+    # chematic_mol::tdt's module doc comment and this session's source
+    # audit) -- a malformed generic tag throws an exception that is NOT
+    # caught inside next()'s own position-advance bookkeeping, so naively
+    # retrying .next()/iterating re-throws on the SAME record indefinitely.
+    # Explicit index access (sup[idx]) sidesteps this: a failure at index i
+    # never blocks reaching index i+1.
+    for row_index in range(len(known_rows)):
+        try:
+            mol = sup[row_index]
+        except Exception as e:
+            rows_out.append({"scenario": name, "row_index": row_index, "status": "error", "error": str(e)})
+            continue
+        if mol is None:
+            rows_out.append({"scenario": name, "row_index": row_index, "status": "error", "error": "rdkit_returned_none"})
+            continue
+
+        props = [
+            [k, mol.GetProp(k)]
+            for k in mol.GetPropNames(includePrivate=False, includeComputed=False)
+            if k != "_Name"
+        ]
+        props.sort()
+
+        rdkit_name = mol.GetProp("_Name") if mol.HasProp("_Name") else ""
+
+        coords_2d = None
+        coords_3d = None
+        if read_coords:
+            try:
+                conf2d = mol.GetConformer(0)
+                coords_2d = [[conf2d.GetAtomPosition(i).x, conf2d.GetAtomPosition(i).y] for i in range(mol.GetNumAtoms())]
+            except ValueError:
+                pass
+            try:
+                conf3d = mol.GetConformer(1)
+                coords_3d = [
+                    [conf3d.GetAtomPosition(i).x, conf3d.GetAtomPosition(i).y, conf3d.GetAtomPosition(i).z]
+                    for i in range(mol.GetNumAtoms())
+                ]
+            except ValueError:
+                pass
+
+        self_consistent = None
+        if row_index < len(known_rows) and known_rows[row_index].get("smiles"):
+            known_mol = Chem.MolFromSmiles(known_rows[row_index]["smiles"])
+            if known_mol is not None:
+                self_consistent = Chem.MolToSmiles(known_mol) == Chem.MolToSmiles(mol)
+
+        rows_out.append(
+            {
+                "scenario": name,
+                "row_index": row_index,
+                "status": "success",
+                "name": rdkit_name,
+                "properties": props,
+                "coordinates_2d": coords_2d,
+                "coordinates_3d": coords_3d,
+                "self_consistent_with_known_smiles": self_consistent,
+            }
+        )
+    return rows_out
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--manifest", required=True)
+    p.add_argument("--fixtures-dir", required=True)
+    p.add_argument("--out", required=True)
+    args = p.parse_args()
+
+    with open(args.manifest) as f:
+        manifest = json.load(f)
+
+    total = 0
+    with open(args.out, "w") as out:
+        for name in sorted(manifest["scenarios"].keys()):
+            scenario = manifest["scenarios"][name]
+            for row in run_scenario(name, scenario, args.fixtures_dir):
+                out.write(json.dumps(row) + "\n")
+                total += 1
+
+    print(f"total_rows={total} rdkit_version={Chem.rdBase.rdkitVersion} out={args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gen_smiles_table_fixtures.py
+++ b/scripts/gen_smiles_table_fixtures.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Generate SMILES-table I/O fixtures for the IO-1 oracle gate.
+
+Produces a set of scenario files (each with a small manifest of KNOWN ground
+truth this script itself authors -- not derived from either chematic or
+RDKit) covering the categories required by the IO-1 acceptance gate:
+space/tab/comma delimiters, header/no-header, name/no-name column, extra
+properties, quoted CSV, blank lines, comments, malformed SMILES, isotopes,
+charges, disconnected structures, stereochemistry.
+
+The "general" scenario draws real, chemically diverse SMILES from the
+Morgan M4-A0 corpus (`/tmp/m4a0/combined_input.csv`, already validated
+elsewhere in this project) rather than hand-authoring hundreds of molecules.
+
+Usage:
+    python scripts/gen_smiles_table_fixtures.py --out-dir <dir> \\
+        --corpus /tmp/m4a0/combined_input.csv --manifest-out <manifest.json>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+
+try:
+    from rdkit import Chem
+except ImportError:
+    print("rdkit is required to author fixtures (validates parseability while generating)", file=sys.stderr)
+    raise
+
+
+def load_corpus(path, limit=None):
+    smis = []
+    with open(path) as f:
+        for line in f:
+            s = line.strip()
+            if s:
+                smis.append(s)
+    if limit:
+        smis = smis[:limit]
+    return smis
+
+
+def rdkit_parses(smi):
+    try:
+        return Chem.MolFromSmiles(smi) is not None
+    except Exception:
+        return False
+
+
+def build_scenarios(corpus):
+    random.seed(42)
+    valid_corpus = [s for s in corpus if rdkit_parses(s)]
+    scenarios = {}
+
+    # --- general: space-delimited, title line, 2 extra property columns ---
+    general_smis = valid_corpus[:150]
+    rows = []
+    for i, smi in enumerate(general_smis):
+        rows.append(
+            {
+                "smiles": smi,
+                "name": f"mol_{i}",
+                "properties": {"Activity": f"{(i % 10) + 0.1:.2f}", "MW": f"{100 + i}.0"},
+            }
+        )
+    scenarios["general_space_titleline"] = {
+        "options": {"delimiter": " ", "smiles_column": 0, "name_column": 1, "title_line": True},
+        "rows": rows,
+        "malformed_row_indices": [],
+    }
+
+    # --- tab-delimited, no collapsing of empty fields ---
+    tab_rows = []
+    for i, smi in enumerate(valid_corpus[150:165]):
+        name = f"tab_{i}" if i % 3 != 0 else ""  # some rows have an empty name field
+        tab_rows.append({"smiles": smi, "name": name, "properties": {"Note": f"n{i}"}})
+    scenarios["tab_delimited"] = {
+        "options": {"delimiter": "\t", "smiles_column": 0, "name_column": 1, "title_line": True},
+        "rows": tab_rows,
+        "malformed_row_indices": [],
+    }
+
+    # --- comma CSV with quoted embedded commas/quotes ---
+    csv_rows = []
+    notes = [
+        "plain note",
+        "has, a comma",
+        'has "quotes" inside',
+        "has, both \"kinds\" of, trouble",
+        "trailing comma,",
+    ]
+    for i, smi in enumerate(valid_corpus[165:180]):
+        csv_rows.append(
+            {"smiles": smi, "name": f"csv_{i}", "properties": {"Note": notes[i % len(notes)]}}
+        )
+    scenarios["csv_quoted"] = {
+        "options": {"delimiter": ",", "smiles_column": 0, "name_column": 1, "title_line": True},
+        "rows": csv_rows,
+        "malformed_row_indices": [],
+    }
+
+    # --- no title line: stable fallback column naming ---
+    no_title_rows = []
+    for i, smi in enumerate(valid_corpus[180:195]):
+        no_title_rows.append(
+            {"smiles": smi, "name": f"nt_{i}", "properties": {"__pos2__": f"v{i}"}}
+        )
+    scenarios["no_title_line"] = {
+        "options": {"delimiter": " ", "smiles_column": 0, "name_column": 1, "title_line": False},
+        "rows": no_title_rows,
+        "malformed_row_indices": [],
+    }
+
+    # --- no name column at all ---
+    no_name_rows = []
+    for i, smi in enumerate(valid_corpus[195:205]):
+        no_name_rows.append({"smiles": smi, "name": "", "properties": {"__pos1__": f"e{i}"}})
+    scenarios["no_name_column"] = {
+        "options": {"delimiter": " ", "smiles_column": 0, "name_column": None, "title_line": False},
+        "rows": no_name_rows,
+        "malformed_row_indices": [],
+    }
+
+    # --- malformed SMILES interspersed with valid ones ---
+    malformed_smis = ["C1CC", "not(a(smiles", "[Xx]", "C(", ")C"]
+    mal_rows = []
+    mal_indices = []
+    good_pool = iter(valid_corpus[205:215])
+    for i in range(10):
+        if i % 2 == 0:
+            mal_rows.append({"smiles": malformed_smis[(i // 2) % len(malformed_smis)], "name": f"bad_{i}", "properties": {}})
+            mal_indices.append(i)
+        else:
+            mal_rows.append({"smiles": next(good_pool), "name": f"good_{i}", "properties": {}})
+    scenarios["malformed_smiles"] = {
+        "options": {"delimiter": " ", "smiles_column": 0, "name_column": 1, "title_line": True},
+        "rows": mal_rows,
+        "malformed_row_indices": mal_indices,
+    }
+
+    # --- blank lines and comment lines interspersed ---
+    blank_comment_smis = valid_corpus[215:225]
+    scenarios["blank_and_comment_lines"] = {
+        "options": {"delimiter": " ", "smiles_column": 0, "name_column": 1, "title_line": True},
+        "rows": [{"smiles": s, "name": f"bc_{i}", "properties": {}} for i, s in enumerate(blank_comment_smis)],
+        "malformed_row_indices": [],
+        "inject_blanks_and_comments": True,
+    }
+
+    # --- isotopes, charges, stereochemistry, disconnected fragments ---
+    special = [
+        ("[13CH4]", "carbon_13"),
+        ("CC(=O)[O-]", "acetate_anion"),
+        ("[NH4+]", "ammonium"),
+        ("C/C=C/C", "trans_2_butene"),
+        ("C/C=C\\C", "cis_2_butene"),
+        ("N[C@@H](C)C(=O)O", "l_alanine"),
+        ("N[C@H](C)C(=O)O", "d_alanine"),
+        ("[Na+].[Cl-]", "sodium_chloride"),
+        ("CCO.CC(=O)O", "disconnected_ethanol_acetic_acid"),
+        ("[2H]C([2H])([2H])O", "deuterated_methanol"),
+    ]
+    scenarios["special_chemistry"] = {
+        "options": {"delimiter": " ", "smiles_column": 0, "name_column": 1, "title_line": True},
+        "rows": [{"smiles": s, "name": n, "properties": {"Category": "special"}} for s, n in special],
+        "malformed_row_indices": [],
+    }
+
+    return scenarios
+
+
+def write_scenario_file(path, scenario, delimiter):
+    opts = scenario["options"]
+    inject = scenario.get("inject_blanks_and_comments", False)
+    lines = []
+    header_cols = ["SMILES"]
+    if opts["name_column"] is not None:
+        header_cols.append("Name")
+    extra_keys = sorted({k for r in scenario["rows"] for k in r["properties"]})
+    header_cols += extra_keys
+    if opts["title_line"]:
+        lines.append(delimiter.join(header_cols))
+
+    for i, row in enumerate(scenario["rows"]):
+        if inject and i == 2:
+            lines.append("# a comment line")
+        if inject and i == 5:
+            lines.append("")
+        fields = [row["smiles"]]
+        if opts["name_column"] is not None:
+            fields.append(row["name"])
+        for k in extra_keys:
+            v = row["properties"].get(k, "")
+            if delimiter == "," and ("," in v or '"' in v):
+                v = '"' + v.replace('"', '""') + '"'
+            fields.append(v)
+        lines.append(delimiter.join(fields))
+
+    with open(path, "w") as f:
+        f.write("\n".join(lines) + "\n")
+    return header_cols, extra_keys
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--out-dir", required=True)
+    p.add_argument("--corpus", required=True)
+    p.add_argument("--manifest-out", required=True)
+    p.add_argument("--corpus-limit", type=int, default=1000)
+    args = p.parse_args()
+
+    import os
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    corpus = load_corpus(args.corpus, args.corpus_limit)
+    scenarios = build_scenarios(corpus)
+
+    manifest = {"scenarios": {}}
+    total_rows = 0
+    for name, scenario in scenarios.items():
+        delim = scenario["options"]["delimiter"]
+        path = os.path.join(args.out_dir, f"{name}.txt")
+        header_cols, extra_keys = write_scenario_file(path, scenario, delim)
+        manifest["scenarios"][name] = {
+            "file": os.path.basename(path),
+            "options": scenario["options"],
+            "extra_property_keys": extra_keys,
+            "rows": scenario["rows"],
+            "malformed_row_indices": scenario["malformed_row_indices"],
+        }
+        total_rows += len(scenario["rows"])
+
+    manifest["total_rows"] = total_rows
+    with open(args.manifest_out, "w") as f:
+        json.dump(manifest, f, indent=2)
+
+    print(f"wrote {len(scenarios)} scenario files, {total_rows} total data rows, manifest -> {args.manifest_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gen_tdt_fixtures.py
+++ b/scripts/gen_tdt_fixtures.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Generate TDT (Daylight Tagged Data) I/O fixtures for the IO-2 oracle gate.
+
+Produces scenario `.tdt` files + a manifest of KNOWN ground truth this
+script itself authors, covering: SMI record, NAME record, arbitrary
+properties, `|` terminator, empty property, repeated property, unknown tag,
+malformed tag (recovery), EOF mid-record, 2D/3D coordinate tags, isotopes,
+charges, stereochemistry, disconnected fragments.
+
+The "general" scenario draws real, chemically diverse SMILES from the
+Morgan M4-A0 corpus rather than hand-authoring hundreds of molecules.
+
+Usage:
+    python scripts/gen_tdt_fixtures.py --out-dir <dir> --corpus <SMILES.csv> \\
+        --manifest-out <manifest.json>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+try:
+    from rdkit import Chem
+except ImportError:
+    print("rdkit is required to author fixtures", file=sys.stderr)
+    raise
+
+
+def load_corpus(path, limit=None):
+    smis = []
+    with open(path) as f:
+        for line in f:
+            s = line.strip()
+            if s:
+                smis.append(s)
+    if limit:
+        smis = smis[:limit]
+    return smis
+
+
+def rdkit_parses(smi):
+    try:
+        return Chem.MolFromSmiles(smi) is not None
+    except Exception:
+        return False
+
+
+def build_scenarios(corpus):
+    valid_corpus = [s for s in corpus if rdkit_parses(s)]
+    scenarios = {}
+
+    general = valid_corpus[:170]
+    scenarios["general"] = {
+        "rows": [
+            {"smiles": s, "name": f"mol_{i}", "properties": {"ACTIVITY": f"{(i % 10) + 0.1:.2f}"}}
+            for i, s in enumerate(general)
+        ],
+        "malformed_row_indices": [],
+    }
+
+    empty_prop = valid_corpus[170:180]
+    scenarios["empty_property"] = {
+        "rows": [{"smiles": s, "name": f"ep_{i}", "properties": {"NOTE": ""}} for i, s in enumerate(empty_prop)],
+        "malformed_row_indices": [],
+    }
+
+    unknown_tags = valid_corpus[180:190]
+    scenarios["unknown_tags"] = {
+        "rows": [
+            {"smiles": s, "name": f"ut_{i}", "properties": {"MFCD": f"{1000+i}", "CAS": f"{64+i}-17-5"}}
+            for i, s in enumerate(unknown_tags)
+        ],
+        "malformed_row_indices": [],
+    }
+
+    special = [
+        ("[13CH4]", "carbon_13"),
+        ("CC(=O)[O-]", "acetate_anion"),
+        ("[NH4+]", "ammonium"),
+        ("C/C=C/C", "trans_2_butene"),
+        ("C/C=C\\C", "cis_2_butene"),
+        ("N[C@@H](C)C(=O)O", "l_alanine"),
+        ("N[C@H](C)C(=O)O", "d_alanine"),
+        ("[Na+].[Cl-]", "sodium_chloride"),
+        ("CCO.CC(=O)O", "disconnected_ethanol_acetic_acid"),
+        ("[2H]C([2H])([2H])O", "deuterated_methanol"),
+    ]
+    scenarios["special_chemistry"] = {
+        "rows": [{"smiles": s, "name": n, "properties": {"CATEGORY": "special"}} for s, n in special],
+        "malformed_row_indices": [],
+    }
+
+    return scenarios
+
+
+def write_tdt_scenario(path, scenario):
+    lines = []
+    for row in scenario["rows"]:
+        lines.append(f"$SMI<{row['smiles']}>")
+        lines.append(f"NAME<{row['name']}>")
+        for k, v in row["properties"].items():
+            lines.append(f"{k}<{v}>")
+        lines.append("|")
+    with open(path, "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+def write_repeated_tag_fixture(path):
+    # FOO appears twice -- last value wins, same position.
+    content = "$SMI<CC>\nNAME<ethane>\nFOO<first>\nBAR<x>\nFOO<second>\n|\n"
+    with open(path, "w") as f:
+        f.write(content)
+
+
+def write_malformed_tag_fixture(path):
+    # Row 0: malformed (missing closing '>'). Row 1: valid. Tests recovery.
+    content = "$SMI<CC>\nBROKEN<no_close\n|\n$SMI<CCO>\nNAME<ethanol>\n|\n"
+    with open(path, "w") as f:
+        f.write(content)
+
+
+def write_eof_mid_record_fixture(path):
+    # No trailing '|' at all -- EOF mid-record.
+    content = "$SMI<CC>\nNAME<ethane>"
+    with open(path, "w") as f:
+        f.write(content)
+
+
+def write_coordinate_fixture(path):
+    # 3-atom molecule (CCO), 2D and 3D coordinate tags -- exercises the
+    # last-atom-drop bug real RDKit has and chematic fixes.
+    content = "$SMI<CCO>\nNAME<ethanol_with_coords>\n2D<0.0,0.0,1.0,0.0,2.0,1.0;>\n3D<0.0,0.0,0.0,1.0,0.0,0.0,2.0,1.0,0.5;>\n|\n"
+    with open(path, "w") as f:
+        f.write(content)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--out-dir", required=True)
+    p.add_argument("--corpus", required=True)
+    p.add_argument("--manifest-out", required=True)
+    p.add_argument("--corpus-limit", type=int, default=1000)
+    args = p.parse_args()
+
+    import os
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    corpus = load_corpus(args.corpus, args.corpus_limit)
+    scenarios = build_scenarios(corpus)
+
+    manifest = {"scenarios": {}}
+    total_rows = 0
+    for name, scenario in scenarios.items():
+        path = os.path.join(args.out_dir, f"{name}.tdt")
+        write_tdt_scenario(path, scenario)
+        manifest["scenarios"][name] = {
+            "file": os.path.basename(path),
+            "rows": scenario["rows"],
+            "malformed_row_indices": scenario["malformed_row_indices"],
+        }
+        total_rows += len(scenario["rows"])
+
+    # Special single-file scenarios, not corpus-derived, each with its own
+    # exact ground truth described inline (not enumerable as "rows").
+    repeated_path = os.path.join(args.out_dir, "repeated_tag.tdt")
+    write_repeated_tag_fixture(repeated_path)
+    manifest["scenarios"]["repeated_tag"] = {
+        "file": "repeated_tag.tdt",
+        "rows": [{"smiles": "CC", "name": "ethane", "properties": {"FOO": "second", "BAR": "x"}}],
+        "malformed_row_indices": [],
+    }
+    total_rows += 1
+
+    malformed_path = os.path.join(args.out_dir, "malformed_tag.tdt")
+    write_malformed_tag_fixture(malformed_path)
+    manifest["scenarios"]["malformed_tag"] = {
+        "file": "malformed_tag.tdt",
+        "rows": [
+            {"smiles": None, "name": None, "properties": {}},  # row 0: malformed, no ground truth
+            {"smiles": "CCO", "name": "ethanol", "properties": {}},
+        ],
+        "malformed_row_indices": [0],
+    }
+    total_rows += 2
+
+    eof_path = os.path.join(args.out_dir, "eof_mid_record.tdt")
+    write_eof_mid_record_fixture(eof_path)
+    manifest["scenarios"]["eof_mid_record"] = {
+        "file": "eof_mid_record.tdt",
+        "rows": [{"smiles": "CC", "name": "ethane", "properties": {}}],
+        "malformed_row_indices": [],
+    }
+    total_rows += 1
+
+    coord_path = os.path.join(args.out_dir, "coordinates.tdt")
+    write_coordinate_fixture(coord_path)
+    manifest["scenarios"]["coordinates"] = {
+        "file": "coordinates.tdt",
+        "rows": [{"smiles": "CCO", "name": "ethanol_with_coords", "properties": {}}],
+        "malformed_row_indices": [],
+        "known_divergent": "RDKit's own coordinate-list parser drops the last atom's position (confirmed bug); chematic fixes it. Coordinate values are NOT gated in the comparator for this scenario.",
+    }
+    total_rows += 1
+
+    manifest["total_rows"] = total_rows
+    with open(args.manifest_out, "w") as f:
+        json.dump(manifest, f, indent=2)
+
+    print(f"wrote {len(manifest['scenarios'])} scenario files, {total_rows} total rows, manifest -> {args.manifest_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smiles_table_io_parity.py
+++ b/scripts/smiles_table_io_parity.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""IO-1 acceptance gate: compares chematic's SMILES-table tokenization
+against real RDKit's, per row, across every scenario in
+`gen_smiles_table_fixtures.py`'s manifest.
+
+**Why this never compares chematic-canonical vs. RDKit-canonical SMILES
+strings directly:** chematic/RDKit canonical-SMILES divergence is a known,
+already-tracked, separate issue in this project (see the project's own
+Morgan/ECFP-parity notes -- canonicalization is an open roadmap item, not
+something this I/O milestone is scoped to fix or measure). A naive
+string-equality gate here would report a large "parity gap" that has
+nothing to do with whether the SMILES-table *tokenizer* correctly split
+each line into (smiles, name, properties) columns -- the actual thing this
+gate needs to prove.
+
+Instead, three independent, tool-neutral checks are combined:
+
+1. **Status parity** -- did both tools agree a row is `success` vs.
+   unparseable, per row.
+2. **Name/property parity** -- exact string equality of the extracted
+   `name` and (key, value) property pairs. Pure tokenization, no chemistry,
+   no canonicalizer involved on either side.
+3. **Self-consistency, per tool, against the manifest's own known ground
+   truth** -- did each tool's *own* canonicalizer agree that what it
+   extracted from the SMILES column represents the same molecule as the
+   manifest's authored SMILES string for that row, when parsed and
+   re-canonicalized entirely within that same tool? This validates each
+   tool's own tokenizer independently (proves the right substring was
+   extracted) without ever comparing chematic's canonical form against
+   RDKit's.
+
+Usage:
+    python scripts/smiles_table_io_parity.py \\
+        --chematic <chematic_smiles_table_dump.jsonl> \\
+        --rdkit-oracle <rdkit_smiles_table_oracle.jsonl> \\
+        --manifest <manifest.json> \\
+        --summary-out <out.json>
+
+    python scripts/smiles_table_io_parity.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def load_jsonl(path):
+    rows = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def key(row):
+    return (row["scenario"], row["row_index"])
+
+
+# Scenarios where chematic's own, documented behavior deliberately diverges
+# from RDKit's -- reported separately below, never counted as a gate
+# failure. See `smiles_table.rs`'s module doc comment for the source-cited
+# justification of each.
+KNOWN_NAME_DIVERGENCE_SCENARIOS = {
+    # name_column=None: RDKit falls back to the physical line number as
+    # `_Name`; chematic's MoleculeRecord::name is simply empty.
+    "no_name_column",
+}
+
+KNOWN_PROPERTY_DIVERGENCE_SCENARIOS = {
+    # RDKit's SmilesMolSupplier has NO CSV-quote-awareness for its comma
+    # delimiter mode at all (confirmed via this oracle, not just inferred):
+    # a quoted field with an embedded comma/quote is split into extra raw
+    # columns by RDKit's literal splitting. Chematic's RFC 4180-subset
+    # quoting support is a deliberate, beneficial divergence.
+    "csv_quoted",
+}
+
+
+def normalize_no_title_line_properties(props_list, extra_keys, name_column, prefix):
+    """When a scenario has no title line, each tool names extra columns
+    with its own fallback convention ("column_N" for chematic, "Column_N"
+    for RDKit, both 0-indexed over the full row) rather than the manifest's
+    abstract key names. Remap `{prefix}_N` -> the manifest's own extra_keys[i]
+    so both sides compare on the same semantic key set -- the naming
+    convention difference is cosmetic, not a real divergence to gate on."""
+    base = 1 if name_column is None else 2
+    index_to_abstract = {base + i: k for i, k in enumerate(extra_keys)}
+    out = {}
+    for k, v in props_list:
+        if k.startswith(prefix):
+            try:
+                idx = int(k[len(prefix) :])
+            except ValueError:
+                out[k] = v
+                continue
+            out[index_to_abstract.get(idx, k)] = v
+        else:
+            out[k] = v
+    return out
+
+
+def run(chematic_rows, rdkit_rows, manifest):
+    chematic_by_key = {key(r): r for r in chematic_rows}
+    rdkit_by_key = {key(r): r for r in rdkit_rows}
+
+    if set(chematic_by_key) != set(rdkit_by_key):
+        missing_in_rdkit = sorted(set(chematic_by_key) - set(rdkit_by_key))
+        missing_in_chematic = sorted(set(rdkit_by_key) - set(chematic_by_key))
+        print(
+            f"PIPELINE ERROR: row key sets differ. missing_in_rdkit={missing_in_rdkit[:5]} "
+            f"missing_in_chematic={missing_in_chematic[:5]}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    total = len(chematic_by_key)
+    status_mismatches = []
+    name_mismatches = []
+    property_mismatches = []
+    known_name_divergences = []
+    known_property_divergences = []
+    chematic_self_consistency_failures = []
+    rdkit_self_consistency_failures = []
+    malformed_row_agreement = {"expected": 0, "both_error": 0, "mismatched": []}
+
+    for k in sorted(chematic_by_key):
+        c = chematic_by_key[k]
+        r = rdkit_by_key[k]
+        scenario_name = k[0]
+        scenario = manifest["scenarios"][scenario_name]
+
+        if c["status"] != r["status"]:
+            status_mismatches.append({"key": k, "chematic": c["status"], "rdkit": r["status"]})
+            continue
+
+        if k[1] in scenario.get("malformed_row_indices", []):
+            malformed_row_agreement["expected"] += 1
+            if c["status"] == "error" and r["status"] == "error":
+                malformed_row_agreement["both_error"] += 1
+            else:
+                malformed_row_agreement["mismatched"].append(k)
+
+        if c["status"] != "success":
+            continue
+
+        if c["name"] != r["name"]:
+            if scenario_name in KNOWN_NAME_DIVERGENCE_SCENARIOS:
+                known_name_divergences.append({"key": k, "chematic": c["name"], "rdkit": r["name"]})
+            else:
+                name_mismatches.append({"key": k, "chematic": c["name"], "rdkit": r["name"]})
+
+        opts = scenario["options"]
+        if opts["title_line"]:
+            c_props = {kk: vv for kk, vv in c["properties"]}
+            r_props = {kk: vv for kk, vv in r["properties"]}
+        else:
+            extra_keys = scenario["extra_property_keys"]
+            c_props = normalize_no_title_line_properties(c["properties"], extra_keys, opts["name_column"], "column_")
+            r_props = normalize_no_title_line_properties(r["properties"], extra_keys, opts["name_column"], "Column_")
+        if c_props != r_props:
+            entry = {"key": k, "chematic": c_props, "rdkit": r_props}
+            if scenario_name in KNOWN_PROPERTY_DIVERGENCE_SCENARIOS:
+                known_property_divergences.append(entry)
+            else:
+                property_mismatches.append(entry)
+
+        if c.get("self_consistent_with_known_smiles") is False:
+            chematic_self_consistency_failures.append(k)
+        if r.get("self_consistent_with_known_smiles") is False:
+            rdkit_self_consistency_failures.append(k)
+
+    success_count = sum(1 for c in chematic_by_key.values() if c["status"] == "success")
+
+    gate_failures = []
+    if status_mismatches:
+        gate_failures.append(f"{len(status_mismatches)} row(s) with status mismatch (asymmetric parse failure)")
+    if name_mismatches:
+        gate_failures.append(f"{len(name_mismatches)} row(s) with name mismatch")
+    if property_mismatches:
+        gate_failures.append(f"{len(property_mismatches)} row(s) with property mismatch")
+    if chematic_self_consistency_failures:
+        gate_failures.append(
+            f"{len(chematic_self_consistency_failures)} row(s) where chematic's own extraction+canonicalization "
+            "disagreed with its own parse of the known ground-truth SMILES (tokenization bug)"
+        )
+    if malformed_row_agreement["mismatched"]:
+        gate_failures.append(
+            f"{len(malformed_row_agreement['mismatched'])} known-malformed row(s) where chematic/RDKit disagreed "
+            "on whether the row is parseable"
+        )
+
+    summary = {
+        "total_rows": total,
+        "success_count": success_count,
+        "error_count": total - success_count,
+        "status_mismatches": status_mismatches,
+        "name_mismatches": name_mismatches,
+        "known_name_divergences_non_gating": known_name_divergences,
+        "property_mismatches": property_mismatches,
+        "known_property_divergences_non_gating": known_property_divergences,
+        "chematic_self_consistency_failures": chematic_self_consistency_failures,
+        "rdkit_self_consistency_failures_non_gating": rdkit_self_consistency_failures,
+        "malformed_row_agreement": malformed_row_agreement,
+        "gate_failures": gate_failures,
+        "gate_passed": len(gate_failures) == 0,
+    }
+
+    if gate_failures:
+        print(f"GATE FAILED: {len(gate_failures)} violation(s):", file=sys.stderr)
+        for msg in gate_failures:
+            print(f"  - {msg}", file=sys.stderr)
+
+    return summary, summary["gate_passed"]
+
+
+def run_self_test():
+    checks = []
+
+    manifest = {
+        "scenarios": {
+            "s1": {"malformed_row_indices": []},
+        }
+    }
+
+    def row(scenario, idx, status, name=None, props=None, self_consistent=None):
+        r = {"scenario": scenario, "row_index": idx, "status": status}
+        if status == "success":
+            r["name"] = name or ""
+            r["properties"] = props or []
+            r["self_consistent_with_known_smiles"] = self_consistent
+        return r
+
+    # exact match
+    c_rows = [row("s1", 0, "success", "a", [["K", "V"]], True)]
+    r_rows = [row("s1", 0, "success", "a", [["K", "V"]], True)]
+    summary, passed = run(c_rows, r_rows, manifest)
+    checks.append(("exact_match_passes", passed is True and summary["name_mismatches"] == []))
+
+    # name mismatch
+    c_rows = [row("s1", 0, "success", "a", [], True)]
+    r_rows = [row("s1", 0, "success", "b", [], True)]
+    summary, passed = run(c_rows, r_rows, manifest)
+    checks.append(("name_mismatch_fails", passed is False and len(summary["name_mismatches"]) == 1))
+
+    # property mismatch
+    c_rows = [row("s1", 0, "success", "a", [["K", "V1"]], True)]
+    r_rows = [row("s1", 0, "success", "a", [["K", "V2"]], True)]
+    summary, passed = run(c_rows, r_rows, manifest)
+    checks.append(("property_mismatch_fails", passed is False and len(summary["property_mismatches"]) == 1))
+
+    # status mismatch
+    c_rows = [row("s1", 0, "success", "a", [], True)]
+    r_rows = [row("s1", 0, "error")]
+    summary, passed = run(c_rows, r_rows, manifest)
+    checks.append(("status_mismatch_fails", passed is False and len(summary["status_mismatches"]) == 1))
+
+    # chematic self-consistency failure gates
+    c_rows = [row("s1", 0, "success", "a", [], False)]
+    r_rows = [row("s1", 0, "success", "a", [], True)]
+    summary, passed = run(c_rows, r_rows, manifest)
+    checks.append(("chematic_self_consistency_gates", passed is False and len(summary["chematic_self_consistency_failures"]) == 1))
+
+    # rdkit self-consistency failure is non-gating
+    c_rows = [row("s1", 0, "success", "a", [], True)]
+    r_rows = [row("s1", 0, "success", "a", [], False)]
+    summary, passed = run(c_rows, r_rows, manifest)
+    checks.append(("rdkit_self_consistency_non_gating", passed is True and len(summary["rdkit_self_consistency_failures_non_gating"]) == 1))
+
+    # both-error on a known-malformed row is fine
+    manifest2 = {"scenarios": {"s1": {"malformed_row_indices": [0]}}}
+    c_rows = [row("s1", 0, "error")]
+    r_rows = [row("s1", 0, "error")]
+    summary, passed = run(c_rows, r_rows, manifest2)
+    checks.append(("known_malformed_both_error_ok", passed is True and summary["malformed_row_agreement"]["both_error"] == 1))
+
+    # pipeline error: mismatched key sets -> hard exit
+    try:
+        run([row("s1", 0, "success", "a", [], True)], [], manifest)
+        pipeline_ok = False
+    except SystemExit as e:
+        pipeline_ok = e.code != 0
+    checks.append(("mismatched_keys_hard_exit", pipeline_ok))
+
+    ok = True
+    for name, passed in checks:
+        status = "OK" if passed else "FAIL"
+        print(f"  self-test {name}: {status}")
+        ok = ok and passed
+    return ok
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--chematic")
+    p.add_argument("--rdkit-oracle")
+    p.add_argument("--manifest")
+    p.add_argument("--summary-out", default=None)
+    p.add_argument("--self-test", action="store_true")
+    args = p.parse_args()
+
+    if args.self_test:
+        ok = run_self_test()
+        sys.exit(0 if ok else 1)
+
+    if not args.chematic or not args.rdkit_oracle or not args.manifest:
+        p.error("--chematic, --rdkit-oracle, and --manifest are required unless --self-test")
+
+    chematic_rows = load_jsonl(args.chematic)
+    rdkit_rows = load_jsonl(args.rdkit_oracle)
+    with open(args.manifest) as f:
+        manifest = json.load(f)
+
+    summary, gate_passed = run(chematic_rows, rdkit_rows, manifest)
+    print(json.dumps(summary, indent=2))
+    if args.summary_out:
+        with open(args.summary_out, "w") as f:
+            json.dump(summary, f, indent=2, sort_keys=True)
+        print(f"summary written to {args.summary_out}")
+
+    sys.exit(0 if gate_passed else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tdt_io_parity.py
+++ b/scripts/tdt_io_parity.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""IO-2 acceptance gate: compares chematic's TDT tokenization against real
+RDKit's, per row, across every scenario in `gen_tdt_fixtures.py`'s manifest.
+
+Same methodology as `scripts/smiles_table_io_parity.py` (see its module
+docs for the full rationale): never compares chematic-canonical vs.
+RDKit-canonical SMILES strings directly. Instead: exact name/property
+string equality, plus each tool's own self-consistency against the
+fixture's known ground-truth SMILES, canonicalized only within that same
+tool.
+
+Two scenarios are treated as KNOWN, non-gating divergences (documented in
+`chematic_mol::tdt`'s module doc comment, both confirmed via this session's
+own oracle runs, not assumed):
+- "coordinates": RDKit's own coordinate-list parser drops the last atom's
+  position (a real bug); chematic fixes it. Coordinate VALUES are not
+  gated for this scenario (name/properties still are).
+- "eof_mid_record": RDKit drops the final tag line when a file has no
+  trailing newline; chematic reads it correctly. Name/property mismatches
+  for this specific scenario are not gated.
+
+Usage:
+    python scripts/tdt_io_parity.py --chematic <chematic_tdt_dump.jsonl> \\
+        --rdkit-oracle <rdkit_tdt_oracle.jsonl> --manifest <manifest.json> \\
+        --summary-out <out.json>
+
+    python scripts/tdt_io_parity.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+KNOWN_DIVERGENT_SCENARIOS = {"coordinates", "eof_mid_record"}
+
+
+def load_jsonl(path):
+    rows = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def key(row):
+    return (row["scenario"], row["row_index"])
+
+
+def run(chematic_rows, rdkit_rows, manifest):
+    chematic_by_key = {key(r): r for r in chematic_rows}
+    rdkit_by_key = {key(r): r for r in rdkit_rows}
+
+    if set(chematic_by_key) != set(rdkit_by_key):
+        missing_in_rdkit = sorted(set(chematic_by_key) - set(rdkit_by_key))
+        missing_in_chematic = sorted(set(rdkit_by_key) - set(chematic_by_key))
+        print(
+            f"PIPELINE ERROR: row key sets differ. missing_in_rdkit={missing_in_rdkit[:5]} "
+            f"missing_in_chematic={missing_in_chematic[:5]}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    total = len(chematic_by_key)
+    status_mismatches = []
+    name_mismatches = []
+    property_mismatches = []
+    coordinate_mismatches = []
+    known_divergences = []
+    chematic_self_consistency_failures = []
+    rdkit_self_consistency_failures = []
+    malformed_row_agreement = {"expected": 0, "both_error": 0, "mismatched": []}
+
+    for k in sorted(chematic_by_key):
+        c = chematic_by_key[k]
+        r = rdkit_by_key[k]
+        scenario_name = k[0]
+        scenario = manifest["scenarios"][scenario_name]
+        known_divergent = scenario_name in KNOWN_DIVERGENT_SCENARIOS
+
+        if c["status"] != r["status"]:
+            entry = {"key": k, "chematic": c["status"], "rdkit": r["status"]}
+            if known_divergent:
+                known_divergences.append(entry)
+            else:
+                status_mismatches.append(entry)
+            continue
+
+        if k[1] in scenario.get("malformed_row_indices", []):
+            malformed_row_agreement["expected"] += 1
+            if c["status"] == "error" and r["status"] == "error":
+                malformed_row_agreement["both_error"] += 1
+            else:
+                malformed_row_agreement["mismatched"].append(k)
+
+        if c["status"] != "success":
+            continue
+
+        if c["name"] != r["name"]:
+            entry = {"key": k, "chematic": c["name"], "rdkit": r["name"]}
+            if known_divergent:
+                known_divergences.append(entry)
+            else:
+                name_mismatches.append(entry)
+
+        c_props = {kk: vv for kk, vv in c["properties"]}
+        r_props = {kk: vv for kk, vv in r["properties"]}
+        if c_props != r_props:
+            entry = {"key": k, "chematic": c_props, "rdkit": r_props}
+            if known_divergent:
+                known_divergences.append(entry)
+            else:
+                property_mismatches.append(entry)
+
+        if c.get("self_consistent_with_known_smiles") is False:
+            chematic_self_consistency_failures.append(k)
+        if r.get("self_consistent_with_known_smiles") is False:
+            rdkit_self_consistency_failures.append(k)
+
+        for dim in ("coordinates_2d", "coordinates_3d"):
+            c_coords, r_coords = c.get(dim), r.get(dim)
+            if c_coords is None and r_coords is None:
+                continue
+            entry = {"key": k, "dim": dim, "chematic": c_coords, "rdkit": r_coords}
+            if c_coords != r_coords:
+                if known_divergent:
+                    known_divergences.append(entry)
+                else:
+                    coordinate_mismatches.append(entry)
+
+    success_count = sum(1 for c in chematic_by_key.values() if c["status"] == "success")
+
+    gate_failures = []
+    if status_mismatches:
+        gate_failures.append(f"{len(status_mismatches)} row(s) with status mismatch")
+    if name_mismatches:
+        gate_failures.append(f"{len(name_mismatches)} row(s) with name mismatch")
+    if property_mismatches:
+        gate_failures.append(f"{len(property_mismatches)} row(s) with property mismatch")
+    if coordinate_mismatches:
+        gate_failures.append(f"{len(coordinate_mismatches)} row(s) with coordinate mismatch")
+    if chematic_self_consistency_failures:
+        gate_failures.append(
+            f"{len(chematic_self_consistency_failures)} row(s) where chematic's own extraction "
+            "disagreed with its own parse of the known ground-truth SMILES (tokenization bug)"
+        )
+    if malformed_row_agreement["mismatched"]:
+        gate_failures.append(
+            f"{len(malformed_row_agreement['mismatched'])} known-malformed row(s) where chematic/RDKit disagreed"
+        )
+
+    summary = {
+        "total_rows": total,
+        "success_count": success_count,
+        "error_count": total - success_count,
+        "status_mismatches": status_mismatches,
+        "name_mismatches": name_mismatches,
+        "property_mismatches": property_mismatches,
+        "coordinate_mismatches": coordinate_mismatches,
+        "known_divergences_non_gating": known_divergences,
+        "chematic_self_consistency_failures": chematic_self_consistency_failures,
+        "rdkit_self_consistency_failures_non_gating": rdkit_self_consistency_failures,
+        "malformed_row_agreement": malformed_row_agreement,
+        "gate_failures": gate_failures,
+        "gate_passed": len(gate_failures) == 0,
+    }
+
+    if gate_failures:
+        print(f"GATE FAILED: {len(gate_failures)} violation(s):", file=sys.stderr)
+        for msg in gate_failures:
+            print(f"  - {msg}", file=sys.stderr)
+
+    return summary, summary["gate_passed"]
+
+
+def run_self_test():
+    checks = []
+    manifest = {"scenarios": {"s1": {"malformed_row_indices": []}, "coordinates": {"malformed_row_indices": []}}}
+
+    def row(scenario, idx, status, name=None, props=None, self_consistent=None):
+        r = {"scenario": scenario, "row_index": idx, "status": status}
+        if status == "success":
+            r["name"] = name or ""
+            r["properties"] = props or []
+            r["self_consistent_with_known_smiles"] = self_consistent
+        return r
+
+    c_rows = [row("s1", 0, "success", "a", [["K", "V"]], True)]
+    r_rows = [row("s1", 0, "success", "a", [["K", "V"]], True)]
+    summary, passed = run(c_rows, r_rows, manifest)
+    checks.append(("exact_match_passes", passed is True))
+
+    c_rows = [row("s1", 0, "success", "a", [], True)]
+    r_rows = [row("s1", 0, "success", "b", [], True)]
+    summary, passed = run(c_rows, r_rows, manifest)
+    checks.append(("name_mismatch_fails", passed is False and len(summary["name_mismatches"]) == 1))
+
+    c_rows = [row("coordinates", 0, "success", "a", [], True)]
+    r_rows = [row("coordinates", 0, "success", "b", [], True)]
+    summary, passed = run(c_rows, r_rows, manifest)
+    checks.append(("known_divergent_scenario_non_gating", passed is True and len(summary["known_divergences_non_gating"]) == 1))
+
+    try:
+        run([row("s1", 0, "success", "a", [], True)], [], manifest)
+        pipeline_ok = False
+    except SystemExit as e:
+        pipeline_ok = e.code != 0
+    checks.append(("mismatched_keys_hard_exit", pipeline_ok))
+
+    ok = True
+    for name, passed in checks:
+        status = "OK" if passed else "FAIL"
+        print(f"  self-test {name}: {status}")
+        ok = ok and passed
+    return ok
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--chematic")
+    p.add_argument("--rdkit-oracle")
+    p.add_argument("--manifest")
+    p.add_argument("--summary-out", default=None)
+    p.add_argument("--self-test", action="store_true")
+    args = p.parse_args()
+
+    if args.self_test:
+        ok = run_self_test()
+        sys.exit(0 if ok else 1)
+
+    if not args.chematic or not args.rdkit_oracle or not args.manifest:
+        p.error("--chematic, --rdkit-oracle, and --manifest are required unless --self-test")
+
+    chematic_rows = load_jsonl(args.chematic)
+    rdkit_rows = load_jsonl(args.rdkit_oracle)
+    with open(args.manifest) as f:
+        manifest = json.load(f)
+
+    summary, gate_passed = run(chematic_rows, rdkit_rows, manifest)
+    print(json.dumps(summary, indent=2))
+    if args.summary_out:
+        with open(args.summary_out, "w") as f:
+            json.dump(summary, f, indent=2, sort_keys=True)
+        print(f"summary written to {args.summary_out}")
+
+    sys.exit(0 if gate_passed else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/README.md
+++ b/validation/README.md
@@ -412,7 +412,32 @@ mid-record, 2D/3D coordinate tags, isotopes, charges, disconnected fragments, st
 | Chematic self-consistency vs. known ground truth | 204/204 (100%) |
 | RDKit self-consistency vs. known ground truth (non-gating) | 204/204 (100%) |
 
+**Performance** (10,000-record synthetic corpus, ~2% deliberately malformed, 5 independent
+process runs, `/usr/bin/time -l`):
+
+| | chematic (`TdtRecordReader`) | RDKit (`TDTMolSupplier`, Python, index-based access) |
+|---|---|---|
+| Records/sec (median of 5 runs) | ~128,000 | ~5,100 |
+| Peak RSS | ~2.4 MB | ~45 MB |
+| Success/error split | 9,800/200 | 9,800/200 (identical) |
+
+RDKit's own numbers use index-based access (`sup[idx]`), the workaround this PR's own oracle
+script needed for RDKit's malformed-tag recovery hazard — an even less apples-to-apples
+comparison than a plain iterator would be. Reported as informational cross-language reference
+only, same policy as IO-1.
+
+**Adversarial/fuzz-style coverage:** 11 deterministic adversarial unit tests (empty/truncated
+input, an oversized line, a 500KB property value, invalid-UTF-8 bytes, 5,000-property records, a
+3,000-atom SMILES field, a malformed/never-terminated coordinate list, a 2,000-iteration seeded
+random-mutation corpus) — same no-cargo-fuzz-harness-exists rationale as IO-1. **One of these
+tests caught a real bug before this PR shipped**: an oversized-line or otherwise-mid-record read
+error left the reader's position at a leftover fragment (e.g. the record's own `|` terminator,
+already consumed into a since-rejected oversized buffer) that got misinterpreted as the start of
+a phantom next record. Fixed by centralizing recovery-to-next-record-boundary at every error exit
+from record-body parsing, not just the malformed-tag case that was tested first.
+
 - **Files:** `crates/chematic-mol/src/tdt.rs`, `crates/chematic-mol/examples/tdt_dump.rs`,
+  `crates/chematic-mol/examples/tdt_benchmark.rs`,
   `scripts/gen_tdt_fixtures.py`, `scripts/gen_rdkit_tdt_oracle.py`, `scripts/tdt_io_parity.py`.
 - **Reference tool:** RDKit 2026.03.3.
 - **How to regenerate:** `python scripts/gen_tdt_fixtures.py --out-dir <dir> --corpus <SMILES.csv>

--- a/validation/README.md
+++ b/validation/README.md
@@ -333,7 +333,30 @@ CXSMILES is not recognized in the SMILES column (parsed via
 RDKit's *own* default for `SmilesMolSupplier`, which explicitly disables
 CXSMILES for this entry point too.
 
+**Performance** (10,000-record synthetic corpus, ~2% deliberately malformed rows to also
+measure invalid-record recovery throughput; 5 independent process runs, `/usr/bin/time -l`):
+
+| | chematic (`SmilesRecordReader`) | RDKit (`SmilesMolSupplier`, Python) |
+|---|---|---|
+| Records/sec (median of 5 runs) | ~137,000 | ~4,200 |
+| Peak RSS | ~2.3 MB | ~45 MB |
+| Success/error split | 9,800/200 | 9,800/200 (identical) |
+
+The ~30x throughput difference is Python-interpreter-call overhead, not a controlled
+same-language comparison — reported as reference/informational only, per the
+"performance is never traded for correctness, and cross-language numbers aren't a gate"
+policy. Both tools agree exactly on which 200/10,000 rows are malformed.
+
+**Adversarial/fuzz-style coverage:** no `cargo-fuzz`/libfuzzer harness exists anywhere in
+this workspace yet, and introducing that toolchain for one text-tokenizer module was judged
+disproportionate — instead, 9 deterministic adversarial unit tests (empty input, truncated
+input mid-record and mid-quote, a line exceeding `max_line_bytes`, a 500KB property value
+within the limit, invalid-UTF-8 byte handling, 5,000-column rows, a 3,000-atom SMILES field,
+and a 2,000-iteration seeded random-mutation corpus) assert only "no panic, no hang, no OOM" —
+never a specific output — since malformed input must degrade to a clean `Err`, never worse.
+
 - **Files:** `crates/chematic-mol/src/smiles_table.rs`, `crates/chematic-mol/examples/smiles_table_dump.rs`,
+  `crates/chematic-mol/examples/smiles_table_benchmark.rs`,
   `scripts/gen_smiles_table_fixtures.py`, `scripts/gen_rdkit_smiles_table_oracle.py`,
   `scripts/smiles_table_io_parity.py`.
 - **Reference tool:** RDKit 2026.03.3.

--- a/validation/README.md
+++ b/validation/README.md
@@ -370,6 +370,58 @@ never a specific output — since malformed input must degrade to a clean `Err`,
   are not committed (regenerable byte-for-byte from the corpus + script); only the generator
   scripts and this summary are.
 
+### IO-2: Daylight TDT file I/O (`.tdt`)
+
+New streaming `TdtRecordReader`/`TdtRecordWriter` in `crates/chematic-mol/src/tdt.rs`, reusing
+`MoleculeRecord`'s (IO-1's shared record type) `coordinates_2d`/`coordinates_3d` fields (unused
+by the SMILES-table format, exactly what TDT's `2D`/`3D` tags need). Built from a source-cited
+audit of RDKit's `TDTMolSupplier`/`TDTWriter` (same pinned commit
+`8afba32ec539dcb2369bc84549d802aca3f7eb39`).
+
+**Four deliberate, documented divergences from RDKit — three fix real bugs the audit/oracle
+found in RDKit itself, not guessed improvements:**
+1. **RDKit's own coordinate-list parser drops the last atom's position** — its comma-tokenizer
+   treats the token containing the trailing `;>` as "found the terminator" and never pushes that
+   token's own numeric value. Confirmed against a live RDKit run (both via source tracing during
+   the audit, and reproduced again by this PR's own oracle: the last atom comes back at
+   `(0,0,0)` from real RDKit). Chematic parses the full list correctly.
+2. **RDKit's `TDTWriter` hard-codes its name tag as `"NAME"` while `TDTMolSupplier`'s own
+   `nameRecord` defaults to `""`** (no tag recognized) — a bare RDKit writer+reader round trip
+   silently loses the molecule name by default, confirmed empirically. Chematic's reader/writer
+   both default `name_tag` to `Some("NAME")`, so the round trip preserves the name out of the box.
+3. **RDKit's malformed-tag recovery has an infinite-loop hazard** — the exception thrown for a
+   missing `>` isn't caught inside `TDTMolSupplier::next()`'s own position-advance bookkeeping,
+   so naively retrying re-throws on the same record forever (confirmed empirically; this PR's own
+   RDKit oracle script had to switch to explicit index-based access, `sup[idx]`, to work around
+   it and make progress). Chematic's reader always scans forward to the next record boundary
+   internally before returning `Err`, so the next `Iterator::next()` call always makes progress.
+4. **RDKit drops the final tag line when a file has no trailing newline — discovered via this
+   PR's own oracle run, not predicted by the initial source audit.** `$SMI<CC>\nNAME<ethane>`
+   with no trailing `\n` yields `_Name == ""` in real RDKit rather than `"ethane"`. Chematic's
+   `BufRead::read_line`-based reader returns a final unterminated line correctly.
+
+**Results (205 rows, 8 scenarios covering SMI/NAME/arbitrary-property records, `|` terminator,
+empty property, repeated property (last-wins), unknown tags, malformed-tag recovery, EOF
+mid-record, 2D/3D coordinate tags, isotopes, charges, disconnected fragments, stereochemistry):**
+
+| Metric | Result |
+|---|---|
+| Status parity | 205/205 (100%) |
+| Known-malformed row correctly rejected by both tools | 1/1 |
+| Name/property/coordinate exact-match (excl. the 2 scenarios with documented divergences above) | 100% |
+| Chematic self-consistency vs. known ground truth | 204/204 (100%) |
+| RDKit self-consistency vs. known ground truth (non-gating) | 204/204 (100%) |
+
+- **Files:** `crates/chematic-mol/src/tdt.rs`, `crates/chematic-mol/examples/tdt_dump.rs`,
+  `scripts/gen_tdt_fixtures.py`, `scripts/gen_rdkit_tdt_oracle.py`, `scripts/tdt_io_parity.py`.
+- **Reference tool:** RDKit 2026.03.3.
+- **How to regenerate:** `python scripts/gen_tdt_fixtures.py --out-dir <dir> --corpus <SMILES.csv>
+  --manifest-out <manifest.json>` + `cargo run -p chematic-mol --release --example tdt_dump --
+  <manifest.json> <dir> <out.jsonl>` + `python scripts/gen_rdkit_tdt_oracle.py --manifest
+  <manifest.json> --fixtures-dir <dir> --out <oracle.jsonl>` + `python scripts/tdt_io_parity.py
+  --chematic <out.jsonl> --rdkit-oracle <oracle.jsonl> --manifest <manifest.json>`. Self-test:
+  `python scripts/tdt_io_parity.py --self-test`.
+
 ## Summary results
 
 See [rdkit/README.md](rdkit/README.md) for per-descriptor breakdowns.

--- a/validation/README.md
+++ b/validation/README.md
@@ -280,6 +280,73 @@ explicit `Err`, never an implicit/guessed mapping.
   <out.jsonl> --rdkit-oracle <gen_ecfp_rdkit_environment_oracle.py output>`. Self-test:
   `python scripts/ecfp_rdkit_morgan_ecfp4_parity.py --self-test`.
 
+### IO-1: SMILES table file I/O (`.smi`/`.smiles`/`.csv`/`.tsv`/`.txt`)
+
+New streaming `SmilesRecordReader`/`SmilesRecordWriter` in
+`crates/chematic-mol/src/smiles_table.rs`, built from a source-cited audit of
+RDKit's `SmilesMolSupplier`/`SmilesWriter` (RDKit commit
+`8afba32ec539dcb2369bc84549d802aca3f7eb39`, the true resolution of tag
+`Release_2026_03_4`) rather than guessed behavior. `chematic.SmilesMolSupplier`/
+`chematic.SmilesWriter` (Python, pyo3) match RDKit's constructor signatures;
+`rdkit_compat.py`'s own wrapper classes of the same names were rewritten to
+delegate to these (previously a separate, non-streaming, whole-file pure-Python
+implementation that used no Rust parser at all).
+
+**Oracle methodology (deliberately avoids the chematic/RDKit canonical-SMILES
+divergence, which is a known, separately-tracked, unrelated issue):** never
+compares chematic-canonical vs. RDKit-canonical SMILES strings directly.
+Instead: (1) exact string equality of extracted `name`/property values
+(pure tokenization, no chemistry); (2) each tool's *own* self-consistency
+against the fixture's known ground-truth SMILES, canonicalized only within
+that same tool — proves each tokenizer extracted the right substring
+without ever comparing the two canonicalizers against each other.
+
+**Results (235 rows, 8 scenarios covering space/tab/comma delimiters,
+header/no-header, name/no-name column, extra properties, quoted CSV, blank
+lines, comments, malformed SMILES, isotopes, charges, disconnected
+fragments, stereochemistry):**
+
+| Metric | Result |
+|---|---|
+| Status parity (success vs. unparseable, per row) | 235/235 (100%) |
+| Known-malformed rows correctly rejected by both tools | 5/5 |
+| Name/property exact-match (excluding 2 documented divergences below) | 100% |
+| Chematic self-consistency vs. known ground truth | 230/230 (100%) |
+| RDKit self-consistency vs. known ground truth (non-gating) | 230/230 (100%) |
+
+**Two deliberate, documented divergences from RDKit found via this oracle
+(not bugs — see `smiles_table.rs`'s module doc comment for the full
+citation):**
+1. `name_column=None` (RDKit's `nameColumn=-1`): RDKit falls back to the
+   physical line number as `_Name`; chematic's `MoleculeRecord::name` is
+   simply empty. Judged a low-value RDKit implementation detail not worth
+   reproducing.
+2. **RDKit's `SmilesMolSupplier` has no CSV-quote-awareness at all** for its
+   comma-delimiter mode — confirmed via this oracle, not merely inferred: a
+   quoted field like `"has, a comma"` is split into extra raw columns by
+   RDKit's literal comma-splitting. Chematic implements a real RFC 4180
+   *subset* (quoted fields, doubled-quote escaping, no multi-line quoted
+   fields) — a genuine improvement, not a matched behavior.
+
+CXSMILES is not recognized in the SMILES column (parsed via
+`chematic_smiles::parse`, which has no CXSMILES support) — this matches
+RDKit's *own* default for `SmilesMolSupplier`, which explicitly disables
+CXSMILES for this entry point too.
+
+- **Files:** `crates/chematic-mol/src/smiles_table.rs`, `crates/chematic-mol/examples/smiles_table_dump.rs`,
+  `scripts/gen_smiles_table_fixtures.py`, `scripts/gen_rdkit_smiles_table_oracle.py`,
+  `scripts/smiles_table_io_parity.py`.
+- **Reference tool:** RDKit 2026.03.3.
+- **How to regenerate:** `python scripts/gen_smiles_table_fixtures.py --out-dir <dir> --corpus
+  <SMILES.csv> --manifest-out <manifest.json>` + `cargo run -p chematic-mol --release --example
+  smiles_table_dump -- <manifest.json> <dir> <out.jsonl>` + `python
+  scripts/gen_rdkit_smiles_table_oracle.py --manifest <manifest.json> --fixtures-dir <dir> --out
+  <oracle.jsonl>` + `python scripts/smiles_table_io_parity.py --chematic <out.jsonl> --rdkit-oracle
+  <oracle.jsonl> --manifest <manifest.json>`. Self-test:
+  `python scripts/smiles_table_io_parity.py --self-test`. The generated fixture files themselves
+  are not committed (regenerable byte-for-byte from the corpus + script); only the generator
+  scripts and this summary are.
+
 ## Summary results
 
 See [rdkit/README.md](rdkit/README.md) for per-descriptor breakdowns.

--- a/validation/smiles_table_io_parity_summary.json
+++ b/validation/smiles_table_io_parity_summary.json
@@ -1,0 +1,257 @@
+{
+  "chematic_self_consistency_failures": [],
+  "error_count": 5,
+  "gate_failures": [],
+  "gate_passed": true,
+  "known_name_divergences_non_gating": [
+    {
+      "chematic": "",
+      "key": [
+        "no_name_column",
+        0
+      ],
+      "rdkit": "0"
+    },
+    {
+      "chematic": "",
+      "key": [
+        "no_name_column",
+        1
+      ],
+      "rdkit": "1"
+    },
+    {
+      "chematic": "",
+      "key": [
+        "no_name_column",
+        2
+      ],
+      "rdkit": "2"
+    },
+    {
+      "chematic": "",
+      "key": [
+        "no_name_column",
+        3
+      ],
+      "rdkit": "3"
+    },
+    {
+      "chematic": "",
+      "key": [
+        "no_name_column",
+        4
+      ],
+      "rdkit": "4"
+    },
+    {
+      "chematic": "",
+      "key": [
+        "no_name_column",
+        5
+      ],
+      "rdkit": "5"
+    },
+    {
+      "chematic": "",
+      "key": [
+        "no_name_column",
+        6
+      ],
+      "rdkit": "6"
+    },
+    {
+      "chematic": "",
+      "key": [
+        "no_name_column",
+        7
+      ],
+      "rdkit": "7"
+    },
+    {
+      "chematic": "",
+      "key": [
+        "no_name_column",
+        8
+      ],
+      "rdkit": "8"
+    },
+    {
+      "chematic": "",
+      "key": [
+        "no_name_column",
+        9
+      ],
+      "rdkit": "9"
+    }
+  ],
+  "known_property_divergences_non_gating": [
+    {
+      "chematic": {
+        "Note": "has, a comma"
+      },
+      "key": [
+        "csv_quoted",
+        1
+      ],
+      "rdkit": {
+        "Column_3": "a comma\"",
+        "Note": "\"has"
+      }
+    },
+    {
+      "chematic": {
+        "Note": "has \"quotes\" inside"
+      },
+      "key": [
+        "csv_quoted",
+        2
+      ],
+      "rdkit": {
+        "Note": "\"has \"\"quotes\"\" inside\""
+      }
+    },
+    {
+      "chematic": {
+        "Note": "has, both \"kinds\" of, trouble"
+      },
+      "key": [
+        "csv_quoted",
+        3
+      ],
+      "rdkit": {
+        "Column_3": "both \"\"kinds\"\" of",
+        "Column_4": "trouble\"",
+        "Note": "\"has"
+      }
+    },
+    {
+      "chematic": {
+        "Note": "trailing comma,"
+      },
+      "key": [
+        "csv_quoted",
+        4
+      ],
+      "rdkit": {
+        "Column_3": "\"",
+        "Note": "\"trailing comma"
+      }
+    },
+    {
+      "chematic": {
+        "Note": "has, a comma"
+      },
+      "key": [
+        "csv_quoted",
+        6
+      ],
+      "rdkit": {
+        "Column_3": "a comma\"",
+        "Note": "\"has"
+      }
+    },
+    {
+      "chematic": {
+        "Note": "has \"quotes\" inside"
+      },
+      "key": [
+        "csv_quoted",
+        7
+      ],
+      "rdkit": {
+        "Note": "\"has \"\"quotes\"\" inside\""
+      }
+    },
+    {
+      "chematic": {
+        "Note": "has, both \"kinds\" of, trouble"
+      },
+      "key": [
+        "csv_quoted",
+        8
+      ],
+      "rdkit": {
+        "Column_3": "both \"\"kinds\"\" of",
+        "Column_4": "trouble\"",
+        "Note": "\"has"
+      }
+    },
+    {
+      "chematic": {
+        "Note": "trailing comma,"
+      },
+      "key": [
+        "csv_quoted",
+        9
+      ],
+      "rdkit": {
+        "Column_3": "\"",
+        "Note": "\"trailing comma"
+      }
+    },
+    {
+      "chematic": {
+        "Note": "has, a comma"
+      },
+      "key": [
+        "csv_quoted",
+        11
+      ],
+      "rdkit": {
+        "Column_3": "a comma\"",
+        "Note": "\"has"
+      }
+    },
+    {
+      "chematic": {
+        "Note": "has \"quotes\" inside"
+      },
+      "key": [
+        "csv_quoted",
+        12
+      ],
+      "rdkit": {
+        "Note": "\"has \"\"quotes\"\" inside\""
+      }
+    },
+    {
+      "chematic": {
+        "Note": "has, both \"kinds\" of, trouble"
+      },
+      "key": [
+        "csv_quoted",
+        13
+      ],
+      "rdkit": {
+        "Column_3": "both \"\"kinds\"\" of",
+        "Column_4": "trouble\"",
+        "Note": "\"has"
+      }
+    },
+    {
+      "chematic": {
+        "Note": "trailing comma,"
+      },
+      "key": [
+        "csv_quoted",
+        14
+      ],
+      "rdkit": {
+        "Column_3": "\"",
+        "Note": "\"trailing comma"
+      }
+    }
+  ],
+  "malformed_row_agreement": {
+    "both_error": 5,
+    "expected": 5,
+    "mismatched": []
+  },
+  "name_mismatches": [],
+  "property_mismatches": [],
+  "rdkit_self_consistency_failures_non_gating": [],
+  "status_mismatches": [],
+  "success_count": 230,
+  "total_rows": 235
+}

--- a/validation/tdt_io_parity_summary.json
+++ b/validation/tdt_io_parity_summary.json
@@ -1,0 +1,114 @@
+{
+  "chematic_self_consistency_failures": [],
+  "coordinate_mismatches": [],
+  "error_count": 1,
+  "gate_failures": [],
+  "gate_passed": true,
+  "known_divergences_non_gating": [
+    {
+      "chematic": [
+        [
+          0.0,
+          0.0
+        ],
+        [
+          1.0,
+          0.0
+        ],
+        [
+          2.0,
+          1.0
+        ]
+      ],
+      "dim": "coordinates_2d",
+      "key": [
+        "coordinates",
+        0
+      ],
+      "rdkit": [
+        [
+          0.0,
+          0.0
+        ],
+        [
+          1.0,
+          0.0
+        ],
+        [
+          0.0,
+          0.0
+        ]
+      ]
+    },
+    {
+      "chematic": [
+        [
+          0.0,
+          0.0,
+          0.0
+        ],
+        [
+          1.0,
+          0.0,
+          0.0
+        ],
+        [
+          2.0,
+          1.0,
+          0.5
+        ]
+      ],
+      "dim": "coordinates_3d",
+      "key": [
+        "coordinates",
+        0
+      ],
+      "rdkit": [
+        [
+          0.0,
+          0.0,
+          0.0
+        ],
+        [
+          1.0,
+          0.0,
+          0.0
+        ],
+        [
+          0.0,
+          0.0,
+          0.0
+        ]
+      ]
+    },
+    {
+      "chematic": "ethane",
+      "key": [
+        "eof_mid_record",
+        0
+      ],
+      "rdkit": ""
+    },
+    {
+      "chematic": {
+        "NAME": "ethane"
+      },
+      "key": [
+        "eof_mid_record",
+        0
+      ],
+      "rdkit": {}
+    }
+  ],
+  "malformed_row_agreement": {
+    "both_error": 1,
+    "expected": 1,
+    "mismatched": []
+  },
+  "name_mismatches": [],
+  "property_mismatches": [],
+  "rdkit_self_consistency_failures_non_gating": [],
+  "status_mismatches": [],
+  "success_count": 204,
+  "total_rows": 205
+}


### PR DESCRIPTION
## Summary (IO-2 of 3, stacked — base is IO-1's branch, not `main`)

Second of the 3-part stacked I/O milestone: `main` → IO-1 (#126) → **IO-2 (this PR)** → IO-3 (MRV). Adds streaming Daylight TDT (Tagged Data) file I/O (`.tdt`) — chematic's counterpart to RDKit's `TDTMolSupplier`/`TDTWriter`.

Mandatory RDKit source audit done first (same pinned commit `8afba32ec539dcb2369bc84549d802aca3f7eb39` as IO-1). Findings documented in `crates/chematic-mol/src/tdt.rs`'s module doc comment.

## Rust core (`chematic-mol::tdt`, new)

- `TdtReaderOptions`/`TdtRecordReader<R: BufRead>`, `TdtWriterOptions`/`TdtRecordWriter<W: Write>`, `TdtError` — reuses `MoleculeRecord` (IO-1's shared record type), including its `coordinates_2d`/`coordinates_3d` fields (unused by the SMILES-table format, exactly what TDT's `2D`/`3D` tags need).

**Four deliberate, documented divergences from RDKit — three fix real bugs the audit/oracle found in RDKit itself, not guessed improvements:**
1. **RDKit's own coordinate-list parser drops the last atom's position** (comma-tokenizer bug, confirmed against a live RDKit run both during the audit and again by this PR's own oracle). Chematic parses the full list correctly.
2. **RDKit's `TDTWriter` hard-codes its name tag as `"NAME"` while `TDTMolSupplier`'s own `nameRecord` defaults to `""`** — a bare RDKit round trip silently loses the name, confirmed empirically. Chematic's reader/writer both default `name_tag` to `Some("NAME")`, fixing the round trip out of the box.
3. **RDKit's malformed-tag recovery has an infinite-loop hazard** — an uncaught exception re-throws on the same record indefinitely if a caller naively retries. Chematic's reader always scans forward to the next record boundary internally before returning `Err`.
4. **Discovered via this PR's own oracle run, not predicted by the initial audit**: RDKit drops the final tag line entirely when a file has no trailing newline. Chematic's `BufRead::read_line`-based reader handles this correctly.

## Python bindings

`chematic.TDTMolSupplier`/`TDTWriter` (pyo3) + matching `rdkit_compat.py` wrappers. `nameRecord` defaults to `"NAME"` (not RDKit's own `""`) to preserve the Rust-level fix at the Python layer too. `confId2D`/`confId3D >= 0` raise `NotImplementedError` — chematic's Python `Mol` wrapper has no coordinate-carrying slot yet, an explicit scope limit (not a silent gap; the Rust API supports coordinates fully and is tested against the real bug above).

## RDKit oracle validation

New fixture generator + real RDKit oracle + comparator (`scripts/gen_tdt_fixtures.py`, `scripts/gen_rdkit_tdt_oracle.py`, `scripts/tdt_io_parity.py`) — **205 rows across 8 scenarios**: SMI/NAME/arbitrary-property records, `|` terminator, empty property, repeated property (last-wins), unknown tags, malformed-tag recovery, EOF mid-record, 2D/3D coordinate tags, isotopes, charges, disconnected fragments, stereochemistry.

Same avoid-canonicalizer-comparison methodology as IO-1 (see `scripts/smiles_table_io_parity.py`'s module docs). **This oracle script itself had to work around RDKit's own malformed-tag recovery hazard** — a plain `for mol in sup` loop crashed with an uncaught `RuntimeError`; switched to index-based `sup[idx]` access, directly re-confirming that finding empirically.

| Metric | Result |
|---|---|
| Status parity | 205/205 (100%) |
| Known-malformed row correctly rejected by both tools | 1/1 |
| Name/property/coordinate exact-match (excl. 2 scenarios with documented divergences above) | 100% |
| Chematic self-consistency vs. known ground truth | 204/204 (100%) |
| RDKit self-consistency vs. known ground truth (non-gating) | 204/204 (100%) |

## Adversarial tests + performance

11 deterministic adversarial unit tests — no `cargo-fuzz` harness exists anywhere in this workspace yet, introducing one for this module was judged disproportionate. **One of these tests caught a real bug before this PR shipped**: an error occurring mid-record-body (oversized line, IO error) left the reader positioned at a leftover fragment of that same record (e.g. its own `|` terminator, already consumed into a since-rejected buffer), misread as a phantom next record on the following call. Fixed by centralizing "recover to next record boundary" at every error exit from record-body parsing.

Performance (10k-record synthetic corpus, ~2% deliberately malformed, 5 independent process runs): chematic ~128,000 records/sec, ~2.4 MB peak RSS; RDKit's Python `TDTMolSupplier` (index-based access) ~5,100 records/sec, ~45 MB (informational cross-language reference only). Both tools agree exactly on which 200/10,000 rows are malformed.

## Non-regression

No existing format parser/writer was modified. Full workspace test suite (including every existing MOL/SDF/CML/CDXML/MOL2/XYZ/PDB/PDBQT/InChI/MolJSON/SMILES-table test) passes unchanged.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --exclude chematic-py --all-targets -- -D warnings`
- [x] `cargo test -p chematic-mol --lib` (190 passed)
- [x] `cargo test -p chematic-py --lib --tests` (via `maturin develop --release` + pytest: 513 passed, 2 pre-existing unrelated failures — same ones already noted in IO-1)
- [x] `cargo test --workspace --exclude chematic-py --lib --tests` (all green)
- [x] `cargo deny --all-features check` (advisories/bans/licenses/sources ok)
- [x] `python3 scripts/check_publish_graph.py` (OK, 18 publishable crates)
- [x] `bash scripts/check.sh` (full workspace incl. chematic-py — all green)
- [x] RDKit oracle: 205/205 status parity, 0 unexplained mismatches (4 documented divergences)
- [x] 11 adversarial tests, 5-run performance benchmark

Not merging — stopping here for review, per the same stacked-draft-and-stop pattern as IO-1.