### PR TITLE
fix(smiles): C1a — safe partial resolution of E/Z marker-carrier normalization

### DIFF
--- a/crates/chematic-smiles/src/canonical.rs
+++ b/crates/chematic-smiles/src/canonical.rs
@@ -380,6 +380,16 @@ struct CanonicalWriter<'a> {
     /// stored here too, pinned to its own plain (non-directional) order, so
     /// a stray parse-time marker on it can't leak through.
     ez_marker: HashMap<BondIdx, BondOrder>,
+    /// Test-only instrumentation: every alkene end for which
+    /// `resolve_ez_marker_for_end` hit the shared-candidate-bond abstain
+    /// guard specifically (as opposed to "not ambiguous" or "no direction
+    /// info at all"). Lets regression tests assert the guard actually
+    /// fired for a given fixture by reading production's own record of
+    /// which branch it took, rather than re-deriving the topology
+    /// condition in the test and hoping it matches. `cfg(test)`-gated —
+    /// zero cost/size impact on release builds.
+    #[cfg(test)]
+    ez_shared_bond_abstains: Vec<AtomIdx>,
 }
 
 impl<'a> CanonicalWriter<'a> {
@@ -396,6 +406,8 @@ impl<'a> CanonicalWriter<'a> {
             ez_group: HashMap::new(),
             ez_flip: HashMap::new(),
             ez_marker: HashMap::new(),
+            #[cfg(test)]
+            ez_shared_bond_abstains: Vec::new(),
         }
     }
 
