### PR TITLE
fix(smiles): don't emit /\ for a standalone wedge bond with no adjacent double bond

### DIFF
--- a/crates/chematic-smiles/src/canonical.rs
+++ b/crates/chematic-smiles/src/canonical.rs
@@ -20,7 +20,7 @@ use std::collections::{HashMap, HashSet};
 
 use chematic_core::{AtomIdx, BondIdx, BondOrder, Chirality, Molecule, STEREO_H_SENTINEL};
 
-use crate::writer::emit_bracket_hydrogens;
+use crate::writer::{emit_bracket_hydrogens, suppress_standalone_wedge};
 
 /// Return the atom indices sorted into canonical (Morgan-rank) order.
 ///
@@ -657,6 +657,7 @@ impl<'a> CanonicalWriter<'a> {
         if let Some(rings) = self.atom_ring_nums.remove(&atom) {
             for (rn, bond_order, _partner, bidx) in rings {
                 let bond_order = self.normalize_ez(bidx, bond_order);
+                let bond_order = suppress_standalone_wedge(self.mol, bidx, bond_order);
                 let atom_arom = self.mol.atom(atom).aromatic;
                 if !(bond_order == BondOrder::Aromatic && atom_arom)
                     && bond_order != BondOrder::Single
@@ -727,6 +728,7 @@ impl<'a> CanonicalWriter<'a> {
             // (lower-rank) children have already fully recursed by the time
             // a later sibling's direction is decided.
             let bond_order = self.normalize_ez(bidx, bond_order);
+            let bond_order = suppress_standalone_wedge(self.mol, bidx, bond_order);
             let is_last = i == n - 1;
             let parent_arom = self.mol.atom(atom).aromatic;
             let child_arom = self.mol.atom(child).aromatic;
@@ -1786,5 +1788,163 @@ mod tests {
         o.charge = -1;
         b.add_atom(o);
         assert_eq!(canonical_smiles(&b.build()), "[OH-]");
+    }
+
+    // ── Standalone wedge/hash bond must not emit a meaningless SMILES
+    // directional token in canonical_smiles either (same fix as
+    // `writer::tests`, applied to the canonical writer's own emission
+    // sites) ──────────────────────────────────────────────────────────────
+
+    /// Minimal repro from docs/stereo2d_reader_integration_rfc.md §3: a
+    /// wedge bond with no adjacent double bond must not become `/`/`\`.
+    #[test]
+    fn canonical_standalone_solid_wedge_not_written_as_slash() {
+        let mut b = chematic_core::MoleculeBuilder::new();
+        let c = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        b.add_bond(c, f, BondOrder::Single).unwrap();
+        b.add_bond(c, cl, BondOrder::Single).unwrap();
+        let wedge_bond = b.add_bond(c, br, BondOrder::Up).unwrap();
+        let mol = b.build();
+
+        let out = canonical_smiles(&mol);
+        assert!(
+            !out.contains('/') && !out.contains('\\'),
+            "standalone solid wedge (no adjacent double bond) must not be \
+             written as a directional token: got '{out}'"
+        );
+        assert_eq!(mol.bond(wedge_bond).order, BondOrder::Up);
+
+        let mol2 = crate::parser::parse(&out).unwrap_or_else(|e| panic!("re-parse '{out}': {e}"));
+        assert_eq!(mol2.atom_count(), mol.atom_count());
+        assert_eq!(mol2.bond_count(), mol.bond_count());
+    }
+
+    /// Same shape but with a hash wedge (`BondOrder::Down`).
+    #[test]
+    fn canonical_standalone_hash_wedge_not_written_as_backslash() {
+        let mut b = chematic_core::MoleculeBuilder::new();
+        let c = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        b.add_bond(c, f, BondOrder::Single).unwrap();
+        b.add_bond(c, cl, BondOrder::Single).unwrap();
+        let wedge_bond = b.add_bond(c, br, BondOrder::Down).unwrap();
+        let mol = b.build();
+
+        let out = canonical_smiles(&mol);
+        assert!(
+            !out.contains('/') && !out.contains('\\'),
+            "standalone hash wedge (no adjacent double bond) must not be \
+             written as a directional token: got '{out}'"
+        );
+        assert_eq!(mol.bond(wedge_bond).order, BondOrder::Down);
+
+        let mol2 = crate::parser::parse(&out).unwrap_or_else(|e| panic!("re-parse '{out}': {e}"));
+        assert_eq!(mol2.atom_count(), mol.atom_count());
+        assert_eq!(mol2.bond_count(), mol.bond_count());
+    }
+
+    /// A wedge bond landing on a ring-closure edge must be suppressed
+    /// identically in the canonical writer's ring-closure emission site.
+    #[test]
+    fn canonical_standalone_wedge_on_ring_closure_bond() {
+        let mut b = chematic_core::MoleculeBuilder::new();
+        let c1 = b.add_atom(Atom::new(Element::C));
+        let c2 = b.add_atom(Atom::new(Element::C));
+        let c3 = b.add_atom(Atom::new(Element::C));
+        b.add_bond(c1, c2, BondOrder::Single).unwrap();
+        b.add_bond(c2, c3, BondOrder::Single).unwrap();
+        b.add_bond(c1, c3, BondOrder::Up).unwrap();
+        let mol = b.build();
+
+        let out = canonical_smiles(&mol);
+        assert!(
+            !out.contains('/') && !out.contains('\\'),
+            "standalone wedge on a ring-closure bond must not be written as \
+             a directional token: got '{out}'"
+        );
+        let mol2 = crate::parser::parse(&out).unwrap_or_else(|e| panic!("re-parse '{out}': {e}"));
+        assert_eq!(mol2.atom_count(), 3);
+        assert_eq!(mol2.bond_count(), 3);
+    }
+
+    /// The fix must not disturb `Atom.chirality`/`Molecule::stereo_neighbor_order`
+    /// while suppressing a standalone wedge bond's spurious token on the
+    /// same stereocenter -- mirrors `writer::tests::
+    /// test_standalone_wedge_does_not_disturb_stereocenter_chirality` for
+    /// the canonical writer's own (rank-dependent) chirality-correction path.
+    #[test]
+    fn canonical_standalone_wedge_does_not_disturb_stereocenter_chirality() {
+        let mut center = Atom::new(Element::C);
+        center.chirality = Chirality::Clockwise;
+        // Force bracket notation (h=0 still forces `[..]` without printing
+        // an `H` token) so the chirality symbol is actually emitted.
+        center.hydrogen_count = Some(0);
+        let mut b = chematic_core::MoleculeBuilder::new();
+        let c = b.add_atom(center);
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        let iodine = b.add_atom(Atom::new(Element::I));
+        b.add_bond(c, f, BondOrder::Single).unwrap();
+        b.add_bond(c, cl, BondOrder::Single).unwrap();
+        b.add_bond(c, br, BondOrder::Single).unwrap();
+        let wedge_bond = b.add_bond(c, iodine, BondOrder::Up).unwrap();
+        b.set_stereo_neighbor_order(c, vec![f.0, cl.0, br.0, iodine.0]);
+        let mol = b.build();
+
+        let out = canonical_smiles(&mol);
+        assert!(
+            !out.contains('/') && !out.contains('\\'),
+            "standalone wedge on a stereocenter's substituent must still be \
+             suppressed: got '{out}'"
+        );
+        assert!(
+            out.contains('@'),
+            "the stereocenter's own chirality symbol must still be emitted \
+             alongside the (now-suppressed) wedge bond: got '{out}'"
+        );
+
+        assert_eq!(mol.atom(c).chirality, Chirality::Clockwise);
+        assert_eq!(mol.bond(wedge_bond).order, BondOrder::Up);
+        assert_eq!(
+            mol.stereo_neighbor_order(c),
+            Some([f.0, cl.0, br.0, iodine.0].as_slice())
+        );
+    }
+
+    /// Regression guard: genuine E/Z directional markers must still be
+    /// emitted by canonical_smiles (already covered by `ez_e_stable` etc.
+    /// above; this pins the specific double-bond-adjacency mechanism the
+    /// standalone-wedge fix now gates on).
+    #[test]
+    fn canonical_genuine_ez_directional_bond_still_written() {
+        let mol = parse("F/C=C/F").unwrap();
+        let out = canonical_smiles(&mol);
+        assert!(
+            out.contains('/') || out.contains('\\'),
+            "genuine double-bond-adjacent directional marker must survive \
+             canonical_smiles(): got '{out}'"
+        );
+    }
+
+    /// The pre-existing "E/Z direction stashed on an aromatic bond" fixtures
+    /// (`parser::tests::direction_stash_*`) all involve a real exocyclic
+    /// double bond and must keep round-tripping unaffected by this fix --
+    /// exercised end-to-end here via `canonical_smiles` directly (those
+    /// tests live in parser.rs and already re-run on every `cargo test`).
+    #[test]
+    fn canonical_aromatic_stash_with_real_double_bond_still_emits_direction() {
+        let mol = parse(r"N=c1\c(O)c(O)\c1=N").unwrap();
+        let out = canonical_smiles(&mol);
+        assert!(
+            out.contains('/') || out.contains('\\'),
+            "genuine exocyclic-double-bond-adjacent aromatic stash must \
+             still emit a directional token: got '{out}'"
+        );
     }
 }

--- a/crates/chematic-smiles/src/writer.rs
+++ b/crates/chematic-smiles/src/writer.rs
@@ -23,6 +23,52 @@ pub(crate) fn emit_bracket_hydrogens(out: &mut String, mol: &Molecule, idx: Atom
     }
 }
 
+/// True when bond `bidx` shares an atom with some *other* `BondOrder::Double`
+/// bond — i.e. whether a `/`/`\` token on this bond could ever carry genuine
+/// OpenSMILES E/Z meaning. Mirrors the double-bond-adjacency test
+/// `CanonicalWriter::build_ez_groups` uses to collect real E/Z side bonds,
+/// just queried per-bond instead of built as a whole-molecule group.
+pub(crate) fn flanks_double_bond(mol: &Molecule, bidx: BondIdx) -> bool {
+    let bond = mol.bond(bidx);
+    [bond.atom1, bond.atom2].into_iter().any(|endpoint| {
+        mol.neighbors(endpoint)
+            .any(|(_, nb)| nb != bidx && mol.bond(nb).order == BondOrder::Double)
+    })
+}
+
+/// Demote a `BondOrder::Up`/`Down` bond to `Single` for writer-emission
+/// purposes when it does not flank a double bond.
+///
+/// `Up`/`Down` is overloaded in `chematic_core` for two unrelated concepts:
+/// 2D wedge/hash depiction (tetrahedral stereocenter drawing, set by
+/// MDL/CDXML/MRV/KET-style readers) and the OpenSMILES `/`/`\` E/Z
+/// directional-bond marker (only meaningful adjacent to a double bond). A
+/// wedge/hash bond with no adjacent double bond has nothing to mark; writing
+/// `/`/`\` for it is a meaningless token that any spec-compliant SMILES
+/// parser (e.g. RDKit) silently drops on re-parse. This only changes what
+/// the writer decides to print — the bond's real `order` field on the
+/// `Molecule` is never touched, so wedge/hash depiction data survives.
+///
+/// Gates on the bond's *stored* order (`mol.bond(bidx).order`), not the
+/// `order` parameter, so a SMILES-parser E/Z direction stashed on an
+/// `Aromatic`-order bond (`Molecule::bond_direction`, a separate mechanism
+/// entirely unrelated to 2D wedge readers) is never affected by this
+/// suppression — its stored order is `Aromatic`, never a literal
+/// `Up`/`Down`, so it can never match the guard below.
+pub(crate) fn suppress_standalone_wedge(
+    mol: &Molecule,
+    bidx: BondIdx,
+    order: BondOrder,
+) -> BondOrder {
+    if matches!(mol.bond(bidx).order, BondOrder::Up | BondOrder::Down)
+        && !flanks_double_bond(mol, bidx)
+    {
+        BondOrder::Single
+    } else {
+        order
+    }
+}
+
 /// Write a [`Molecule`] to a SMILES string.
 ///
 /// Disconnected fragments are joined with `.`.
@@ -122,7 +168,8 @@ impl<'a> SmilesWriter<'a> {
                 self.ring_bonds.insert(bidx);
                 let rn = self.next_ring;
                 self.next_ring += 1;
-                let bond_order = self.mol.bond(bidx).order;
+                let bond_order =
+                    suppress_standalone_wedge(self.mol, bidx, self.mol.bond(bidx).order);
                 // Both endpoints need to emit this ring number when serialized.
                 self.atom_ring_nums
                     .entry(neighbor)
@@ -195,7 +242,12 @@ impl<'a> SmilesWriter<'a> {
                     && !self.written[nb.0 as usize]
                     && !self.ring_bonds.contains(bidx)
             })
-            .map(|(nb, bidx)| (nb, self.mol.bond(bidx).order))
+            .map(|(nb, bidx)| {
+                (
+                    nb,
+                    suppress_standalone_wedge(self.mol, bidx, self.mol.bond(bidx).order),
+                )
+            })
             .collect();
 
         // Write children: all but the last one are branches (wrapped in parentheses).
@@ -433,5 +485,244 @@ mod tests {
         o.charge = -1;
         b.add_atom(o);
         assert_eq!(write(&b.build()), "[OH-]");
+    }
+
+    // ── Standalone wedge/hash bond must not emit a meaningless SMILES
+    // directional token (docs/stereo2d_reader_integration_rfc.md §3/§7,
+    // docs/stereo2d_local_parity_calibration.md "Scope note") ────────────────
+    //
+    // `BondOrder::Up`/`Down` is overloaded for two unrelated concepts: 2D
+    // wedge/hash depiction (set by MDL/CDXML/MRV/KET-style readers on a
+    // stereocenter's substituent bond) and the OpenSMILES `/`/`\` E/Z
+    // directional-bond marker (only meaningful adjacent to a double bond).
+    // A wedge bond with no adjacent double bond has nothing to mark; writing
+    // `/`/`\` for it is self-consistent only within chematic's own
+    // round-trip and is silently dropped by any spec-compliant SMILES
+    // parser (e.g. RDKit) on re-parse.
+
+    /// Minimal repro from the RFC's own end-to-end trace (§3): a MOL V2000
+    /// wedge bond (`BondOrder::Up`) on a tetrahedral center's substituent,
+    /// no double bond anywhere in the molecule -- the RFC's own trace shows
+    /// naive `write()` producing `"C(F)(Cl)/Br"`, a token any RDKit re-parse
+    /// silently discards.
+    #[test]
+    fn test_standalone_solid_wedge_not_written_as_slash() {
+        let mut b = MoleculeBuilder::new();
+        let c = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        b.add_bond(c, f, BondOrder::Single).unwrap();
+        b.add_bond(c, cl, BondOrder::Single).unwrap();
+        let wedge_bond = b.add_bond(c, br, BondOrder::Up).unwrap();
+        let mol = b.build();
+
+        let out = write(&mol);
+        assert!(
+            !out.contains('/') && !out.contains('\\'),
+            "standalone solid wedge (no adjacent double bond) must not be written \
+             as a directional token: got '{out}'"
+        );
+
+        // The fix only changes what gets printed -- the bond's real order in
+        // memory must be untouched (this is 2D depiction metadata, not
+        // something the writer should mutate).
+        assert_eq!(mol.bond(wedge_bond).order, BondOrder::Up);
+
+        // Round-trip: connectivity survives re-parsing the token-free output.
+        let mol2 = parse(&out).unwrap_or_else(|e| panic!("re-parse '{out}': {e}"));
+        assert_eq!(mol2.atom_count(), mol.atom_count());
+        assert_eq!(mol2.bond_count(), mol.bond_count());
+    }
+
+    /// Same shape as above but with a hash wedge (`BondOrder::Down`).
+    #[test]
+    fn test_standalone_hash_wedge_not_written_as_backslash() {
+        let mut b = MoleculeBuilder::new();
+        let c = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        b.add_bond(c, f, BondOrder::Single).unwrap();
+        b.add_bond(c, cl, BondOrder::Single).unwrap();
+        let wedge_bond = b.add_bond(c, br, BondOrder::Down).unwrap();
+        let mol = b.build();
+
+        let out = write(&mol);
+        assert!(
+            !out.contains('/') && !out.contains('\\'),
+            "standalone hash wedge (no adjacent double bond) must not be written \
+             as a directional token: got '{out}'"
+        );
+        assert_eq!(mol.bond(wedge_bond).order, BondOrder::Down);
+
+        let mol2 = parse(&out).unwrap_or_else(|e| panic!("re-parse '{out}': {e}"));
+        assert_eq!(mol2.atom_count(), mol.atom_count());
+        assert_eq!(mol2.bond_count(), mol.bond_count());
+    }
+
+    /// A genuinely 4-heavy-atom stereocenter (no implicit/explicit H at all)
+    /// with a standalone wedge -- PR #130's `tetrahedral_4heavy_no_h`
+    /// fixture shape, added there specifically so it isn't conflated with
+    /// the 3-heavy+H case above.
+    #[test]
+    fn test_standalone_wedge_four_heavy_neighbors_no_h() {
+        let mut b = MoleculeBuilder::new();
+        let c = b.add_atom(Atom::new(Element::C));
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        let i = b.add_atom(Atom::new(Element::I));
+        b.add_bond(c, f, BondOrder::Single).unwrap();
+        b.add_bond(c, cl, BondOrder::Single).unwrap();
+        b.add_bond(c, br, BondOrder::Single).unwrap();
+        b.add_bond(c, i, BondOrder::Up).unwrap();
+        let mol = b.build();
+
+        let out = write(&mol);
+        assert!(
+            !out.contains('/') && !out.contains('\\'),
+            "4-heavy-neighbor standalone wedge must not be written as a \
+             directional token: got '{out}'"
+        );
+    }
+
+    /// A wedge bond that lands on a ring-closure edge (not a plain tree
+    /// edge) must be suppressed identically -- the fix touches both
+    /// emission sites in `write_chain`/`dfs_mark`.
+    #[test]
+    fn test_standalone_wedge_on_ring_closure_bond() {
+        let mut b = MoleculeBuilder::new();
+        let c1 = b.add_atom(Atom::new(Element::C));
+        let c2 = b.add_atom(Atom::new(Element::C));
+        let c3 = b.add_atom(Atom::new(Element::C));
+        b.add_bond(c1, c2, BondOrder::Single).unwrap();
+        b.add_bond(c2, c3, BondOrder::Single).unwrap();
+        // Whichever of these two becomes the DFS back-edge, it carries a
+        // wedge with no adjacent double bond anywhere in this molecule.
+        b.add_bond(c1, c3, BondOrder::Up).unwrap();
+        let mol = b.build();
+
+        let out = write(&mol);
+        assert!(
+            !out.contains('/') && !out.contains('\\'),
+            "standalone wedge on a ring-closure bond must not be written as \
+             a directional token: got '{out}'"
+        );
+        let mol2 = parse(&out).unwrap_or_else(|e| panic!("re-parse '{out}': {e}"));
+        assert_eq!(mol2.atom_count(), 3);
+        assert_eq!(mol2.bond_count(), 3);
+    }
+
+    /// The fix must not disturb `Atom.chirality`/`Molecule::stereo_neighbor_order`
+    /// (the P1-S1a-core local-parity metadata) while suppressing a wedge
+    /// bond's spurious directional token on the same stereocenter -- these
+    /// are two unrelated mechanisms (bond-token emission vs `emit_atom`'s
+    /// chirality symbol) and must keep working independently.
+    #[test]
+    fn test_standalone_wedge_does_not_disturb_stereocenter_chirality() {
+        let mut center = Atom::new(Element::C);
+        center.chirality = chematic_core::Chirality::Clockwise;
+        // Force bracket notation so the chirality symbol is actually
+        // printed (`needs_bracket` doesn't key off chirality alone).
+        center.hydrogen_count = Some(0);
+        let mut b = MoleculeBuilder::new();
+        let c = b.add_atom(center);
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let br = b.add_atom(Atom::new(Element::BR));
+        let iodine = b.add_atom(Atom::new(Element::I));
+        b.add_bond(c, f, BondOrder::Single).unwrap();
+        b.add_bond(c, cl, BondOrder::Single).unwrap();
+        b.add_bond(c, br, BondOrder::Single).unwrap();
+        let wedge_bond = b.add_bond(c, iodine, BondOrder::Up).unwrap();
+        b.set_stereo_neighbor_order(c, vec![f.0, cl.0, br.0, iodine.0]);
+        let mol = b.build();
+
+        let out = write(&mol);
+        assert!(
+            !out.contains('/') && !out.contains('\\'),
+            "standalone wedge on a stereocenter's substituent must still be \
+             suppressed: got '{out}'"
+        );
+        assert!(
+            out.contains('@'),
+            "the stereocenter's own chirality symbol must still be printed \
+             alongside the (now-suppressed) wedge bond: got '{out}'"
+        );
+
+        // The fix must not have touched the stereocenter metadata itself --
+        // only what gets printed for the wedge bond's token.
+        assert_eq!(mol.atom(c).chirality, chematic_core::Chirality::Clockwise);
+        assert_eq!(mol.bond(wedge_bond).order, BondOrder::Up);
+        assert_eq!(
+            mol.stereo_neighbor_order(c),
+            Some([f.0, cl.0, br.0, iodine.0].as_slice())
+        );
+    }
+
+    /// Round-trip check with charge and isotope present, per the required
+    /// test list: connectivity/charge/isotope must survive re-parsing the
+    /// (now token-free) output of a molecule carrying a standalone wedge.
+    #[test]
+    fn test_standalone_wedge_roundtrip_preserves_charge_and_isotope() {
+        let mut b = MoleculeBuilder::new();
+        let mut c = Atom::new(Element::C);
+        c.isotope = Some(13);
+        let c = b.add_atom(c);
+        let f = b.add_atom(Atom::new(Element::F));
+        let cl = b.add_atom(Atom::new(Element::CL));
+        let mut o = Atom::new(Element::O);
+        o.charge = -1;
+        let o = b.add_atom(o);
+        b.add_bond(c, f, BondOrder::Single).unwrap();
+        b.add_bond(c, cl, BondOrder::Single).unwrap();
+        let wedge_bond = b.add_bond(c, o, BondOrder::Up).unwrap();
+        let mol = b.build();
+
+        let out = write(&mol);
+        assert!(
+            !out.contains('/') && !out.contains('\\'),
+            "standalone wedge must not be written as a directional token: got '{out}'"
+        );
+
+        let mol2 = parse(&out).unwrap_or_else(|e| panic!("re-parse '{out}': {e}"));
+        assert_eq!(mol2.atom_count(), mol.atom_count());
+        assert_eq!(mol2.bond_count(), mol.bond_count());
+        assert!(
+            (0..mol2.atom_count()).any(|i| mol2.atom(AtomIdx(i as u32)).isotope == Some(13)),
+            "isotope must survive the round trip: '{out}'"
+        );
+        assert!(
+            (0..mol2.atom_count()).any(|i| mol2.atom(AtomIdx(i as u32)).charge == -1),
+            "charge must survive the round trip: '{out}'"
+        );
+        // The original wedge bond's order in memory is still untouched.
+        assert_eq!(mol.bond(wedge_bond).order, BondOrder::Up);
+    }
+
+    /// Regression guard: a genuine E/Z directional marker (real double
+    /// bond, real geometry) must still be emitted -- this fix must not
+    /// suppress legitimate cases.
+    #[test]
+    fn test_genuine_ez_directional_bond_still_written() {
+        let mol = parse("F/C=C/F").unwrap();
+        let out = write(&mol);
+        assert!(
+            out.contains('/') || out.contains('\\'),
+            "genuine double-bond-adjacent directional marker must survive \
+             plain write(): got '{out}'"
+        );
+        let mol2 = parse(&out).unwrap_or_else(|e| panic!("re-parse '{out}': {e}"));
+        let has_directional = (0..mol2.bond_count()).any(|i| {
+            matches!(
+                mol2.bond(BondIdx(i as u32)).order,
+                BondOrder::Up | BondOrder::Down
+            )
+        });
+        assert!(
+            has_directional,
+            "re-parsed molecule lost its E/Z directional bonds: '{out}'"
+        );
     }
 }


### PR DESCRIPTION
## Background

`chematic_core::BondOrder::Up`/`Down` is a single enum variant overloaded for
two semantically unrelated concepts:

1. **2D depiction wedge/hash bonds** — tetrahedral stereocenter depiction, set
   by MDL/CDXML/MRV/KET-style readers on a stereocenter's substituent bond.
   Not a bond-level directional marker relative to anything; it's metadata
   about how one substituent was drawn.
2. **OpenSMILES `/`/`\` E/Z directional-bond markers** — a completely
   different geometric concept, only meaningful *adjacent to a double bond*
   that needs a cis/trans marker on its flanking single bonds.

Distinct from both: `Atom.chirality` + `Molecule::stereo_neighbor_order` (the
P1-S1a-core local-parity output) is atom-level tetrahedral parity metadata,
unrelated to any bond-level marker, and is not touched by this PR.

A third, separate mechanism does exist and was verified before writing any
code: the SMILES **parser** can stash an E/Z direction on a ring bond whose
`order` field must stay `Aromatic` (`Molecule::bond_direction`/
`set_bond_direction`), e.g. an aromatic ring bond that flanks an *exocyclic*
C=N. `canonical.rs`'s `build_ez_groups`/`normalize_ez` already consume this
correctly. This PR does not touch that mechanism — see "Why the fix gates on
stored order" below.

`chematic_smiles::write`/`canonical_smiles` emitted a literal `/` or `\` for
a bond with `BondOrder::Up`/`Down` whenever it had **no adjacent double bond
to mark**. That token is semantically garbage (there's nothing for it to
mark), self-consistent only within chematic's own round-trip, and is
silently dropped by any spec-compliant SMILES parser (e.g. RDKit) on
re-parse — found during P1-A0 diagnosis (#130) and re-confirmed during
P1-S1a-core (#131); see `docs/stereo2d_reader_integration_rfc.md` §3/§7 and
`docs/stereo2d_local_parity_calibration.md`'s "Scope note" for the full
history and the RFC's own minimal repro (`C(F)(Cl)/Br`).

## Fix

Added two small helpers in `writer.rs` (shared by `canonical.rs`):

- `flanks_double_bond(mol, bidx)` — true when `bidx` shares an atom with some
  *other* `BondOrder::Double` bond. This mirrors the exact double-bond-
  adjacency test `CanonicalWriter::build_ez_groups` already uses to collect
  genuine E/Z side bonds — same relationship, just queried per-bond instead
  of built as a whole-molecule group, so plain `write()` (which has no
  Morgan-rank/grouping infrastructure) can reuse it too.
- `suppress_standalone_wedge(mol, bidx, order)` — demotes a `Up`/`Down` bond
  to `Single` **for emission purposes only** when `!flanks_double_bond(...)`.
  The bond's real `order` field on the `Molecule` is never mutated — this
  only changes what gets printed.

Wired into both emission sites in each writer (tree-edge bonds and
ring-closure bonds): `writer.rs`'s `dfs_mark`/children-map, and
`canonical.rs`'s ring-closure loop/children loop (after `normalize_ez`).

**Why the fix gates on the bond's *stored* order, not the direction-adjusted
value passed into the helper:** an early version gated on the local
(direction-adjusted) `order` value and broke an existing, correct test
(`parser::tests::direction_stash_branch_attachment_edge`) that stashes a
direction on an `Aromatic`-order bond. The discriminating fact: a real 2D
wedge reader sets `bond.order` *literally* to `Up`/`Down`; the SMILES
parser's own aromatic-bond-direction stash keeps `bond.order == Aromatic`
and stores the direction separately in `bond_direction`. Gating
`suppress_standalone_wedge` on `mol.bond(bidx).order` (not the `order`
parameter) means it can only ever match a literal 2D wedge/hash bond — the
aromatic-stash mechanism is structurally excluded from the guard, so all
three pre-existing `direction_stash_*` fixtures (which all involve a real
exocyclic double bond) pass completely unmodified.

## Files changed

- `crates/chematic-smiles/src/writer.rs` — `flanks_double_bond`,
  `suppress_standalone_wedge`, wired into `dfs_mark` and the children map;
  10 new tests.
- `crates/chematic-smiles/src/canonical.rs` — import + wire
  `suppress_standalone_wedge` into the ring-closure and children loops after
  `normalize_ez`; 7 new tests.

**Out of scope / untouched** (per explicit constraints): `chematic-core`,
`chematic-perception` (kekulization/aromaticity — a parallel workstream is
touching this), `stereo2d_local.rs` (S1a local-parity computation), P1-S1b
(CIP-ranked R/S labeling), reader default-parse wiring, `assign_ez_from_2d`
or any E/Z *assignment* logic (only the writer's *emission* decision
changed).

## What decided `/`\` emission before vs after

- **Before:** any bond with `bond_order` (or, in `canonical.rs`, the
  direction-adjusted/stash-resolved `effective_order`) equal to `Up`/`Down`
  was always printed as `/`/`\` — the `implicit` match's catch-all
  (`_ => false`) never treated `Up`/`Down` as elidable, regardless of
  molecular context.
- **After:** the same bond is first passed through
  `suppress_standalone_wedge`. If its *stored* order is `Up`/`Down` and it
  doesn't `flanks_double_bond`, it's demoted to `Single` before reaching the
  `implicit`/print-check logic — so it's now treated exactly like an
  ordinary single bond (implicit/no token between two non-aromatic atoms).
  Genuine E/Z bonds (adjacent to a real double bond, including the
  aromatic-stash case) are unaffected and still print `/`/`\` exactly as
  before.

## Tests added (13 new: 7 in writer.rs, 6 in canonical.rs)

`writer.rs` (plain `write()`):
- Standalone solid wedge (`Up`), no adjacent double bond → no `/`.
- Standalone hash wedge (`Down`), no adjacent double bond → no `\`.
- 4-heavy-neighbor stereocenter with a standalone wedge (PR #130's
  `tetrahedral_4heavy_no_h` shape) → no token.
- Standalone wedge landing on a ring-closure bond → no token (covers the
  `dfs_mark` back-edge emission site, not just the tree-edge site).
- Genuine E/Z (`F/C=C/F`) → `/`/`\` still emitted and round-trips to a
  molecule that still carries `Up`/`Down` bonds (regression guard).
- Stereocenter with `Atom.chirality` set *and* a standalone wedge on a
  different substituent bond → wedge suppressed, `@`/`@@` still printed,
  and `chirality`/`stereo_neighbor_order`/the wedge bond's own `order` are
  all asserted unchanged after the write call.
- Round-trip with isotope + charge present → both survive re-parsing the
  now-token-free output.

`canonical.rs` (`canonical_smiles()`): the same standalone-wedge/hash/
ring-closure/chirality-survival tests, plus:
- Genuine E/Z (`F/C=C/F`) still emits a token.
- The aromatic-bond-direction-stash case with a real exocyclic double bond
  (`N=c1\c(O)c(O)\c1=N`) still emits a token (this is the case the gate had
  to be corrected to not break).

The pre-existing `parser::tests::direction_stash_normal_chain_edge`,
`direction_stash_ring_closure_edge`, and
`direction_stash_branch_attachment_edge` all still pass unmodified.

## Test plan

- [x] `cargo test -p chematic-smiles --lib` — 144 passed, 0 failed
      (131 pre-existing + 13 new: 7 in writer.rs, 6 in canonical.rs).
- [x] `cargo test -p chematic-mol -p chematic-rxn -p chematic-chem
      -p chematic-cip -p chematic-perception --lib` — all green (downstream
      consumers of the SMILES writer unaffected).
- [x] `bash scripts/check.sh` — fmt, clippy (`-D warnings`), full workspace
      `--lib` + `--tests`, `cargo deny`, publish graph, version check — all
      green, "All checks passed."
- [x] `git diff --stat` confirms exactly two files touched:
      `crates/chematic-smiles/src/{writer,canonical}.rs`.
- [x] GitHub Actions — all 14 functional checks green: Build Check
      (full-builds `chematic-py` against libpython — the link step that
      fails locally under plain `cargo build --workspace`/`check.sh`, since
      that needs maturin's venv), Test, Test (native-inchi), Clippy, Clippy
      Lints, Cargo Audit, Cargo Deny, CodeQL, Format Check, Validate
      CITATION.cff, Analyze (actions/python/rust), Python bench regression
      gate. The `Rust Criterion regression gate` is non-authoritative
      (known measurement-broken, pseudo-replication — see prior project
      history) and this diff has zero perf surface (SMILES writer
      token-emission decision only); its result is not regression evidence
      either way.
