### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet — everything below `[0.6.0]` has shipped._
+
+## [0.6.0] — 2026-07-25
+
 ### Added — `chematic-fp` / Python / WASM
 
 - **Promoted the RDKit-bit-exact Morgan/ECFP4 path (`rdkit_morgan_ecfp4_experimental`)
@@ -51,6 +55,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every surface — never a silent fallback to the default Hückel-based `ecfp4()` engine,
   which would look successful while returning bits from an incompatible hash. Regression-
   tested on all three surfaces via the shared corpus's error fixture.
+
+### Added — `chematic-perception`
+
+- **`assign_aromaticity_authoritative_experimental(mol)` / `apply_aromaticity_authoritative_experimental(mol)`** — a new, opt-in aromatic-flag engine that makes `build_molecule_from_model`'s promotion/demotion decision authoritative in *both* directions: an atom's flag reflects the Hückel model's actual computed verdict, promoted when the model confirms it and **demoted** when a stale parser-set `aromatic: true` the model doesn't independently confirm survived from the input. The existing default (`apply_aromaticity`/`apply_aromaticity_ex`) is **unchanged** — verified byte-identical against `main` on a representative set of tricky fixtures (heteroaromatic implicit-H cases, the fused-diazine fix target, the still-open azulene gap, Kekulé input), not just by code inspection.
+- As part of building this, fixed a real misclassification in `ring_pi_electrons`'s `CarbonExocyclicHeteroatomDouble` rule: a ring-fusion bond into an *adjacent* ring's heteroatom was scored the same as a genuine exocyclic substituent (like tropone's `C=O`), wrongly zeroing that atom's π contribution and — when both fusion atoms of a bicyclic system were affected — landing the ring on exactly π=4 (`Antiaromatic`), a Pass-1 verdict marked non-retryable and so permanently excluded from Pass 2's correction mechanism. Fixed generally (bond-level ring-membership check, no molecule-specific allowlist): fixes quinazoline/quinoxaline/naphthyridine/purine-shaped fused diazines (29 of a 33-molecule cluster; the remaining 4 are compound cases blocked by a second, independent, out-of-scope mechanism) with an unattempted beneficial side effect of also resolving 32 pre-existing `KNOWN_BRIDGEHEAD_N_FALSE_POSITIVES` regression pins and 2 open oracle findings (including the PR #86 purine reproducer).
+- **Known, honestly-documented limitations of the new opt-in engine** (not regressions — these molecules were never correctly handled before either): azulene-type non-alternant fused rings (49 molecules) are an architectural gap — each ortho-fused ring independently gets an odd Pass-1 π count and neither seeds Pass 2, since no single SSSR ring can see azulene's whole-perimeter 10π delocalized system. The already-shipped, separately opt-in `apply_aromaticity_rdkit_parity_experimental` engine does resolve this (and the fused-diazine cluster) at 99.9956% corpus-wide agreement, but promoting *that* engine to the default remains a distinct, bigger decision this change does not make.
+
+### Fixed — `chematic-smiles`
+
+- **Canonical output could place an E/Z direction marker on a different substituent bond depending on input atom order/spelling** — the same alkene, written two semantically-identical ways, could canonicalize to two different (though individually valid) strings: permutation invariance held for the underlying stereo *assignment* but not for marker *placement*. Fixed via a new resolution pass (`resolve_ez_markers`) that deterministically picks the rank-lowest substituent as the canonical carrier for every double bond with stereo on both ends, covering trisubstituted/tetrasubstituted alkenes, the aromatic bond-direction stash, and ring-closure bonds. Two known, deliberately conservative exceptions remain unresolved rather than risk corruption: a double bond with a non-stereogenic end, and two independently-stereogenic double bonds that happen to share one physical candidate bond (18 molecules total) — resolving either case's carrier without the other visible can corrupt geometry, and there is no processing order avoiding a *different* order-dependence, so this case is left exactly as input-spelled. Tracked as [#149](https://github.com/kent-tokyo/chematic/issues/149) for a future joint-resolution design. Zero semantic corruption confirmed via two independent methods on every measured molecule.
+- Permutation invariance (measured on a 4,992-molecule proxy corpus, separately from idempotence per this project's convention): **92.99% → 98.08%** (264 of 282 known-divergent molecules now converge; the 18 residual cases above are the entire gap). Idempotence unaffected (98.44%, unchanged — its own residual is a separate, pre-existing aromaticity round-trip issue).
+- Investigated and **ruled out** a previously-diagnosed "bridged-bicyclic ring-closure ordering" permutation-invariance bug (`docs/canonical_smiles_residual_rfc.md`'s "Root Cause 2") — the two SMILES claimed to be "two spellings of the same molecule" turned out, per independent RDKit `MolToInchi` verification, to be genuinely different constitutional isomers; chematic's differing canonical output for them is correct, not a bug. An additional 22-molecule probe using RDKit-`RenumberAtoms`-generated genuine same-molecule respellings (bridged/spiro/fused/cage systems, including stereocenters and a heteroatom bridgehead) found zero convergence failures. No production code changed for this finding; the RFC and test suite were corrected instead.
+
+### Fixed — `scripts`
+
+- `scripts/canonical_residual_diagnosis.py` called RDKit's `FindMolChiralCenters` with a kwarg name (`useLegacy`) the currently-pinned RDKit version no longer accepts (`useLegacyImplementation`) — a pre-existing tooling bug found while re-verifying the E/Z-marker fix above, fixed as its own small change so it doesn't need an external workaround to run.
 
 ## [0.5.0] — 2026-07-23
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,5 +22,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.5.0
+version: 0.6.0
 date-released: "2026-06-26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -180,10 +180,10 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.5.0
+# chematic v0.6.0
 # Python 3.12.x  |  darwin arm64
 #
-# Descriptor accuracy (benchmark 2026-07-17, v0.5.0 vs RDKit 2026.03.3):
+# Descriptor accuracy (benchmark 2026-07-17, v0.6.0 vs RDKit 2026.03.3):
 #   MW / HBA / HBD / ARC  100%   (4,999-mol ChEMBL subset)
 #   TPSA                  100%   within ±0.1 Å²
 #   LogP (Crippen)        100%*  (max Δ = 1.1×10⁻¹³)
@@ -407,6 +407,12 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +1
 
 ## Recent Development (v0.4.x Era)
 
+**v0.6.0** (2026-07-25): **RDKit-bit-exact ECFP4 cross-language stable API, canonical SMILES E/Z marker consistency, opt-in authoritative aromaticity demotion**
+- `chematic-fp`/Python/WASM: promoted the RDKit-bit-exact Morgan/ECFP4 path to a documented, cross-language opt-in API (`Mol.rdkit_ecfp4()` in Python, `rdkit_ecfp4_bitvec()` in WASM), generalized to an independently oracle-verified `(radius, fpSize)` matrix (4×5 = 20 cells, closed enums so an unsupported combination can't be constructed). Rust/Python/WASM verified byte-identical by actually building and running all three, not "identical by construction." `ecfp4()`'s default behavior is unchanged
+- `chematic-smiles`: fixed canonical output placing an E/Z direction marker on a different substituent bond depending on input atom order — permutation invariance for marker placement **93.0% → 98.1%** (264/282 known-divergent molecules now converge; 18 residual cases deliberately left unresolved to avoid corrupting a shared-carrier-bond edge case, tracked as [#149](https://github.com/kent-tokyo/chematic/issues/149)). Also investigated and **ruled out** a previously-suspected bridged-bicyclic canonicalization bug — the two SMILES in question turned out to be genuinely different molecules per independent RDKit InChI verification, not a chematic defect
+- `chematic-perception`: new opt-in `apply_aromaticity_authoritative_experimental` — makes aromatic-flag promotion/demotion fully authoritative to the Hückel model's actual verdict in both directions (the default `apply_aromaticity`/`apply_aromaticity_ex` are unchanged, verified byte-identical). Fixed a ring-fusion-bond misclassification affecting fused diazines (quinazoline/quinoxaline/purine-shaped rings) as part of this work, with a beneficial side effect of also resolving 32 pre-existing false-positive regression pins
+- Full details and known limitations in `CHANGELOG.md`
+
 **v0.5.0** (2026-07-23): **CIP-independent 2D wedge parity, charge-aware kekulization (6 previously-hard-failing molecule classes), non-silent PAINS/Brenk budget matching**
 - `chematic-perception`: new `local_parity_from_wedges`/`apply_local_parity_from_wedges` — computes `Atom.chirality`/`stereo_neighbor_order` directly from wedge/hash bonds and 2D coordinates without any CIP ranking, so a CIP tie can't erase a known local parity; sign convention measured against RDKit's raw chiral tag, not derived by analogy. Not yet wired into any reader's default parse path
 - `chematic-core`: `kekulize()`'s atom-matching rules were charge-blind and missing Tellurium — tropylium, imidazolium, pyridinium, pyrylium, tellurophene, and phosphole now kekulize successfully, bond-for-bond identical to RDKit, with zero regressions; `Element::normal_valences()` gained a source-verified Tellurium entry, fixing a resulting ECFP4 aromaticity mismatch
@@ -557,7 +563,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v0.5.0)
+├── Cargo.toml                    workspace root (v0.6.0)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)
@@ -610,7 +616,7 @@ If you use chematic in academic or research work, please cite:
   author    = {kent-tokyo},
   title     = {chematic: A pure-Rust cheminformatics toolkit},
   url       = {https://github.com/kent-tokyo/chematic},
-  version   = {0.5.0},
+  version   = {0.6.0},
   year      = {2026},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +1
 
 ---
 
-## Recent Development (v0.4.x Era)
+## Recent Development
 
 **v0.6.0** (2026-07-25): **RDKit-bit-exact ECFP4 cross-language stable API, canonical SMILES E/Z marker consistency, opt-in authoritative aromaticity demotion**
 - `chematic-fp`/Python/WASM: promoted the RDKit-bit-exact Morgan/ECFP4 path to a documented, cross-language opt-in API (`Mol.rdkit_ecfp4()` in Python, `rdkit_ecfp4_bitvec()` in WASM), generalized to an independently oracle-verified `(radius, fpSize)` matrix (4×5 = 20 cells, closed enums so an unsupported combination can't be constructed). Rust/Python/WASM verified byte-identical by actually building and running all three, not "identical by construction." `ecfp4()`'s default behavior is unchanged

--- a/README_ja.md
+++ b/README_ja.md
@@ -276,7 +276,7 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi      
 
 ---
 
-## 最近の開発（v0.4.x）
+## 最近の開発
 
 **v0.6.0**（2026-07-25）: **RDKit bit-exact ECFP4のクロス言語stable API化、canonical SMILESのE/Zマーカー一貫性、opt-in芳香族flag authoritative降格**
 - `chematic-fp`/Python/WASM: RDKit bit-exact Morgan/ECFP4パスをクロス言語opt-in APIとして公開（Python `Mol.rdkit_ecfp4()`、WASM `rdkit_ecfp4_bitvec()`）。radius×fpSizeの20セル全てを個別にlive RDKit oracleで再検証（closed enumで未対応値は構築不可）。Rust/Python/WASMを実際にビルド・実行してbyte-identicalを確認済み。`ecfp4()`の既定動作は無変更

--- a/README_ja.md
+++ b/README_ja.md
@@ -106,10 +106,10 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.5.0
+# chematic v0.6.0
 # Python 3.12.x  |  darwin arm64
 #
-# Descriptor accuracy (benchmark 2026-06, v0.5.0 vs RDKit 2026.03.3):
+# Descriptor accuracy (benchmark 2026-06, v0.6.0 vs RDKit 2026.03.3):
 #   MW / HBA / HBD / ARC  100%   (4,999-mol ChEMBL subset)
 #   TPSA                  98.1%
 #   LogP (Crippen)        ~99%
@@ -277,6 +277,12 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi      
 ---
 
 ## 最近の開発（v0.4.x）
+
+**v0.6.0**（2026-07-25）: **RDKit bit-exact ECFP4のクロス言語stable API化、canonical SMILESのE/Zマーカー一貫性、opt-in芳香族flag authoritative降格**
+- `chematic-fp`/Python/WASM: RDKit bit-exact Morgan/ECFP4パスをクロス言語opt-in APIとして公開（Python `Mol.rdkit_ecfp4()`、WASM `rdkit_ecfp4_bitvec()`）。radius×fpSizeの20セル全てを個別にlive RDKit oracleで再検証（closed enumで未対応値は構築不可）。Rust/Python/WASMを実際にビルド・実行してbyte-identicalを確認済み。`ecfp4()`の既定動作は無変更
+- `chematic-smiles`: 入力のatom順序によってE/Z方向マーカーが異なる側鎖bondへ載る問題を修正 — permutation invariance **93.0% → 98.1%**（264/282件が収束、残り18件はshared-carrier-bondの破損リスクを避けるため意図的に未解決、issue [#149](https://github.com/kent-tokyo/chematic/issues/149)で追跡）。また、bridged-bicyclic canonicalizationの既存バグ疑惑を調査し**誤診断と判明**（RDKit InChIで検証した結果、問題とされた2つのSMILESは実際には異なる分子だった）
+- `chematic-perception`: 新規opt-in `apply_aromaticity_authoritative_experimental` — 芳香族flagの昇格/降格をHückelモデルの計算結果に対して双方向で忠実にする（既定の`apply_aromaticity`/`apply_aromaticity_ex`は無変更、byte-identical確認済み）。fused diazine（quinazoline/quinoxaline/purine型）のring-fusion bond誤分類も修正、既存の32件のfalse-positive regression pinも副次的に解消
+- 詳細な項目別数値と既知の制限事項は `CHANGELOG.md` を参照
 
 **v0.5.0**（2026-07-23）: **CIP不要の2Dウェッジ由来local parity、charge対応kekulization（従来失敗していた6分子クラス）、PAINS/Brenkのbudget付きmatching**
 - `chematic-perception`: `local_parity_from_wedges`/`apply_local_parity_from_wedges` を新規追加 — CIPランキングを一切使わず、wedge/hash結合と2D座標から直接 `Atom.chirality`/`stereo_neighbor_order` を計算。符号規約はRDKitの生のchiral tagに対して実測で決定（類推ではない）。まだどのreaderのデフォルトparseからも呼ばれない

--- a/README_zh.md
+++ b/README_zh.md
@@ -246,6 +246,76 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi      
 
 ## 近期开发
 
+**v0.6.0**（2026-07-25）：**RDKit bit-exact ECFP4 跨语言稳定 API、canonical SMILES 的 E/Z 标记一致性、opt-in 芳香性标志权威降级**
+- `chematic-fp`/Python/WASM：将 RDKit bit-exact 的 Morgan/ECFP4 路径提升为文档化的跨语言 opt-in API（Python `Mol.rdkit_ecfp4()`，WASM `rdkit_ecfp4_bitvec()`），并推广为独立验证过的 `(radius, fpSize)` 矩阵（4×5=20 个组合，均为不可构造非法值的封闭枚举）。Rust/Python/WASM 三端均实际构建并运行验证 bit-exact 一致，而非仅"设计上应当一致"。`ecfp4()` 的默认行为不变
+- `chematic-smiles`：修复了 canonical 输出中 E/Z 方向标记依输入原子顺序落在不同取代基键上的问题——标记放置的置换不变性从 **93.0% 提升到 98.1%**（282 个已知发散分子中 264 个现已收敛；剩余 18 例为避免破坏共享候选键的边界情况而故意保留未解决，追踪于 [#149](https://github.com/kent-tokyo/chematic/issues/149)）。同时排查并**排除**了此前怀疑的桥环双环 canonicalization 缺陷——经独立 RDKit InChI 验证，涉及的两个 SMILES 实际上是不同的分子，并非 chematic 的缺陷
+- `chematic-perception`：新增 opt-in 的 `apply_aromaticity_authoritative_experimental`——使芳香性标志的升级/降级双向完全服从 Hückel 模型的实际计算结果（默认的 `apply_aromaticity`/`apply_aromaticity_ex` 保持不变，已验证 byte-identical）。在此过程中修复了影响并环二氮杂环（quinazoline/quinoxaline/purine 型环）的环并键误分类问题，附带解决了 32 个已有的假阳性回归 pin
+- 完整细节和已知限制见 `CHANGELOG.md`
+
+**v0.5.0**（2026-07-23）：**CIP 无关的 2D 楔形键 local parity、charge 感知 kekulization（此前 6 类分子解析失败）、PAINS/Brenk 的 budget 化非静默匹配**
+- `chematic-perception`：新增 `local_parity_from_wedges`/`apply_local_parity_from_wedges`——完全不依赖 CIP 排序，直接从楔形/虚线键与 2D 坐标计算 `Atom.chirality`/`stereo_neighbor_order`，因此 CIP 排序打平也不会抹去已知的 local parity；符号约定针对 RDKit 原始 chiral tag 实测确定，而非类推得出。尚未接入任何 reader 的默认解析路径
+- `chematic-core`：`kekulize()` 的原子匹配规则此前对电荷不敏感且缺失 Tellurium 处理——tropylium、imidazolium、pyridinium、pyrylium、tellurophene、phosphole 现均可成功 kekulize，且与 RDKit 逐键一致，零回归；`Element::normal_valences()` 新增了经源码验证的 Tellurium 条目，修复了由此导致的 ECFP4 芳香性不一致
+- `chematic-perception`：charge 感知的 Hückel π 电子计数——tropylium、imidazolium、pyridinium、pyrylium 现已与 RDKit 的芳香原子/键标志完全一致（tellurophene/phosphole 及更广泛的权威降级修复仍待解决，单独追踪）
+- `chematic-smiles`：修复两个 writer 缺陷——bracket 强制原子（isotope/charge/atom-map）此前会静默丢弃隐式氢（`[NH4+]` → `[N+]`）；无相邻双键的独立楔形键此前被错误写成无意义的 SMILES `/`、`\` 标记
+- `chematic-smarts`/`chematic-chem`：对称目标上的 PAINS/Brenk 子结构匹配此前可能挂起数分钟；VF2 现引入显式访问 budget，返回真正的三态结果（`Found`/`NotFound`/`BudgetExhausted`），探索耗尽绝不会被静默折叠为假阴性——后续的对称感知候选排序（可让现有 budget 正确解决部分保守标记案例）追踪于 [#139](https://github.com/kent-tokyo/chematic/issues/139)
+- 完整细节、语料库层面的前后对比数字及已知限制见 `CHANGELOG.md`
+
+**v0.4.30**（2026-07-17）：**`chematic-cip` opt-in 接入全部接口、SMARTS `[rN]` 修复、新 RDKit-parity 芳香性引擎、5 处立体元数据缺陷修复**
+- `chematic-smarts`：修复 `[rN]`（环大小 SMARTS，如 `[r5]`/`[r6]`）被错误地等同于 `[kN]` 的"任意环"语义——RDKit 真正的 `[rN]` 含义是"该原子所在的*最小*环恰好为 N 大小"，是完全不同的谓词（实测确认：在共享 5 元环与 6 元环的并环原子上，RDKit 的 `[k6]` 匹配但 `[r6]` 不匹配）。未改动环模型本身——`[rN]` 现拥有基于 chematic 现有 SSSR 计算的独立 `MinRingSize` 原语。SMARTS 匹配集合与 RDKit 的一致率在 5,000 分子语料库上从 **96.9% 提升到 99.93%**，零回归；详见 `docs/rdkit_compat.md` 的 "SMARTS-R0"/"SMARTS-R1" 条目
+- Milestone 5A：从所有公开接口 opt-in 访问精确引擎——`chematic_chem::assign_cip_with_mode(mol, CipMode::Accurate)`（Rust）、`Mol.cip_stereo(mode="accurate")` + `Mol.cip_stereo_unresolved()`（Python）、`cip_assignments_accurate_json`/`cip_unresolved_json`（WASM）。所有默认接口（`assign_cip()`、`cip_stereo()`、无后缀的 WASM 函数）保持不变——纯增量，非默认切换；合并语义（精确引擎的四面体 R/S + legacy 的 E/Z，因精确引擎不计算键立体）及"绝不猜测"契约（打平/超预算情况显式暴露，绝不静默回退）详见 `docs/cip_accurate_rfc.md` 的 Milestone 5A 条目
+- Milestone 4 关口达成：全语料库、按表示稳定性分层的 oracle-stable 一致率达 99.64%（原始一致率 99.38%，4160/4186）——最后剩余的 11 行磷残差经查明为 oracle 不稳定（RDKit 自身标签在化学中性的 Kekulé 重新拼写下会变化），并非 chematic 缺陷；15 行 Rule 5 笼状家族仍延后处理，不受此关口影响
+- 精确引擎（携带溯源信息、逐层递归的 digraph 比较器——Rule 1a/1b/2，外加芳香环立体中心的 RDKit 兼容 MANCUDE 分数原子序数）已通过上述 opt-in API 提供，但尚未成为 `assign_cip()` 背后的默认实现
+- 发现并修复一个真实的约 10-14 倍性能回归（SSSR 被误用于布尔型环键判断，替换为 O(V+E) 桥边 DFS）；CI Criterion 关口的引导脚本修复；一项 Criterion 关口可靠性发现（伪重复采样问题，[#70](https://github.com/kent-tokyo/chematic/issues/70)）——已落地流程级重新设计（独立进程运行观测、两阶段筛选、同一二进制空对照）。后续修复（[#117](https://github.com/kent-tokyo/chematic/pull/117)）解决了通过真实 CI 运行发现的两个更具体的缺陷：Stage 1 的 3 组符号检验在结构上永远无法失败（替换为纯幅度路由筛选，阈值来自对 28 次历史无操作运行的离线评估），Stage 2 的符号检验对较小的构建/代码生成差异同样不敏感（改为符号检验 + 实际效应阈值的组合关口）。该关口仍为非必需项；同一二进制空对照对跨二进制代码生成差异的盲区是已知、已报告但尚未修复的缺口
+- Milestone 4A：`CipCode::LowerR`/`LowerS`——Rule 5（伪不对称性），仅限 2 行已验证独立案例；发现一个三臂对称笼状家族（15 行）在此两两配对架构下被证明无法触及，延后为 Milestone 4A-2（需要对称性/自同构检测）
+- Milestone 4A-0：从零重新冻结残差为 34 行并对其 100% 机械分类（0 项未解释）——15 行 Rule 5/伪不对称性（4A-2 笼状家族）、8 行 Rule 4 候选（通过结构同一性检查正面确认，非排除法推断）、11 行磷（9 行比较器缺陷导致"错误"+2 行确实打平）
+- `chematic-perception`：新增 opt-in 的 `assign_aromaticity_rdkit_parity_experimental`/`apply_aromaticity_rdkit_parity_experimental`——对 RDKit 真实芳香性算法的源码级验证移植，在 4,999/5,000 个可比分子上实现 **100.0000% 原子/键一致率**。未接入默认路径（`RdkitLike`/`Huckel` 保持不变）；默认提升被一个与此引擎无关、已存在的 canonical-SMILES-writer 敏感性问题所阻塞
+- 修复了同一"元数据未复制"缺陷的 5 个实例（`MoleculeBuilder` 重建时未调用 `copy_stereo_groups_from`/`copy_stereo_from`/`copy_bond_directions_from`），各自静默丢弃 `stereo_neighbor_order` 或更严重：`apply_kekule`（P0）、`enumerate_stereoisomers`（可能静默翻转新分配立体中心的 CIP 编码）、`transfer_hydrogen_aromatic`/`clone_mol`（后者已删除，改用 `Molecule::clone`）、`transfer_hydrogen`、以及 `invert_stereocenter`（结果发现它对纯 `@`/`@@` SMILES 输入是功能性空操作，属于另一个更严重的缺陷）
+- `chematic-smiles`：将芳香键方向暂存逻辑统一整合到 3 条 parser 键创建路径（链边/环闭合/分支连接）共用的辅助函数中——修复了一处 canonical round-trip 表示不稳定问题（4,994/5,000 → 5,000/5,000 稳定）；未修复 `assign_ez` 对该旁路通道本身存在的既有盲区（作为后续任务追踪）
+- 实验性 CIP 引擎的全语料库准确率从 96.68% 提升到 99.38%（原始）/ 99.64%（oracle-stable），对比现代 RDKit `rdCIPLabeler`（零回归）——完整里程碑历史见 `docs/cip_accurate_rfc.md`
+- 基准测试已刷新（`benchmarks/2026-07-17.md`，Apple M4）：此前的 ECFP4 吞吐量头条数字（3.6 µs/mol，比 RDKit 快 5–14 倍）在干净重新测量下未能复现——本 README 及 `docs/` 中已更新为今日实测数字（多样化语料库上约 78 µs/mol / 2–3 倍）；描述符准确率数字复现良好
+
+**v0.4.29**（2026-07-10）：**Kabsch 旋转缺陷修复 + SDF V3000/CDXML 写入、Avalon 指纹、O3A**
+- `chematic-3d`：修复 `align_coords` 的 Kabsch 旋转计算方向错误——对任何非纯平移的对齐都会给出严重偏大的 RMSD（在此修复前已随 v0.4.28 发布到 crates.io/PyPI/npm）；新增用于 O3A 原子对应关系的 `correspondence_search`
+- `chematic-mol`：SDF V3000 写入接线；CDXML 写入
+- `chematic-fp`：Avalon 指纹
+
+**v0.4.28**（2026-07-09）：**SMARTS 性能优化、注册表重新同步**
+- `chematic-smarts`：存在性检查短路——`bulk.substructure_search` 比 RDKit 快 2.2 倍
+- v0.4.23–v0.4.27 期间未推送 git tag（crates.io 通过手动 `cargo publish` 保持最新，但 PyPI/npm/GitHub Releases 落后）——本版本重新同步三个注册表
+
+**v0.4.27**（2026-07-04）：**描述符修复、RWMol/FCFP、veridict CI 关口**
+- `chematic-chem`：修复 `kappa1-3`、`balaban_j`、`labute_asa`、`bcut2d`、`hall_kier_alpha` 描述符
+- `chematic-fp`：`useFeatures=True` 的 FCFP
+- `chematic-mol`：RWMol 原地编辑
+- CI：基于 veridict 的性能/Criterion/准确率漂移回归关口；修复集成测试 CI 覆盖缺口
+
+**v0.4.26**（2026-06-29）：**反应中的 E/Z 立体转移 + 验证 Sprint 6/7**
+- `chematic-rxn`：反应产物现在会在 `run_reactants()` 中保留来自反应物的 `/`/`\` 双键几何信息（此前在转化过程中丢失）
+- 验证：canonical SMILES 与 RDKit 的差异化验证（Sprint 6）；SMARTS/芳香性差异化测试及 I/O 兼容性（rdkit_compat Sprint 7）；将剩余的 RDKit canonical 差异根因定位到芳香性 round-trip，而非 Morgan 排序
+
+**v0.4.25**（2026-06-29）：**`chematic.rdkit_compat` 层**
+- `chematic-py`：RDKit API 兼容层（Sprint 1–5）——Morgan `bitInfo`、Fingerprint/Mol/Atom/Bond/RingInfo 兼容性、针对 RDKit 的差异化测试；流式 `SDMolSupplier`/`SDWriter`/`Mol.GetProp`
+- `chematic-perception`：`AromaticityAlgorithm::RdkitLike`——匹配 RDKit 模型的 Se/Te 硫族芳香性
+
+**v0.4.24**（2026-06-29）：**CIP Rule 5、桥头原子/可旋转键/TPSA/摩尔折射率达到 100%、HDF 指纹**
+- `chematic-chem`：CIP Rule 5 立体打破平局（立体中心一致率 99.8% → 99.98%，对比 RDKit）；桥头原子检测 98.5% → 100%；可旋转键 99.1% → 100%；TPSA 100%；摩尔折射率 97.5% → 100%（3 环 XOR 增强）——均在 5,000 分子 ChEMBL 语料库上测得
+- `chematic-py`：`bulk.descriptors_array()` 列式 numpy 输出；真正流式 SDF（`SdfFileReader`/`iter_sdf_batched`）；`screen()` 化合物筛选工作流
+- LLM/RAG：表示路由器（`to_llm_text`、`best_representation`）、分子上下文包、**超维指纹（HDF）**——无需训练的稠密分子向量
+
+**v0.4.23**（2026-06-26）：**LogP 96.5% → 99.7%**
+- `chematic-chem`：修复 `crippen_anchor_sets` 使用 `uniquify: false`，使对称三键（内部炔）能得到两种 VF2 匹配方向，而不是其中一种回退到通用的 `[#6]` 值
+
+**v0.4.22**（2026-06-26）：**CITATION.cff + `chematic.doctor()`**
+- `chematic-py`：`doctor()` 自诊断；README 新增按功能可靠性矩阵
+
+**v0.4.21**（2026-06-25）：**面向 LLM/Jupyter 的 HTML/Markdown 报告**
+- `chematic-py`：`chematic.report()` 自包含 HTML 化合物网格、`chematic.compare()`、`mol.review()` Markdown 分析
+- 文档：`benchmarks/`/`validation/` 可复现准确率历史
+
+**v0.4.20**（2026-06-25）：**ETKDG 扭转知识库 44 → 80 条规则、`mol.describe()`/`diff()`**
+- `chematic-3d`：为 6/5 元脂肪环新增椅式/信封式环构象；SMARTS 匹配的扭转规则作为高精度预检层
+- `chematic-py`：面向 LLM/MCP agent 的 `mol.describe()`/`mol.diff(other)`；`bulk.generate_3d`/`tanimoto_matrix`/`standardize`
+
 **v0.4.19**（2026-06-23）：**PDF/EPS 输出、ChemicalJSON、新描述符、WASM −38.5%**
 - `chematic-depict`：`depict_pdf()` / `depict_eps()` — PDF 和 EPS 输出；纯 Rust，无需外部工具
 - `chematic-mol`：**ChemicalJSON** — `parse_cjson()` / `write_cjson()` 支持 Avogadro2 / MolSSI 互操作

--- a/README_zh.md
+++ b/README_zh.md
@@ -244,7 +244,7 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi      
 
 ---
 
-## 近期开发（v0.4.x）
+## 近期开发
 
 **v0.4.19**（2026-06-23）：**PDF/EPS 输出、ChemicalJSON、新描述符、WASM −38.5%**
 - `chematic-depict`：`depict_pdf()` / `depict_eps()` — PDF 和 EPS 输出；纯 Rust，无需外部工具

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.5.0 | Yes | Current release — active support |
+| v0.6.0 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.5.0) receives all security updates.  
+**Active Support**: Latest release (v0.6.0) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -16,12 +16,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.5.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.5.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.5.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.5.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.5.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.5.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.6.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.6.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.6.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.6.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.6.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.6.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -16,14 +16,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.5.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.6.0" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.5.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.5.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.5.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.5.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.5.0" }
-chematic-cip        = { path = "../chematic-cip",        version = "0.5.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.6.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.6.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.6.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.6.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.6.0" }
+chematic-cip        = { path = "../chematic-cip",        version = "0.6.0" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.5.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.5.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.6.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.6.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -22,10 +22,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.5.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.5.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.5.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.5.0" }
+chematic-core = { path = "../chematic-core", version = "0.6.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.6.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.6.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.6.0" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.5.0" }
+chematic-core = { path = "../chematic-core", version = "0.6.0" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.5.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.5.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.6.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.6.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -22,13 +22,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.5.0" }
+chematic-core = { path = "../chematic-core", version = "0.6.0" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.5.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.5.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.5.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.5.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.6.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.6.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.6.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.6.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -18,10 +18,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.5.0", path = "../chematic-core" }
-chematic-smiles = { version = "0.5.0", path = "../chematic-smiles" }
-chematic-chem = { version = "0.5.0", path = "../chematic-chem" }
-chematic-rxn = { version = "0.5.0", path = "../chematic-rxn" }
+chematic-core = { version = "0.6.0", path = "../chematic-core" }
+chematic-smiles = { version = "0.6.0", path = "../chematic-smiles" }
+chematic-chem = { version = "0.6.0", path = "../chematic-chem" }
+chematic-rxn = { version = "0.6.0", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.5.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.5.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.6.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.6.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -17,12 +17,12 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.5.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.5.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.5.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.5.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.5.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.5.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.5.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.5.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.5.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.6.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.6.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.6.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.6.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.6.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.6.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.6.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.6.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.6.0" }

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -16,9 +16,9 @@ documentation = "https://docs.rs/chematic-mol"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.5.0" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.5.0" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.5.0" }
+chematic-core        = { path = "../chematic-core",        version = "0.6.0" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.6.0" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.6.0" }
 serde_json           = "1.0"
 
 [dev-dependencies]

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.5.0" }
+chematic-core = { path = "../chematic-core", version = "0.6.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,16 +25,16 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.5.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.5.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.5.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.5.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.5.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.5.0", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.5.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.5.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.5.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.5.0" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.5.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.5.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.5.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.6.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.6.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.6.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.6.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.6.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.6.0", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.6.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.6.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.6.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.6.0" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.6.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.6.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.6.0" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-rxn"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.5.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.5.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.5.0" }
+chematic-core   = { path = "../chematic-core",   version = "0.6.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.6.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.6.0" }
 rustc-hash = "2"

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.5.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.5.0" }
+chematic-core = { path = "../chematic-core", version = "0.6.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.6.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.5.0" }
+chematic-core = { path = "../chematic-core", version = "0.6.0" }
 
 [dev-dependencies]
 # Test-only: re-aromatizing after an explicit kekulize+apply_kekule round

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -25,16 +25,16 @@ crate-type = ["cdylib", "rlib"]
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["console"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.5.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.5.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.5.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.5.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.5.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.5.0", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.5.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.5.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.5.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.5.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.5.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.5.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.5.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.6.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.6.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.6.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.6.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.6.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.6.0", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.6.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.6.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.6.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.6.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.6.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.6.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.6.0" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -33,15 +33,15 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.5.0", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.5.0", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.5.0", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.5.0", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.5.0", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.5.0", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.5.0", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.5.0", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.5.0", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.5.0", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.5.0", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.5.0", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.6.0", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.6.0", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.6.0", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.6.0", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.6.0", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.6.0", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.6.0", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.6.0", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.6.0", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.6.0", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.6.0", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.6.0", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,6 +1,6 @@
 # Benchmark
 
-Measured environment: Python 3.13.6, Apple M4, chematic v0.5.0, RDKit 2026.03.3.
+Measured environment: Python 3.13.6, Apple M4, chematic v0.6.0, RDKit 2026.03.3.
 Full methodology and raw numbers: [`benchmarks/2026-07-17.md`](../benchmarks/2026-07-17.md).
 
 ---

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -2,7 +2,7 @@
 
 Summary of descriptor accuracy against RDKit on a ChEMBL-derived corpus.
 
-**Environment:** Python 3.12, Apple M-series, chematic v0.5.0, RDKit 2026.03.3
+**Environment:** Python 3.12, Apple M-series, chematic v0.6.0, RDKit 2026.03.3
 
 ---
 


### PR DESCRIPTION
## Summary
- Release commit for v0.6.0 (RDKit bit-exact ECFP4 stable API, canonical SMILES E/Z carrier consistency, opt-in aromaticity authoritative demotion)
- Follow-up doc fixes: drop stale "(v0.4.x Era)" label from Recent Development headers; backfill README_zh.md's Recent Development content through v0.6.0

## Test plan
- [x] `bash scripts/check.sh` green locally before each commit