@@ -625,6 +637,8 @@ impl<'a> CanonicalWriter<'a> {
         // with an extra redundant marker. Reverted in favor of this
         // simpler, provably no-op-on-failure form.)
         if stereo_alkene_ends.contains(&carrier.0) || stereo_alkene_ends.contains(&sibling.0) {
+            #[cfg(test)]
+            self.ez_shared_bond_abstains.push(alkene_end);
             return;
         }
 
@@ -1915,6 +1929,67 @@ mod tests {
         double_bond_is_e_mol(&mol)
     }
 
+    fn raw_dir(mol: &Molecule, bidx: BondIdx) -> Option<BondOrder> {
+        let order = mol.bond(bidx).order;
+        if matches!(order, BondOrder::Up | BondOrder::Down) {
+            return Some(order);
+        }
+        mol.bond_direction(bidx)
+    }
+
+    /// Whether `end`'s substituent side of a double bond points "up",
+    /// reading whichever substituent actually carries a direction marker
+    /// via the fixed, rank-based reference (lower-`ranks` substituent) with
+    /// sibling-complement fallback -- the same reference `resolve_ez_marker_
+    /// for_end` uses to pick a canonical carrier. Shared by
+    /// `double_bond_is_e_mol` (single representative bond) and
+    /// `geometry_fingerprint` (every stereogenic bond) so there is exactly
+    /// one implementation of "which substituent to trust" for tests, not
+    /// two that could silently disagree.
+    fn up_of_reference(mol: &Molecule, ranks: &[u64], end: AtomIdx) -> Option<bool> {
+        let subs: Vec<(AtomIdx, BondIdx)> = mol
+            .neighbors(end)
+            .filter(|&(_, b)| mol.bond(b).order != BondOrder::Double)
+            .collect();
+        match subs.len() {
+            1 => {
+                let (_, bidx) = subs[0];
+                let dir = raw_dir(mol, bidx)?;
+                Some(CanonicalWriter::direction_is_up(
+                    dir,
+                    mol.bond(bidx).atom1,
+                    end,
+                ))
+            }
+            2 => {
+                let reference = *subs
+                    .iter()
+                    .min_by_key(|&&(a, _)| ranks[a.0 as usize])
+                    .expect("subs has 2 elements");
+                let sibling = if reference.0 == subs[0].0 {
+                    subs[1]
+                } else {
+                    subs[0]
+                };
+                if let Some(dir) = raw_dir(mol, reference.1) {
+                    Some(CanonicalWriter::direction_is_up(
+                        dir,
+                        mol.bond(reference.1).atom1,
+                        end,
+                    ))
+                } else {
+                    let dir = raw_dir(mol, sibling.1)?;
+                    Some(!CanonicalWriter::direction_is_up(
+                        dir,
+                        mol.bond(sibling.1).atom1,
+                        end,
+                    ))
+                }
+            }
+            _ => None,
+        }
+    }
+
     /// Like `double_bond_is_e`, but tries every double bond in the molecule
     /// (not just the first one found) and returns the first that yields a
     /// defined answer -- a molecule can have an earlier, non-stereogenic
@@ -1922,66 +1997,50 @@ mod tests {
     /// substituent at all) ahead of its actual stereo alkene in bond order.
     fn double_bond_is_e_mol(mol: &Molecule) -> Option<bool> {
         let ranks = morgan_ranks(mol);
-
-        fn raw_dir(mol: &Molecule, bidx: BondIdx) -> Option<BondOrder> {
-            let order = mol.bond(bidx).order;
-            if matches!(order, BondOrder::Up | BondOrder::Down) {
-                return Some(order);
-            }
-            mol.bond_direction(bidx)
-        }
-
-        let up_of_reference = |end: AtomIdx| -> Option<bool> {
-            let subs: Vec<(AtomIdx, BondIdx)> = mol
-                .neighbors(end)
-                .filter(|&(_, b)| mol.bond(b).order != BondOrder::Double)
-                .collect();
-            match subs.len() {
-                1 => {
-                    let (_, bidx) = subs[0];
-                    let dir = raw_dir(mol, bidx)?;
-                    Some(CanonicalWriter::direction_is_up(
-                        dir,
-                        mol.bond(bidx).atom1,
-                        end,
-                    ))
-                }
-                2 => {
-                    let reference = *subs
-                        .iter()
-                        .min_by_key(|&&(a, _)| ranks[a.0 as usize])
-                        .expect("subs has 2 elements");
-                    let sibling = if reference.0 == subs[0].0 {
-                        subs[1]
-                    } else {
-                        subs[0]
-                    };
-                    if let Some(dir) = raw_dir(mol, reference.1) {
-                        Some(CanonicalWriter::direction_is_up(
-                            dir,
-                            mol.bond(reference.1).atom1,
-                            end,
-                        ))
-                    } else {
-                        let dir = raw_dir(mol, sibling.1)?;
-                        Some(!CanonicalWriter::direction_is_up(
-                            dir,
-                            mol.bond(sibling.1).atom1,
-                            end,
-                        ))
-                    }
-                }
-                _ => None,
-            }
-        };
-
         mol.bonds()
             .filter(|(_, b)| b.order == BondOrder::Double)
             .find_map(|(_, b)| {
-                let ua = up_of_reference(b.atom1)?;
-                let ub = up_of_reference(b.atom2)?;
+                let ua = up_of_reference(mol, &ranks, b.atom1)?;
+                let ub = up_of_reference(mol, &ranks, b.atom2)?;
                 Some(ua != ub)
             })
+    }
+
+    /// A geometry fingerprint suitable for comparing two *different* parses
+    /// of the same molecule (e.g. original input vs. a canonical-output
+    /// reparse) -- one E/Z fact per stereogenic double bond (both ends have
+    /// at least one substituent), via `up_of_reference`. Ordered by each
+    /// bond's lower-ranked endpoint: `ranks` is a molecule-intrinsic, permutation-
+    /// invariant key (unlike `BondIdx`/bond-parse-order, which differs
+    /// between two independently-atom-ordered spellings of the same
+    /// molecule), so this ordering lines up positionally across the two
+    /// parses being compared as long as neither parse gained or lost a
+    /// stereogenic double bond.
+    fn geometry_fingerprint(mol: &Molecule) -> Vec<Option<bool>> {
+        let ranks = morgan_ranks(mol);
+        let mut doubles: Vec<(u64, BondIdx)> = mol
+            .bonds()
+            .filter(|(_, b)| b.order == BondOrder::Double)
+            .filter(|(_, b)| {
+                CanonicalWriter::end_has_substituent(mol, b.atom1)
+                    && CanonicalWriter::end_has_substituent(mol, b.atom2)
+            })
+            .map(|(bidx, b)| {
+                let key = ranks[b.atom1.0 as usize].min(ranks[b.atom2.0 as usize]);
+                (key, bidx)
+            })
+            .collect();
+        doubles.sort_by_key(|&(k, _)| k);
+
+        doubles
+            .into_iter()
+            .map(|(_, bidx)| {
+                let bond = mol.bond(bidx);
+                let ua = up_of_reference(mol, &ranks, bond.atom1)?;
+                let ub = up_of_reference(mol, &ranks, bond.atom2)?;
+                Some(ua != ub)
+            })
+            .collect()
     }
 
     const EZ_STABLE_CORPUS: &[&str] = &[
@@ -2434,6 +2493,104 @@ mod tests {
                  geometry to make this a meaningful check (got {ez_before:?})"
             );
         }
+    }
+
+    /// The 18 real-corpus molecules (out of the 282-molecule `has_ez_marker`
+    /// diagnosis subset, re-measured on this fix) where the shared-
+    /// candidate-bond guard in `resolve_ez_marker_for_end` fires and
+    /// canonicalization deliberately does NOT converge to one string --
+    /// persisted as a permanent regression fixture set per PR review (see
+    /// the tracking issue "canonical E/Z: jointly resolve shared carrier
+    /// bonds across coupled stereo systems" for what a real fix would need).
+    ///
+    /// Two things this asserts per fixture, deliberately NOT just "the
+    /// string is unchanged" (brittle, and not what's under test):
+    ///  1. The guard actually fired -- read from `ez_shared_bond_abstains`,
+    ///     production's own record of which branch `resolve_ez_marker_for_
+    ///     end` took, not re-derived from the topology in this test (which
+    ///     could be true for some unrelated end while production actually
+    ///     exited via "not ambiguous" or "no direction info" instead).
+    ///  2. Zero semantic corruption: `geometry_fingerprint` (marker-
+    ///     placement-invariant, cross-parse-comparable) is identical
+    ///     between the original parse and a reparse of its canonical
+    ///     output.
+    ///
+    /// This Rust test is a regression tripwire, not a semantic oracle --
+    /// `geometry_fingerprint` only checks *this crate's own* reading of E/Z
+    /// stays put; the authoritative structural proof (independent RDKit
+    /// comparison across all 4,992 measured molecules, not just these 18)
+    /// lives in the PR's own verification, not reimplemented here.
+    const EZ_SHARED_CANDIDATE_BOND_RESIDUALS: &[&str] = &[
+        r"CCCCC/N=c1\c(O)c(O)\c1=N/[C@@H](Cc1ccc(NC(=O)c2c(Cl)cncc2Cl)cc1)C(=O)O",
+        r"O=C(Nc1ccc(C[C@H](/N=c2\c(O)c(O)\c2=N/Cc2ccccc2)C(=O)O)cc1)c1c(Cl)cncc1Cl",
+        r"CCC/N=c1\c(O)c(O)\c1=N/[C@@H](Cc1ccc(NC(=O)c2c(Cl)cncc2Cl)cc1)C(=O)O",
+        r"O=C(Nc1ccc(C[C@H](/N=c2\c(O)c(O)\c2=N/c2ccccc2)C(=O)O)cc1)c1c(Cl)cncc1Cl",
+        r"CC(C)(C)/N=c1\c(O)c(O)\c1=N/[C@@H](Cc1ccc(NC(=O)c2c(Cl)cncc2Cl)cc1)C(=O)O",
+        r"CC1=C2CC[C@H](/C=N/N=C(N)N)[C@@]2(C)CC/C1=N\N=C(N)N",
+        r"CC1=C2CC[C@@H](/C=N/N=C(N)N)[C@@]2(C)CC/C1=N\N=C(N)N",
+        r"COC(=O)/C=C/[C@H]1CCC2=C(C)/C(=N/N=C(N)N)CC[C@@]21C",
+        r"CCOC(=O)C1=C(C)N=C(C)/C(=C(/O)OCC)C1c1cccc(I)c1",
+        r"CCOC(=O)C1=C(C)N=C(C)/C(=C(/O)OCC)C1c1ccc(I)cc1",
+        r"CCO/C(O)=C1\C(C)=NC(C)=C(C(=O)OC)C1c1ccccc1C(F)(F)F",
+        r"CCOC(=O)C1=C(C)N=C(C)/C(=C(/O)OCC)C1c1ccccc1OC",
+        r"CCO/C(O)=C1\C(C)=NC(C)=C(C(=O)OC)C1c1ccccc1[N+](=O)[O-]",
+        r"CCO/C(O)=C1\C(C)=NC(C)=C(C(=O)OC)C1c1ccc([N+](=O)[O-])cc1",
+        r"CCOC(=O)C1=C(C)N=C(C)/C(=C(/O)OCC)C1c1cccc(C)c1",
+        r"CCOC(=O)C1=C(C)N=C(C)/C(=C(/O)OCC)C1c1cccc(OC)c1",
+        r"CCO/C(O)=C1\C(C)=NC(C)=C(C(=O)OC)C1c1cccc(C(F)(F)F)c1",
+        r"CCO/C(O)=C(\C1=NCCN1)c1nnc(N)s1",
+    ];
+
+    #[test]
+    fn ez_carrier_shared_candidate_bond_residuals_never_corrupt() {
+        for &s in EZ_SHARED_CANDIDATE_BOND_RESIDUALS {
+            let mol = parse(s).unwrap_or_else(|e| panic!("parse '{s}': {e}"));
+            let ranks = winning_individualized_ranks(&mol);
+            let mut writer = CanonicalWriter::new(&mol, &ranks);
+            writer.resolve_ez_markers();
+            assert!(
+                !writer.ez_shared_bond_abstains.is_empty(),
+                "expected the shared-candidate-bond guard to fire for '{s}', \
+                 but resolve_ez_marker_for_end never recorded an abstain -- \
+                 this fixture may no longer belong in this residual set"
+            );
+
+            let canon = canonical_smiles(&mol);
+            let before = geometry_fingerprint(&mol);
+            let mol2 = parse(&canon).unwrap_or_else(|e| panic!("re-parse '{canon}': {e}"));
+            let after = geometry_fingerprint(&mol2);
+            assert_eq!(
+                before, after,
+                "canonicalizing '{s}' -> '{canon}' must not change E/Z \
+                 geometry, even though this shared-bond shape is a known, \
+                 deliberately-abstained residual (not resolved to one \
+                 canonical string)"
+            );
+            assert!(
+                before.iter().any(|f| f.is_some()),
+                "test setup sanity: '{s}' must have at least one defined \
+                 geometry fact to make this a meaningful check"
+            );
+        }
+    }
+
+    /// Positive control for `geometry_fingerprint`: without this, the
+    /// "before == after" check above would pass vacuously if the fingerprint
+    /// function were broken and always returned e.g. all-`None` or some
+    /// other input-insensitive constant. Flipping one real mark in one of
+    /// the residual fixtures (`/N=c1\...` -> `/N=c1/...`) must change the
+    /// fingerprint, proving the function actually reads the input.
+    #[test]
+    fn geometry_fingerprint_is_sensitive_to_a_real_flip() {
+        let original = "CCCCC/N=c1\\c(O)c(O)\\c1=N/[C@@H](Cc1ccc(NC(=O)c2c(Cl)cncc2Cl)cc1)C(=O)O";
+        let flipped = "CCCCC/N=c1/c(O)c(O)\\c1=N/[C@@H](Cc1ccc(NC(=O)c2c(Cl)cncc2Cl)cc1)C(=O)O";
+        let fp_original = geometry_fingerprint(&parse(original).unwrap());
+        let fp_flipped = geometry_fingerprint(&parse(flipped).unwrap());
+        assert_ne!(
+            fp_original, fp_flipped,
+            "geometry_fingerprint must be sensitive to a real E/Z flip, or \
+             the no-corruption check above is vacuous"
+        );
     }
 
     /// Both stereo double bonds' E/Z parity in a molecule with (at least)

--- a/crates/chematic-smiles/src/canonical.rs
+++ b/crates/chematic-smiles/src/canonical.rs
@@ -368,6 +368,18 @@ struct CanonicalWriter<'a> {
     /// every remaining bond in the group is flipped so the first directional
     /// bond of each system is always `/`, regardless of input spelling.
     ez_flip: HashMap<BondIdx, bool>,
+    /// Resolved "which bond carries the `/`/`\` marker" override, computed
+    /// once up front by [`Self::resolve_ez_markers`] and consulted by every
+    /// site that would otherwise read the bond's raw parse-time direction
+    /// (literal `Up`/`Down` order, or the aromatic-bond-direction stash).
+    /// Bonds not present here fall back to that raw reading unchanged — this
+    /// map only ever contains entries for the substituent bonds of a
+    /// tri-/tetra-substituted stereo alkene end, where the *choice* of which
+    /// substituent carries the mark is otherwise input-order-dependent (see
+    /// `resolve_ez_markers` for why). A demoted (no-longer-marked) bond is
+    /// stored here too, pinned to its own plain (non-directional) order, so
+    /// a stray parse-time marker on it can't leak through.
+    ez_marker: HashMap<BondIdx, BondOrder>,
 }
 
 impl<'a> CanonicalWriter<'a> {
@@ -383,6 +395,267 @@ impl<'a> CanonicalWriter<'a> {
             out: String::new(),
             ez_group: HashMap::new(),
             ez_flip: HashMap::new(),
+            ez_marker: HashMap::new(),
+        }
+    }
+
+    /// The raw parse-time direction of `bidx`, if any: a literal `Up`/`Down`
+    /// bond order, or (when both endpoints are aromatic) the stashed
+    /// direction of an adjacent exocyclic double bond. This is the
+    /// *unresolved* reading — [`Self::effective_order`] is what emission
+    /// code should use instead, since it additionally applies
+    /// `resolve_ez_markers`'s carrier choice on top of this.
+    fn raw_input_direction(&self, bidx: BondIdx) -> Option<BondOrder> {
+        let order = self.mol.bond(bidx).order;
+        if matches!(order, BondOrder::Up | BondOrder::Down) {
+            return Some(order);
+        }
+        self.mol.bond_direction(bidx)
+    }
+
+    /// Strip directionality from a bond order, leaving its "plain" chemical
+    /// order untouched: `Up`/`Down` becomes `Single` (the literal-marker
+    /// case), anything else (notably `Aromatic`, the stash case) is
+    /// returned as-is. Used to demote a substituent bond that must no
+    /// longer carry the `/`/`\` marker in the output.
+    fn plain_order(order: BondOrder) -> BondOrder {
+        if matches!(order, BondOrder::Up | BondOrder::Down) {
+            BondOrder::Single
+        } else {
+            order
+        }
+    }
+
+    /// The effective direction to use when emitting `bidx`: `resolve_ez_markers`'s
+    /// resolved choice if this bond participates in a tri-/tetra-substituted
+    /// stereo alkene end, otherwise the unresolved raw parse-time direction
+    /// (literal order or aromatic-bond-direction stash), otherwise the
+    /// bond's own real chemical order. Every write-time site that needs "the
+    /// order to show for this bond" (ring-closure emission and tree-edge
+    /// emission alike) must go through this, not read `bond_direction`/
+    /// `order` directly, or the two sites can disagree on which bond a
+    /// moved E/Z marker landed on.
+    fn effective_order(&self, bidx: BondIdx) -> BondOrder {
+        if let Some(&resolved) = self.ez_marker.get(&bidx) {
+            return resolved;
+        }
+        self.raw_input_direction(bidx)
+            .unwrap_or(self.mol.bond(bidx).order)
+    }
+
+    /// Return `true` if `dir` encodes "up" (`/`, read atom1→atom2) as seen
+    /// from `alkene_end`'s side of `bond` — the same atom1/atom2-relative
+    /// convention `chematic_chem::cip::substituent_is_up` uses to read a
+    /// marker back out, so a value written here round-trips identically.
+    fn direction_is_up(dir: BondOrder, bond_atom1: AtomIdx, alkene_end: AtomIdx) -> bool {
+        match dir {
+            BondOrder::Up => bond_atom1 == alkene_end,
+            BondOrder::Down => bond_atom1 != alkene_end,
+            _ => false, // never called with a non-directional `dir`
+        }
+    }
+
+    /// The inverse of `direction_is_up`: which `Up`/`Down` order to store on
+    /// `bond` so that, read from `alkene_end`'s side, it encodes `want_up`.
+    fn direction_for_up(bond_atom1: AtomIdx, alkene_end: AtomIdx, want_up: bool) -> BondOrder {
+        if (bond_atom1 == alkene_end) == want_up {
+            BondOrder::Up
+        } else {
+            BondOrder::Down
+        }
+    }
+
+    /// Resolve, for every tri-/tetra-substituted stereo alkene end, which ONE
+    /// of its ≥2 non-double-bond substituent bonds should carry the `/`/`\`
+    /// marker in the output — deterministically, from the molecule's own
+    /// (already fully individualized) canonical ranks, rather than just
+    /// inheriting whichever bond the original parse happened to mark.
+    ///
+    /// **The bug this fixes** (canonical-residual RFC, Root cause 1): SMILES
+    /// only requires ONE of an alkene carbon's ≥2 substituent bonds to carry
+    /// an explicit marker (the geometry of the other is implied — at a
+    /// trigonal alkene carbon with two substituents, they are always on
+    /// opposite sides). *Which* substituent gets marked is a free choice at
+    /// write time, but the writer previously just checked "does this
+    /// specific bond already carry a direction", inherited straight from
+    /// parse time — so two RDKit-valid respellings of the identical molecule
+    /// that mark different substituents produced two different (but
+    /// chemically identical) canonical outputs. Resolving the carrier here,
+    /// once, from topology + rank alone, makes the choice depend only on the
+    /// molecule itself, not on which substituent the input happened to mark.
+    ///
+    /// The carrier is whichever substituent atom has the numerically lowest
+    /// `self.ranks` value; `self.ranks` is the *fully discrete* (all-distinct)
+    /// winning individualized ranking used for this entire write (see
+    /// `winning_individualized_ranks`), so this pick is a total, molecule-
+    /// derived order — invariant across any input atom permutation/spelling
+    /// — with no remaining tie to break (any leftover tie implies the two
+    /// substituents are automorphic, so either choice writes the same
+    /// string). Runs before `build_ez_groups`/ring discovery/DFS write, so it
+    /// depends only on molecule topology, never on write order.
+    ///
+    /// Deliberately narrow to exactly 2 substituents (the only case a valid
+    /// sp2 alkene carbon — one double bond + up to two single bonds — can
+    /// have): 0 or 1 substituent has no ambiguity to resolve, and >2 cannot
+    /// occur for a real double bond, so it's left untouched rather than
+    /// guessed at.
+    fn resolve_ez_markers(&mut self) {
+        if self.ranks.is_empty() {
+            return;
+        }
+
+        // Precompute the full set of atoms `resolve_ez_marker_for_end` will
+        // treat as an ambiguous stereo-alkene end (topology-only, so this
+        // set doesn't depend on processing order below). Needed so two
+        // *different*, independently stereogenic double bonds that happen
+        // to share one candidate substituent bond between them (e.g. two
+        // adjacent ring stereocenters connected by the very ring-closure
+        // bond each would otherwise use as a candidate carrier) can be
+        // detected — see the guard in `resolve_ez_marker_for_end`.
+        let mut stereo_alkene_ends: HashSet<AtomIdx> = HashSet::new();
+        for bidx in 0..self.mol.bond_count() {
+            let bond = self.mol.bond(BondIdx(bidx as u32));
+            if bond.order != BondOrder::Double {
+                continue;
+            }
+            if !Self::end_has_substituent(self.mol, bond.atom1)
+                || !Self::end_has_substituent(self.mol, bond.atom2)
+            {
+                continue;
+            }
+            for end in [bond.atom1, bond.atom2] {
+                let sub_count = self
+                    .mol
+                    .neighbors(end)
+                    .filter(|&(_, b)| self.mol.bond(b).order != BondOrder::Double)
+                    .count();
+                if sub_count == 2 {
+                    stereo_alkene_ends.insert(end);
+                }
+            }
+        }
+
+        for bidx in 0..self.mol.bond_count() {
+            let bidx = BondIdx(bidx as u32);
+            let bond = self.mol.bond(bidx);
+            if bond.order != BondOrder::Double {
+                continue;
+            }
+            // A double bond only has E/Z stereo at all when BOTH ends have
+            // at least one substituent (matching `chematic_chem::cip::
+            // assign_ez`'s own `subs_a1.is_empty() || subs_a2.is_empty()`
+            // guard) — e.g. a ketone/aldehyde `C=O` never does (the O side
+            // has none). Skipping both ends together, not just the O side,
+            // matters: the carbon side of such a bond can still have 2
+            // substituents of its own (e.g. two ring bonds) that already
+            // carry a marker belonging to a wholly different, genuinely
+            // stereogenic double bond elsewhere (a ring-closure bond can be
+            // shared between two different rings' substituent lists) —
+            // resolving a "carrier" for the non-stereogenic end would move
+            // or duplicate that unrelated marker.
+            if Self::end_has_substituent(self.mol, bond.atom1)
+                && Self::end_has_substituent(self.mol, bond.atom2)
+            {
+                self.resolve_ez_marker_for_end(bond.atom1, &stereo_alkene_ends);
+                self.resolve_ez_marker_for_end(bond.atom2, &stereo_alkene_ends);
+            }
+        }
+    }
+
+    fn end_has_substituent(mol: &Molecule, end: AtomIdx) -> bool {
+        mol.neighbors(end)
+            .any(|(_, b)| mol.bond(b).order != BondOrder::Double)
+    }
+
+    /// Resolve the marker carrier for one alkene end (see
+    /// [`Self::resolve_ez_markers`]). Substituents are filtered by bond
+    /// order (`!= Double`), not by comparing against a specific double-bond
+    /// `BondIdx`, so an allene/cumulene terminus correctly excludes *every*
+    /// double bond at `alkene_end`, matching `chematic_chem::cip::assign_ez`'s
+    /// own substituent-collection convention.
+    fn resolve_ez_marker_for_end(
+        &mut self,
+        alkene_end: AtomIdx,
+        stereo_alkene_ends: &HashSet<AtomIdx>,
+    ) {
+        let subs: Vec<(AtomIdx, BondIdx)> = self
+            .mol
+            .neighbors(alkene_end)
+            .filter(|&(_, b)| self.mol.bond(b).order != BondOrder::Double)
+            .collect();
+        if subs.len() != 2 {
+            return; // no ambiguity (0/1), or not a valid alkene carbon (>2)
+        }
+
+        let carrier = *subs
+            .iter()
+            .min_by_key(|&&(a, _)| self.ranks[a.0 as usize])
+            .expect("subs has exactly 2 elements");
+        let sibling = if carrier.0 == subs[0].0 {
+            subs[1]
+        } else {
+            subs[0]
+        };
+
+        // Abstain entirely when either candidate substituent is itself
+        // another double bond's ambiguous stereo end (a rare but real
+        // shape: two adjacent stereocenters -- e.g. two ring carbons each
+        // bearing their own exocyclic stereo double bond -- sharing the
+        // very ring-closure bond each would otherwise use as a candidate
+        // carrier). Resolving one end's carrier independently of the
+        // other's can move or demote a mark the *other* system's own
+        // resolution is simultaneously relying on for the same physical
+        // bond, corrupting its geometry; there is no processing order that
+        // avoids this without one end's resolution depending on the
+        // other's *already-resolved* (not raw) value, which would make the
+        // whole computation depend on which double bond happens to be
+        // visited first — reintroducing exactly the kind of order-
+        // dependence this fix exists to remove. Leaving both ends exactly
+        // as the input spelled them is always safe (never corrupts the
+        // encoded geometry); it just leaves *this* rare shared-bond
+        // interaction outside what this fix resolves.
+        //
+        // (A less conservative variant was tried: allow the move but skip
+        // *demoting* a shared sibling, leaving it redundantly-but-
+        // consistently marked. Measured empirically against the same
+        // real-corpus shared-bond cases this guard is designed for, it
+        // produced identical convergence (264/282) — the two marks end up
+        // on different bonds depending on which substituent the *input*
+        // happened to mark, so the output still doesn't converge, just
+        // with an extra redundant marker. Reverted in favor of this
+        // simpler, provably no-op-on-failure form.)
+        if stereo_alkene_ends.contains(&carrier.0) || stereo_alkene_ends.contains(&sibling.0) {
+            return;
+        }
+
+        let carrier_dir = self.raw_input_direction(carrier.1);
+        let sibling_dir = self.raw_input_direction(sibling.1);
+
+        match (carrier_dir, sibling_dir) {
+            (Some(dir), _) => {
+                // Carrier already marked (possibly the sibling too, in
+                // malformed/redundant input) — keep it, demote any other.
+                self.ez_marker.insert(carrier.1, dir);
+                if sibling_dir.is_some() {
+                    self.ez_marker
+                        .insert(sibling.1, Self::plain_order(self.mol.bond(sibling.1).order));
+                }
+            }
+            (None, Some(sibling_dir)) => {
+                // The actual bug case: move the marker from the sibling onto
+                // the canonical carrier, preserving the encoded geometry via
+                // the trigonal-carbon sibling-complement identity (the same
+                // fact `chematic_chem::cip::highest_stereo_sub` relies on to
+                // read a marker back out from either substituent).
+                let sibling_bond = self.mol.bond(sibling.1);
+                let sibling_up = Self::direction_is_up(sibling_dir, sibling_bond.atom1, alkene_end);
+                let carrier_bond = self.mol.bond(carrier.1);
+                let chosen = Self::direction_for_up(carrier_bond.atom1, alkene_end, !sibling_up);
+                self.ez_marker.insert(carrier.1, chosen);
+                self.ez_marker
+                    .insert(sibling.1, Self::plain_order(sibling_bond.order));
+            }
+            (None, None) => {} // no direction info at this end at all
         }
     }
 
