### PR TITLE
fix(smarts): cap VF2 backtracking for PAINS/Brenk with a non-silent budget outcome

### DIFF
--- a/crates/chematic-chem/src/alerts.rs
+++ b/crates/chematic-chem/src/alerts.rs
@@ -11,8 +11,30 @@ use chematic_core::{
 };
 use chematic_perception::find_sssr;
 use chematic_smarts::{
-    MatchConfig, QueryMolecule, find_matches_with_rings_and_config, parse_smarts,
+    MatchConfig, MatchOutcome, QueryMolecule, find_matches_with_rings_and_config_checked,
+    has_match_bounded, parse_smarts,
 };
+
+/// Hard ceiling on VF2 recursive visits per pattern per molecule.
+///
+/// Existence-only matching (`has_match_bounded`, below) stops enumerating once
+/// a match is *found*, but on a highly symmetric target (e.g. a symmetric
+/// macrocycle) VF2 can still backtrack combinatorially just to find — or rule
+/// out — that first match. This budget caps that search. Same value already
+/// used for the same reason in `standardize::SaltCatalog::is_salt` and
+/// `chematic-wasm`'s SMARTS entry points.
+///
+/// **Exhaustion is not "no match".** When the budget runs out mid-pattern,
+/// `has_match_bounded` reports [`MatchOutcome::BudgetExhausted`] — a distinct
+/// outcome from `NotFound` — and every function below folds that into the
+/// *positive* side of its return value (conservative / fail-safe: an unclear
+/// pattern is reported as if it alerted, never silently as clean). Callers
+/// that need the real three-way distinction per pattern use the `_checked`
+/// variants ([`pains_matches_checked`], [`brenk_matches_checked`]), which
+/// `drug_score`'s `f_tox` explicitly does not need to since it just wants a
+/// hit count and inherits this same fail-safe fold via `pains_matches`/
+/// `brenk_matches`.
+const ALERT_MAX_VISIT_BUDGET: u64 = 1_000_000;
 
 /// Return a copy of `mol` with all implicit H atoms materialized as explicit
 /// graph nodes.  PAINS patterns (and many RDKit SMARTS) are written for
@@ -2060,76 +2082,101 @@ fn compiled_brenk_patterns() -> &'static [(&'static str, QueryMolecule)] {
     })
 }
 
-/// Returns the names of all PAINS patterns that match `mol`.
+/// Runs `patterns` against `mol` with an existence-only, budget-bounded VF2
+/// search, returning one `(name, MatchOutcome)` per pattern — never per
+/// embedding (see `MatchOutcome::Found`'s doc: this reports *whether* a rule
+/// matched at least once, not how many times or where).
 ///
-/// An empty vec means no PAINS alerts were triggered.
+/// This is the shared core behind [`pains_matches_checked`] /
+/// [`brenk_matches_checked`] and, transitively, every coarser PAINS/Brenk
+/// function in this module.
+fn checked_matches(
+    mol: &Molecule,
+    patterns: &'static [(&'static str, QueryMolecule)],
+) -> Vec<(&'static str, MatchOutcome)> {
+    let mol_h = add_explicit_hs(mol);
+    let rings = find_sssr(&mol_h);
+    let config = MatchConfig {
+        max_visit_budget: Some(ALERT_MAX_VISIT_BUDGET),
+        ..Default::default()
+    };
+    patterns
+        .iter()
+        .map(|(name, q)| (*name, has_match_bounded(q, &mol_h, &rings, &config)))
+        .collect()
+}
+
+/// Folds a `checked_matches` result down to `Vec<name>` the same way the
+/// coarser PAINS/Brenk functions below do: both `Found` and
+/// `BudgetExhausted` count as "alert present" (fail-safe — an unresolved
+/// pattern is reported as if it matched, never silently as clean). Only
+/// `NotFound` is excluded.
+fn fold_conservative(checked: Vec<(&'static str, MatchOutcome)>) -> Vec<&'static str> {
+    checked
+        .into_iter()
+        .filter(|(_, outcome)| *outcome != MatchOutcome::NotFound)
+        .map(|(name, _)| name)
+        .collect()
+}
+
+/// Returns `(name, MatchOutcome)` for every PAINS pattern, distinguishing a
+/// confirmed match (`Found`), a confirmed non-match (`NotFound`), and a VF2
+/// visit-budget cutoff that resolved neither way (`BudgetExhausted`).
+///
+/// Use this over [`pains_matches`] when a caller must not conflate "no alert"
+/// with "couldn't tell" — [`pains_matches`] necessarily folds the two
+/// together into its plain `Vec<&str>` shape (documented there).
+pub fn pains_matches_checked(mol: &Molecule) -> Vec<(&'static str, MatchOutcome)> {
+    checked_matches(mol, compiled_pains_patterns())
+}
+
+/// Returns `(name, MatchOutcome)` for every Brenk pattern — see
+/// [`pains_matches_checked`].
+pub fn brenk_matches_checked(mol: &Molecule) -> Vec<(&'static str, MatchOutcome)> {
+    checked_matches(mol, compiled_brenk_patterns())
+}
+
+/// Returns the names of all PAINS patterns that match `mol`, or whose result
+/// could not be resolved within the VF2 visit budget (folded in as if
+/// matched — see [`pains_matches_checked`] for the real three-way outcome).
+///
+/// An empty vec means every pattern was confirmed *not* to match. It does
+/// NOT distinguish "confirmed clean" from "some pattern was unresolved" —
+/// that distinction doesn't exist in this function's shape by construction;
+/// callers that need it use [`pains_matches_checked`].
 ///
 /// The molecule is expanded to explicit H form before matching because the
 /// PAINS SMARTS patterns reference explicit hydrogen atoms (`[#1]`).
 pub fn pains_matches(mol: &Molecule) -> Vec<&'static str> {
-    let mol_h = add_explicit_hs(mol);
-    let rings = find_sssr(&mol_h);
-    // Each pattern only needs an existence check — only the name is kept,
-    // never the match maps — so stop at the first embedding per pattern.
-    let config = MatchConfig {
-        max_matches: Some(1),
-        uniquify: false,
-        ..Default::default()
-    };
-    compiled_pains_patterns()
-        .iter()
-        .filter(|(_, q)| !find_matches_with_rings_and_config(q, &mol_h, &rings, &config).is_empty())
-        .map(|(name, _)| *name)
-        .collect()
+    fold_conservative(pains_matches_checked(mol))
 }
 
-/// Returns `true` when no PAINS alerts are triggered.
+/// Returns `true` only when every PAINS pattern was confirmed *not* to match.
+/// A VF2 visit-budget cutoff on any pattern counts as "does not pass" (see
+/// [`pains_matches`]).
 pub fn pains_passes(mol: &Molecule) -> bool {
-    let mol_h = add_explicit_hs(mol);
-    let rings = find_sssr(&mol_h);
-    let config = MatchConfig {
-        max_matches: Some(1),
-        ..Default::default()
-    };
-    compiled_pains_patterns()
+    pains_matches_checked(mol)
         .iter()
-        .all(|(_, q)| find_matches_with_rings_and_config(q, &mol_h, &rings, &config).is_empty())
+        .all(|(_, outcome)| *outcome == MatchOutcome::NotFound)
 }
 
-/// Returns the names of all Brenk structural alerts that match `mol`.
+/// Returns the names of all Brenk structural alerts that match `mol`, or
+/// whose result could not be resolved within the VF2 visit budget (folded in
+/// as if matched — see [`pains_matches`] for the same policy on PAINS).
 ///
-/// An empty vec means no Brenk alerts were triggered.
+/// An empty vec means every pattern was confirmed not to match.
 ///
 /// Brenk et al. 2008 structural alerts for drug design (J. Med. Chem. 51, 5149–5171).
 /// These patterns identify problematic functional groups and structural features.
 pub fn brenk_matches(mol: &Molecule) -> Vec<&'static str> {
-    let mol_h = add_explicit_hs(mol);
-    let rings = find_sssr(&mol_h);
-    // Each pattern only needs an existence check — only the name is kept,
-    // never the match maps — so stop at the first embedding per pattern.
-    let config = MatchConfig {
-        max_matches: Some(1),
-        uniquify: false,
-        ..Default::default()
-    };
-    compiled_brenk_patterns()
-        .iter()
-        .filter(|(_, q)| !find_matches_with_rings_and_config(q, &mol_h, &rings, &config).is_empty())
-        .map(|(name, _)| *name)
-        .collect()
+    fold_conservative(brenk_matches_checked(mol))
 }
 
