### PR TITLE
fix(smiles): preserve implicit hydrogens on bracket-forced atoms

### DIFF
--- a/crates/chematic-mol/src/mol2000.rs
+++ b/crates/chematic-mol/src/mol2000.rs
@@ -638,6 +638,28 @@ M  END
     }
 
     #[test]
+    fn test_charged_atom_writes_implicit_h_in_smiles() {
+        // MOL V2000 has no per-atom H-count field, so a charged atom read from
+        // this format always has `hydrogen_count: None` (the format leaves
+        // implicit H to be inferred, unlike bracket SMILES). Regression test
+        // for a bug where the SMILES writer silently dropped these inferred
+        // hydrogens on bracket atoms forced by charge/isotope/atom-map
+        // (found via MRV oracle validation, see validation/mrv_io_parity_summary.json).
+        let mol_str = "\
+charged
+  chematic
+
+  1  0  0  0  0  0  0  0  0  0  0 V2000
+    0.0000    0.0000    0.0000 N   0  3  0  0  0  0  0  0  0  0  0  0
+M  END
+";
+        let (mol, _) = parse_mol(mol_str).expect("parse should succeed");
+        assert_eq!(mol.atom(AtomIdx(0)).hydrogen_count, None);
+        assert_eq!(chematic_smiles::write(&mol), "[NH4+]");
+        assert_eq!(chematic_smiles::canonical_smiles(&mol), "[NH4+]");
+    }
+
+    #[test]
     fn test_round_trip() {
         // Parse → write → parse again; atom and bond counts must match.
         let (mol1, meta1) = parse_mol(ETHANOL_MOL).expect("first parse");

--- a/crates/chematic-smiles/src/canonical.rs
+++ b/crates/chematic-smiles/src/canonical.rs
@@ -20,6 +20,8 @@ use std::collections::{HashMap, HashSet};
 
 use chematic_core::{AtomIdx, BondIdx, BondOrder, Chirality, Molecule, STEREO_H_SENTINEL};
 
+use crate::writer::emit_bracket_hydrogens;
+
 /// Return the atom indices sorted into canonical (Morgan-rank) order.
 ///
 /// The returned `Vec<usize>` lists atom positions (0-based) in the order they
@@ -783,14 +785,7 @@ impl<'a> CanonicalWriter<'a> {
                 Chirality::None => {}
             }
 
-            if let Some(h) = atom.hydrogen_count
-                && h > 0
-            {
-                self.out.push('H');
-                if h > 1 {
-                    self.out.push_str(&h.to_string());
-                }
-            }
+            emit_bracket_hydrogens(&mut self.out, self.mol, idx);
 
             match atom.charge {
                 0 => {}
@@ -1736,5 +1731,60 @@ mod tests {
     fn ez_simple_bond_direction_normalized_symmetric() {
         assert!(same_canonical("F/C=C/F", r"F\C=C\F"));
         assert!(same_canonical("C(/F)=C/F", r"C(\F)=C\F"));
+    }
+
+    // Bracket atoms with `hydrogen_count: None` must still get their implicit
+    // hydrogens written by the canonical writer too — same bug/fixtures as
+    // writer::tests::test_bracket_implicit_h_*.
+    use chematic_core::{Atom, Element};
+
+    #[test]
+    fn canonical_bracket_implicit_h_ammonium_charge_only() {
+        let mut b = chematic_core::MoleculeBuilder::new();
+        let mut n = Atom::new(Element::N);
+        n.charge = 1;
+        b.add_atom(n);
+        assert_eq!(canonical_smiles(&b.build()), "[NH4+]");
+    }
+
+    #[test]
+    fn canonical_bracket_implicit_h_isotope_only() {
+        let mut b = chematic_core::MoleculeBuilder::new();
+        let mut c = Atom::new(Element::C);
+        c.isotope = Some(13);
+        b.add_atom(c);
+        assert_eq!(canonical_smiles(&b.build()), "[13CH4]");
+    }
+
+    #[test]
+    fn canonical_bracket_implicit_h_atom_map_only() {
+        let mut b = chematic_core::MoleculeBuilder::new();
+        let mut c0 = Atom::new(Element::C);
+        c0.atom_map = Some(7);
+        let c0 = b.add_atom(c0);
+        let c1 = b.add_atom(Atom::new(Element::C));
+        b.add_bond(c0, c1, BondOrder::Single).unwrap();
+        assert_eq!(canonical_smiles(&b.build()), "C[CH3:7]");
+    }
+
+    #[test]
+    fn canonical_bracket_implicit_h_isotope_and_atom_map() {
+        let mut b = chematic_core::MoleculeBuilder::new();
+        let mut c0 = Atom::new(Element::C);
+        c0.isotope = Some(13);
+        c0.atom_map = Some(7);
+        let c0 = b.add_atom(c0);
+        let c1 = b.add_atom(Atom::new(Element::C));
+        b.add_bond(c0, c1, BondOrder::Single).unwrap();
+        assert_eq!(canonical_smiles(&b.build()), "C[13CH3:7]");
+    }
+
+    #[test]
+    fn canonical_bracket_implicit_h_hydroxide_charge_only() {
+        let mut b = chematic_core::MoleculeBuilder::new();
+        let mut o = Atom::new(Element::O);
+        o.charge = -1;
+        b.add_atom(o);
+        assert_eq!(canonical_smiles(&b.build()), "[OH-]");
     }
 }

--- a/crates/chematic-smiles/src/writer.rs
+++ b/crates/chematic-smiles/src/writer.rs
@@ -7,6 +7,22 @@ use std::collections::{HashMap, HashSet};
 
 use chematic_core::{AtomIdx, BondIdx, BondOrder, Molecule};
 
+/// Write the `H`/`Hn` token for a bracket atom's hydrogen count.
+///
+/// Uses `implicit_hcount` rather than `atom.hydrogen_count` directly so that
+/// atoms forced into bracket notation by isotope/charge/atom-map (but with no
+/// explicit H count recorded) still get their inferred hydrogens written,
+/// e.g. `[NH4+]` rather than `[N+]`.
+pub(crate) fn emit_bracket_hydrogens(out: &mut String, mol: &Molecule, idx: AtomIdx) {
+    let h = chematic_core::implicit_hcount(mol, idx);
+    if h > 0 {
+        out.push('H');
+        if h > 1 {
+            out.push_str(&h.to_string());
+        }
+    }
+}
+
 /// Write a [`Molecule`] to a SMILES string.
 ///
 /// Disconnected fragments are joined with `.`.
@@ -237,14 +253,7 @@ impl<'a> SmilesWriter<'a> {
                 chematic_core::Chirality::None => {}
             }
 
-            if let Some(h) = atom.hydrogen_count
-                && h > 0
-            {
-                self.out.push('H');
-                if h > 1 {
-                    self.out.push_str(&h.to_string());
-                }
-            }
+            emit_bracket_hydrogens(&mut self.out, self.mol, idx);
 
             match atom.charge {
                 0 => {}
@@ -367,5 +376,62 @@ mod tests {
     #[test]
     fn test_roundtrip_caffeine() {
         roundtrip("Cn1cnc2c1c(=O)n(c(=O)n2C)C");
+    }
+
+    // Bracket atoms with `hydrogen_count: None` (implicit H left uninferred by the
+    // caller, e.g. after a programmatic charge/isotope/atom-map edit) must still get
+    // their implicit hydrogens written — regression tests for the bracket-H bug found
+    // via MRV oracle validation (isotope_0/2/3, charge_0/3, atom_map_0/1/2, disconnected_3
+    // in validation/mrv_io_parity_summary.json).
+    use chematic_core::{Atom, Element, MoleculeBuilder};
+
+    #[test]
+    fn test_bracket_implicit_h_ammonium_charge_only() {
+        let mut b = MoleculeBuilder::new();
+        let mut n = Atom::new(Element::N);
+        n.charge = 1;
+        b.add_atom(n);
+        assert_eq!(write(&b.build()), "[NH4+]");
+    }
+
+    #[test]
+    fn test_bracket_implicit_h_isotope_only() {
+        let mut b = MoleculeBuilder::new();
+        let mut c = Atom::new(Element::C);
+        c.isotope = Some(13);
+        b.add_atom(c);
+        assert_eq!(write(&b.build()), "[13CH4]");
+    }
+
+    #[test]
+    fn test_bracket_implicit_h_atom_map_only() {
+        let mut b = MoleculeBuilder::new();
+        let mut c0 = Atom::new(Element::C);
+        c0.atom_map = Some(7);
+        let c0 = b.add_atom(c0);
+        let c1 = b.add_atom(Atom::new(Element::C));
+        b.add_bond(c0, c1, BondOrder::Single).unwrap();
+        assert_eq!(write(&b.build()), "[CH3:7]C");
+    }
+
+    #[test]
+    fn test_bracket_implicit_h_isotope_and_atom_map() {
+        let mut b = MoleculeBuilder::new();
+        let mut c0 = Atom::new(Element::C);
+        c0.isotope = Some(13);
+        c0.atom_map = Some(7);
+        let c0 = b.add_atom(c0);
+        let c1 = b.add_atom(Atom::new(Element::C));
+        b.add_bond(c0, c1, BondOrder::Single).unwrap();
+        assert_eq!(write(&b.build()), "[13CH3:7]C");
+    }
+
+    #[test]
+    fn test_bracket_implicit_h_hydroxide_charge_only() {
+        let mut b = MoleculeBuilder::new();
+        let mut o = Atom::new(Element::O);
+        o.charge = -1;
+        b.add_atom(o);
+        assert_eq!(write(&b.build()), "[OH-]");
     }
 }


### PR DESCRIPTION
## Summary

- Fixes a structural data-loss bug: bracket atoms forced into `[...]` notation by isotope, charge, or atom-map (rather than an explicit H count) silently dropped their hydrogens — e.g. `[NH4+]` was written back out as `[N+]`.
- Both the plain writer (`writer.rs`) and the canonical writer (`canonical.rs`) now route hydrogen emission through one shared `emit_bracket_hydrogens()` helper backed by `chematic_core::implicit_hcount()`, instead of each reading `atom.hydrogen_count` directly. This removes the duplicated logic that let the two writers drift — a fix could previously land in one and not the other.
- Not SMILES-specific: this affects every non-SMILES reader that leaves `hydrogen_count: None` and lets implicit H be inferred (MOL V2000 has no H-count field at all, so every atom it produces takes this path). A MOL V2000 → SMILES integration test is included alongside the direct unit tests to prove the fix holds across format boundaries, not just for bracket SMILES round-trips.
- Originally surfaced via IO-3 (MRV) RDKit-oracle validation: 9/206 fixtures hit exactly this shape (`isotope_0/2/3`, `charge_0/3`, `atom_map_0/1/2`, `disconnected_3` in `validation/mrv_io_parity_summary.json`, tracked under `chematic_smiles_writer_bracket_h_count_bug`). MRV itself (PR #128) is untouched by this PR — re-running the oracle to confirm 9→0 is deferred until #126/#127/#128 are rebased onto `main` after this merges. That rebase/restack is intentionally **not** part of this PR.

## Test plan

- [x] `cargo test -p chematic-smiles -p chematic-mol --lib --quiet` — new + existing tests green
- [x] `cargo test --workspace --lib --quiet` — no regressions workspace-wide
- [x] `bash scripts/check.sh` — fmt/clippy/tests/deny/version all pass
- [x] 5 new unit tests per writer (`writer.rs`, `canonical.rs`): `[NH4+]`, `[13CH4]`, `[CH3:7]`, `[13CH3:7]`, `[OH-]` built directly with `hydrogen_count: None` (not via the SMILES parser, which would mask the bug)
- [x] 1 new integration test (`mol2000.rs`): MOL V2000 charged-nitrogen block → `chematic_smiles::write`/`canonical_smiles` → `[NH4+]`