### PR TITLE
feat(perception): P1-S1a-core -- CIP-independent local parity from wedges

### DIFF
--- a/crates/chematic-core/src/molecule.rs
+++ b/crates/chematic-core/src/molecule.rs
@@ -708,6 +708,11 @@ impl Molecule {
         self.atoms[idx.0 as usize].cip_code = code;
     }
 
+    /// Set the tetrahedral chirality (`@`/`@@`) of atom `idx` in-place.
+    pub fn set_chirality(&mut self, idx: AtomIdx, chirality: crate::atom::Chirality) {
+        self.atoms[idx.0 as usize].chirality = chirality;
+    }
+
     /// Return the enhanced stereo groups attached to this molecule.
     pub fn stereo_groups(&self) -> &[StereoGroup] {
         &self.stereo_groups

--- a/crates/chematic-perception/src/lib.rs
+++ b/crates/chematic-perception/src/lib.rs
@@ -15,6 +15,7 @@ pub mod sssr;
 pub mod stereo_validation;
 
 pub mod stereo2d;
+pub mod stereo2d_local;
 
 pub use aromaticity::{
     AromaticityAlgorithm, AromaticityModel, AtomElectronTrace, ConjugatedComponent,
@@ -53,6 +54,7 @@ pub use stereo2d::{
     StereoAssignment2D, apply_stereo_from_2d, assign_ez_from_2d, assign_stereo_from_2d,
     cip_ez_descriptor,
 };
+pub use stereo2d_local::{apply_local_parity_from_wedges, local_parity_from_wedges};
 
 use chematic_core::{AtomIdx, Molecule};
 

--- a/crates/chematic-perception/src/stereo2d.rs
+++ b/crates/chematic-perception/src/stereo2d.rs
@@ -210,10 +210,10 @@ fn cross2d(vx: f64, vy: f64, ux: f64, uy: f64) -> f64 {
 
 /// 3D point (x, y, z).
 #[derive(Clone, Copy)]
-struct P3 {
-    x: f64,
-    y: f64,
-    z: f64,
+pub(crate) struct P3 {
+    pub(crate) x: f64,
+    pub(crate) y: f64,
+    pub(crate) z: f64,
 }
 
 fn assign_rs(mol: &Molecule, coords: &[(f64, f64)], center: AtomIdx) -> Option<CipCode> {
@@ -262,7 +262,7 @@ fn assign_rs(mol: &Molecule, coords: &[(f64, f64)], center: AtomIdx) -> Option<C
 /// Up (wedge toward viewer) → +1.0
 /// Down (dash away from viewer) → -1.0
 /// Anything else → 0.0
-fn wedge_z(mol: &Molecule, center: AtomIdx, neighbor: AtomIdx) -> f64 {
+pub(crate) fn wedge_z(mol: &Molecule, center: AtomIdx, neighbor: AtomIdx) -> f64 {
     // Check bond center→neighbor
     if let Some((_, bond)) = mol.bond_between(center, neighbor) {
         match bond.order {
@@ -312,7 +312,7 @@ fn rank4(mol: &Molecule, center: AtomIdx, subs: &[AtomIdx; 4]) -> Option<[u8; 4]
 // Signed volume
 // ---------------------------------------------------------------------------
 
-fn signed_volume(p1: P3, p2: P3, p3: P3, p4: P3) -> f64 {
+pub(crate) fn signed_volume(p1: P3, p2: P3, p3: P3, p4: P3) -> f64 {
     let (ax, ay, az) = (p1.x - p4.x, p1.y - p4.y, p1.z - p4.z);
     let (bx, by, bz) = (p2.x - p4.x, p2.y - p4.y, p2.z - p4.z);
     let (cx, cy, cz) = (p3.x - p4.x, p3.y - p4.y, p3.z - p4.z);

--- a/crates/chematic-perception/src/stereo2d_local.rs
+++ b/crates/chematic-perception/src/stereo2d_local.rs
@@ -1,0 +1,508 @@
+//! Local (CIP-independent) tetrahedral parity from wedge bonds and 2D coordinates.
+//!
+//! [`local_parity_from_wedges`] computes `Atom.chirality` plus a matching
+//! `stereo_neighbor_order` directly from wedge/hash bonds and a 2D layout,
+//! using only the neighbor order already present in `mol` (the order the
+//! reader built the adjacency list in). It never consults CIP priority --
+//! unlike [`crate::stereo2d::assign_stereo_from_2d`], which ranks substituents
+//! by CIP to produce an R/S label. A CIP tie must not prevent a molecule from
+//! having *some* known chirality: the wedge drawing itself is a complete,
+//! CIP-independent statement of local parity, and CIP ranking is a separate,
+//! strictly later, optional stage (mirroring how RDKit's own pipeline keeps
+//! geometry-to-parity and parity-to-label as two independent stages).
+//!
+//! **Convention** (measured against RDKit's `CHI_TETRAHEDRAL_CW`/`CCW` tag on
+//! frame-aligned fixtures -- i.e. fixtures where chematic's `mol.neighbors()`
+//! order and RDKit's `GetNeighbors()` order are confirmed identical, not
+//! derived by analogy to the CIP R/S convention):
+//! - 4 explicit neighbors: viewing *from* the first neighbor (in `mol`'s
+//!   adjacency order) toward the center, the remaining three go
+//!   counterclockwise for [`Chirality::CounterClockwise`] (`@`), clockwise for
+//!   [`Chirality::Clockwise`] (`@@`) -- `chematic_core::Chirality`'s own
+//!   documented convention.
+//! - 3 heavy neighbors + 1 implicit H: no synthetic 3D position is invented
+//!   for the H, matching RDKit's own `atomChiralTypeFromBondDirPseudo3D`
+//!   nNbrs==3 path, which computes purely from the 3 real bond vectors *from
+//!   the center atom* (mathematically the same triple product as the 4-real
+//!   case with the center itself, rather than a neighbor, as the pivot). The
+//!   resulting `stereo_neighbor_order` places [`STEREO_H_SENTINEL`] *last*;
+//!   the sign flips relative to the 4-explicit case because the pivot moved
+//!   from "first neighbor" to "center" (an independently-calibrated, not
+//!   assumed, relationship -- confirmed by an odd-permutation cross-check
+//!   against RDKit's own root-atom SMILES output for the same fixture).
+//!
+//! This module never calls into `cip_priority` and never touches
+//! `Atom.cip_code`. Nothing in the reader crates calls this yet -- integration
+//! is a separate, later step.
+
+use chematic_core::{AtomIdx, Chirality, Molecule, STEREO_H_SENTINEL};
+
+use crate::stereo2d::{P3, signed_volume, wedge_z};
+
+/// Tolerance below which a signed volume is treated as coplanar/degenerate.
+const VOLUME_EPS: f64 = 1e-6;
+
+/// Compute local tetrahedral parity for `center` from wedge bonds and 2D
+/// coordinates, without any CIP ranking.
+///
+/// Returns `(chirality, stereo_neighbor_order)` on success, using the
+/// neighbor order already recorded in `mol` (see module docs for the exact
+/// sign convention). Returns `None` when:
+/// - `center` doesn't have exactly 4 explicit neighbors, or exactly 3
+///   explicit neighbors with `implicit_hcount(mol, center) == 1` (any other
+///   neighbor count, or a 3-neighbor atom whose "missing" valence isn't a
+///   single implicit H, isn't a tetrahedral stereocenter this function
+///   handles);
+/// - any required neighbor's or the center's 2D coordinate is missing;
+/// - more than one neighbor bond carries a wedge/hash (contradictory
+///   notation -- a valid wedge drawing has at most one non-planar bond per
+///   stereocenter);
+/// - the resulting signed volume is (near-)zero, i.e. the drawing is
+///   coplanar/degenerate -- including the case where no bond is wedged at all.
+pub fn local_parity_from_wedges(
+    mol: &Molecule,
+    coords: &[(f64, f64)],
+    center: AtomIdx,
+) -> Option<(Chirality, Vec<u32>)> {
+    let nbs: Vec<AtomIdx> = mol.neighbors(center).map(|(nb, _)| nb).collect();
+
+    match nbs.len() {
+        4 => tetrahedral_4(mol, coords, center, &nbs),
+        3 if chematic_core::implicit_hcount(mol, center) == 1 => {
+            tetrahedral_3_implicit_h(mol, coords, center, &nbs)
+        }
+        _ => None,
+    }
+}
+
+fn point_for(coords: &[(f64, f64)], mol: &Molecule, center: AtomIdx, nb: AtomIdx) -> Option<P3> {
+    let (x, y) = coords.get(nb.0 as usize).copied()?;
+    Some(P3 {
+        x,
+        y,
+        z: wedge_z(mol, center, nb),
+    })
+}
+
+/// At most one wedge/hash bond may originate from `center`; more than one is
+/// contradictory notation.
+fn has_at_most_one_wedge(mol: &Molecule, center: AtomIdx, nbs: &[AtomIdx]) -> bool {
+    nbs.iter()
+        .filter(|&&nb| wedge_z(mol, center, nb) != 0.0)
+        .count()
+        <= 1
+}
+
+fn tetrahedral_4(
+    mol: &Molecule,
+    coords: &[(f64, f64)],
+    center: AtomIdx,
+    nbs: &[AtomIdx],
+) -> Option<(Chirality, Vec<u32>)> {
+    if !has_at_most_one_wedge(mol, center, nbs) {
+        return None;
+    }
+    let pts: Vec<P3> = nbs
+        .iter()
+        .map(|&nb| point_for(coords, mol, center, nb))
+        .collect::<Option<_>>()?;
+
+    // Apex = first-listed neighbor; viewed = the other three, in order.
+    let vol = signed_volume(pts[1], pts[2], pts[3], pts[0]);
+    if vol.abs() < VOLUME_EPS {
+        return None;
+    }
+    let chirality = if vol < 0.0 {
+        Chirality::CounterClockwise
+    } else {
+        Chirality::Clockwise
+    };
+    let order = nbs.iter().map(|a| a.0).collect();
+    Some((chirality, order))
+}
+
+fn tetrahedral_3_implicit_h(
+    mol: &Molecule,
+    coords: &[(f64, f64)],
+    center: AtomIdx,
+    nbs: &[AtomIdx],
+) -> Option<(Chirality, Vec<u32>)> {
+    if !has_at_most_one_wedge(mol, center, nbs) {
+        return None;
+    }
+    let pts: Vec<P3> = nbs
+        .iter()
+        .map(|&nb| point_for(coords, mol, center, nb))
+        .collect::<Option<_>>()?;
+    let (cx, cy) = coords.get(center.0 as usize).copied()?;
+    let center_pt = P3 {
+        x: cx,
+        y: cy,
+        z: 0.0,
+    };
+
+    // No synthetic position for the implicit H: the triple product of the
+    // three real bond vectors from `center` already carries full parity.
+    let vol = signed_volume(pts[0], pts[1], pts[2], center_pt);
+    if vol.abs() < VOLUME_EPS {
+        return None;
+    }
+    let chirality = if vol < 0.0 {
+        Chirality::Clockwise
+    } else {
+        Chirality::CounterClockwise
+    };
+    let mut order: Vec<u32> = nbs.iter().map(|a| a.0).collect();
+    order.push(STEREO_H_SENTINEL);
+    Some((chirality, order))
+}
+
+/// Apply [`local_parity_from_wedges`] to every eligible atom in `mol`,
+/// writing `Atom.chirality` and `stereo_neighbor_order` in-place.
+///
+/// Does not touch `Atom.cip_code`. Not called by any reader yet -- callers
+/// opt in explicitly.
+pub fn apply_local_parity_from_wedges(mol: &mut Molecule, coords: &[(f64, f64)]) {
+    let atom_indices: Vec<AtomIdx> = mol.atoms().map(|(idx, _)| idx).collect();
+    for idx in atom_indices {
+        if let Some((chirality, order)) = local_parity_from_wedges(mol, coords, idx) {
+            mol.set_chirality(idx, chirality);
+            mol.set_stereo_neighbor_order(idx, order);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chematic_core::{Atom, BondOrder, Element, MoleculeBuilder};
+
+    /// Asymmetric, non-degenerate 4-position layout (same shape used by the
+    /// P1-A0 diagnosis fixtures) so no accidental coplanarity sneaks in.
+    fn quad_positions() -> [(f64, f64); 4] {
+        [(-1.0, 0.4), (0.9, 0.7), (-0.5, -1.1), (0.8, -0.6)]
+    }
+
+    fn chfclbr(wedge_on_first: bool) -> (Molecule, Vec<(f64, f64)>, AtomIdx) {
+        let mut b = MoleculeBuilder::new();
+        let c = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        let i = b.add_atom(Atom::new(Element::I));
+        let order = if wedge_on_first {
+            BondOrder::Up
+        } else {
+            BondOrder::Single
+        };
+        b.add_bond(c, f, order).unwrap();
+        b.add_bond(c, cl, BondOrder::Single).unwrap();
+        b.add_bond(c, br, BondOrder::Single).unwrap();
+        b.add_bond(c, i, BondOrder::Single).unwrap();
+        let quad = quad_positions();
+        let coords = vec![(0.0, 0.0), quad[0], quad[1], quad[2], quad[3]];
+        (b.build(), coords, c)
+    }
+
+    #[test]
+    fn tetrahedral_4heavy_wedge_gives_counterclockwise() {
+        // Matches the calibration fixture measured against RDKit directly:
+        // wedge on the first-declared bond -> negative volume -> CCW,
+        // cross-checked against RDKit's CHI_TETRAHEDRAL_CCW on the same
+        // frame-aligned neighbor order.
+        let (mol, coords, c) = chfclbr(true);
+        let (chirality, order) = local_parity_from_wedges(&mol, &coords, c).unwrap();
+        assert_eq!(chirality, Chirality::CounterClockwise);
+        assert_eq!(order, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn tetrahedral_4heavy_no_h_all_explicit() {
+        // C(F)(Cl)(Br)(I): zero H anywhere, still just the 4-explicit path.
+        let (mol, coords, c) = chfclbr(true);
+        assert!(local_parity_from_wedges(&mol, &coords, c).is_some());
+    }
+
+    #[test]
+    fn tetrahedral_4neighbors_explicit_h() {
+        let mut b = MoleculeBuilder::new();
+        let c = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        let h = b.add_atom(Atom::new(Element::H));
+        b.add_bond(c, f, BondOrder::Up).unwrap();
+        b.add_bond(c, cl, BondOrder::Single).unwrap();
+        b.add_bond(c, br, BondOrder::Single).unwrap();
+        b.add_bond(c, h, BondOrder::Single).unwrap();
+        let quad = quad_positions();
+        let coords = vec![(0.0, 0.0), quad[0], quad[1], quad[2], quad[3]];
+        let mol = b.build();
+        let (chirality, order) = local_parity_from_wedges(&mol, &coords, c).unwrap();
+        assert_eq!(chirality, Chirality::CounterClockwise);
+        assert_eq!(order, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn wedge_hash_inversion_flips_chirality() {
+        let (mol_wedge, coords, c) = chfclbr(true);
+        let (wedge_chirality, _) = local_parity_from_wedges(&mol_wedge, &coords, c).unwrap();
+
+        let mut b = MoleculeBuilder::new();
+        let c2 = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        let i = b.add_atom(Atom::new(Element::I));
+        b.add_bond(c2, f, BondOrder::Down).unwrap();
+        b.add_bond(c2, cl, BondOrder::Single).unwrap();
+        b.add_bond(c2, br, BondOrder::Single).unwrap();
+        b.add_bond(c2, i, BondOrder::Single).unwrap();
+        let mol_hash = b.build();
+        let (hash_chirality, _) = local_parity_from_wedges(&mol_hash, &coords, c2).unwrap();
+
+        assert_ne!(wedge_chirality, hash_chirality);
+    }
+
+    #[test]
+    fn bond_atom_order_inversion_flips_chirality() {
+        // Same physical molecule, same wedge (still on C-F, positions
+        // unchanged) -- only the BOND BLOCK lists the four bonds in reverse
+        // (I, Br, Cl, F instead of F, Cl, Br, I). Reversing a 4-element list
+        // is an even permutation, so per the calibration this must give the
+        // SAME sign, matching RDKit's own behavior on the equivalent
+        // reordering (confirmed against real RDKit output, not assumed).
+        let (mol1, coords, c1) = chfclbr(true);
+        let (chirality1, _) = local_parity_from_wedges(&mol1, &coords, c1).unwrap();
+
+        let mut b = MoleculeBuilder::new();
+        let c2 = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        let i = b.add_atom(Atom::new(Element::I));
+        b.add_bond(c2, i, BondOrder::Single).unwrap();
+        b.add_bond(c2, br, BondOrder::Single).unwrap();
+        b.add_bond(c2, cl, BondOrder::Single).unwrap();
+        b.add_bond(c2, f, BondOrder::Up).unwrap();
+        let mol2 = b.build();
+        let (chirality2, order2) = local_parity_from_wedges(&mol2, &coords, c2).unwrap();
+
+        assert_eq!(chirality1, chirality2);
+        assert_eq!(order2, vec![4, 3, 2, 1]);
+    }
+
+    #[test]
+    fn multiple_stereocenters_both_assigned() {
+        // Two independent CHFClBr-like centers joined by a bond; each should
+        // get its own chirality without interference.
+        let mut b = MoleculeBuilder::new();
+        let c1 = b.add_atom(Atom::new(Element::C));
+        let f1 = b.add_atom(Atom::new(Element::F));
+        let cl1 = b.add_atom(Atom::new(Element::CL));
+        let br1 = b.add_atom(Atom::new(Element::BR));
+        let c2 = b.add_atom(Atom::new(Element::C));
+        let f2 = b.add_atom(Atom::new(Element::F));
+        let cl2 = b.add_atom(Atom::new(Element::CL));
+        let br2 = b.add_atom(Atom::new(Element::BR));
+        b.add_bond(c1, f1, BondOrder::Up).unwrap();
+        b.add_bond(c1, cl1, BondOrder::Single).unwrap();
+        b.add_bond(c1, br1, BondOrder::Single).unwrap();
+        b.add_bond(c1, c2, BondOrder::Single).unwrap();
+        b.add_bond(c2, f2, BondOrder::Down).unwrap();
+        b.add_bond(c2, cl2, BondOrder::Single).unwrap();
+        b.add_bond(c2, br2, BondOrder::Single).unwrap();
+        let quad = quad_positions();
+        let coords = vec![
+            (0.0, 0.0),
+            quad[0],
+            quad[1],
+            quad[2],
+            (3.0, 0.0),
+            (3.0 + quad[0].0, quad[0].1),
+            (3.0 + quad[1].0, quad[1].1),
+            (3.0 + quad[2].0, quad[2].1),
+        ];
+        let mut mol = b.build();
+        apply_local_parity_from_wedges(&mut mol, &coords);
+        assert_eq!(mol.atom(c1).chirality, Chirality::CounterClockwise);
+        assert_eq!(mol.atom(c2).chirality, Chirality::Clockwise);
+        // cip_code must stay untouched -- this module never assigns it.
+        assert_eq!(mol.atom(c1).cip_code, None);
+        assert_eq!(mol.atom(c2).cip_code, None);
+    }
+
+    #[test]
+    fn cip_priority_tie_still_gets_chirality() {
+        // Two neighbors (F and Cl) are placed so the local geometry is
+        // unambiguous, but with a tied CIP-relevant substituent pair the
+        // CIP-based assign_stereo_from_2d would refuse (see rank4's
+        // Ordering::Equal -> None branch in stereo2d.rs). This module never
+        // calls rank4/cip_priority, so a CIP tie must not matter at all.
+        let mut b = MoleculeBuilder::new();
+        let c = b.add_atom(Atom::new(Element::C));
+        // Two identical -CH2-CH3 branches: tied under any CIP ranking, but
+        // geometrically perfectly resolvable from wedge + coordinates.
+        let et1 = b.add_atom(Atom::new(Element::C));
+        let et1b = b.add_atom(Atom::new(Element::C));
+        let et2 = b.add_atom(Atom::new(Element::C));
+        let et2b = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        b.add_bond(c, et1, BondOrder::Single).unwrap();
+        b.add_bond(et1, et1b, BondOrder::Single).unwrap();
+        b.add_bond(c, et2, BondOrder::Single).unwrap();
+        b.add_bond(et2, et2b, BondOrder::Single).unwrap();
+        b.add_bond(c, f, BondOrder::Up).unwrap();
+        let h = b.add_atom(Atom::new(Element::H));
+        b.add_bond(c, h, BondOrder::Single).unwrap();
+        let quad = quad_positions();
+        let coords = vec![
+            (0.0, 0.0),
+            quad[0],
+            (quad[0].0 + 0.3, quad[0].1 + 1.0),
+            quad[1],
+            (quad[1].0 + 0.3, quad[1].1 - 1.0),
+            quad[2],
+            quad[3],
+        ];
+        let mol = b.build();
+
+        // Sanity check: the CIP-dependent path really does refuse this atom
+        // (tied ethyl branches), so the two functions are genuinely being
+        // exercised on the same tie condition.
+        let cip_result = crate::stereo2d::assign_stereo_from_2d(&mol, &coords);
+        assert!(cip_result.get(c).is_none(), "CIP-based path should tie");
+
+        let (chirality, _) = local_parity_from_wedges(&mol, &coords, c).unwrap();
+        assert_ne!(chirality, Chirality::None);
+    }
+
+    #[test]
+    fn missing_coordinates_no_assignment() {
+        let (mol, mut coords, c) = chfclbr(true);
+        coords.truncate(3); // drop the last neighbor's coordinate entirely
+        assert!(local_parity_from_wedges(&mol, &coords, c).is_none());
+    }
+
+    #[test]
+    fn degenerate_coplanar_no_assignment() {
+        let mut b = MoleculeBuilder::new();
+        let c = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        let i = b.add_atom(Atom::new(Element::I));
+        // No wedge bonds at all -- every z is 0, so the volume is exactly 0.
+        b.add_bond(c, f, BondOrder::Single).unwrap();
+        b.add_bond(c, cl, BondOrder::Single).unwrap();
+        b.add_bond(c, br, BondOrder::Single).unwrap();
+        b.add_bond(c, i, BondOrder::Single).unwrap();
+        let quad = quad_positions();
+        let coords = vec![(0.0, 0.0), quad[0], quad[1], quad[2], quad[3]];
+        let mol = b.build();
+        assert!(local_parity_from_wedges(&mol, &coords, c).is_none());
+    }
+
+    #[test]
+    fn contradictory_wedges_no_assignment() {
+        let mut b = MoleculeBuilder::new();
+        let c = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        let i = b.add_atom(Atom::new(Element::I));
+        // Two wedges from the same center: contradictory notation.
+        b.add_bond(c, f, BondOrder::Up).unwrap();
+        b.add_bond(c, cl, BondOrder::Up).unwrap();
+        b.add_bond(c, br, BondOrder::Single).unwrap();
+        b.add_bond(c, i, BondOrder::Single).unwrap();
+        let quad = quad_positions();
+        let coords = vec![(0.0, 0.0), quad[0], quad[1], quad[2], quad[3]];
+        let mol = b.build();
+        assert!(local_parity_from_wedges(&mol, &coords, c).is_none());
+    }
+
+    #[test]
+    fn tetrahedral_3heavy_implicit_h_wedge() {
+        let mut b = MoleculeBuilder::new();
+        let c = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        b.add_bond(c, f, BondOrder::Up).unwrap();
+        b.add_bond(c, cl, BondOrder::Single).unwrap();
+        b.add_bond(c, br, BondOrder::Single).unwrap();
+        let quad = quad_positions();
+        let coords = vec![(0.0, 0.0), quad[0], quad[1], quad[2]];
+        let mol = b.build();
+        // Matches the calibration fixture measured against RDKit: 3 heavy
+        // neighbors + implicit H, wedge on the first bond -> RDKit's raw
+        // CHI_TETRAHEDRAL_CW (and independently confirmed via RDKit's own
+        // root-atom SMILES [C@H](F)(Cl)Br for the wedge case, translated
+        // through the H-last vs H-first permutation parity).
+        let (chirality, order) = local_parity_from_wedges(&mol, &coords, c).unwrap();
+        assert_eq!(chirality, Chirality::Clockwise);
+        assert_eq!(order, vec![1, 2, 3, STEREO_H_SENTINEL]);
+    }
+
+    #[test]
+    fn tetrahedral_3heavy_implicit_h_hash_inverts() {
+        let mut b = MoleculeBuilder::new();
+        let c = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        b.add_bond(c, f, BondOrder::Down).unwrap();
+        b.add_bond(c, cl, BondOrder::Single).unwrap();
+        b.add_bond(c, br, BondOrder::Single).unwrap();
+        let quad = quad_positions();
+        let coords = vec![(0.0, 0.0), quad[0], quad[1], quad[2]];
+        let mol = b.build();
+        let (chirality, _) = local_parity_from_wedges(&mol, &coords, c).unwrap();
+        assert_eq!(chirality, Chirality::CounterClockwise);
+    }
+
+    #[test]
+    fn tetrahedral_3heavy_bond_order_reversed_inverts() {
+        // Same physical molecule and wedge as tetrahedral_3heavy_implicit_h_wedge
+        // (positions unchanged) -- only the bond block lists the three bonds
+        // in reverse (Br, Cl, F instead of F, Cl, Br). Reversing a 3-element
+        // list is an odd permutation (unlike the 4-neighbor case), so per
+        // calibration the sign must flip.
+        let mut b = MoleculeBuilder::new();
+        let c = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        b.add_bond(c, br, BondOrder::Single).unwrap();
+        b.add_bond(c, cl, BondOrder::Single).unwrap();
+        b.add_bond(c, f, BondOrder::Up).unwrap();
+        let quad = quad_positions();
+        let coords = vec![(0.0, 0.0), quad[0], quad[1], quad[2]];
+        let mol = b.build();
+        let (chirality, order) = local_parity_from_wedges(&mol, &coords, c).unwrap();
+        assert_eq!(order, vec![3, 2, 1, STEREO_H_SENTINEL]);
+        assert_eq!(chirality, Chirality::CounterClockwise);
+    }
+
+    #[test]
+    fn only_three_heavy_no_implicit_h_no_assignment() {
+        // 3 explicit neighbors but valence implies 0 implicit H (e.g. a
+        // charged center) -- not the 3-heavy-plus-H shape this function
+        // handles, so it must refuse rather than guess.
+        let mut b = MoleculeBuilder::new();
+        let mut n_atom = Atom::new(Element::N);
+        n_atom.charge = 1;
+        let n = b.add_atom(n_atom);
+        let c1 = b.add_atom(Atom::new(Element::C));
+        let c2 = b.add_atom(Atom::new(Element::C));
+        let c3 = b.add_atom(Atom::new(Element::C));
+        b.add_bond(n, c1, BondOrder::Double).unwrap();
+        b.add_bond(n, c2, BondOrder::Single).unwrap();
+        b.add_bond(n, c3, BondOrder::Single).unwrap();
+        let quad = quad_positions();
+        let coords = vec![(0.0, 0.0), quad[0], quad[1], quad[2]];
+        let mol = b.build();
+        assert!(local_parity_from_wedges(&mol, &coords, n).is_none());
+    }
+}

--- a/crates/chematic-perception/src/stereo2d_local.rs
+++ b/crates/chematic-perception/src/stereo2d_local.rs
@@ -88,12 +88,28 @@ fn point_for(coords: &[(f64, f64)], mol: &Molecule, center: AtomIdx, nb: AtomIdx
     })
 }
 
+/// `Some(true)`/`Some(false)` for a clearly negative/non-negative volume;
+/// `None` when it's within [`VOLUME_EPS`] of zero, i.e. no reliable sign at
+/// all. Used by the isolated-wedge consistency checks below so a degenerate
+/// isolated volume can't be miscoded as "non-negative" and spuriously agree
+/// with a real one.
+fn volume_sign(volume: f64) -> Option<bool> {
+    if volume.abs() < VOLUME_EPS {
+        None
+    } else {
+        Some(volume < 0.0)
+    }
+}
+
 /// When two or more of `pts` (indices `0..pts.len()`) carry a nonzero wedge
-/// z, each must independently imply the same local parity -- computed by
-/// zeroing every *other* wedged point's z and checking the sign of
-/// `signed_volume(pts[1], pts[2], pts[3], pts[0])` -- before the combined
+/// z, each must independently imply the same, unambiguous local parity --
+/// computed by zeroing every *other* wedged point's z and checking the sign
+/// of `signed_volume(pts[1], pts[2], pts[3], pts[0])` -- before the combined
 /// (all-real-z-at-once) volume is trusted as a single tetrahedron. A single
-/// wedge (or none) trivially agrees with itself.
+/// wedge (or none) trivially agrees with itself. Any isolated volume that's
+/// itself degenerate (near-zero) counts as disagreement, not as a
+/// non-negative match -- otherwise a degenerate wedge could spuriously
+/// "agree" with a real one.
 ///
 /// Measured against RDKit, not assumed (see
 /// `docs/stereo2d_local_parity_calibration.md`): RDKit either explicitly
@@ -108,7 +124,7 @@ fn wedges_agree_4(pts: &[P3]) -> bool {
     if wedged.len() <= 1 {
         return true;
     }
-    let isolated_is_negative = |i: usize| -> bool {
+    let isolated_sign = |i: usize| -> Option<bool> {
         let iso: Vec<P3> = (0..4)
             .map(|j| {
                 if j == i {
@@ -118,12 +134,12 @@ fn wedges_agree_4(pts: &[P3]) -> bool {
                 }
             })
             .collect();
-        signed_volume(iso[1], iso[2], iso[3], iso[0]) < 0.0
+        volume_sign(signed_volume(iso[1], iso[2], iso[3], iso[0]))
     };
-    let first = isolated_is_negative(wedged[0]);
-    wedged[1..]
-        .iter()
-        .all(|&i| isolated_is_negative(i) == first)
+    let Some(first) = isolated_sign(wedged[0]) else {
+        return false;
+    };
+    wedged[1..].iter().all(|&i| isolated_sign(i) == Some(first))
 }
 
 /// Same consistency check as [`wedges_agree_4`], but for the 3-heavy case
@@ -133,7 +149,7 @@ fn wedges_agree_3(pts: &[P3], center_pt: P3) -> bool {
     if wedged.len() <= 1 {
         return true;
     }
-    let isolated_is_negative = |i: usize| -> bool {
+    let isolated_sign = |i: usize| -> Option<bool> {
         let iso: Vec<P3> = (0..3)
             .map(|j| {
                 if j == i {
@@ -143,12 +159,12 @@ fn wedges_agree_3(pts: &[P3], center_pt: P3) -> bool {
                 }
             })
             .collect();
-        signed_volume(iso[0], iso[1], iso[2], center_pt) < 0.0
+        volume_sign(signed_volume(iso[0], iso[1], iso[2], center_pt))
     };
-    let first = isolated_is_negative(wedged[0]);
-    wedged[1..]
-        .iter()
-        .all(|&i| isolated_is_negative(i) == first)
+    let Some(first) = isolated_sign(wedged[0]) else {
+        return false;
+    };
+    wedged[1..].iter().all(|&i| isolated_sign(i) == Some(first))
 }
 
 fn tetrahedral_4(
@@ -566,6 +582,54 @@ mod tests {
         let (chirality, order) = local_parity_from_wedges(&mol, &coords, c).unwrap();
         assert_eq!(chirality, Chirality::Clockwise);
         assert_eq!(order, vec![1, 2, 3, STEREO_H_SENTINEL]);
+    }
+
+    #[test]
+    fn dual_wedge_one_isolated_volume_degenerate_rejected() {
+        // F, Cl, I placed collinear (all on y=0) and Br off that line. Wedging
+        // F (the apex) gives a clear, non-degenerate isolated volume; wedging
+        // Br (a "viewed" point) with F/Cl/I collinear makes THAT isolated
+        // volume exactly zero (a degenerate 2-real-point simplex), even
+        // though the two real z values and the combined volume are both
+        // perfectly ordinary. Without the tri-state volume_sign guard, a
+        // near-zero isolated volume's `< 0.0` bool would read as "not
+        // negative" and could spuriously agree with a real sign -- this must
+        // reject instead.
+        let mut b = MoleculeBuilder::new();
+        let c = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        let i = b.add_atom(Atom::new(Element::I));
+        b.add_bond(c, f, BondOrder::Up).unwrap();
+        b.add_bond(c, cl, BondOrder::Single).unwrap();
+        b.add_bond(c, br, BondOrder::Up).unwrap();
+        b.add_bond(c, i, BondOrder::Single).unwrap();
+        let coords = vec![(0.0, 0.0), (1.0, 0.0), (2.0, 0.0), (0.0, 1.0), (3.0, 0.0)];
+        let mol = b.build();
+        assert!(local_parity_from_wedges(&mol, &coords, c).is_none());
+    }
+
+    #[test]
+    fn dual_wedge_both_isolated_volumes_degenerate_rejected() {
+        // All four substituents collinear: wedging either Cl or Br in
+        // isolation (holding the other three at z=0) gives an exactly-zero
+        // volume for both, not just one. The tri-state guard must reject on
+        // the very first degenerate isolated volume it finds, without ever
+        // reaching a real sign to (spuriously) agree with.
+        let mut b = MoleculeBuilder::new();
+        let c = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        let i = b.add_atom(Atom::new(Element::I));
+        b.add_bond(c, f, BondOrder::Single).unwrap();
+        b.add_bond(c, cl, BondOrder::Up).unwrap();
+        b.add_bond(c, br, BondOrder::Up).unwrap();
+        b.add_bond(c, i, BondOrder::Single).unwrap();
+        let coords = vec![(0.0, 0.0), (1.0, 0.0), (2.0, 0.0), (3.0, 0.0), (4.0, 0.0)];
+        let mol = b.build();
+        assert!(local_parity_from_wedges(&mol, &coords, c).is_none());
     }
 
     #[test]

--- a/crates/chematic-perception/src/stereo2d_local.rs
+++ b/crates/chematic-perception/src/stereo2d_local.rs
@@ -54,9 +54,13 @@ const VOLUME_EPS: f64 = 1e-6;
 ///   single implicit H, isn't a tetrahedral stereocenter this function
 ///   handles);
 /// - any required neighbor's or the center's 2D coordinate is missing;
-/// - more than one neighbor bond carries a wedge/hash (contradictory
-///   notation -- a valid wedge drawing has at most one non-planar bond per
-///   stereocenter);
+/// - two or more wedge/hash bonds originate from `center` and imply
+///   *different* local parity when each is considered in isolation (all
+///   other wedges zeroed) -- a single consistent parity across every wedge
+///   is valid notation (e.g. one substituent wedged forward, another hashed
+///   back), but disagreement means the drawing itself doesn't describe one
+///   tetrahedron. Measured against RDKit, not assumed: see
+///   `docs/stereo2d_local_parity_calibration.md`;
 /// - the resulting signed volume is (near-)zero, i.e. the drawing is
 ///   coplanar/degenerate -- including the case where no bond is wedged at all.
 pub fn local_parity_from_wedges(
@@ -84,13 +88,67 @@ fn point_for(coords: &[(f64, f64)], mol: &Molecule, center: AtomIdx, nb: AtomIdx
     })
 }
 
-/// At most one wedge/hash bond may originate from `center`; more than one is
-/// contradictory notation.
-fn has_at_most_one_wedge(mol: &Molecule, center: AtomIdx, nbs: &[AtomIdx]) -> bool {
-    nbs.iter()
-        .filter(|&&nb| wedge_z(mol, center, nb) != 0.0)
-        .count()
-        <= 1
+/// When two or more of `pts` (indices `0..pts.len()`) carry a nonzero wedge
+/// z, each must independently imply the same local parity -- computed by
+/// zeroing every *other* wedged point's z and checking the sign of
+/// `signed_volume(pts[1], pts[2], pts[3], pts[0])` -- before the combined
+/// (all-real-z-at-once) volume is trusted as a single tetrahedron. A single
+/// wedge (or none) trivially agrees with itself.
+///
+/// Measured against RDKit, not assumed (see
+/// `docs/stereo2d_local_parity_calibration.md`): RDKit either explicitly
+/// refuses a tag ("conflicting stereochemistry") or silently falls back to
+/// a dual-volume heuristic whose result doesn't reliably match its own tag
+/// once two wedges disagree in isolation -- neither is safe to reproduce, so
+/// this rejects rather than guesses. Whenever the isolated parities *do*
+/// agree, the combined volume's sign matched RDKit's clean (unwarned) tag on
+/// every measured fixture.
+fn wedges_agree_4(pts: &[P3]) -> bool {
+    let wedged: Vec<usize> = (0..4).filter(|&i| pts[i].z != 0.0).collect();
+    if wedged.len() <= 1 {
+        return true;
+    }
+    let isolated_is_negative = |i: usize| -> bool {
+        let iso: Vec<P3> = (0..4)
+            .map(|j| {
+                if j == i {
+                    pts[j]
+                } else {
+                    P3 { z: 0.0, ..pts[j] }
+                }
+            })
+            .collect();
+        signed_volume(iso[1], iso[2], iso[3], iso[0]) < 0.0
+    };
+    let first = isolated_is_negative(wedged[0]);
+    wedged[1..]
+        .iter()
+        .all(|&i| isolated_is_negative(i) == first)
+}
+
+/// Same consistency check as [`wedges_agree_4`], but for the 3-heavy case
+/// where the pivot is `center_pt` (never one of `pts`) rather than `pts[0]`.
+fn wedges_agree_3(pts: &[P3], center_pt: P3) -> bool {
+    let wedged: Vec<usize> = (0..3).filter(|&i| pts[i].z != 0.0).collect();
+    if wedged.len() <= 1 {
+        return true;
+    }
+    let isolated_is_negative = |i: usize| -> bool {
+        let iso: Vec<P3> = (0..3)
+            .map(|j| {
+                if j == i {
+                    pts[j]
+                } else {
+                    P3 { z: 0.0, ..pts[j] }
+                }
+            })
+            .collect();
+        signed_volume(iso[0], iso[1], iso[2], center_pt) < 0.0
+    };
+    let first = isolated_is_negative(wedged[0]);
+    wedged[1..]
+        .iter()
+        .all(|&i| isolated_is_negative(i) == first)
 }
 
 fn tetrahedral_4(
@@ -99,13 +157,14 @@ fn tetrahedral_4(
     center: AtomIdx,
     nbs: &[AtomIdx],
 ) -> Option<(Chirality, Vec<u32>)> {
-    if !has_at_most_one_wedge(mol, center, nbs) {
-        return None;
-    }
     let pts: Vec<P3> = nbs
         .iter()
         .map(|&nb| point_for(coords, mol, center, nb))
         .collect::<Option<_>>()?;
+
+    if !wedges_agree_4(&pts) {
+        return None;
+    }
 
     // Apex = first-listed neighbor; viewed = the other three, in order.
     let vol = signed_volume(pts[1], pts[2], pts[3], pts[0]);
@@ -127,9 +186,6 @@ fn tetrahedral_3_implicit_h(
     center: AtomIdx,
     nbs: &[AtomIdx],
 ) -> Option<(Chirality, Vec<u32>)> {
-    if !has_at_most_one_wedge(mol, center, nbs) {
-        return None;
-    }
     let pts: Vec<P3> = nbs
         .iter()
         .map(|&nb| point_for(coords, mol, center, nb))
@@ -140,6 +196,10 @@ fn tetrahedral_3_implicit_h(
         y: cy,
         z: 0.0,
     };
+
+    if !wedges_agree_3(&pts, center_pt) {
+        return None;
+    }
 
     // No synthetic position for the implicit H: the triple product of the
     // three real bond vectors from `center` already carries full parity.
@@ -405,13 +465,21 @@ mod tests {
 
     #[test]
     fn contradictory_wedges_no_assignment() {
+        // NOT "two wedges are always contradictory" -- two wedges/hashes from
+        // the same center are valid notation as long as each implies the
+        // same local parity in isolation (see valid_dual_wedge_* below and
+        // wedges_agree_4's doc comment). This specific fixture (F and Cl both
+        // marked solid wedge, on quad_positions()'s first two slots) was
+        // measured to give genuinely DISAGREEING per-wedge-alone parity, so
+        // it stays a rejection case -- confirmed against RDKit directly
+        // (docs/stereo2d_local_parity_calibration.md), not assumed from the
+        // "two wedges" shape alone.
         let mut b = MoleculeBuilder::new();
         let c = b.add_atom(Atom::new(Element::C));
         let f = b.add_atom(Atom::new(Element::F));
         let cl = b.add_atom(Atom::new(Element::CL));
         let br = b.add_atom(Atom::new(Element::BR));
         let i = b.add_atom(Atom::new(Element::I));
-        // Two wedges from the same center: contradictory notation.
         b.add_bond(c, f, BondOrder::Up).unwrap();
         b.add_bond(c, cl, BondOrder::Up).unwrap();
         b.add_bond(c, br, BondOrder::Single).unwrap();
@@ -420,6 +488,84 @@ mod tests {
         let coords = vec![(0.0, 0.0), quad[0], quad[1], quad[2], quad[3]];
         let mol = b.build();
         assert!(local_parity_from_wedges(&mol, &coords, c).is_none());
+    }
+
+    #[test]
+    fn dual_wedge_disagreeing_parity_rejected() {
+        // A second, independent disagreeing-parity negative fixture (3-heavy
+        // + implicit H, opposite directions this time: F solid wedge, Cl
+        // hash). Measured against RDKit directly: it explicitly warns
+        // ("conflicting stereochemistry - bond wedging contradiction") and
+        // returns CHI_UNSPECIFIED -- RDKit's own parser agrees this is
+        // genuinely unresolvable, not just this function being conservative.
+        let mut b = MoleculeBuilder::new();
+        let c = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        b.add_bond(c, f, BondOrder::Up).unwrap();
+        b.add_bond(c, cl, BondOrder::Down).unwrap();
+        b.add_bond(c, br, BondOrder::Single).unwrap();
+        let quad = quad_positions();
+        let coords = vec![(0.0, 0.0), quad[0], quad[1], quad[2]];
+        let mol = b.build();
+        assert!(local_parity_from_wedges(&mol, &coords, c).is_none());
+    }
+
+    #[test]
+    fn valid_dual_wedge_solid_and_hash_on_different_bonds_accepted() {
+        // Ported verbatim (same shape) from PR #130's frozen RDKit-checked
+        // fixtures tetrahedral_4neighbors_explicit_h / tetrahedral_4heavy_no_h
+        // (docs/stereo2d_reader_integration_rfc.md): a solid wedge to one
+        // substituent (Br) and a hash to a DIFFERENT substituent (I) on the
+        // same center is standard, unambiguous notation, not contradictory --
+        // confirmed against RDKit directly: it accepts with a clean,
+        // unwarned CHI_TETRAHEDRAL_CW tag. An earlier version of this module
+        // rejected any center with more than one wedge/hash outright, which
+        // would have silently mis-rejected this exact, real, valid drawing.
+        let mut b = MoleculeBuilder::new();
+        let c = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        let i = b.add_atom(Atom::new(Element::I));
+        b.add_bond(c, f, BondOrder::Single).unwrap();
+        b.add_bond(c, cl, BondOrder::Single).unwrap();
+        b.add_bond(c, br, BondOrder::Up).unwrap();
+        b.add_bond(c, i, BondOrder::Down).unwrap();
+        let quad = quad_positions();
+        let coords = vec![(0.0, 0.0), quad[0], quad[1], quad[2], quad[3]];
+        let mol = b.build();
+        let (chirality, order) = local_parity_from_wedges(&mol, &coords, c).unwrap();
+        assert_eq!(chirality, Chirality::Clockwise);
+        assert_eq!(order, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn valid_dual_wedge_3heavy_same_direction_accepted() {
+        // Counter-intuitive but measured, not assumed: two wedges pointing
+        // the SAME direction (F and Cl both solid wedge) on a 3-heavy +
+        // implicit-H center is not automatically contradictory either -- for
+        // THIS geometry the two wedges' isolated parities happen to agree,
+        // and RDKit independently accepts it with a clean, unwarned
+        // CHI_TETRAHEDRAL_CW tag. Contrast with contradictory_wedges_no_assignment
+        // above, which also has two same-direction wedges but on a different
+        // (4-heavy) geometry where they disagree -- "same direction" is not
+        // itself the discriminator, per-wedge-isolated-parity agreement is.
+        let mut b = MoleculeBuilder::new();
+        let c = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        b.add_bond(c, f, BondOrder::Up).unwrap();
+        b.add_bond(c, cl, BondOrder::Up).unwrap();
+        b.add_bond(c, br, BondOrder::Single).unwrap();
+        let quad = quad_positions();
+        let coords = vec![(0.0, 0.0), quad[0], quad[1], quad[2]];
+        let mol = b.build();
+        let (chirality, order) = local_parity_from_wedges(&mol, &coords, c).unwrap();
+        assert_eq!(chirality, Chirality::Clockwise);
+        assert_eq!(order, vec![1, 2, 3, STEREO_H_SENTINEL]);
     }
 
     #[test]

--- a/docs/stereo2d_local_parity_calibration.md
+++ b/docs/stereo2d_local_parity_calibration.md
@@ -89,12 +89,57 @@ exactly what the direct RDKit-tag comparison above also gives. Two
 independent derivations agreeing is the actual basis for confidence here, not
 either one alone.
 
-## Contradictory-wedge and degenerate-geometry rejection
+## Multi-wedge consistency (revised after #131 review)
 
-`local_parity_from_wedges` returns `None` when more than one neighbor bond
-carries a wedge/hash from the same center (see the two-simultaneous-wedges
-finding above), or when the computed volume is within `1e-6` of zero
-(coplanar/degenerate, including the "no wedge at all" case).
+The first version of this module rejected outright whenever more than one
+neighbor bond carried a wedge/hash. That was too strict, and was itself an
+unverified assumption -- exactly the failure mode this whole document exists
+to avoid. Caught in review: PR #130's own frozen fixtures
+`tetrahedral_4neighbors_explicit_h` / `tetrahedral_4heavy_no_h` each carry
+*two* wedges (a solid wedge to one substituent, a hash to a different one),
+and RDKit accepts both cleanly. The outright multi-wedge rejection would have
+silently mis-rejected real, valid drawings.
+
+Measured (`.venv/bin/python`, rdkit==2026.03.3) on 5 dual-wedge fixtures,
+each run through both a "per-wedge-alone" computation (the *already
+calibrated* single-wedge formula above, applied once per wedged bond with
+every other wedge's z zeroed) and RDKit's own parse, with per-fixture stderr
+captured separately so warnings are unambiguous:
+
+| fixture | per-wedge-alone parities | combined (all real z at once) | RDKit |
+|---|---|---|---|
+| 4-heavy, opposite dir (Br up, I down) | CW, CW (agree) | CW | clean `CW` tag |
+| 3-heavy, same dir (F up, Cl up) | CW, CW (agree) | CW | clean `CW` tag |
+| 4-heavy, same dir (Br up, I up) | CW, CCW (disagree) | CCW | clean `CW` tag (mismatches combined!) |
+| 3-heavy, opposite dir (F up, Cl down) | CW, CCW (disagree) | CCW | **warns** "conflicting stereochemistry", `CHI_UNSPECIFIED` |
+| 4-heavy, F up + Cl up (the pre-existing `contradictory_wedges_no_assignment` test's exact geometry) | CCW, CW (disagree) | CW | clean `CW` tag (mismatches combined!) |
+
+Two things fell out of this table that weren't obvious beforehand:
+
+1. **"Same direction" vs "opposite direction" is not the discriminator.**
+   Both a same-direction and an opposite-direction pair show up on the
+   *agree* side, and both also show up on the *disagree* side, depending on
+   which two bonds and which coordinates are involved. Only the actual
+   per-wedge-alone computation predicts it — this was checked, not assumed,
+   after "same-direction-is-bad" was floated and directly falsified by the
+   very first counterexample.
+2. **Once the isolated parities disagree, the combined (all-z-at-once)
+   volume is not trustworthy** — it agreed with RDKit's own fallback tag in
+   neither disagreement case above (rows 3 and 5), and in row 4 RDKit itself
+   refuses outright. Whenever the isolated parities *agree*, the combined
+   volume's sign matched RDKit's clean, unwarned tag in every measured case.
+
+**Rule implemented in `wedges_agree_4`/`wedges_agree_3`:** for each wedged
+neighbor, recompute the parity formula with every *other* wedge zeroed; if
+zero or one bond is wedged, there's nothing to check. If two or more are
+wedged, all isolated parities must agree, or `local_parity_from_wedges`
+returns `None`.
+
+## Degenerate-geometry rejection
+
+`local_parity_from_wedges` also returns `None` when the computed volume is
+within `1e-6` of zero (coplanar/degenerate, including the "no wedge at all"
+case).
 
 ## Reproducing this measurement
 

--- a/docs/stereo2d_local_parity_calibration.md
+++ b/docs/stereo2d_local_parity_calibration.md
@@ -1,0 +1,118 @@
+# P1-S1a-core: local parity sign convention, measured against RDKit
+
+`chematic_perception::local_parity_from_wedges` (`crates/chematic-perception/src/stereo2d_local.rs`)
+computes `Atom.chirality` + `stereo_neighbor_order` from wedge bonds and 2D
+coordinates, with **zero CIP involvement**. This note records how its sign
+convention was pinned down, so a future change doesn't have to re-derive it
+by analogy (the failure mode this note exists to prevent).
+
+## Why not just reason it out on paper
+
+`chematic_core::Chirality`'s own doc comment already states the convention
+("`@` = counterclockwise looking from the first neighbor"), but two things
+are *not* obvious from that sentence alone:
+
+1. Whether chematic's chosen "first neighbor" (`mol.neighbors(center)`
+   insertion order) is even in the same frame as whatever RDKit's
+   `CHI_TETRAHEDRAL_CW`/`CCW` tag is relative to.
+2. What the right formula is for a 3-heavy+implicit-H center, where there's
+   no explicit position for the 4th (H) neighbor.
+
+Both were resolved by direct measurement against real RDKit output on MOL
+V2000 fixtures, not by extending the existing CIP-based `assign_rs`'s
+lowest-priority-behind convention by analogy — a sign bug picked to match a
+handful of fixtures is indistinguishable from a correct one until it's wrong
+on a fixture you didn't test.
+
+## Frame alignment (measured, not assumed)
+
+For every fixture, chematic's `mol.neighbors(center)` order (bond
+declaration order) and RDKit's `atom.GetNeighbors()` order were dumped side
+by side from the *same* MOL block text. They were identical in every case,
+including after reversing the bond block. Both engines index a stereocenter's
+neighbors by bond-declaration order, so raw parity values are directly
+comparable without any permutation translation.
+
+## 4 explicit neighbors
+
+Formula: apex = `order[0]`, viewed = `order[1..3]`.
+`vol = signed_volume(pos[order[1]], pos[order[2]], pos[order[3]], pos[order[0]])`.
+
+Measured on 5 fixtures (wedge on first bond, wedge on last bond, hash
+inversion, full bond-order reversal, two simultaneous wedges):
+
+| vol sign | RDKit tag |
+|---|---|
+| negative | `CHI_TETRAHEDRAL_CCW` |
+| positive | `CHI_TETRAHEDRAL_CW` |
+
+Consistent across a hash-vs-wedge sign flip and a full 4-element bond-order
+reversal (an even permutation — sign correctly preserved in both engines).
+The two-simultaneous-wedges fixture disagreed with a naive sign read (RDKit
+still emits *some* tag via its own dual-volume fallback logic) — this is the
+concrete evidence behind the "contradictory wedges → no assignment" rule:
+`local_parity_from_wedges` refuses rather than picks a side.
+
+## 3 heavy neighbors + implicit H
+
+RDKit's own `atomChiralTypeFromBondDirPseudo3D` (nNbrs==3 path, read from
+source at the pinned commit below) does not synthesize a position for the
+missing H at all — it computes a triple product of the three *real* bond
+vectors **from the center atom**. `signed_volume(p1, p2, p3, p4)` is already
+exactly `p4`'s the pivot; setting `p4 = center` reproduces RDKit's formula
+verbatim:
+
+`vol = signed_volume(pos[order[0]], pos[order[1]], pos[order[2]], center_pos)`
+
+Measured on 4 fixtures (wedge on first bond, hash inversion, wedge on a
+different bond, full 3-element bond-order reversal):
+
+| vol sign | RDKit tag |
+|---|---|
+| negative | `CHI_TETRAHEDRAL_CW` |
+| positive | `CHI_TETRAHEDRAL_CCW` |
+
+Note the mapping is the **opposite** polarity from the 4-neighbor case —
+expected, since the pivot moved from "first neighbor" to "center", a
+genuinely different geometric setup, not a bug.
+
+This was cross-checked a second, independent way: RDKit's own non-canonical,
+rooted SMILES output for the wedge fixture is `[C@H](F)(Cl)Br` (order
+`[H, F, Cl, Br]`, i.e. H *first*, since the bracket atom is the traversal
+root with no preceding atom — matching chematic's parser's own
+`begin_stereo_if_chiral` convention for a root atom). Moving H from the front
+to the back of a 4-slot list (chematic's chosen convention: H goes *last* in
+`stereo_neighbor_order` for the 3-heavy case) is a 4-cycle, i.e. 3
+transpositions, an odd permutation — so the symbol must flip: `@` → `@@`.
+That predicts `Chirality::Clockwise` for the same wedge fixture, which is
+exactly what the direct RDKit-tag comparison above also gives. Two
+independent derivations agreeing is the actual basis for confidence here, not
+either one alone.
+
+## Contradictory-wedge and degenerate-geometry rejection
+
+`local_parity_from_wedges` returns `None` when more than one neighbor bond
+carries a wedge/hash from the same center (see the two-simultaneous-wedges
+finding above), or when the computed volume is within `1e-6` of zero
+(coplanar/degenerate, including the "no wedge at all" case).
+
+## Reproducing this measurement
+
+The calibration was done with a throwaway script (not checked in) that
+builds MOL V2000 block text by hand, feeds the identical text to RDKit
+(`.venv/bin/python`, rdkit==2026.03.3) and to hand-derived arithmetic
+mirroring `signed_volume`/`wedge_z`, and compares. RDKit source referenced at
+commit `8afba32ec539dcb2369bc84549d802aca3f7eb39` (same pin used by
+`docs/stereo2d_reader_integration_rfc.md`), specifically
+`Code/GraphMol/Chirality.cpp`'s `atomChiralTypeFromBondDirPseudo3D`.
+
+## Scope note
+
+This module never calls `chematic_perception::cip_priority` and never writes
+`Atom.cip_code`. It is not called from any reader yet, and the SMILES writer
+is unchanged — both are deliberately out of scope for this step (see
+`docs/stereo2d_reader_integration_rfc.md` for the full integration-boundary
+design and the reason the writer's existing standalone-wedge bug — it emits
+a meaningless `/`/`\` token for a wedge bond with no adjacent double bond,
+independently re-encountered while validating this module's output — must be
+fixed before any reader wires this in automatically).

--- a/docs/stereo2d_local_parity_calibration.md
+++ b/docs/stereo2d_local_parity_calibration.md
@@ -135,6 +135,29 @@ zero or one bond is wedged, there's nothing to check. If two or more are
 wedged, all isolated parities must agree, or `local_parity_from_wedges`
 returns `None`.
 
+### Tri-state guard on the isolated volumes (revised after a second #131 review)
+
+The first version of `wedges_agree_4`/`wedges_agree_3` compared isolated
+volumes via a bare `signed_volume(...) < 0.0` bool. That silently treats a
+near-zero (degenerate) isolated volume as "not negative" — the same bucket
+as a genuinely positive one — so a degenerate isolated wedge could
+spuriously "agree" with a real one and slip through. Fixed with
+`volume_sign(volume) -> Option<bool>`: `None` when `volume.abs() <
+VOLUME_EPS`, `Some(volume < 0.0)` otherwise. All isolated signs must be
+`Some` *and* equal; a single `None` rejects immediately, without needing to
+check the rest.
+
+Two regression fixtures pin this: one where the apex's own wedge gives a
+clear sign but a *different* wedged neighbor's isolated volume is exactly
+zero because the apex and the two non-wedged viewed points are collinear
+(constructed algebraically: for a "viewed" point's isolated volume,
+`signed_volume(viewed_i, viewed_j, viewed_k, apex)` with only `viewed_i`
+carrying z reduces to `z_i * cross2d((viewed_j - apex), (viewed_k - apex))`,
+which is exactly zero iff apex/viewed_j/viewed_k are collinear — independent
+of `z_i`'s value or sign); and one where all four substituents are placed
+collinear, making every isolated volume for any wedged pair among them
+exactly zero. Both reject.
+
 ## Degenerate-geometry rejection
 
 `local_parity_from_wedges` also returns `None` when the computed volume is


### PR DESCRIPTION
## What this is

`chematic_perception::local_parity_from_wedges` computes `Atom.chirality` +
`stereo_neighbor_order` directly from wedge/hash bonds and 2D coordinates,
using the neighbor order already present in the molecule (`mol.neighbors()`).
**It never calls CIP ranking and never touches `Atom.cip_code`.**

This is the first implementation step following the P1-A0 diagnosis (#130):
S1a (parity, CIP-independent) before S1b (CIP-ranked R/S label on top of it).
A CIP tie must not prevent a molecule from having a known local parity --
the wedge drawing is a complete statement on its own.

## Gate: RDKit chiral tag, not R/S

Per the design established during #130's review, the correctness bar here
is agreement with RDKit's raw `CHI_TETRAHEDRAL_CW`/`CCW` tag -- **not** R/S
label agreement (R/S needs CIP, which this function deliberately never
calls).

The sign convention was **measured**, not derived by analogy to the existing
CIP-based `assign_rs`: built matching MOL V2000 fixtures, confirmed
chematic's `mol.neighbors()` order and RDKit's `GetNeighbors()` order are
identical (both are bond-declaration order, so no permutation translation is
needed), then read off which raw signed-volume sign corresponds to which
RDKit tag. Cross-checked a second, independent way via RDKit's own rooted
non-canonical SMILES output and an odd/even-permutation argument -- the two
derivations agree. Full methodology in
`docs/stereo2d_local_parity_calibration.md`.

The 3-heavy+implicit-H case mirrors RDKit's own
`atomChiralTypeFromBondDirPseudo3D` (read from source at the pinned commit
`8afba32ec539dcb2369bc84549d802aca3f7eb39`): no synthetic 3D position is
invented for the missing H. Chematic's existing `signed_volume` already
reduces to RDKit's exact triple product when the center atom itself (not a
neighbor) is used as the pivot.

## Multiple wedges from the same center are not automatically contradictory

An earlier version of this PR rejected any stereocenter with more than one
wedge/hash bond outright. That was an unverified assumption, caught in
review: PR #130's own frozen fixtures (`tetrahedral_4neighbors_explicit_h`,
`tetrahedral_4heavy_no_h`) each legitimately carry a solid wedge to one
substituent and a hash to a *different* one, and RDKit accepts both
cleanly. The blanket rejection would have silently mis-rejected real, valid
drawings.

Fixed: when two or more bonds from a center are wedged, each is checked in
isolation (the already-calibrated single-wedge formula, with every other
wedge zeroed) and all isolated parities must agree -- using a tri-state
sign (`Some(negative)`/`Some(non-negative)`/`None` for a degenerate isolated
volume, not a bare bool, so a degenerate isolated wedge can't spuriously
"agree" with a real one) -- before the combined (all-real-z-at-once) volume
is trusted. Disagreement, or any isolated volume being itself degenerate,
rejects. Measured against RDKit on 5 dual-wedge fixtures -- not derived from
a same-direction/opposite-direction guess, which a first hypothesis floated
and the very first counterexample falsified. Full table in
`docs/stereo2d_local_parity_calibration.md`.

## Test coverage (all required cases from the P1-A0 follow-up spec)

- 3 heavy + implicit H
- 4 neighbors + explicit H
- true 4-heavy (no H anywhere)
- wedge/hash inversion
- bond atom-order inversion (both 3- and 4-neighbor: even vs odd permutation, verified to flip/preserve sign correctly in each case)
- multiple stereocenters
- CIP-priority tie (still produces chirality -- verified against the CIP-based path genuinely refusing the same fixture)
- missing coordinates -> no assignment
- degenerate/coplanar geometry -> no assignment
- two wedges implying disagreeing local parity -> no assignment (two independent fixtures)
- two wedges implying agreeing local parity, on different bonds -> accepted (ported from #130's real fixture geometry, both the 4-neighbor and 3-heavy+implicit-H code paths)
- one isolated wedge volume degenerate while the other is real -> no assignment
- both isolated wedge volumes degenerate -> no assignment

## Plumbing

Adds `chematic_core::Molecule::set_chirality` (no public setter existed;
mirrors the existing `set_cip_code`).

## Explicitly out of scope (per the agreed subsequent order)

- Not called from any reader's default parse path.
- Does not change the SMILES writer. While validating output through the
  existing canonical writer I re-encountered concrete evidence of its
  already-known standalone-wedge bug (`BondOrder::Up`/`Down` is overloaded
  for wedge depiction *and* SMILES `/`/`\` E/Z markers, so a lone wedge bond
  gets written as a meaningless directional token) -- this reinforces why
  that fix has to land before any reader wires this function in
  automatically, not something to fix in this PR.
- Does not add CIP-ranked R/S labeling (P1-S1b, builds on top of this later).
- Branch forked directly from `main` at `659baca`; does not stack on #129 or #130.

Diagnosis-only siblings (aromaticity, descriptor census, canonical-SMILES
residual, ETKDG gap, accurate-CIP audit, ECFP4 bit-exact matrix) are running
in parallel on separate branches/PRs, all also forked from the same
`main@659baca` and not touching this branch's files.

Not merged -- awaiting review. Originally forked from `main@659baca`, before
#129/#130 landed; see the rebase verification section below for the current
state.

## Rebase verification — 2026-07-22

- Rebasing target: `main@48eb526d46eadd3bd3fc042a4d42c9f162397c9d`
- Previous head: `8fac340acb586138bbaf3cda3bfce39df175bb70`
- Current head: `9e310b9bccd85d506c0e736f6d0d10aff9bbdf0a`
- Range-diff: 3/3 commits unchanged
- Conflicts: none
- Dedicated oracle: N/A (code + inline tests only, no diagnosis-script artifacts on this branch); `cargo test -p chematic-perception --lib stereo2d_local` 19/19 passed
- `bash scripts/check.sh`: passed
- GitHub Actions: CI green / Security green / Bench green