-/// Returns `true` when no Brenk structural alerts are triggered.
+/// Returns `true` only when every Brenk pattern was confirmed *not* to match.
 pub fn brenk_passes(mol: &Molecule) -> bool {
-    let mol_h = add_explicit_hs(mol);
-    let rings = find_sssr(&mol_h);
-    let config = MatchConfig {
-        max_matches: Some(1),
-        ..Default::default()
-    };
-    compiled_brenk_patterns()
+    brenk_matches_checked(mol)
         .iter()
-        .all(|(_, q)| find_matches_with_rings_and_config(q, &mol_h, &rings, &config).is_empty())
+        .all(|(_, outcome)| *outcome == MatchOutcome::NotFound)
 }
 
 /// Returns `(passes, alert_names)` in a single explicit-H + SSSR + pattern pass.
@@ -2137,22 +2184,11 @@ pub fn brenk_passes(mol: &Molecule) -> bool {
 /// Equivalent to calling `pains_passes(mol)` and `pains_matches(mol)` separately,
 /// but avoids duplicating the expensive explicit-H conversion and 480-pattern scan.
 pub fn pains_passes_and_matches(mol: &Molecule) -> (bool, Vec<&'static str>) {
-    let mol_h = add_explicit_hs(mol);
-    let rings = find_sssr(&mol_h);
-    // Each pattern only needs an existence check — only the name is kept,
-    // never the match maps — so stop at the first embedding per pattern.
-    let config = MatchConfig {
-        max_matches: Some(1),
-        uniquify: false,
-        ..Default::default()
-    };
-    let names: Vec<&'static str> = compiled_pains_patterns()
+    let checked = pains_matches_checked(mol);
+    let passes = checked
         .iter()
-        .filter(|(_, q)| !find_matches_with_rings_and_config(q, &mol_h, &rings, &config).is_empty())
-        .map(|(name, _)| *name)
-        .collect();
-    let passes = names.is_empty();
-    (passes, names)
+        .all(|(_, outcome)| *outcome == MatchOutcome::NotFound);
+    (passes, fold_conservative(checked))
 }
 
 /// Returns `(passes, alert_names)` in a single explicit-H + SSSR + pattern pass.
@@ -2160,22 +2196,11 @@ pub fn pains_passes_and_matches(mol: &Molecule) -> (bool, Vec<&'static str>) {
 /// Equivalent to calling `brenk_passes(mol)` and `brenk_matches(mol)` separately,
 /// but avoids duplicating the expensive explicit-H conversion and ~300-pattern scan.
 pub fn brenk_passes_and_matches(mol: &Molecule) -> (bool, Vec<&'static str>) {
-    let mol_h = add_explicit_hs(mol);
-    let rings = find_sssr(&mol_h);
-    // Each pattern only needs an existence check — only the name is kept,
-    // never the match maps — so stop at the first embedding per pattern.
-    let config = MatchConfig {
-        max_matches: Some(1),
-        uniquify: false,
-        ..Default::default()
-    };
-    let names: Vec<&'static str> = compiled_brenk_patterns()
+    let checked = brenk_matches_checked(mol);
+    let passes = checked
         .iter()
-        .filter(|(_, q)| !find_matches_with_rings_and_config(q, &mol_h, &rings, &config).is_empty())
-        .map(|(name, _)| *name)
-        .collect();
-    let passes = names.is_empty();
-    (passes, names)
+        .all(|(_, outcome)| *outcome == MatchOutcome::NotFound);
+    (passes, fold_conservative(checked))
 }
 
 // ---------------------------------------------------------------------------
@@ -2207,13 +2232,25 @@ fn matches_detailed_impl(
 ) -> Vec<(&'static str, Vec<AtomIdx>)> {
     let mol_h = add_explicit_hs(mol);
     let rings = find_sssr(&mol_h);
-    let config = MatchConfig::default();
+    // This path enumerates every embedding (needed for highlighting), so it
+    // can't be existence-only — but it still gets the same visit-budget
+    // safety net as the existence-only variants above, so a pathological
+    // symmetric target fails fast instead of hanging.
+    let config = MatchConfig {
+        max_visit_budget: Some(ALERT_MAX_VISIT_BUDGET),
+        ..Default::default()
+    };
     patterns
         .iter()
         .filter_map(|(name, q)| {
-            let ms = find_matches_with_rings_and_config(q, &mol_h, &rings, &config);
+            let (ms, budget_exhausted) =
+                find_matches_with_rings_and_config_checked(q, &mol_h, &rings, &config);
             if ms.is_empty() {
-                return None;
+                // Same fail-safe policy as the existence-only functions above:
+                // a budget cutoff is reported as present (empty highlight set,
+                // since no embedding was collected before the cutoff), never
+                // silently dropped like a confirmed non-match.
+                return budget_exhausted.then(|| (*name, Vec::new()));
             }
             Some((*name, heavy_atoms_from_matches(&ms, &mol_h)))
         })

--- a/crates/chematic-chem/src/alerts.rs
+++ b/crates/chematic-chem/src/alerts.rs
@@ -2089,15 +2089,35 @@ fn compiled_brenk_patterns() -> &'static [(&'static str, QueryMolecule)] {
 ///
 /// This is the shared core behind [`pains_matches_checked`] /
 /// [`brenk_matches_checked`] and, transitively, every coarser PAINS/Brenk
-/// function in this module.
+/// function in this module. Always uses the real production budget
+/// ([`ALERT_MAX_VISIT_BUDGET`]) — see [`checked_matches_with_budget`] for the
+/// budget-injectable version tests use to exercise the exhaustion path
+/// deterministically and near-instantly, without needing a specific
+/// pathological molecule or the real (slow) budget.
 fn checked_matches(
     mol: &Molecule,
     patterns: &'static [(&'static str, QueryMolecule)],
 ) -> Vec<(&'static str, MatchOutcome)> {
+    checked_matches_with_budget(mol, patterns, ALERT_MAX_VISIT_BUDGET)
+}
+
+/// Like [`checked_matches`], but with an injectable visit budget instead of
+/// the hardcoded [`ALERT_MAX_VISIT_BUDGET`]. Production call sites always go
+/// through [`checked_matches`] (real budget, unchanged behaviour); this
+/// exists so tests can force `MatchOutcome::BudgetExhausted` on demand (e.g.
+/// `budget: 0` exhausts on the very first VF2 visit, deterministically,
+/// regardless of molecule or pattern) instead of relying on a real
+/// pathological molecule actually exhausting the production budget, which
+/// can take tens of seconds.
+fn checked_matches_with_budget(
+    mol: &Molecule,
+    patterns: &'static [(&'static str, QueryMolecule)],
+    budget: u64,
+) -> Vec<(&'static str, MatchOutcome)> {
     let mol_h = add_explicit_hs(mol);
     let rings = find_sssr(&mol_h);
     let config = MatchConfig {
-        max_visit_budget: Some(ALERT_MAX_VISIT_BUDGET),
+        max_visit_budget: Some(budget),
         ..Default::default()
     };
     patterns
@@ -2409,9 +2429,19 @@ mod tests {
     /// positive without the 19s cost, but is a separate, larger project.
     ///
     /// This test intentionally exercises the *real* production budget, so
-    /// it is genuinely slow in debug builds (observed ~35s locally) --
+    /// it is genuinely slow in debug builds (observed ~25-35s locally) --
     /// that slowness is itself part of what's being pinned, not a mistake.
+    /// `#[ignore]`d so it doesn't add permanent latency (or flakiness under
+    /// concurrent-CI CPU contention) to the default suite -- run explicitly
+    /// with `cargo test -p chematic-chem --lib -- --ignored
+    /// test_pains_di_tert_butylphenol_is_accepted_false_positive`. See
+    /// `checked_matches_zero_budget_is_deterministic_budget_exhausted` below
+    /// for the fast, deterministic test of the same fold behaviour that
+    /// *does* run by default.
     #[test]
+    #[ignore = "slow real-budget VF2 calibration (~25-35s debug) -- pins a \
+                known, accepted false positive on a common symmetric \
+                scaffold; run explicitly, see doc comment above"]
     fn test_pains_di_tert_butylphenol_is_accepted_false_positive() {
         let smiles = "CC(C)(C)c1cc(C(=O)/C=C/c2ccsc2)cc(C(C)(C)C)c1O";
         let start = std::time::Instant::now();
@@ -2445,6 +2475,40 @@ mod tests {
             elapsed < std::time::Duration::from_secs(90),
             "expected this to fail fast within the visit budget (bounded, \
              just not free) -- took {elapsed:?}, expected well under 90s"
+        );
+    }
+
+    /// Fast, deterministic default-suite replacement for the `#[ignore]`d
+    /// real-budget calibration test above. Reuses the same real molecule and
+    /// pattern (`tert_butyl_B(1)` on the di-tert-butylphenol scaffold -- big
+    /// enough that this pattern doesn't hit `has_match_bounded`'s "query
+    /// bigger than target" early exit, the same way the slow test's `Found`
+    /// is never returned in that case either) but with `budget: 0` instead of
+    /// the real production budget: the very first VF2 visit is already
+    /// abandoned (see `match_vf2::match_recursive`'s early-exit branch), so
+    /// the outcome is deterministically `BudgetExhausted` and near-instant --
+    /// no backtracking search actually runs. This exercises the thing that
+    /// matters -- budget exhaustion folds to a conservative alert, never
+    /// silently to "no match" -- without waiting on the real (slow) budget.
+    #[test]
+    fn checked_matches_zero_budget_is_deterministic_budget_exhausted() {
+        let smiles = "CC(C)(C)c1cc(C(=O)/C=C/c2ccsc2)cc(C(C)(C)C)c1O";
+        let checked = checked_matches_with_budget(&mol(smiles), compiled_pains_patterns(), 0);
+
+        let outcome = checked
+            .iter()
+            .find(|(name, _)| *name == "tert_butyl_B(1)")
+            .map(|(_, outcome)| *outcome);
+        assert_eq!(
+            outcome,
+            Some(MatchOutcome::BudgetExhausted),
+            "budget=0 must resolve tert_butyl_B(1) to BudgetExhausted -- a \
+             zero budget can never prove a negative (or a positive)"
+        );
+        assert!(
+            fold_conservative(checked).contains(&"tert_butyl_B(1)"),
+            "BudgetExhausted must fold into the flagged/alert side, never \
+             silently dropped as if NotFound"
         );
     }
 }

--- a/crates/chematic-chem/src/alerts.rs
+++ b/crates/chematic-chem/src/alerts.rs
@@ -2380,4 +2380,71 @@ mod tests {
             "Mannich base should trigger PAINS mannich_A"
         );
     }
