### PR TITLE
fix(scripts): use RDKit's current FindMolChiralCenters kwarg name

### DIFF
--- a/scripts/canonical_residual_diagnosis.py
+++ b/scripts/canonical_residual_diagnosis.py
@@ -94,7 +94,7 @@ def extract_features(mol) -> MolFeatures:
     rings = tuple(sorted(len(r) for r in mol.GetRingInfo().AtomRings()))
     centers = tuple(sorted(
         lbl for _, lbl in Chem.FindMolChiralCenters(
-            mol, includeUnassigned=True, useLegacy=False)
+            mol, includeUnassigned=True, useLegacyImplementation=False)
     ))
     ez = tuple(sorted(
         str(b.GetStereo()) for b in mol.GetBonds()


### PR DESCRIPTION
## Summary

`scripts/canonical_residual_diagnosis.py` calls
`Chem.FindMolChiralCenters(mol, includeUnassigned=True, useLegacy=False)`,
but the installed RDKit (2026.3.x) only accepts `useLegacyImplementation`
(confirmed via `help(Chem.FindMolChiralCenters)`: signature is `force`,
`includeUnassigned`, `includeCIP`, `useLegacyImplementation`, no
`useLegacy`). Every invocation of `extract_features` — i.e. every run of
the script against real molecules — raised
`TypeError: FindMolChiralCenters() got an unexpected keyword argument
'useLegacy'` before measuring anything.

Fix: rename the kwarg to `useLegacyImplementation`, preserving the
original intent (force the modern, non-legacy stereo-perception code
path, `False`).

## Scope

- **Touched:** `scripts/canonical_residual_diagnosis.py`, one line.
- Nothing else. Forked from `main@b84c28e` directly, not stacked on any
  other branch/PR.

## How this was found

While independently re-verifying PR #148 (canonical-SMILES E/Z
marker-carrier fix), which needed to run this script against a real
corpus. Worked around there via a temporary, non-repo monkeypatch shim
(not committed) so that PR's own measurement could proceed; this PR fixes
the actual bug in the repo instead, split out per review since it's a
diagnostic-tooling fix, unrelated to the E/Z fix itself.

## Verification

- `python scripts/canonical_residual_diagnosis.py --self-test` passes.
- A real end-to-end run against a 50-molecule sample completes
  successfully (previously crashed with the `TypeError` above on the
  first molecule containing a stereocenter).
- `bash scripts/check.sh` green.

## Test plan

- [x] `--self-test` passes.
- [x] Real 50-molecule sample run completes end-to-end without error.
- [x] `bash scripts/check.sh` green.
- [ ] Not merged.