@@ -390,10 +663,6 @@ impl<'a> CanonicalWriter<'a> {
     /// into one group per connected E/Z system (order-independent — depends
     /// only on molecule topology, not on canonical ranks or write order).
     fn build_ez_groups(&mut self) {
-        fn is_directional(mol: &Molecule, bidx: BondIdx, order: BondOrder) -> bool {
-            matches!(order, BondOrder::Up | BondOrder::Down) || mol.bond_direction(bidx).is_some()
-        }
-
         fn find(group: &mut HashMap<BondIdx, BondIdx>, x: BondIdx) -> BondIdx {
             let parent = *group.get(&x).unwrap_or(&x);
             if parent == x {
@@ -425,8 +694,14 @@ impl<'a> CanonicalWriter<'a> {
                     if nb_bidx == bidx {
                         continue;
                     }
-                    let nb_order = self.mol.bond(nb_bidx).order;
-                    if is_directional(self.mol, nb_bidx, nb_order) {
+                    // `effective_order` (not the raw bond order/stash) so a
+                    // marker `resolve_ez_markers` moved onto a different
+                    // substituent is grouped by its NEW carrier bond, not
+                    // its old (now-demoted) one.
+                    if matches!(
+                        self.effective_order(nb_bidx),
+                        BondOrder::Up | BondOrder::Down
+                    ) {
                         side_bonds.push(nb_bidx);
                     }
                 }
@@ -472,6 +747,12 @@ impl<'a> CanonicalWriter<'a> {
     }
 
     fn write_all(mut self) -> String {
+        // Phase -1: pick, for every tri-/tetra-substituted stereo alkene
+        // end, which substituent bond canonically carries the `/`/`\`
+        // marker (topology + rank only — independent of write order, and of
+        // which substituent the original parse happened to mark).
+        self.resolve_ez_markers();
+
         // Phase 0: group directional bonds into connected E/Z systems
         // (topology-only, independent of canonical order).
         self.build_ez_groups();
@@ -583,10 +864,12 @@ impl<'a> CanonicalWriter<'a> {
                 let bond = self.mol.bond(bidx);
                 // A ring bond forced to Aromatic (e.g. adjacent to an
                 // exocyclic C=N) may carry its true E/Z direction stashed
-                // separately rather than in `order` itself — consult that
-                // first so the direction still reaches the writer.
-                let stashed_direction = self.mol.bond_direction(bidx);
-                let effective_order = stashed_direction.unwrap_or(bond.order);
+                // separately rather than in `order` itself; a bond flanking
+                // a tri-/tetra-substituted stereo alkene may instead carry
+                // `resolve_ez_markers`'s resolved choice. `effective_order`
+                // checks both, in that priority, before falling back to the
+                // bond's own real order.
+                let effective_order = self.effective_order(bidx);
                 // Direction seen from `neighbor` (the open atom) going toward `atom`.
                 let order_at_open = match effective_order {
                     BondOrder::Up => {
@@ -605,18 +888,13 @@ impl<'a> CanonicalWriter<'a> {
                     }
                     other => other,
                 };
-                // Suppress stereo at the close atom to avoid conflicting ring-closure
-                // chars, falling back to the bond's real order — Aromatic for a
-                // stashed direction (implicit ring bond, no char), Single for a
-                // genuine directional single bond (existing behavior).
+                // Suppress stereo at the close atom to avoid conflicting
+                // ring-closure chars, falling back to the bond's own plain
+                // (non-directional) order: `Aromatic` unchanged for a
+                // stashed/resolved direction (implicit ring bond, no char),
+                // `Single` for a genuine literal directional single bond.
                 let order_at_close = match effective_order {
-                    BondOrder::Up | BondOrder::Down => {
-                        if stashed_direction.is_some() {
-                            bond.order
-                        } else {
-                            BondOrder::Single
-                        }
-                    }
+                    BondOrder::Up | BondOrder::Down => Self::plain_order(bond.order),
                     other => other,
                 };
                 self.atom_ring_nums.entry(neighbor).or_default().push((
@@ -692,10 +970,11 @@ impl<'a> CanonicalWriter<'a> {
             })
             .map(|(nb, bidx)| {
                 let bond = self.mol.bond(bidx);
-                // See the ring-closure site above: a stashed direction takes
-                // priority over `order` itself (e.g. an aromatic ring bond
-                // that flanks an exocyclic C=N).
-                let effective_order = self.mol.bond_direction(bidx).unwrap_or(bond.order);
+                // See the ring-closure site above: `effective_order` applies
+                // `resolve_ez_markers`'s resolved carrier choice and the
+                // aromatic-bond-direction stash, both ahead of the bond's
+                // own literal order.
+                let effective_order = self.effective_order(bidx);
                 // Direction seen from `atom` going toward `nb`.
                 let order = match effective_order {
                     BondOrder::Up => {
@@ -1604,32 +1883,105 @@ mod tests {
     // canonical_diff idempotency failures are large fused-polycyclic atom-ranking
     // non-convergence, not a `/`,`\` direction bug — see docs/rdkit_compat.md.)
 
-    /// E/Z parity of the first C=C/C=N double bond: `Some(true)` = E (opposite
-    /// outward directions), `Some(false)` = Z, `None` = no specified geometry.
+    /// E/Z parity of the first stereo double bond: `Some(true)` = E (the two
+    /// *reference* substituents are on opposite sides), `Some(false)` = Z,
+    /// `None` = no specified geometry.
+    ///
+    /// At each end, the reference substituent is whichever of its (at most
+    /// two) non-double-bond neighbors has the lower `morgan_ranks` value —
+    /// a deterministic, structure-derived choice (not CIP priority, but
+    /// consistent across any re-parse of the same molecule, which is all
+    /// this self-consistency check needs) — falling back to the sibling's
+    /// marker via the trigonal-carbon complement identity when the
+    /// reference substituent's own bond isn't the one marked.
+    ///
+    /// A prior version of this helper picked "whichever substituent bond
+    /// happens to be marked, in adjacency order" instead of a fixed
+    /// structural reference. That is parse-order-dependent: at a
+    /// trisubstituted end, adjacency order is just first-encountered-in-the-
+    /// input order, not tied to which substituent is higher priority, so
+    /// comparing (say) the low-priority substituent at one end against the
+    /// high-priority one at the other can silently invert the apparent
+    /// parity. It happened to still pass before `resolve_ez_markers`
+    /// existed only because canonicalization never relocated a marker to a
+    /// *different* substituent, so both sides of the before/after
+    /// comparison picked the same (arbitrary) atom by construction. Once a
+    /// marker can legitimately move to a different, equally-valid carrier,
+    /// that construction no longer holds, and the fixed rank-based
+    /// reference is what actually verifies "the encoded geometry didn't
+    /// change" rather than "the same accidental artifact survived".
     fn double_bond_is_e(smiles: &str) -> Option<bool> {
         let mol = parse(smiles).unwrap();
-        let (a1, a2) = mol
-            .bonds()
-            .find(|(_, b)| b.order == BondOrder::Double)
-            .map(|(_, b)| (b.atom1, b.atom2))?;
-        let outward = |end: AtomIdx, other: AtomIdx| -> Option<bool> {
-            for (nb, bidx) in mol.neighbors(end) {
-                if nb == other {
-                    continue;
-                }
-                let b = mol.bond(bidx);
-                match b.order {
-                    // `Up` means "up" along atom1→atom2; flip when `end` is atom2.
-                    BondOrder::Up => return Some(b.atom1 == end),
-                    BondOrder::Down => return Some(b.atom1 != end),
-                    _ => {}
-                }
+        double_bond_is_e_mol(&mol)
+    }
+
+    /// Like `double_bond_is_e`, but tries every double bond in the molecule
+    /// (not just the first one found) and returns the first that yields a
+    /// defined answer -- a molecule can have an earlier, non-stereogenic
+    /// double bond (e.g. a ketone's `C=O`, whose oxygen side has no
+    /// substituent at all) ahead of its actual stereo alkene in bond order.
+    fn double_bond_is_e_mol(mol: &Molecule) -> Option<bool> {
+        let ranks = morgan_ranks(mol);
+
+        fn raw_dir(mol: &Molecule, bidx: BondIdx) -> Option<BondOrder> {
+            let order = mol.bond(bidx).order;
+            if matches!(order, BondOrder::Up | BondOrder::Down) {
+                return Some(order);
             }
-            None
+            mol.bond_direction(bidx)
+        }
+
+        let up_of_reference = |end: AtomIdx| -> Option<bool> {
+            let subs: Vec<(AtomIdx, BondIdx)> = mol
+                .neighbors(end)
+                .filter(|&(_, b)| mol.bond(b).order != BondOrder::Double)
+                .collect();
+            match subs.len() {
+                1 => {
+                    let (_, bidx) = subs[0];
+                    let dir = raw_dir(mol, bidx)?;
+                    Some(CanonicalWriter::direction_is_up(
+                        dir,
+                        mol.bond(bidx).atom1,
+                        end,
+                    ))
+                }
+                2 => {
+                    let reference = *subs
+                        .iter()
+                        .min_by_key(|&&(a, _)| ranks[a.0 as usize])
+                        .expect("subs has 2 elements");
+                    let sibling = if reference.0 == subs[0].0 {
+                        subs[1]
+                    } else {
+                        subs[0]
+                    };
+                    if let Some(dir) = raw_dir(mol, reference.1) {
+                        Some(CanonicalWriter::direction_is_up(
+                            dir,
+                            mol.bond(reference.1).atom1,
+                            end,
+                        ))
+                    } else {
+                        let dir = raw_dir(mol, sibling.1)?;
+                        Some(!CanonicalWriter::direction_is_up(
+                            dir,
+                            mol.bond(sibling.1).atom1,
+                            end,
+                        ))
+                    }
+                }
+                _ => None,
+            }
         };
-        let sa = outward(a1, a2)?;
-        let sb = outward(a2, a1)?;
-        Some(sa != sb)
+
+        mol.bonds()
+            .filter(|(_, b)| b.order == BondOrder::Double)
+            .find_map(|(_, b)| {
+                let ua = up_of_reference(b.atom1)?;
+                let ub = up_of_reference(b.atom2)?;
+                Some(ua != ub)
+            })
     }
 
     const EZ_STABLE_CORPUS: &[&str] = &[
@@ -1946,5 +2298,194 @@ mod tests {
             "genuine exocyclic-double-bond-adjacent aromatic stash must \
              still emit a directional token: got '{out}'"
         );
+    }
+
+    // ── E/Z marker-carrier normalization (fix/canonical-ez-carrier-
+    // normalization) ─────────────────────────────────────────────────────
+    //
+    // At a tri-/tetra-substituted stereo alkene end, SMILES only requires
+    // ONE of its ≥2 substituent bonds to carry the `/`/`\` marker -- the
+    // other's position is implied (a trigonal alkene carbon has exactly two
+    // sides). *Which* substituent gets the mark used to be whatever the
+    // parser happened to read, so two RDKit-valid respellings of the same
+    // molecule that mark different substituents produced two different
+    // canonical outputs (docs/canonical_smiles_residual_rfc.md, Root cause
+    // 1). `resolve_ez_markers` picks the marker carrier deterministically
+    // from canonical rank instead. Every case below is a real molecule from
+    // the residual corpus (`validation/results/
+    // canonical_residual_diagnosis_summary.json`'s `permutation_invariance_
+    // failures_sample`), pinned as a regression guard, not a synthetic
+    // approximation of the bug.
+
+    /// Assert `a` and `b` -- two real, already-observed-divergent canonical
+    /// outputs of the SAME molecule -- now canonicalize identically, AND
+    /// that the E/Z geometry each encodes is unchanged by that
+    /// canonicalization (checked via `double_bond_is_e`, not string
+    /// comparison, per the "zero new semantic changes" requirement).
+    #[track_caller]
+    fn assert_ez_carrier_pair_resolved(a: &str, b: &str) {
+        let want_a = double_bond_is_e(a);
+        let want_b = double_bond_is_e(b);
+        let canon_a = canonical_smiles(&parse(a).unwrap());
+        let canon_b = canonical_smiles(&parse(b).unwrap());
+        assert_eq!(
+            canon_a, canon_b,
+            "two divergent real-corpus spellings of the same molecule must \
+             now canonicalize identically: '{a}' -> '{canon_a}' vs '{b}' -> '{canon_b}'"
+        );
+        assert_eq!(
+            double_bond_is_e(&canon_a),
+            want_a,
+            "canonicalizing '{a}' -> '{canon_a}' changed its E/Z geometry"
+        );
+        assert_eq!(
+            double_bond_is_e(&canon_b),
+            want_b,
+            "canonicalizing '{b}' -> '{canon_b}' changed its E/Z geometry"
+        );
+    }
+
+    /// Simplest case: a disubstituted-vs-trisubstituted amidine carbon with
+    /// exactly two non-H substituents (methylamino / 4-iodobenzylamino), no
+    /// ring at all. The two spellings mark different substituents.
+    #[test]
+    fn ez_carrier_trisub_no_ring() {
+        assert_ez_carrier_pair_resolved("Ic1ccc(cc1)CN/C(=N/C)NC", "Ic1ccc(cc1)CNC(=N/C)/NC");
+    }
+
+    /// Tetrasubstituted alkene: both ends have two real substituents (no
+    /// implicit H on either alkene carbon), so both ends independently pick
+    /// a canonical carrier.
+    #[test]
+    fn ez_carrier_tetrasub_no_ring() {
+        assert_ez_carrier_pair_resolved(
+            "COc1ccc(/C=C(\\C)C(=O)c2cc(OC)c(OC)c(OC)c2)cc1O",
+            "COc1ccc(/C=C(C(=O)c2cc(OC)c(OC)c(OC)c2)\\C)cc1O",
+        );
+    }
+
+    /// One candidate substituent is reached via a plain tree edge, the
+    /// other via the SAME alkene end's ring-closure bond (an aliphatic
+    /// cyclopentylidene hydrazone) -- covers "E/Z bond that is also part of
+    /// a ring closure" directly, with no aromaticity involved at all.
+    #[test]
+    fn ez_carrier_ring_closure_candidate() {
+        assert_ez_carrier_pair_resolved(
+            "OC(=O)CCCCCCC/1CCCC1=N/NCCCCCC",
+            "OC(=O)CCCCCCC1CCC/C1=N\\NCCCCCC",
+        );
+    }
+
+    /// The aromatic-bond-direction stash (`resolve_aromatic_direction_stash`
+    /// in parser.rs) combined with a ring-closure candidate: a four-membered
+    /// ring carbon carries an exocyclic C=N imine, and the mark can validly
+    /// land on either its plain ring tree-edge or its ring-closure bond
+    /// (both aromatic-aromatic, so both route through the stash side
+    /// channel, not a literal `Up`/`Down` bond order). This is the exact
+    /// intersection the RFC's dominant root cause calls out: tri-substituted
+    /// + aromatic stash + ring closure, all at once.
+    ///
+    /// This same ring also has a ketone (`c(=O)`) adjacent to the imine,
+    /// sharing a ring bond with it -- a ketone's carbon has two ring-bond
+    /// "substituents" of its own even though a ketone has no E/Z stereo at
+    /// all (the oxygen side has none). `resolve_ez_markers` must recognize
+    /// the ketone end is not stereogenic (both ends of a double bond need a
+    /// substituent) and never touch that shared bond on the ketone's
+    /// account, or it can move/erase the imine's own marker -- this pin
+    /// exercises that guard too, not just the ring-closure/stash mechanism.
+    #[test]
+    fn ez_carrier_aromatic_stash_ring_closure() {
+        assert_ez_carrier_pair_resolved(
+            "c4(c(cncc4Cl)Cl)C(=O)Nc3ccc(cc3)C[C@H](/N=c/2c(=O)c(c2N1CCSCC1)O)C(=O)O",
+            "c4(c(cncc4Cl)Cl)C(=O)Nc3ccc(cc3)C[C@H](/N=c2\\c(=O)c(c2N1CCSCC1)O)C(=O)O",
+        );
+    }
+
+    /// Two DIFFERENT, independently stereogenic double bonds (two exocyclic
+    /// imines on the same four-membered ring) can end up sharing the very
+    /// ring-closure bond each would otherwise use as one of its own two
+    /// candidate carriers. Resolving one end's carrier independently of the
+    /// other's could move or demote a mark the other system relies on for
+    /// the same physical bond -- `resolve_ez_markers` must detect this and
+    /// abstain for BOTH ends rather than risk corrupting either one's
+    /// geometry. This is a real corpus molecule that a fully general
+    /// carrier choice does NOT resolve to one canonical string (a known,
+    /// documented residual -- see the module-level fix commit), but its E/Z
+    /// geometry must never change either way.
+    #[test]
+    fn ez_carrier_shared_bond_between_two_stereo_systems_never_corrupts() {
+        let a = "OC(=O)[C@H](Cc2ccc(NC(c3c(Cl)cncc3Cl)=O)cc2)/N=c1/c(c(c1O)O)=N/CCCCC";
+        let b = "OC(=O)[C@H](Cc2ccc(NC(c3c(Cl)cncc3Cl)=O)cc2)/N=c\\1c(/c(c1O)O)=N/CCCCC";
+        for s in [a, b] {
+            let mol = parse(s).unwrap();
+            let ez_before = ez_pair(&mol);
+            let canon = canonical_smiles(&mol);
+            let mol2 = parse(&canon).unwrap_or_else(|e| panic!("re-parse '{canon}': {e}"));
+            let ez_after = ez_pair(&mol2);
+            assert_eq!(
+                ez_before, ez_after,
+                "canonicalizing '{s}' -> '{canon}' must not change either \
+                 imine's E/Z geometry, even though this shared-bond shape \
+                 is not resolved to one canonical string"
+            );
+            assert!(
+                ez_before.0.is_some() && ez_before.1.is_some(),
+                "test setup sanity: both imines in '{s}' must have a defined \
+                 geometry to make this a meaningful check (got {ez_before:?})"
+            );
+        }
+    }
+
+    /// Both stereo double bonds' E/Z parity in a molecule with (at least)
+    /// two -- used by `ez_carrier_shared_bond_between_two_stereo_systems_
+    /// never_corrupts` to check geometry survives even where string
+    /// convergence isn't achieved. Returns `(first, second)` in bond-index
+    /// order (stable within one parse, which is all this same-molecule
+    /// before/after comparison needs).
+    fn ez_pair(mol: &Molecule) -> (Option<bool>, Option<bool>) {
+        fn raw_dir(mol: &Molecule, bidx: BondIdx) -> Option<BondOrder> {
+            let order = mol.bond(bidx).order;
+            if matches!(order, BondOrder::Up | BondOrder::Down) {
+                return Some(order);
+            }
+            mol.bond_direction(bidx)
+        }
+
+        let doubles: Vec<BondIdx> = (0..mol.bond_count())
+            .map(|i| BondIdx(i as u32))
+            .filter(|&b| mol.bond(b).order == BondOrder::Double)
+            .filter(|&b| {
+                let bond = mol.bond(b);
+                CanonicalWriter::end_has_substituent(mol, bond.atom1)
+                    && CanonicalWriter::end_has_substituent(mol, bond.atom2)
+            })
+            .collect();
+        assert_eq!(
+            doubles.len(),
+            2,
+            "expected exactly 2 stereogenic double bonds"
+        );
+        let ez = |bidx: BondIdx| -> Option<bool> {
+            let bond = mol.bond(bidx);
+            let outward = |end: AtomIdx, other: AtomIdx| -> Option<bool> {
+                for (nb, b) in mol.neighbors(end) {
+                    if nb == other {
+                        continue;
+                    }
+                    if let Some(dir) = raw_dir(mol, b) {
+                        return Some(CanonicalWriter::direction_is_up(
+                            dir,
+                            mol.bond(b).atom1,
+                            end,
+                        ));
+                    }
+                }
+                None
+            };
+            let ua = outward(bond.atom1, bond.atom2)?;
+            let ub = outward(bond.atom2, bond.atom1)?;
+            Some(ua != ub)
+        };
+        (ez(doubles[0]), ez(doubles[1]))
     }
 }

--- a/docs/canonical_smiles_residual_rfc.md
+++ b/docs/canonical_smiles_residual_rfc.md
@@ -2,6 +2,20 @@
 
 Status: **Diagnosis complete. No production behavior change.**
 
+> **Update (C1a):** Root Cause 1 (the dominant, E/Z-marker-carrier cluster
+> described below) has a safe, verified **partial** fix — branch
+> `fix/canonical-ez-carrier-normalization`, PR #148. 264/282 of the
+> `has_ez_marker` diagnosis subset now converge to one canonical string; 18
+> remain a deliberate, documented residual (two independently stereogenic
+> double bonds sharing one candidate carrier bond — see tracking issue
+> "canonical E/Z: jointly resolve shared carrier bonds across coupled stereo
+> systems"). Zero semantic corruption in either case. Root Causes 2 and 3
+> below are still untouched/deferred. See
+> `validation/results/canonical_ez_carrier_c1a_reconciliation.json` for the
+> full count reconciliation (including why this doc's/task history's "281"
+> and the committed diagnosis artifact's "282" are not a regression against
+> each other).
+
 Branch: `diag/canonical-smiles-residual` (forked from `main`@`659baca221f71f135ce0e1780e71245d8770f132`).
 
 ## Scope declaration

--- a/validation/results/canonical_ez_carrier_c1a_reconciliation.json
+++ b/validation/results/canonical_ez_carrier_c1a_reconciliation.json
@@ -1,0 +1,48 @@
+{
+  "purpose": "Reconciles every E/Z-carrier-cluster count referenced across this fix's history (task brief's approximate '281', the two different committed diagnosis-artifact counts, and this PR's own fresh measurements), so a future reader does not mistake an instrument/definition change for a regression. Every row below is a DIFFERENT, explicitly-labeled instrument -- never pooled.",
+  "provenance_of_the_281_vs_282_discrepancy": {
+    "commit_676c752_original_diagnosis": {
+      "description": "First diagnosis PR. The diagnosis script itself had an undercounting bug (fixed in the next commit) -- NOT a difference in the fix or the molecule set.",
+      "total_check2_failures": 281,
+      "has_ez_marker_true": 281
+    },
+    "commit_6ffd697_diag_script_correction": {
+      "description": "diag(smiles): unify Check 2/3, correct permutation-invariance undercount -- same corpus, same base commit, corrected script. This is the count the task brief's approximate '281' should be read against; it is the one this PR's fix was actually measured against throughout.",
+      "total_check2_failures": 348,
+      "has_ez_marker_true": 282,
+      "has_ez_marker_false": 66
+    },
+    "conclusion": "281 -> 282 (has_ez_marker subset) is NOT a regression and NOT re-measurement drift on a moved main. It is a one-time, already-committed correction to the diagnosis script's own undercounting bug, made in a prior PR, before this fix branch existed. This PR's fix was measured against 282 (the corrected, current count) throughout."
+  },
+  "this_prs_own_fresh_measurement": {
+    "corpus_caveat": "The literal 5,000-molecule corpus that scripts/canonical_residual_diagnosis.py and scripts/bench5k.py normally take as an argument (~/Downloads/SMILES.csv) was not accessible from this task's sandboxed environment. All numbers in this section use a 4,992-of-5,000-molecule PROXY corpus instead: the 'smiles' field recovered from every row of the already-committed validation/results/canonical_residual_diagnosis.jsonl (itself Check-1 exact-string-parity output against RDKit, i.e. essentially the whole corpus except the 8 molecules where chematic's string already matched RDKit's byte-for-byte). This is a PROXY, not the literal 5,000-molecule corpus -- do not describe it as such elsewhere.",
+    "has_ez_marker_282_subset_instrument": {
+      "description": "Direct convergence check: re-canonicalize both of each fixture's known-divergent 'distinct_outputs' spellings and check whether they now collapse to one string.",
+      "converge": 264,
+      "still_diverge_residual": 18,
+      "note": "18 residual = the shared-candidate-bond guard's deliberate abstain (see tracking issue). All 18 confirmed zero semantic corruption."
+    },
+    "full_4992_proxy_corpus_before_vs_after": {
+      "description": "scripts/canonical_residual_diagnosis.py (seed=0, k=8), same tool, run twice: 'before' = crates/chematic-smiles/src/canonical.rs at base commit b84c28e (pre-fix), 'after' = this PR's HEAD (d763cad).",
+      "before_check2_permutation_invariance_fail": 350,
+      "before_check2_permutation_invariance_pct": 92.99,
+      "after_check2_permutation_invariance_fail": 96,
+      "after_check2_permutation_invariance_pct": 98.08,
+      "before_check3_idempotence_fail": 78,
+      "after_check3_idempotence_fail": 78,
+      "idempotence_note": "Identical before/after (78 == 78) -- this fix does not touch the pre-existing, out-of-scope aromaticity round-trip issue (RFC Root Cause 3).",
+      "set_diff_after_minus_before_regressions": [],
+      "set_diff_after_minus_before_count": 0,
+      "set_diff_before_minus_after_fixed_count": 254,
+      "residual_intersection_count": 96,
+      "residual_breakdown": {
+        "relabel_only_shared_bond_guard": 18,
+        "idempotence_only_preexisting_aromaticity": 78,
+        "both": 0
+      },
+      "semantic_corruption_before": 0,
+      "semantic_corruption_after": 0
+    }
+  },
+  "honest_headline": "264/282 (93.6%) of the has_ez_marker diagnosis subset now converge to one canonical string. NOT literally 'all 281' or 'all 282'. 18 residual cases are a documented, safety-motivated incompleteness (shared-candidate-bond guard, tracked in a follow-up issue), not a correctness regression -- zero semantic corruption measured in either the before or after run."
+}


### PR DESCRIPTION
## C1a: safe, verified partial resolution — not "C1 complete"

This is **C1a**: a safe, general fix for the dominant sub-case of the E/Z
marker-carrier normalization gap, verified to introduce zero regressions and
zero semantic corruption. It resolves **264/282 (93.6%)** of the
`has_ez_marker` diagnosis subset, not the full 281/282 originally targeted.
The remaining 18 are a deliberate, documented abstain (see "Known residual"
below and the tracking issue linked there) — not silently dropped, not
hidden in the numbers.

## Summary

`normalize_ez` in `crates/chematic-smiles/src/canonical.rs` correctly normalizes E/Z flip *polarity* per connected system, but inherited whichever substituent the **input** SMILES happened to mark with `/`/`\` as the direction carrier (either a literal `Up`/`Down` bond order, or the aromatic `bond_direction` stash from `resolve_aromatic_direction_stash` in `parser.rs`). Two semantically identical spellings of the same alkene could therefore canonicalize to different — though individually correct — strings: permutation invariance held for the underlying stereo *assignment*, but not for marker *placement*.

### Mechanism

**Before:** the writer's `dfs_mark`/`write_chain` emission sites read whichever bond the parser happened to leave literally marked (`BondOrder::Up`/`Down`) or stashed (`Molecule::bond_direction`), with no re-derivation step.

**After:** a new pass, `resolve_ez_markers` (runs before `build_ez_groups`, as "Phase -1" of `write_all`), walks every double bond where both ends have ≥1 substituent and picks the rank-lowest-ranked substituent as the canonical carrier. When the raw input marked the *other* (sibling) substituent instead, the mark is relocated via the trigonal-carbon sibling-complement identity (`up(sibling) == !up(carrier)`) — the same identity `chematic_chem::cip::highest_stereo_sub` relies on to read a marker back out from either substituent. The result is cached in a new `ez_marker: HashMap<BondIdx, BondOrder>` field, consulted by a new `effective_order` helper ahead of the raw literal/stash direction at both emission sites (`dfs_mark`'s ring-closure path and `write_chain`'s tree-edge path); `build_ez_groups` groups on the resolved value too.

Covers all three explicitly-required cases: tri/tetrasubstituted alkenes (rank-based carrier choice has no special-casing by substitution count), the aromatic bond-direction stash (`effective_order` reads `raw_input_direction`, which falls back to `Molecule::bond_direction`), and ring-closure bonds (the resolution runs before DFS/ring-closure emission and is keyed by `BondIdx`, so it applies identically whether the bond ends up as a tree edge or a ring closure).

### Known residual: shared-candidate-bond guard (not fixed here — tracked separately)

A double bond only has E/Z stereo when *both* ends have ≥1 substituent (a ketone/aldehyde `C=O` never does) — resolving a "carrier" for a non-stereogenic end anyway could move or erase a mark a neighboring, genuinely stereogenic double bond relies on for the same bond. Guarded against (topology-only, order-independent).

The harder case: two **independently** stereogenic double bonds occasionally share one physical bond (typically a ring closure) as a candidate carrier — e.g. two ring carbons each bearing their own exocyclic imine. Resolving either end's carrier independently of the other's can corrupt the other's geometry, and there is no processing order that avoids this without introducing a *different* order-dependence (which end gets visited first). **This PR abstains entirely** in that case (leave both ends exactly as input-spelled — always safe, never corrupts, but doesn't converge to one string either). This affects exactly the **18** residual molecules below.

A less conservative variant was tried and measured before settling on blanket-abstain: allow the carrier move but skip *demoting* a shared sibling (leaving it redundantly-but-consistently marked instead). Measured directly against the same real-corpus shared-bond cases (convergence of the two known-divergent spellings, not just "did output change"): **identical result, 264/282 either way** — the two marks just end up on different bonds depending on which substituent the *input* happened to mark, so output still didn't converge, only with an extra redundant marker. Reverted in favor of the simpler, provably-safe blanket-abstain form (see code comment on `resolve_ez_marker_for_end`).

**Tracking issue for a real fix:** #149 — "canonical E/Z: jointly resolve shared carrier bonds across coupled stereo systems".

The 18 residual molecules are now a **permanent regression test**
(`ez_carrier_shared_candidate_bond_residuals_never_corrupt`), not just a
one-off debug probe: it asserts, per fixture, that (a) the guard actually
fired — read from a `cfg(test)`-only instrumentation field on
`CanonicalWriter` that records production's own record of which branch
`resolve_ez_marker_for_end` took, not a re-derivation in the test that could
silently mismatch which branch production actually took — and (b) a new
`geometry_fingerprint` helper (marker-placement-invariant, cross-parse-
comparable via canonical-rank ordering) is unchanged across canonicalize-
then-reparse. A companion positive-control test
(`geometry_fingerprint_is_sensitive_to_a_real_flip`) guards against that
check passing vacuously.

## Scope

- **Touched:** `crates/chematic-smiles/src/canonical.rs` (production fix + tests), `docs/canonical_smiles_residual_rfc.md` (pointer to this PR), `validation/results/canonical_ez_carrier_c1a_reconciliation.json` (new — count provenance, see below). No other file changed.
- **Out of scope, untouched:** aromaticity (chematic-perception), the K2b authoritative-demotion work, bridged-ring canonicalization ordering, `BondStereo`/E-Z assignment logic itself, `chematic-fp` (Track B).
- **No fixture-specific allowlist in production code** — the fix is a general, rank-based mechanism; the only special-casing is the two topology-only guards above. (The 18 fixtures in the new test ARE fixture-specific, as regression tests always are — that's normal, not a special-cased production path.)
- **Split out of this PR, forked from `main@b84c28e` instead:** the `Chem.FindMolChiralCenters(..., useLegacy=False)` vs `useLegacyImplementation` RDKit API-drift fix to `scripts/canonical_residual_diagnosis.py` — a real, pre-existing, unrelated bug found while verifying this PR, but a diagnostic-tooling change, not part of this fix. See its own PR.

## Count provenance — why "281" and "282" both appear, and it's not a regression

`validation/results/canonical_ez_carrier_c1a_reconciliation.json` (new in this PR) has the full detail. Short version: the task brief's approximate "281" traces to diagnosis commit `676c752` (281 total failures). A **later, already-committed** commit `6ffd697` ("unify Check 2/3, correct permutation-invariance undercount") fixed an undercounting bug in the diagnosis **script itself** on the same corpus, revealing 348 total failures, of which **282** are `has_ez_marker`. That correction predates this fix branch entirely — this PR was measured against 282 throughout. 281→282 is a script-accuracy correction, not drift or a regression.

## Verification

### Corpus construction

`~/Downloads/SMILES.csv` (the literal 5,000-molecule corpus `bench5k.py`/`canonical_residual_diagnosis.py` normally take as an argument) was not accessible from this sandboxed environment. As a **proxy — not the full corpus** — the original input SMILES for 4,992 of the 5,000 corpus molecules were recovered from the already-committed `validation/results/canonical_residual_diagnosis.jsonl` (each row's `smiles` field — this file is Check-1 exact-string-parity output against RDKit, essentially the whole corpus except the 8 molecules where chematic already matched RDKit's string byte-for-byte). This proxy-corpus caveat applies to every full-corpus number below.

### Before/after, same tool, same seed, 4,992-molecule proxy corpus (NOT the 5,000-molecule corpus)

Ran the project's own `scripts/canonical_residual_diagnosis.py` — via a **temporary local workaround** (a monkeypatch shim outside the repo, translating the `useLegacy` kwarg) for the pre-existing RDKit API-drift bug being fixed in the separate diagnostic-tooling PR referenced above; once that PR lands, re-verification should use the fixed script directly — with identical `seed=0`, `k=8` against:
- **before:** `crates/chematic-smiles/src/canonical.rs` checked out at base commit `b84c28e` (pre-fix)
- **after:** the same file at this PR's HEAD

| | Permutation invariance (Check 2) | Idempotence (Check 3) |
|---|---|---|
| **Before** | 4,642 / 4,992 = **92.99%** | 4,914 / 4,992 = **98.44%** |
| **After** | 4,896 / 4,992 = **98.08%** | 4,914 / 4,992 = **98.44%** |

Reported **separately**, as required. **98.08% is the measured number — not 100%, and not to be quoted as such anywhere (README/CHANGELOG included).** Idempotence is untouched by this fix (identical 78 failures before and after; pre-existing aromaticity round-trip issue, RFC Root Cause 3, explicitly out of scope / deferred to the aromaticity track).

**Regression gate (set diff by SMILES, both fresh runs, never against the committed jsonl):**
- `after_fail − before_fail` (molecules that started passing and now fail) = **0 — empty**. No regression.
- `before_fail − after_fail` (molecules fixed) = **254**. Large and relabeling-dominated, confirming the fix is live in the measured build (not a stale-binary artifact).
- `after_fail ∩ before_fail` = **96** = **18** relabel-only (the shared-bond-guard residual, in-scope but deliberately abstained) **+ 78** idempotence-only (pre-existing aromaticity Root Cause 3, out of scope, unchanged) **+ 0** detected-via-both.
- `fail_semantically_DIFFERENT_outputs` = **0** in both before and after runs — no molecule's actual structure/stereo ever differed across outputs, only the string. Confirms zero semantic corruption.

The 18 residual molecules are individually confirmed — now via the **permanent** Rust regression test described above, not just an ad hoc debug probe — to all trigger the documented shared-candidate-bond guard specifically; no unexplained "stranger" failures.

### Honest count against the "281 rows" acceptance criterion

**This does not resolve literally "all 281" or "all 282."** Using the diagnosis JSONL's `has_ez_marker` subset (282 molecules with known divergent spellings) as the most direct instrument: **264/282 (93.6%) now converge to one canonical string; 18/282 remain divergent**, deliberately left as-is by the shared-candidate-bond abstain guard described above. Both the "264" instrument and the full-corpus-proxy "254 fixed" number above are consistent (different instruments, same underlying cluster — see the reconciliation JSON). Zero of the 18 residual cases produce semantically-different output — they're a documented, safety-motivated incompleteness, not a correctness regression.

### Semantic-change check

Cross-checked via two independent tools, both agreeing on zero semantic corruption across the whole measured set: (1) the diagnosis script's own RDKit-based Check 4 (`fail_semantically_DIFFERENT_outputs: 0` in both runs), and (2) a Rust harness against `chematic_chem::cip::assign_cip` (not importable from `chematic-smiles` itself — chematic-smiles sits below chematic-chem in the dependency graph — so verification only, never used in the fix) confirming no molecule's actual R/S or E/Z assignment changed, only which bond carries the marker. The 18 residual fixtures additionally now have a permanent in-crate regression test (`geometry_fingerprint`-based, marker-placement-invariant) rather than relying only on the ad hoc verification above.

### Determinism

Canonical output confirmed byte-identical across ≥3 independent process invocations, including with a full `cargo clean` rebuild between each (ruling out both process-random `HashMap` iteration order and binary-caching artifacts as a source of nondeterminism).

### `bash scripts/check.sh`

Green (fmt / clippy / test / test-integration / deny / publish-graph / version), run immediately before each commit.

### CI

All 15 GitHub Actions checks passed on the prior revision of this PR (CodeQL/Analyze ×3, Build Check, Cargo Audit, Cargo Deny, Clippy, Clippy Lints, Format Check, Python bench regression gate, Rust Criterion regression gate, Test, Test (native-inchi), Validate CITATION.cff) — re-confirming after this revision's push.

## Disclosures

- **Shared `.venv` editable install overwritten.** During earlier measurement work in this task, `maturin develop` was inadvertently invoked with the shared main-repo `.venv` on `PATH` instead of an isolated one, redirecting its `chematic` editable install from a different worktree (`agent-a7e6a2dcc1ba0cc9b`) to this one. All subsequent measurement in this PR used a properly isolated scratch venv, but the shared `.venv`'s install was not reverted. If anything else (e.g. the concurrent ECFP4/chematic-fp stream) does `import chematic` against the shared venv, it may currently resolve to this worktree's build rather than its own.
- **RDKit API-drift bug in `scripts/canonical_residual_diagnosis.py`** — real, pre-existing, found while verifying this PR, being fixed properly in a separate diagnostic-tooling PR (forked from `main@b84c28e`, not stacked on this one) rather than left as a permanent external-shim workaround.

## Test plan

- [x] `cargo test -p chematic-smiles --lib` — 151/151 pass, including the original 5 `ez_carrier_*` tests (trisubstituted/tetrasubstituted alkenes, ring-closure candidates, the aromatic-stash+ring-closure combination, the shared-bond-never-corrupts single-fixture guard) plus the new 18-fixture permanent regression test and its positive control.
- [x] `bash scripts/check.sh` green.
- [x] Full 4,992-molecule proxy-corpus before/after diff: 0 regressions, 254 fixed, 96 residual fully attributed (18 in-scope-abstained + 78 out-of-scope pre-existing), 0 semantic corruption in either run.
- [x] Determinism confirmed across 3 process invocations with full rebuilds between each.
- [x] All 15 CI checks (CI/Security/Bench) green on the prior push.
- [ ] Not merged — coordinator will rebase onto latest `main` and re-check CI before final merge.