+
+    /// Pins the accepted false-positive tradeoff for `ALERT_MAX_VISIT_BUDGET`
+    /// on a common, ordinary scaffold -- so it can't silently change again.
+    ///
+    /// `CC(C)(C)c1cc(C(=O)/C=C/c2ccsc2)cc(C(C)(C)C)c1O` is a 2,6-di-tert-
+    /// -butylphenol (BHT-class antioxidant) with a thienyl chalcone
+    /// substituent -- an ordinary drug-like structure, not an exotic
+    /// macrocycle. Its two tert-butyl groups give the `tert_butyl_B(1)`
+    /// PAINS pattern's search enough local symmetry (each tert-butyl's 3
+    /// methyls, each methyl's 3 H's, both tert-butyl groups mutually
+    /// symmetric under the ring) to blow up VF2 the same way the reported
+    /// macrocycle does, just via gem-dimethyl/tert-butyl symmetry instead of
+    /// ring symmetry.
+    ///
+    /// Verified against the true unpatched (no budget at all) baseline: the
+    /// correct answer is `NotFound` (`tert_butyl_B` genuinely does not
+    /// match), but proving that takes ~19s. At `ALERT_MAX_VISIT_BUDGET`
+    /// (1,000,000), the search hasn't resolved either way yet -- this is
+    /// `MatchOutcome::BudgetExhausted`, folded (per the documented,
+    /// deliberately fail-safe policy on `ALERT_MAX_VISIT_BUDGET`) into
+    /// `pains_matches`'s output as if it *had* matched. That is a real,
+    /// accepted false positive (and, via `drug_score::f_tox`, a halved
+    /// `drug_score` for this molecule) -- explicitly signed off on in favour
+    /// of staying fast and never silently reporting "clean" on a cutoff. A
+    /// real fix (symmetry-aware VF2 match ordering to prune automorphic
+    /// branches before they're re-explored) would eliminate this false
+    /// positive without the 19s cost, but is a separate, larger project.
+    ///
+    /// This test intentionally exercises the *real* production budget, so
+    /// it is genuinely slow in debug builds (observed ~35s locally) --
+    /// that slowness is itself part of what's being pinned, not a mistake.
+    #[test]
+    fn test_pains_di_tert_butylphenol_is_accepted_false_positive() {
+        let smiles = "CC(C)(C)c1cc(C(=O)/C=C/c2ccsc2)cc(C(C)(C)C)c1O";
+        let start = std::time::Instant::now();
+        let checked = pains_matches_checked(&mol(smiles));
+        let elapsed = start.elapsed();
+
+        let outcome = checked
+            .iter()
+            .find(|(name, _)| *name == "tert_butyl_B(1)")
+            .map(|(_, outcome)| *outcome);
+        assert_eq!(
+            outcome,
+            Some(MatchOutcome::BudgetExhausted),
+            "tert_butyl_B(1) is expected to hit the visit budget on this \
+             molecule -- if this changed to Found/NotFound, either the \
+             budget, the pattern, or the VF2 search order changed and this \
+             pin needs re-evaluating, not silently updating"
+        );
+
+        // The documented fail-safe fold: BudgetExhausted still surfaces
+        // wherever pains_matches() would surface a real Found. Checked via
+        // fold_conservative directly (not a second pains_matches() call) so
+        // this test doesn't re-run the same ~30s search twice.
+        assert!(
+            fold_conservative(checked.clone()).contains(&"tert_butyl_B(1)"),
+            "BudgetExhausted must fold into pains_matches() as flagged, not \
+             silently disappear as if NotFound"
+        );
+
+        assert!(
+            elapsed < std::time::Duration::from_secs(90),
+            "expected this to fail fast within the visit budget (bounded, \
+             just not free) -- took {elapsed:?}, expected well under 90s"
+        );
+    }
 }

--- a/crates/chematic-chem/src/alerts.rs
+++ b/crates/chematic-chem/src/alerts.rs
@@ -2104,11 +2104,16 @@ fn checked_matches(
 /// Like [`checked_matches`], but with an injectable visit budget instead of
 /// the hardcoded [`ALERT_MAX_VISIT_BUDGET`]. Production call sites always go
 /// through [`checked_matches`] (real budget, unchanged behaviour); this
-/// exists so tests can force `MatchOutcome::BudgetExhausted` on demand (e.g.
-/// `budget: 0` exhausts on the very first VF2 visit, deterministically,
-/// regardless of molecule or pattern) instead of relying on a real
-/// pathological molecule actually exhausting the production budget, which
-/// can take tens of seconds.
+/// exists so tests can force `MatchOutcome::BudgetExhausted` on demand
+/// instead of relying on a real pathological molecule actually exhausting
+/// the production budget, which can take tens of seconds.
+///
+/// For patterns that reach the VF2 recursion path, `budget: 0`
+/// deterministically produces `BudgetExhausted` on the first attempted
+/// visit. Structural early exits in [`has_match_bounded`] — e.g. a query
+/// pattern with more atoms than the target molecule — still return
+/// `NotFound` without ever consuming budget, regardless of what `budget` is
+/// set to.
 fn checked_matches_with_budget(
     mol: &Molecule,
     patterns: &'static [(&'static str, QueryMolecule)],
@@ -2160,10 +2165,9 @@ pub fn brenk_matches_checked(mol: &Molecule) -> Vec<(&'static str, MatchOutcome)
 /// could not be resolved within the VF2 visit budget (folded in as if
 /// matched — see [`pains_matches_checked`] for the real three-way outcome).
 ///
-/// An empty vec means every pattern was confirmed *not* to match. It does
-/// NOT distinguish "confirmed clean" from "some pattern was unresolved" —
-/// that distinction doesn't exist in this function's shape by construction;
-/// callers that need it use [`pains_matches_checked`].
+/// An empty vector means every pattern was conclusively `NotFound`. For
+/// *returned* names, this API does not distinguish a confirmed match from
+/// `BudgetExhausted` — use [`pains_matches_checked`] for that distinction.
 ///
 /// The molecule is expanded to explicit H form before matching because the
 /// PAINS SMARTS patterns reference explicit hydrogen atoms (`[#1]`).
@@ -2184,7 +2188,9 @@ pub fn pains_passes(mol: &Molecule) -> bool {
 /// whose result could not be resolved within the VF2 visit budget (folded in
 /// as if matched — see [`pains_matches`] for the same policy on PAINS).
 ///
-/// An empty vec means every pattern was confirmed not to match.
+/// An empty vector means every pattern was conclusively `NotFound`. For
+/// *returned* names, this API does not distinguish a confirmed match from
+/// `BudgetExhausted` — use [`brenk_matches_checked`] for that distinction.
 ///
 /// Brenk et al. 2008 structural alerts for drug design (J. Med. Chem. 51, 5149–5171).
 /// These patterns identify problematic functional groups and structural features.
@@ -2245,10 +2251,34 @@ fn heavy_atoms_from_matches(
 }
 
 /// Shared implementation: scan `patterns` against `mol` and return matching
-/// alert names with their heavy-atom indices.
+/// alert names with their heavy-atom indices. Always uses the real
+/// production budget ([`ALERT_MAX_VISIT_BUDGET`]) — see
+/// [`matches_detailed_impl_with_budget`] for the budget-injectable version
+/// tests use to exercise the "found some, then cut off" case deterministically
+/// and near-instantly.
+///
+/// **Budget exhaustion note:** an entry with an empty `atom_indices` vec can
+/// mean one of two things — see the public doc comments on
+/// [`pains_matches_detailed`]/[`brenk_matches_detailed`] for the caller-facing
+/// contract. In particular, when the search is cut off before enumeration
+/// completes, any embeddings collected *before* the cutoff are discarded
+/// rather than returned as a silently-incomplete highlight set.
 fn matches_detailed_impl(
     mol: &Molecule,
     patterns: &'static [(&'static str, QueryMolecule)],
+) -> Vec<(&'static str, Vec<AtomIdx>)> {
+    matches_detailed_impl_with_budget(mol, patterns, ALERT_MAX_VISIT_BUDGET)
+}
+
+/// Like [`matches_detailed_impl`], but with an injectable visit budget. Lets
+/// tests deterministically force the "some embeddings were collected, then
+/// the budget ran out mid-enumeration" case (a non-zero but insufficient
+/// budget) without needing a real pathological molecule and the real (slow)
+/// production budget.
+fn matches_detailed_impl_with_budget(
+    mol: &Molecule,
+    patterns: &'static [(&'static str, QueryMolecule)],
+    budget: u64,
 ) -> Vec<(&'static str, Vec<AtomIdx>)> {
     let mol_h = add_explicit_hs(mol);
     let rings = find_sssr(&mol_h);
@@ -2257,7 +2287,7 @@ fn matches_detailed_impl(
     // safety net as the existence-only variants above, so a pathological
     // symmetric target fails fast instead of hanging.
     let config = MatchConfig {
-        max_visit_budget: Some(ALERT_MAX_VISIT_BUDGET),
+        max_visit_budget: Some(budget),
         ..Default::default()
     };
     patterns
@@ -2265,13 +2295,21 @@ fn matches_detailed_impl(
         .filter_map(|(name, q)| {
             let (ms, budget_exhausted) =
                 find_matches_with_rings_and_config_checked(q, &mol_h, &rings, &config);
-            if ms.is_empty() {
-                // Same fail-safe policy as the existence-only functions above:
-                // a budget cutoff is reported as present (empty highlight set,
-                // since no embedding was collected before the cutoff), never
-                // silently dropped like a confirmed non-match.
-                return budget_exhausted.then(|| (*name, Vec::new()));
+
+            if budget_exhausted {
+                // Enumeration is incomplete -- whatever embeddings were
+                // collected before the cutoff are NOT the full match set, so
+                // they must never be returned as though they were exhaustive.
+                // Same fail-safe policy as the existence-only functions
+                // above: a budget cutoff is reported as present (flagged),
+                // never silently dropped like a confirmed non-match.
+                return Some((*name, Vec::new()));
             }
+
+            if ms.is_empty() {
+                return None;
+            }
+
             Some((*name, heavy_atoms_from_matches(&ms, &mol_h)))
         })
         .collect()
@@ -2279,10 +2317,19 @@ fn matches_detailed_impl(
 
 /// Like [`pains_matches`] but also returns the matched heavy-atom indices.
 ///
-/// Returns `Vec<(name, atom_indices)>` — one entry per triggered alert.
-/// The `atom_indices` identify the heavy atoms in `mol` that are part of the
+/// Returns `Vec<(name, atom_indices)>` — one entry per triggered alert. The
+/// `atom_indices` identify the heavy atoms in `mol` that are part of the
 /// problematic substructure, suitable for use with
 /// `chematic_depict::render_svg_highlighted`.
+///
+/// **An entry with an empty `atom_indices` vec means that alert rule's
+/// search was cut off by the VF2 visit budget before enumeration could
+/// complete** — not a normal match with zero atoms. Non-empty indices are
+/// only ever returned when enumeration ran to completion. Callers must not
+/// interpret an empty vec as "matched, but no atoms to highlight"; treat it
+/// the same as any other flagged-but-unresolved alert (see
+/// [`pains_matches_checked`] for the equivalent distinction on the coarser
+/// existence-only API).
 pub fn pains_matches_detailed(mol: &Molecule) -> Vec<(&'static str, Vec<AtomIdx>)> {
     matches_detailed_impl(mol, compiled_pains_patterns())
 }
@@ -2290,6 +2337,12 @@ pub fn pains_matches_detailed(mol: &Molecule) -> Vec<(&'static str, Vec<AtomIdx>
 /// Like [`brenk_matches`] but also returns the matched heavy-atom indices.
 ///
 /// Returns `Vec<(name, atom_indices)>` — one entry per triggered alert.
+///
+/// **An entry with an empty `atom_indices` vec means that alert rule's
+/// search was cut off by the VF2 visit budget before enumeration could
+/// complete** — not a normal match with zero atoms. Non-empty indices are
+/// only ever returned when enumeration ran to completion. See
+/// [`pains_matches_detailed`] for the full explanation.
 pub fn brenk_matches_detailed(mol: &Molecule) -> Vec<(&'static str, Vec<AtomIdx>)> {
     matches_detailed_impl(mol, compiled_brenk_patterns())
 }
@@ -2509,6 +2562,44 @@ mod tests {
             fold_conservative(checked).contains(&"tert_butyl_B(1)"),
             "BudgetExhausted must fold into the flagged/alert side, never \
              silently dropped as if NotFound"
+        );
+    }
+
+    /// Regression test for a real bug: `matches_detailed_impl` used to check
+    /// `ms.is_empty()` before `budget_exhausted`, so when the search found
+    /// *some* embeddings before the budget ran out, it returned those
+    /// partial embeddings as though they were the complete, exhaustive match
+    /// set -- silently misrepresenting an incomplete highlight set as a full
+    /// one.
+    ///
+    /// `budget: 3` against benzene's 6-fold-symmetric `c` query
+    /// deterministically finds 2 (of 6 possible) embeddings before
+    /// exhausting -- empirically verified: budget 0-1 -> 0 matches
+    /// (exhausted), budget 2 -> 1 (exhausted), budget 3 -> 2 (exhausted), ...,
+    /// budget 7+ -> all 6 (not exhausted). Budget 3 is exactly the "found
+    /// some, not all" case the fix targets, deterministically and
+    /// near-instantly (benzene is tiny; no real backtracking search needed).
+    #[test]
+    fn matches_detailed_never_returns_partial_highlights_on_budget_exhaustion() {
+        let benzene = mol("c1ccccc1");
+        let query = parse_smarts("c").unwrap();
+        let patterns: &'static [(&'static str, QueryMolecule)] =
+            Box::leak(vec![("test_c", query)].into_boxed_slice());
+
+        let result = matches_detailed_impl_with_budget(&benzene, patterns, 3);
+
+        assert_eq!(
+            result.len(),
+            1,
+            "the pattern must still be reported as flagged, not dropped, \
+             when its search was cut off"
+        );
+        assert_eq!(result[0].0, "test_c");
+        assert!(
+            result[0].1.is_empty(),
+            "a budget cutoff mid-enumeration must report an EMPTY highlight \
+             set, never the partial embeddings collected before the cutoff \
+             -- those are not the complete, exhaustive match"
         );
     }
 }

--- a/crates/chematic-chem/src/drug_score.rs
+++ b/crates/chematic-chem/src/drug_score.rs
@@ -110,6 +110,15 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "slow real-budget VF2 calibration (~200ms release / ~3-5s debug \
+                in isolation, but a real-budget VF2 search is a poor fit for \
+                the default suite under concurrent CI load) -- run explicitly \
+                with `cargo test -p chematic-chem --lib -- --ignored \
+                drug_score_pathological_macrocycle_does_not_hang`. The \
+                underlying budget-exhaustion-folds-to-flagged mechanism this \
+                test exercises has a fast, deterministic default-suite test \
+                in alerts.rs \
+                (checked_matches_zero_budget_is_deterministic_budget_exhausted)."]
     fn drug_score_pathological_macrocycle_does_not_hang() {
         // Regression test for the exact repro molecule from PR #137's descriptor
         // census RFC (`docs/descriptor_census_rfc.md` on `diag/descriptor-census`):
@@ -121,9 +130,13 @@ mod tests {
         // The fix adds a hard VF2 visit-budget cap (`MatchConfig::max_visit_budget`)
         // to every PAINS/Brenk match site in `alerts.rs`, on top of the existing
         // existence-only `max_matches: Some(1)` short-circuit — so a pathological
-        // symmetric target fails fast (safe "no match" within budget) instead of
-        // hanging. This test has no per-test timeout mechanism to hook into (none
-        // exists elsewhere in this suite), so it asserts wall-clock elapsed time
+        // symmetric target fails fast instead of hanging. A budget cutoff is
+        // never silently read as "no match": it resolves to
+        // `MatchOutcome::BudgetExhausted`, which folds into `pains_matches`'s
+        // output as if it *had* matched (fail-safe: flag when uncertain, never
+        // silently clean — see `alerts::checked_matches`/`fold_conservative`).
+        // This test has no per-test timeout mechanism to hook into (none exists
+        // elsewhere in this suite), so it asserts wall-clock elapsed time
         // directly; 30s is generous slack over the ~200ms (release) / ~5s (debug)
         // observed locally, while still catching a regression back to "hangs".
         let m =

--- a/crates/chematic-chem/src/drug_score.rs
+++ b/crates/chematic-chem/src/drug_score.rs
@@ -110,6 +110,36 @@ mod tests {
     }
 
     #[test]
+    fn drug_score_pathological_macrocycle_does_not_hang() {
+        // Regression test for the exact repro molecule from PR #137's descriptor
+        // census RFC (`docs/descriptor_census_rfc.md` on `diag/descriptor-census`):
+        // a symmetric bis-isoquinolinium macrocycle that, before this fix, drove
+        // `drug_score` -> `alerts::pains_matches` -> `match_vf2::match_recursive`
+        // into a multi-minute VF2 combinatorial blowup (confirmed via a stack
+        // sampler showing zero forward progress ~15 recursion levels deep).
+        //
+        // The fix adds a hard VF2 visit-budget cap (`MatchConfig::max_visit_budget`)
+        // to every PAINS/Brenk match site in `alerts.rs`, on top of the existing
+        // existence-only `max_matches: Some(1)` short-circuit — so a pathological
+        // symmetric target fails fast (safe "no match" within budget) instead of
+        // hanging. This test has no per-test timeout mechanism to hook into (none
+        // exists elsewhere in this suite), so it asserts wall-clock elapsed time
+        // directly; 30s is generous slack over the ~200ms (release) / ~5s (debug)
+        // observed locally, while still catching a regression back to "hangs".
+        let m =
+            mol("C1=C\\c2ccc(cc2)C[n+]2ccc(c3ccccc32)NCCCCCCCCCCNc2cc[n+](c3ccccc23)Cc2ccc/1cc2");
+        let start = std::time::Instant::now();
+        let score = drug_score(&m);
+        let elapsed = start.elapsed();
+        assert!(score.is_finite(), "drug_score must return a finite value");
+        assert!(
+            elapsed < std::time::Duration::from_secs(30),
+            "drug_score on the pathological macrocycle took {elapsed:?}, expected it to \
+             fail fast within the VF2 visit budget"
+        );
+    }
+
+    #[test]
     fn drug_score_factors_independent() {
         // Each factor function stays in [0, 1]
         for logp in [-5.0, 0.0, 2.5, 5.0, 10.0] {

--- a/crates/chematic-chem/src/lib.rs
+++ b/crates/chematic-chem/src/lib.rs
@@ -78,8 +78,9 @@ pub use admet::{
     ppb_percent,
 };
 pub use alerts::{
-    brenk_matches, brenk_matches_detailed, brenk_passes, brenk_passes_and_matches, pains_matches,
-    pains_matches_detailed, pains_passes, pains_passes_and_matches,
+    brenk_matches, brenk_matches_checked, brenk_matches_detailed, brenk_passes,
+    brenk_passes_and_matches, pains_matches, pains_matches_checked, pains_matches_detailed,
+    pains_passes, pains_passes_and_matches,
 };
 pub use atropisomer::{AtropisomerType, assign_atropisomer_chirality, detect_atropisomers};
 pub use brics::{BricsConfig, brics_bonds, brics_fragments, brics_fragments_with_config};

--- a/crates/chematic-smarts/src/lib.rs
+++ b/crates/chematic-smarts/src/lib.rs
@@ -17,8 +17,9 @@ pub mod query;
 pub use cache::{SmartsCache, named_pattern};
 pub use cx::{CxQueryAtomProp, CxSmarts, parse_cxsmarts};
 pub use match_vf2::{
-    MatchConfig, find_matches, find_matches_with_config, find_matches_with_rings,
-    find_matches_with_rings_and_config,
+    MatchConfig, MatchOutcome, find_matches, find_matches_with_config, find_matches_with_rings,
+    find_matches_with_rings_and_config, find_matches_with_rings_and_config_checked,
+    has_match_bounded,
 };
 pub use mcs::{AtomCompare, BondCompare, McsConfig, find_mcs, find_mcs_with_config};
 pub use parser::{SmartsError, parse_smarts};

--- a/crates/chematic-smarts/src/match_vf2.rs
+++ b/crates/chematic-smarts/src/match_vf2.rs
@@ -36,6 +36,15 @@ struct EvalCtx<'a> {
     /// recursive-SMARTS `$(...)`).  Decremented on every `match_recursive` /
     /// `has_match_recursive` entry.  `u64::MAX` when no limit is configured.
     visit_budget: std::cell::Cell<u64>,
+    /// Set to `true` the moment a recursive call is abandoned because
+    /// `visit_budget` was already at zero (see the early-exit branches in
+    /// `match_recursive` / `has_match_recursive`). This is the ONLY reliable
+    /// signal that the search was cut short before it could finish exploring
+    /// the state space — a plain "did we find zero results" check cannot
+    /// distinguish a truncated search from a genuinely exhaustive one that
+    /// happened to use its very last unit of budget on its final (successful)
+    /// step. Callers must treat `true` here as "unknown", never as "no match".
+    budget_exhausted: std::cell::Cell<bool>,
     /// Lazily-computed, memoized per atom index: the size of the *smallest* SSSR
     /// ring containing that atom (`None` if the atom is in no ring). Backs `[rN]`
     /// (`AtomPrimitive::MinRingSize`) — computed at most once per `find_matches`
@@ -178,31 +187,49 @@ pub fn find_matches_with_rings(
 }
 
 /// Like [`find_matches_with_config`] but reuses a pre-computed [`RingSet`].
+///
+/// **Silent-truncation note:** if `config.max_visit_budget` is set and gets
+/// exhausted mid-search, this returns whatever partial result set it had
+/// collected so far — which may be empty even when a match actually exists.
+/// Callers that set a budget and need to tell "confirmed no match" apart from
+/// "the search was cut off" must use
+/// [`find_matches_with_rings_and_config_checked`] instead; folding the two
+/// together into a plain empty `Vec` here is the documented behaviour of this
+/// function (kept for the existing unbounded call sites), not a recommendation.
 pub fn find_matches_with_rings_and_config(
     query: &QueryMolecule,
     mol: &Molecule,
     rings: &RingSet,
     config: &MatchConfig,
 ) -> Vec<FxHashMap<usize, AtomIdx>> {
+    find_matches_with_rings_and_config_checked(query, mol, rings, config).0
+}
+
+/// Like [`find_matches_with_rings_and_config`], but also reports whether
+/// `config.max_visit_budget` was exhausted before the search finished — see
+/// [`MatchOutcome`] / [`has_match_bounded`] for the same distinction on an
+/// existence-only search.
+///
+/// When the returned `bool` is `true`, the returned `Vec` is **not**
+/// authoritative: more embeddings may exist beyond what was collected before
+/// the cutoff, and an empty `Vec` does not mean no match exists. Callers must
+/// not treat `(vec![], true)` the same as `(vec![], false)`.
+pub fn find_matches_with_rings_and_config_checked(
+    query: &QueryMolecule,
+    mol: &Molecule,
+    rings: &RingSet,
+    config: &MatchConfig,
+) -> (Vec<FxHashMap<usize, AtomIdx>>, bool) {
     if query.atoms.is_empty() {
-        return vec![];
+        return (vec![], false);
     }
     // A query with more heavy atoms than the target can never match (RDKit PR #9201).
     if query.atoms.len() > mol.atom_count() {
-        return vec![];
+        return (vec![], false);
     }
 
-    let ctx = EvalCtx {
-        mol,
-        rings,
-        config,
-        visit_budget: std::cell::Cell::new(config.max_visit_budget.unwrap_or(u64::MAX)),
-        min_ring_size_by_atom: std::cell::RefCell::new(None),
-    };
-    let mut mapping: FxHashMap<usize, AtomIdx> = FxHashMap::default();
-    let mut results: Vec<FxHashMap<usize, AtomIdx>> = Vec::new();
-
-    match_recursive(query, &ctx, &mut mapping, &mut results, config.max_matches);
+    let (mut results, budget_exhausted) =
+        run_match_recursive(query, mol, rings, config, config.max_matches);
 
     // Deduplicate matches: keep only one mapping per unique set of target atoms.
     if config.uniquify {
@@ -214,7 +241,84 @@ pub fn find_matches_with_rings_and_config(
         });
     }
 
-    results
+    (results, budget_exhausted)
+}
+
+/// Outcome of an existence-only VF2 search bounded by
+/// `MatchConfig::max_visit_budget` — see [`has_match_bounded`].
+///
+/// The whole point of this type is that `BudgetExhausted` must never be
+/// treated as `NotFound`: a cut-off search has not ruled anything out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchOutcome {
+    /// At least one embedding was found.
+    Found,
+    /// The search explored the whole state space (within budget) and
+    /// confirmed no embedding exists.
+    NotFound,
+    /// `max_visit_budget` was exhausted before the search could find a match
+    /// or rule one out. A match may still exist — this is a distinct,
+    /// explicit "unknown", not a negative.
+    BudgetExhausted,
+}
+
+/// Existence-only VF2 search: stops at the first embedding instead of
+/// enumerating, and returns a [`MatchOutcome`] that keeps "confirmed no
+/// match" distinguishable from "the visit budget ran out before this could
+/// be resolved".
+///
+/// Prefer this over `find_matches_with_rings_and_config(..).is_empty()`
+/// whenever a caller only needs a yes/no per query (e.g. PAINS/Brenk
+/// structural alerts: "does pattern X match at least once") *and* sets
+/// `max_visit_budget` — the plain `is_empty()` check cannot tell a budget
+/// cutoff apart from a genuine negative, silently turning a "don't know"
+/// into "no alert".
+pub fn has_match_bounded(
+    query: &QueryMolecule,
+    mol: &Molecule,
+    rings: &RingSet,
+    config: &MatchConfig,
+) -> MatchOutcome {
+    if query.atoms.is_empty() {
+        return MatchOutcome::NotFound;
+    }
+    if query.atoms.len() > mol.atom_count() {
+        return MatchOutcome::NotFound;
+    }
+    let (results, budget_exhausted) = run_match_recursive(query, mol, rings, config, Some(1));
+    if !results.is_empty() {
+        MatchOutcome::Found
+    } else if budget_exhausted {
+        MatchOutcome::BudgetExhausted
+    } else {
+        MatchOutcome::NotFound
+    }
+}
+
+/// Shared driver behind [`find_matches_with_rings_and_config_checked`] and
+/// [`has_match_bounded`]: builds the per-call [`EvalCtx`], runs
+/// [`match_recursive`], and reports whether the visit budget was exhausted.
+fn run_match_recursive(
+    query: &QueryMolecule,
+    mol: &Molecule,
+    rings: &RingSet,
+    config: &MatchConfig,
+    max: Option<usize>,
+) -> (Vec<FxHashMap<usize, AtomIdx>>, bool) {
+    let ctx = EvalCtx {
+        mol,
+        rings,
+        config,
+        visit_budget: std::cell::Cell::new(config.max_visit_budget.unwrap_or(u64::MAX)),
+        budget_exhausted: std::cell::Cell::new(false),
+        min_ring_size_by_atom: std::cell::RefCell::new(None),
+    };
+    let mut mapping: FxHashMap<usize, AtomIdx> = FxHashMap::default();
+    let mut results: Vec<FxHashMap<usize, AtomIdx>> = Vec::new();
+
+    match_recursive(query, &ctx, &mut mapping, &mut results, max);
+
+    (results, ctx.budget_exhausted.get())
 }
 
 // ---------------------------------------------------------------------------
@@ -241,6 +345,7 @@ fn match_recursive(
     // Decrement shared visit budget; stop if exhausted.
     let remaining = ctx.visit_budget.get();
     if remaining == 0 {
+        ctx.budget_exhausted.set(true);
         return;
     }
     ctx.visit_budget.set(remaining - 1);
@@ -497,6 +602,7 @@ fn has_match_recursive(
     // — only enabled when max_visit_budget is explicitly set).
     let remaining = ctx.visit_budget.get();
     if remaining == 0 {
+        ctx.budget_exhausted.set(true);
         return false;
     }
     ctx.visit_budget.set(remaining - 1);
@@ -777,6 +883,89 @@ mod tests {
         // With zero budget the search returns immediately — may or may not find a match.
         // Just verify it does not panic.
         let _ = m;
+    }
+
+    // ── MatchOutcome / has_match_bounded: budget-exhaustion must be a
+    // distinct, non-negative outcome, never silently folded into "no match" ──
+
+    #[test]
+    fn has_match_bounded_found_with_generous_budget() {
+        let mol = parse("CCO").unwrap();
+        let q = parse_smarts("O").unwrap();
+        let rings = find_sssr(&mol);
+        let config = MatchConfig {
+            max_visit_budget: Some(10_000),
+            ..MatchConfig::default()
+        };
+        assert_eq!(
+            has_match_bounded(&q, &mol, &rings, &config),
+            MatchOutcome::Found
+        );
+    }
+
+    #[test]
+    fn has_match_bounded_not_found_is_exhaustive_not_a_guess() {
+        let mol = parse("CC").unwrap(); // no oxygen anywhere
+        let q = parse_smarts("O").unwrap();
+        let rings = find_sssr(&mol);
+        let config = MatchConfig {
+            max_visit_budget: Some(10_000),
+            ..MatchConfig::default()
+        };
+        assert_eq!(
+            has_match_bounded(&q, &mol, &rings, &config),
+            MatchOutcome::NotFound
+        );
+    }
+
+    #[test]
+    fn has_match_bounded_zero_budget_is_indeterminate_not_not_found() {
+        // The pattern genuinely matches (CCO contains O), but a budget of 0
+        // means the search never gets to look. The result MUST be
+        // `BudgetExhausted`, never `NotFound` -- conflating the two is
+        // exactly the silent-false-negative bug this API exists to prevent.
+        let mol = parse("CCO").unwrap();
+        let q = parse_smarts("O").unwrap();
+        let rings = find_sssr(&mol);
+        let config = MatchConfig {
+            max_visit_budget: Some(0),
+            ..MatchConfig::default()
+        };
+        assert_eq!(
+            has_match_bounded(&q, &mol, &rings, &config),
+            MatchOutcome::BudgetExhausted
+        );
+    }
+
+    #[test]
+    fn find_matches_with_rings_and_config_checked_reports_exhaustion() {
+        let mol = parse("CCO").unwrap();
+        let q = parse_smarts("O").unwrap();
+        let rings = find_sssr(&mol);
+
+        // Generous budget: real match, not exhausted.
+        let generous = MatchConfig {
+            max_visit_budget: Some(10_000),
+            ..MatchConfig::default()
+        };
+        let (matches, exhausted) =
+            find_matches_with_rings_and_config_checked(&q, &mol, &rings, &generous);
+        assert!(!matches.is_empty());
+        assert!(!exhausted);
+
+        // Zero budget: a match exists but the search never ran -- must be
+        // reported as exhausted, not silently equivalent to a real negative.
+        let starved = MatchConfig {
+            max_visit_budget: Some(0),
+            ..MatchConfig::default()
+        };
+        let (matches, exhausted) =
+            find_matches_with_rings_and_config_checked(&q, &mol, &rings, &starved);
+        assert!(matches.is_empty());
+        assert!(
+            exhausted,
+            "zero budget must be reported as exhausted, not as a confirmed negative"
+        );
     }
 
     // ── RDKit PR #9201: query > target early exit ─────────────────────────────


### PR DESCRIPTION
## Declaration

- **Branch:** `fix/pains-vf2-existence-only-cap`, forked from `main`@`659baca221f71f135ce0e1780e71245d8770f132`, rebased onto `main`@`80c346df31fb39f836aeebee1c1519e25c82c3bd` (post-#131) after review — no conflicts (#131 touched `chematic-core`/`chematic-perception`, unrelated to this PR's files).
- **Files touched:**
  - `crates/chematic-smarts/src/match_vf2.rs` — new `MatchOutcome` enum + `has_match_bounded` (existence-only, budget-bounded) + `find_matches_with_rings_and_config_checked` (enumeration variant that also reports budget exhaustion) + `budget_exhausted` tracking in `EvalCtx`. `find_matches_with_rings_and_config`'s signature is unchanged (now a thin wrapper) — every existing caller elsewhere in the codebase (`standardize.rs`, `chematic-wasm`) is untouched.
  - `crates/chematic-smarts/src/lib.rs` — re-export the three new symbols.
  - `crates/chematic-chem/src/alerts.rs` — PAINS/Brenk matching rebuilt on `has_match_bounded`; new `pains_matches_checked`/`brenk_matches_checked`; `matches_detailed_impl` uses the checked enumeration variant; new `checked_matches_with_budget` (budget-injectable helper, review-requested — see Test structure below); regression tests pinning the accepted di-tert-butylphenol tradeoff, both real-budget (`#[ignore]`d) and fast/deterministic.
  - `crates/chematic-chem/src/lib.rs` — re-export the two new `_checked` functions.
  - `crates/chematic-chem/src/drug_score.rs` — regression test only, now `#[ignore]`d with a fast alerts.rs replacement (see below); no production logic change — `f_tox` already inherits the fix by calling the existing `pains_matches`/`brenk_matches`.
- **Explicitly out of scope, not touched:** `crates/chematic-perception/**`, `crates/chematic-core/**` (incl. anything stereo-related), `crates/chematic-py/**` (existing `pains_matches_detailed`/`brenk_matches_detailed` Python bindings keep their current 2-tuple shape unchanged), `standardize.rs`'s `SaltCatalog::is_salt` and `chematic-wasm`'s SMARTS entry points (pre-existing, separately-documented budget-cap users — not this task's scope), symmetry-aware VF2 match ordering (the real fix for the false-positive class documented below — a separate, larger project, noted as follow-up only), and every other in-flight branch/PR (`feat/io-mrv`, `feat/io-tdt`, `feat/io-smiles-supplier-writer`, `fix/smiles-bracket-implicit-h`, `diag/stereo-reader-integration-boundary`, `feat/stereo2d-local-parity`, `diag/aromaticity-rdkit-parity`, `diag/canonical-smiles-residual`, `diag/etkdg-3d-gap`, `diag/accurate-cip-audit`, `diag/ecfp4-bitexact-api`, `diag/descriptor-census`).
- **Deliverables:** the `match_vf2.rs`/`alerts.rs` fix, four regression tests (2 real-budget `#[ignore]`d calibration tests + 2 fast default-suite tests), this PR.
- **Stop condition:** `bash scripts/check.sh` and the full workspace test suite pass; PR opened against `main`; no merge.
- **API/design note:** the three-state `MatchOutcome`/fail-safe-fold design and the production `ALERT_MAX_VISIT_BUDGET = 1_000_000` constant are unchanged from the coordinator's prior approval — this update is test-structure-only (see "Test structure" below) plus a doc-comment fix.

## Root cause

PR #137's descriptor-census RFC (`diag/descriptor-census:docs/descriptor_census_rfc.md`) found a real multi-minute hang in `Mol.descriptors()`. Stack trace at the point of the hang:

```
Mol.descriptors() -> chematic_chem::drug_score::drug_score
                   -> chematic_chem::alerts::pains_matches
                   -> chematic_smarts::match_vf2::find_matches_with_rings_and_config
                   -> match_vf2::match_recursive  (recursed ~15 levels deep, zero forward progress)
```

Repro molecule (a symmetric bis-isoquinolinium macrocycle):

```
C1=C\c2ccc(cc2)C[n+]2ccc(c3ccccc32)NCCCCCCCCCCNc2cc[n+](c3ccccc23)Cc2ccc/1cc2
```

`chematic_smarts::match_vf2` already had an existence-only short-circuit (`max_matches: Some(1)`, added in #63) wired into every PAINS/Brenk function — so "does this pattern match at least once" was already satisfied. What was missing: a hard ceiling on how much VF2 backtracking a single pattern's existence search can do. Existence-only stops enumerating *after* a match is found; on a highly symmetric target it can still explore an exponential number of dead-end branches while *searching* for that first match, or while proving none exists.

## Fix, and the correctness property that shaped its final shape

First pass: added a `max_visit_budget` cap (an existing `chematic-smarts` facility, already used the same way by `standardize::SaltCatalog::is_salt` and `chematic-wasm`) to every PAINS/Brenk `MatchConfig` in `alerts.rs`. That alone would have been enough to stop the hang, but it has a latent correctness bug: `match_vf2`'s existing budget mechanism (`EvalCtx::visit_budget`) has no way to tell "the search proved no match exists" apart from "the search was cut off before it could tell" — both come back as an empty `Vec`. Folding a budget cutoff into "no match" turns a hang into a silent false negative: a real PAINS hit could go unreported with no signal that anything was uncertain.

Fixed at the root, in `match_vf2.rs`:

- `EvalCtx` gained a `budget_exhausted: Cell<bool>`, set only in the exact branch where a recursive call is abandoned because the budget was *already* zero on entry (`match_recursive` and `has_match_recursive`, both — the latter backs recursive-SMARTS `$(...)`, which shares the same budget). This is deliberately not "did we find zero results" or "is remaining budget zero after the call" — either of those is ambiguous when a search happens to finish its last useful step on its very last unit of budget. The flag is only ever set at the moment a call is turned away empty-handed, which is unambiguous.
- New `MatchOutcome { Found, NotFound, BudgetExhausted }` and `has_match_bounded(query, mol, rings, config) -> MatchOutcome`: an existence-only search (stops at the first embedding) that returns the real three-way outcome instead of a boolean.
- New `find_matches_with_rings_and_config_checked(..) -> (Vec<...>, bool)`: same as the existing enumeration function, plus the exhaustion flag, for the one call site (`matches_detailed_impl`, backing the atom-highlighting `pains_matches_detailed`/`brenk_matches_detailed`) that must enumerate every embedding rather than stop at one.
- `find_matches_with_rings_and_config`'s public signature is untouched — it's now a thin wrapper discarding the second element of the checked variant's tuple. Every existing caller outside this PR (including `standardize.rs`'s `is_salt` and `chematic-wasm`'s SMARTS entry points, which also set `max_visit_budget`) is behaviourally identical to before; their pre-existing, separately-documented "budget cutoff reads as false" tradeoff is untouched, not newly introduced by this PR.

In `alerts.rs`, every PAINS/Brenk function is rebuilt on top of `has_match_bounded`:

- `pains_matches_checked`/`brenk_matches_checked` (new, public): `Vec<(&'static str, MatchOutcome)>` — the real three-way signal, one entry per *rule*, never per embedding.
- `pains_matches`/`brenk_matches`/`pains_passes`/`brenk_passes`/`pains_passes_and_matches`/`brenk_passes_and_matches` (existing signatures, unchanged): now thin folds over the checked result. Since a plain `Vec<&str>` / `bool` genuinely cannot carry three states, they make an explicit, documented, fail-safe choice — `BudgetExhausted` counts as "alert present" alongside `Found`, never silently as clean. `drug_score`'s `f_tox` calls these unchanged functions, so it inherits this fail-safe fold automatically without any change to `drug_score.rs`'s production code.
- `matches_detailed_impl` (backs the atom-highlighting API): uses the checked enumeration variant; a pattern whose search was cut short is always surfaced (name present, empty highlight set) rather than silently dropped — **including when the search had already collected some (but not all) embeddings before the cutoff** (fixed in review — see "Second review round" below; the highlight set is only ever non-empty when enumeration ran to completion).

## Known, accepted limitation: false positives on symmetric-but-ordinary scaffolds

Verifying against a 1,000-molecule ChEMBL sample (see Verification) surfaced a second, independent pathological case: `CC(C)(C)c1cc(C(=O)/C=C/c2ccsc2)cc(C(C)(C)C)c1O`, a 2,6-di-tert-butylphenol (BHT-class antioxidant) with a thienyl chalcone substituent — an **ordinary, common drug-like scaffold**, not an exotic macrocycle. Its two tert-butyl groups give the `tert_butyl_B(1)` PAINS pattern's search enough local symmetry (3 equivalent methyls per tert-butyl, 3 equivalent H's per methyl, both tert-butyl groups symmetric under the ring) to blow up VF2 the same general way the reported macrocycle does — this time via gem-dimethyl/tert-butyl symmetry rather than ring symmetry.

Verified against the true unpatched (no budget at all) baseline: the correct answer is `NotFound` — `tert_butyl_B` genuinely does not match this molecule — but proving that takes **~19s**. At the shipped budget (1,000,000 visits), the search hasn't resolved either way when the cutoff hits: this is `MatchOutcome::BudgetExhausted`, which folds into `pains_matches()`'s output exactly like a real `Found` (per the fail-safe policy above). Concretely, for this molecule: `pains_matches` reports a `tert_butyl_B(1)` PAINS hit that doesn't really exist, and `drug_score::f_tox` (which multiplies by 0.5 per PAINS hit) **halves its `drug_score`**.

**The tradeoff, explicitly:** no fixed budget is simultaneously fast, correct, and bounded for this class of structure. A higher budget (confirmed: 20,000,000 resolves this specific case to the correct `NotFound`) trades the current ~1s false positive for a ~20s true negative — and offers no guarantee some other real molecule doesn't need even more. **Decision (confirmed by the coordinator): ship with 1,000,000, keep the false positive.** Rationale: fast, never silently folds an unresolved search into "clean", and "flag when uncertain" is the pre-authorized safe-fallback behavior for exactly this situation — a false positive that a human/downstream filter can review is preferable to either a multi-second-to-tens-of-seconds cost on every call touching a symmetric scaffold, or a silent false negative. The originally-reported macrocycle is unaffected either way — it already resolves comfortably (150ms–5s) within this budget.

**Follow-up, explicitly out of scope for this PR:** the real fix is symmetry-aware VF2 match ordering (detecting and pruning automorphic branches before they're independently re-explored), which would eliminate this false-positive class without the ~20s cost. That's a separate, larger algorithmic project and is not attempted here.

## Test structure (updated after review)

Both real-molecule regression tests exercise the actual production `ALERT_MAX_VISIT_BUDGET` (1,000,000) — fine individually (~200ms-5s and ~25-35s respectively) but a bad fit for the default `cargo test`/`scripts/check.sh` path: permanent added latency, and a real-budget VF2 backtrack is exactly the kind of CPU-bound work that gets slower and more flake-prone under concurrent CI load. Per review, they're now split into a slow, on-demand calibration test and a fast, deterministic default-suite test each:

| Real-budget calibration (`#[ignore]`d, run on demand) | Fast default-suite replacement |
|---|---|
| `drug_score.rs::drug_score_pathological_macrocycle_does_not_hang` — the RFC's exact repro SMILES through the real `drug_score()`/`ALERT_MAX_VISIT_BUDGET` path. ~200ms release / ~3-5s debug in isolation. | Covered by `alerts.rs`'s fast test (below) plus the pre-existing fast `drug_score_*` tests — the budget/fold mechanism `drug_score` depends on is exercised without waiting on this specific molecule. |
| `alerts.rs::test_pains_di_tert_butylphenol_is_accepted_false_positive` — pins the accepted tradeoff: `tert_butyl_B(1)` resolves to `BudgetExhausted` (not `Found`/`NotFound`) on the real molecule at the real budget, folds into `pains_matches()`, completes within 90s. ~25-35s debug. | `alerts.rs::checked_matches_zero_budget_is_deterministic_budget_exhausted` — same real molecule/pattern pair, but via the new `checked_matches_with_budget(mol, patterns, budget)` helper with `budget: 0`. The very first VF2 visit is already abandoned (`match_vf2::match_recursive`'s early-exit branch fires immediately), so the outcome is deterministically `BudgetExhausted`, near-instant, and asserts the actual thing that matters — the fold to "flagged", never silently to "no match" — without needing the real (slow) budget. |

`checked_matches_with_budget` is `checked_matches`'s existing body parameterized on budget instead of the hardcoded constant; `checked_matches` (used by every production call site) is now a one-line wrapper calling it with `ALERT_MAX_VISIT_BUDGET` — no behavior change for any real caller.

Both `#[ignore]`d tests stay in the codebase, runnable on demand, one at a time:

```
cargo test -p chematic-chem --lib \
  drug_score_pathological_macrocycle_does_not_hang \
  -- --ignored --exact

cargo test -p chematic-chem --lib \
  test_pains_di_tert_butylphenol_is_accepted_false_positive \
  -- --ignored --exact
```

Also fixed in this pass: a stale comment in `drug_score.rs`'s (now-ignored) macrocycle test described the design backwards — it said a budget cutoff was a "safe 'no match' within budget"; the actual shipped design conservatively folds `BudgetExhausted` into "alert present" (flagged), never into "no match"/clean.

## Second review round: one real bug + doc-comment corrections

- **Real bug, fixed:** `matches_detailed_impl` (backing `pains_matches_detailed`/`brenk_matches_detailed`) checked `ms.is_empty()` *before* `budget_exhausted`. So whenever the search collected ≥1 embedding before the budget ran out mid-enumeration, it returned those partial embeddings as the complete highlight set — silently presenting an incomplete result as exhaustive, for an API whose whole point is enumerating every embedding. Fixed by checking `budget_exhausted` first (unconditional early return with an empty highlight vec on exhaustion, regardless of how many embeddings were already collected). New deterministic regression test: `matches_detailed_impl_with_budget` (same budget-injectable shape as `checked_matches`/`checked_matches_with_budget`) with `budget: 3` against benzene's 6-fold-symmetric `c` query collects exactly 2 of 6 embeddings before exhausting (verified empirically across budgets 0–100) — the exact "found some, not all" case, deterministic and near-instant. Verified the test actually catches the bug by temporarily reverting the fix and confirming it fails, then restored. `pains_matches_detailed`/`brenk_matches_detailed`'s public doc comments now explicitly state that an empty `atom_indices` vec means the search was cut off by the budget (not a real zero-atom match), and non-empty indices are only ever returned when enumeration completed.
- **Doc fix:** `checked_matches_with_budget`'s comment overclaimed `budget: 0` forces `BudgetExhausted` "regardless of molecule or pattern" — false, since `has_match_bounded`'s structural early exits (e.g. query bigger than target) return `NotFound` without ever consuming budget. Corrected.
- **Doc fix:** `pains_matches`/`brenk_matches`'s comments were internally contradictory — they said both "empty vec means confirmed NotFound" and "can't distinguish confirmed-clean from unresolved". An empty vec IS unambiguously confirmed-clean (`BudgetExhausted` patterns are included by name in the vec); the real ambiguity is only for a *returned* name (can't tell `Found` from `BudgetExhausted` there without `pains_matches_checked`/`brenk_matches_checked`). Corrected on both.

No change to `MatchOutcome`, the fail-safe fold policy, or `ALERT_MAX_VISIT_BUDGET = 1,000,000` from this round either.

## Verification

- **`chematic-smarts` unit tests** (`match_vf2.rs`, 4 new, 151 total in the crate, all passing): lock in that `has_match_bounded`/`find_matches_with_rings_and_config_checked` return `BudgetExhausted` — never `NotFound` — when a real match exists but the budget is `0`, and `Found`/`NotFound` correctly otherwise. Deterministic and fast (budget=0 forces exhaustion on demand).
- **Honesty note on the originally-reported molecule:** measured directly (both the true unpatched `main@659baca` baseline and the final patched code), calling `pains_matches`/`drug_score` on the macrocycle SMILES alone does *not* reproduce a multi-minute hang in this environment — it resolves in well under a budget of 1,000,000 visits either way (confirmed empirically: 0/478 patterns hit `BudgetExhausted` on it). The RFC's "several minutes" most likely describes the full `Mol.descriptors()` ~195-key computation (of which `drug_score`/`pains_matches` is one part caught mid-sample by the stack sampler) and/or a debug (non-`--release`) Python extension build — and the di-tert-butylphenol finding above shows the "several minutes" attribution is very plausible even without this exact macrocycle, since ordinary molecules can independently cost tens of seconds. Either way, the fix targets exactly the call path and mechanism the RFC's stack trace named, and the deterministic `match_vf2.rs` unit tests prove the safety net works when a budget genuinely runs out, independent of which molecule trips it.
- **No regression on well-behaved molecules:** all 12 pre-existing PAINS/Brenk tests in `alerts.rs` pass unchanged. Diffed `pains_matches`/`brenk_matches`/`pains_matches_detailed`/`brenk_matches_detailed` at the shipped budget (1,000,000) vs. a 20x higher budget (20,000,000) across a full 1,000-molecule sample of the 5,000-molecule ChEMBL corpus from `diag/descriptor-census:scripts/descriptor_census_corpus.smi` (read via `git show`, not merged/copied into this branch, per "reuse, don't build a new one"): **exactly one difference in 1,000 molecules** — the di-tert-butylphenol case documented above (which is a lower bound on the true rate: any molecule needing *more* than 20,000,000 visits would show `BudgetExhausted` at both budgets and look identical in this diff while still being wrong).
- `cargo test -p chematic-smarts --lib` (151 tests, ~0.03s) and `cargo test -p chematic-chem --lib` (708 tests incl. 3 new fast tests, 4 ignored, ~1.7s) all pass — default suite is fast, no 25-80s tests in the critical path.
- Both `#[ignore]`d real-budget tests re-run explicitly and confirmed passing (35.43s combined, this round).
- `bash scripts/check.sh` passes end-to-end (~92s: fmt, clippy -D warnings, workspace lib+integration tests, cargo-deny, publish graph, version consistency).
