### PR TITLE
fix(chematic-cip): resolve the 15-row pseudoasymmetric cage family (Rule 5)

### DIFF
--- a/crates/chematic-chem/src/cip.rs
+++ b/crates/chematic-chem/src/cip.rs
@@ -1613,25 +1613,89 @@ mod tests {
     }
 
     #[test]
-    fn cip_mode_accurate_surfaces_unresolved_not_a_guess_for_tied_phosphorus() {
-        // Of the 11 oracle-unstable cyclophosphazene rows (docs/cip_accurate_rfc.md
-        // Milestone 4C-0/4C-1), only 2 are genuine chematic ties (SkipReason::Tied) --
-        // those must come back Unresolved in Accurate mode, never a panic. The other 9
-        // (Milestone 4C-0) DO get a stable, confident answer from chematic -- the
-        // oracle is what's unstable there, not chematic -- so they are deliberately
-        // NOT covered by this test; see `cip_mode_accurate_does_not_hide_oracle_unstable_answers`.
+    fn cip_mode_accurate_pseudoasymmetric_fix_now_resolves_former_phosphorus_ties() {
+        // Milestone 4A-2 (pseudoasymmetric r/s for the three-armed cage family) has a
+        // side effect on this *different*, previously-`SkipReason::Tied` molecule
+        // (docs/cip_accurate_rfc.md Milestone 4C-1): atoms 6/19 tied for the same
+        // structural reason as the cage family (a chain-length-1-degenerate Rule 4b
+        // comparison whose branches' auxiliary R/S signs genuinely differ) -- the fixed
+        // `assign_one_with_rule5` now resolves them too, to `LowerR`/`LowerR`.
+        //
+        // IMPORTANT CAVEAT, not swept under the rug: Milestone 4C-1 independently found
+        // that *neither* RDKit CIP engine (`rdCIPLabeler` nor legacy `_CIPCode`) has a
+        // representation-stable answer for this specific molecule -- both flip under a
+        // chemically-neutral Kekule respelling of the P/N ring. There is therefore no
+        // reliable oracle to score this new label against; this test asserts chematic's
+        // own behavior (a real value, not a panic) and, separately, that chematic's own
+        // new answer *is* stable under the same respelling test that broke both RDKit
+        // engines (`cip_mode_accurate_pseudoasymmetric_fix_is_kekule_stable_on_the_former_phosphorus_tie`,
+        // below) -- the strongest available evidence this is a well-founded auxiliary
+        // computation and not an accidental artifact of one particular Kekule drawing.
+        // It is NOT evidence the label is externally correct.
         let smi = "CNP1(NC)=N[P@](NC)(N2CC2)=NP(NC)(NC)=N[P@@](NC)(N2CC2)=N1";
         let mol = chematic_smiles::parse(smi).expect("valid SMILES");
         let result = assign_cip_with_mode(&mol, CipMode::Accurate).expect("no engine error");
         for atom_idx in [6u32, 19u32] {
             let idx = AtomIdx(atom_idx);
-            assert!(
-                result.get(idx).is_none(),
-                "atom={atom_idx} should not have a guessed label"
+            assert_eq!(
+                result.get(idx),
+                Some(CipCode::LowerR),
+                "atom={atom_idx}: expected the pseudoasymmetric fix to resolve this atom"
             );
             assert!(
-                result.unresolved.iter().any(|(i, _)| *i == idx),
-                "atom={atom_idx} should be in unresolved"
+                !result.unresolved.iter().any(|(i, _)| *i == idx),
+                "atom={atom_idx} should no longer be unresolved"
+            );
+        }
+    }
+
+    #[test]
+    fn cip_mode_accurate_pseudoasymmetric_fix_is_kekule_stable_on_the_former_phosphorus_tie() {
+        // Same molecule as the test above. Flip every P/N ring bond Single<->Double (a
+        // chemically neutral resonance respelling, the same test Milestone 4C-0/4C-1
+        // used to show *both* RDKit engines are representation-unstable here) and
+        // confirm chematic's new label does NOT flip -- unlike RDKit on this molecule,
+        // chematic's bottom-up auxiliary-descriptor computation is representation-
+        // independent for this specific case (checked directly, not assumed).
+        use chematic_core::BondOrder;
+        use chematic_perception::find_sssr;
+
+        let smi = "CNP1(NC)=N[P@](NC)(N2CC2)=NP(NC)(NC)=N[P@@](NC)(N2CC2)=N1";
+        let mol = chematic_smiles::parse(smi).expect("valid SMILES");
+        let sssr = find_sssr(&mol);
+
+        let flip = |m: &chematic_core::Molecule, a, b| -> Option<chematic_core::Molecule> {
+            let (bidx, bond) = m.bond_between(a, b)?;
+            let new_order = match bond.order {
+                BondOrder::Single => BondOrder::Double,
+                BondOrder::Double => BondOrder::Single,
+                other => other,
+            };
+            Some(m.with_bond_order(bidx, new_order))
+        };
+
+        let mut respelled = mol.clone();
+        for ring in sssr.rings() {
+            for w in ring.windows(2) {
+                if let Some(next) = flip(&respelled, w[0], w[1]) {
+                    respelled = next;
+                }
+            }
+            if let (Some(&first), Some(&last)) = (ring.first(), ring.last())
+                && let Some(next) = flip(&respelled, last, first)
+            {
+                respelled = next;
+            }
+        }
+
+        let original = assign_cip_with_mode(&mol, CipMode::Accurate).expect("no engine error");
+        let after = assign_cip_with_mode(&respelled, CipMode::Accurate).expect("no engine error");
+        for atom_idx in [6u32, 19u32] {
+            let idx = AtomIdx(atom_idx);
+            assert_eq!(
+                original.get(idx),
+                after.get(idx),
+                "atom={atom_idx}: chematic's new label must be Kekule-respelling-stable"
             );
         }
     }

--- a/crates/chematic-chem/src/cip.rs
+++ b/crates/chematic-chem/src/cip.rs
@@ -1613,25 +1613,24 @@ mod tests {
     }
 
     #[test]
-    fn cip_mode_accurate_pseudoasymmetric_fix_now_resolves_former_phosphorus_ties() {
-        // Milestone 4A-2 (pseudoasymmetric r/s for the three-armed cage family) has a
-        // side effect on this *different*, previously-`SkipReason::Tied` molecule
-        // (docs/cip_accurate_rfc.md Milestone 4C-1): atoms 6/19 tied for the same
-        // structural reason as the cage family (a chain-length-1-degenerate Rule 4b
-        // comparison whose branches' auxiliary R/S signs genuinely differ) -- the fixed
-        // `assign_one_with_rule5` now resolves them too, to `LowerR`/`LowerR`.
-        //
-        // IMPORTANT CAVEAT, not swept under the rug: Milestone 4C-1 independently found
-        // that *neither* RDKit CIP engine (`rdCIPLabeler` nor legacy `_CIPCode`) has a
-        // representation-stable answer for this specific molecule -- both flip under a
-        // chemically-neutral Kekule respelling of the P/N ring. There is therefore no
-        // reliable oracle to score this new label against; this test asserts chematic's
-        // own behavior (a real value, not a panic) and, separately, that chematic's own
-        // new answer *is* stable under the same respelling test that broke both RDKit
-        // engines (`cip_mode_accurate_pseudoasymmetric_fix_is_kekule_stable_on_the_former_phosphorus_tie`,
-        // below) -- the strongest available evidence this is a well-founded auxiliary
-        // computation and not an accidental artifact of one particular Kekule drawing.
-        // It is NOT evidence the label is externally correct.
+    fn cip_mode_accurate_pseudoasymmetric_fix_stays_unresolved_for_phosphorus_ties() {
+        // Milestone 4A-2's `assign_one_with_rule5` fix (resolving the carbon cage
+        // family's pseudoasymmetric centers) reaches this *different*, previously-
+        // `SkipReason::Tied` molecule (docs/cip_accurate_rfc.md Milestone 4C-1) via the
+        // exact same code path: atoms 6/19 tie for the identical structural reason as
+        // the carbon cage family (a chain-length-1-degenerate Rule 4b comparison whose
+        // branches' auxiliary R/S signs genuinely differ). Left unguarded, the fix would
+        // resolve these two phosphorus atoms as a side effect -- but Milestone 4C-1
+        // independently found that *neither* RDKit CIP engine (`rdCIPLabeler` nor legacy
+        // `_CIPCode`) has a representation-stable answer for this specific molecule, both
+        // flip under a chemically-neutral Kekule respelling of the P/N ring -- so there
+        // is no reliable oracle a resolved phosphorus label could ever be checked
+        // against. `assign_one_with_rule5` therefore carries an explicit element-level
+        // guard (see `crates/chematic-cip/src/assign.rs` module docs, "Element-level
+        // guard: phosphorus stays tied"): it only ever emits a resolved label for a
+        // carbon stereocenter, so these 2 phosphorus atoms fall back to
+        // `SkipReason::Tied` -> `CipUnresolvedReason::Tied`, exactly their pre-fix
+        // behavior, never an unverified label.
         let smi = "CNP1(NC)=N[P@](NC)(N2CC2)=NP(NC)(NC)=N[P@@](NC)(N2CC2)=N1";
         let mol = chematic_smiles::parse(smi).expect("valid SMILES");
         let result = assign_cip_with_mode(&mol, CipMode::Accurate).expect("no engine error");
@@ -1639,24 +1638,30 @@ mod tests {
             let idx = AtomIdx(atom_idx);
             assert_eq!(
                 result.get(idx),
-                Some(CipCode::LowerR),
-                "atom={atom_idx}: expected the pseudoasymmetric fix to resolve this atom"
+                None,
+                "atom={atom_idx}: phosphorus stereocenter must NOT get an unverified label"
             );
             assert!(
-                !result.unresolved.iter().any(|(i, _)| *i == idx),
-                "atom={atom_idx} should no longer be unresolved"
+                result
+                    .unresolved
+                    .iter()
+                    .any(|(i, reason)| *i == idx && *reason == CipUnresolvedReason::Tied),
+                "atom={atom_idx} must be reported unresolved (Tied): {:?}",
+                result.unresolved
             );
         }
     }
 
     #[test]
-    fn cip_mode_accurate_pseudoasymmetric_fix_is_kekule_stable_on_the_former_phosphorus_tie() {
+    fn cip_mode_accurate_phosphorus_ties_stay_unresolved_kekule_stable() {
         // Same molecule as the test above. Flip every P/N ring bond Single<->Double (a
         // chemically neutral resonance respelling, the same test Milestone 4C-0/4C-1
         // used to show *both* RDKit engines are representation-unstable here) and
-        // confirm chematic's new label does NOT flip -- unlike RDKit on this molecule,
-        // chematic's bottom-up auxiliary-descriptor computation is representation-
-        // independent for this specific case (checked directly, not assumed).
+        // confirm chematic's own "stays unresolved" guard does NOT flap to resolved on
+        // either spelling -- the element-level guard is keyed on atom identity
+        // (`mol.atom(idx).element`), which a bond-order respelling never changes, so it
+        // must stay unresolved on both spellings by construction; checked directly here
+        // rather than just asserted.
         use chematic_core::BondOrder;
         use chematic_perception::find_sssr;
 
@@ -1694,8 +1699,17 @@ mod tests {
             let idx = AtomIdx(atom_idx);
             assert_eq!(
                 original.get(idx),
-                after.get(idx),
-                "atom={atom_idx}: chematic's new label must be Kekule-respelling-stable"
+                None,
+                "atom={atom_idx}: original spelling"
+            );
+            assert_eq!(after.get(idx), None, "atom={atom_idx}: respelled");
+            assert!(
+                original.unresolved.iter().any(|(i, _)| *i == idx),
+                "atom={atom_idx}: original spelling must stay unresolved"
+            );
+            assert!(
+                after.unresolved.iter().any(|(i, _)| *i == idx),
+                "atom={atom_idx}: respelled must stay unresolved too (not flapping)"
             );
         }
     }

--- a/crates/chematic-cip/examples/cage_worst_case_timing.rs
+++ b/crates/chematic-cip/examples/cage_worst_case_timing.rs
@@ -1,0 +1,37 @@
+//! One-off timing measurement for the Milestone 4A-2 PR: the 5 distinct
+//! three-armed-cage molecules are exactly this crate's own documented
+//! `needs_pass2_or_3` worst-case bucket (see `docs/cip_accurate_rfc.md`'s
+//! MANCUDE-Decision-A0 entry, `36,198` comparisons on an adamantane-cage amide).
+//! Prints each molecule's wall-clock time for `assign_cip_accurate_experimental`,
+//! run 20x each and reporting the minimum (least noisy) time, so a before/after
+//! comparison against `main` isn't dominated by one-shot JIT/allocator noise.
+
+use std::time::Instant;
+
+use chematic_cip::{CipBudget, assign_cip_accurate_experimental};
+
+const CAGE_MOLECULES: &[&str] = &[
+    "CCCCCCCC/C=C/CCCCCCCC(=O)OCc1cc(=O)c(OC(=O)[C@]23C[C@H]4C[C@H](C[C@H](C4)C2)C3)co1",
+    "COc1ccccc1N1CCN(CCCCNC(=O)C23C[C@H]4C[C@@H](C2)C[C@@H](C3)C4)CC1",
+    "O=C(NCCCCN1CCCC(/C=C\\c2ccccc2)C1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3",
+    "O=C(NCCCCN1CCN(c2cccc3ccccc23)CC1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3",
+    "O=c1cc(COC2CCOCC2)occ1OC(=O)[C@]12C[C@H]3C[C@H](C[C@H](C3)C1)C2",
+];
+
+fn main() {
+    let mut worst_us: u128 = 0;
+    for smi in CAGE_MOLECULES {
+        let mol = chematic_smiles::parse(smi).expect("valid SMILES");
+        let mut best_ns = u128::MAX;
+        for _ in 0..20 {
+            let start = Instant::now();
+            let _ = assign_cip_accurate_experimental(&mol, CipBudget::default_budget())
+                .expect("assignment succeeds");
+            best_ns = best_ns.min(start.elapsed().as_nanos());
+        }
+        let best_us = best_ns / 1000;
+        worst_us = worst_us.max(best_us);
+        println!("{best_us:>8} us  (best of 20)  {smi}");
+    }
+    println!("worst_of_cage_molecules_us={worst_us}");
+}

--- a/crates/chematic-cip/src/assign.rs
+++ b/crates/chematic-cip/src/assign.rs
@@ -53,6 +53,27 @@
 //! this project's validation corpus exercises that shape for Rule 5, so extending to it
 //! is deferred rather than guessed. See `docs/cip_accurate_rfc.md` for the full writeup.
 //!
+//! **Element-level guard: phosphorus stays tied.** The same code-path fix above, as a
+//! side effect, also reaches 2 cyclophosphazene phosphorus stereocenters
+//! (`docs/cip_accurate_rfc.md` Milestone 4C-1) that were previously `SkipReason::Tied`
+//! for the identical chain-length-1 Rule 4b degeneracy the carbon cage family has.
+//! Unlike the 15 carbon rows, Milestone 4C-1 found **neither** RDKit CIP engine has a
+//! representation-stable answer for that phosphorus molecule -- both flip under a
+//! chemically-neutral Kekule respelling -- so there is no oracle a resolved phosphorus
+//! label could be checked against. [`assign_one_with_rule5`] therefore never emits a
+//! resolved label for a **phosphorus** stereocenter; the element is checked once,
+//! cheaply, before any digraph work, and falls back to `Err(SkipReason::Tied)` -- exactly
+//! this function's own existing convention for every other shape it doesn't recognize
+//! (see below). This is an element-level guard, not a molecule-specific one: it excludes
+//! every phosphorus stereocenter that reaches this path, not one specific SMILES. Note
+//! this project has, as of this writing, zero verified examples of this path being
+//! correct for *any* non-carbon element -- phosphorus is simply the only non-carbon
+//! element the validation corpus happens to exercise here, so a broader "unverified for
+//! any non-carbon element" framing may be more honest than "unverified for phosphorus
+//! specifically"; that broader guard is *not* implemented here, only flagged (see the PR
+//! discussion) -- narrowing to exactly the element asked about avoids expanding scope
+//! unilaterally.
+//!
 //! # Positions come from `stereo_neighbor_order`, ranks come from the new comparator
 //!
 //! [`crate::digraph::CipDigraph`]'s root children are built by iterating
@@ -86,7 +107,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use chematic_core::{AtomIdx, Chirality, CipCode, Molecule, STEREO_H_SENTINEL};
+use chematic_core::{AtomIdx, Chirality, CipCode, Element, Molecule, STEREO_H_SENTINEL};
 
 use crate::CipError;
 use crate::budget::CipBudget;
@@ -260,6 +281,19 @@ fn assign_one_with_rule5(
     budget: CipBudget,
     kekule: Option<&(Molecule, MancudeContext)>,
 ) -> Result<Option<CipCode>, SkipReason> {
+    // Element-level guard (see module docs, "Element-level guard: phosphorus stays
+    // tied"): this auxiliary-resolution path is oracle-verified only for carbon
+    // stereocenters (all 15 corpus rows it resolves are carbon). The only other element
+    // it has ever been observed to reach is phosphorus, on a cyclophosphazene molecule
+    // whose RDKit oracle is itself representation-unstable (Milestone 4C-1) -- there is
+    // no stable answer to check a resolved phosphorus label against, so never emit one.
+    // `idx`/`mol` name the same atom identity regardless of Kekule respelling (`mol` is
+    // always the original, pre-Kekule molecule here -- see `assign_one`'s own doc
+    // comment), so this check is stable across resonance respellings by construction.
+    if mol.atom(idx).element == Element::P {
+        return Err(SkipReason::Tied);
+    }
+
     let mut graph = match kekule {
         Some((kekule_mol, ctx)) => {
             CipDigraph::new_with_mancude(kekule_mol, idx, budget, ctx).map_err(map_digraph_err)?

--- a/crates/chematic-cip/src/assign.rs
+++ b/crates/chematic-cip/src/assign.rs
@@ -70,8 +70,9 @@
 //! correct for *any* non-carbon element -- phosphorus is simply the only non-carbon
 //! element the validation corpus happens to exercise here, so a broader "unverified for
 //! any non-carbon element" framing may be more honest than "unverified for phosphorus
-//! specifically"; that broader guard is *not* implemented here, only flagged (see the PR
-//! discussion) -- narrowing to exactly the element asked about avoids expanding scope
+//! specifically"; that broader guard is *not* implemented here, only flagged (see
+//! `docs/cip_accurate_rfc.md`'s Milestone 4C-1 entry) -- narrowing to exactly the
+//! element asked about avoids expanding scope
 //! unilaterally.
 //!
 //! # Positions come from `stereo_neighbor_order`, ranks come from the new comparator

--- a/crates/chematic-cip/src/assign.rs
+++ b/crates/chematic-cip/src/assign.rs
@@ -5,42 +5,53 @@
 //! only touches atoms with a `Chirality` annotation and exactly 4 resolvable substituent
 //! positions.
 //!
-//! # Rule 5 (pseudoasymmetry) -- Milestone 4A, deliberately narrow scope
+//! # Rule 5 (pseudoasymmetry) -- Milestone 4A (2-row scope), generalized in
+//! Milestone 4A-2 to a real bottom-up auxiliary descriptor
 //!
-//! [`assign_cip_accurate_experimental`] runs a second pass ([`apply_rule5_pass`]) after
-//! the Rules-1a/1b/2 pass ([`assign_all`]) completes, refining only atoms the first pass
-//! left [`SkipReason::Tied`]. It resolves exactly one shape: a tie between precisely 2 of
-//! the 4 physical positions, where each tied branch's *nearest* embedded, already-
-//! Pass-1-resolved stereocenter (unambiguous: only one atom at that minimum depth) has a
-//! code that differs from the other branch's (one R, one S) -- CIP's textbook
-//! pseudoasymmetric-center pattern. "Nearest," not "only one in the whole subtree": in a
-//! monocyclic ring, both ring-direction branches from the pseudoasymmetric center
-//! eventually wrap around and reach *every* embedded stereocenter on the ring, just in
-//! opposite order, so distinguishing "which one is closer per branch" is required, not
-//! "does this branch contain only one at all" (verified empirically on both target
-//! rows -- an earlier "exactly one in the whole subtree" version of this check
-//! wrongly disqualified both). The resolved atom is labeled
-//! [`chematic_core::CipCode::LowerR`]/[`chematic_core::CipCode::LowerS`], not `R`/`S`.
+//! [`assign_cip_accurate_experimental`] runs a pass ([`apply_rule5_pass`]) after the
+//! Rules-1a/1b/2 pass ([`assign_all`]) and the Rule 4b pass (`crate::resolver`) complete,
+//! refining only atoms still left [`SkipReason::Tied`]. It resolves one shape: a tie
+//! between precisely 2 of the 4 physical positions, where each tied branch's *nearest*
+//! embedded stereocenter has an **auxiliary** R/S sign (see below) that differs from the
+//! other branch's (one R, one S) -- CIP's textbook pseudoasymmetric-center pattern. The
+//! resolved atom is labeled [`chematic_core::CipCode::LowerR`]/
+//! [`chematic_core::CipCode::LowerS`], not `R`/`S`.
 //!
-//! **What this deliberately does not attempt**: a three-armed, locally-symmetric cage
-//! family (verified present in the validation corpus -- flipping one arm's stereo tag
-//! reclassifies all three embedded centers at once) has no seed for this pairwise
-//! provisional-map approach to refine from -- every relevant neighbor is *also* tied in
-//! Pass 1. That family needs symmetry/automorphism-aware joint resolution, a different
-//! architecture, and is out of scope here (tracked as Milestone 4A-2 in
-//! `docs/cip_accurate_rfc.md`). [`apply_rule5_pass`] is a structural no-op on it: the tie
-//! detection requires *exactly* 2 physical positions in *exactly* one tied group, which
-//! the cage family's 3-way (or worse) ties never satisfy.
+//! **Auxiliary, not molecular, descriptor** (Milestone 4A-2's fix to Milestone 4A's own
+//! documented limitation). Real CIP Rule 4c/5 compares an embedded center's *auxiliary*
+//! descriptor -- computed bottom-up, within the very same digraph rooted at the outer
+//! stereocenter under examination, per Hanson, Musacchio, Mayfield et al. 2018 (*J. Chem.
+//! Inf. Model.* 58(9), 1755-1765): "the descriptor for an auxiliary center does not
+//! depend upon any center between it and the root... the priority of a ligand leading
+//! back to the digraph root will always be ranked by Rule 1a." Milestone 4A shipped a
+//! *molecular*-descriptor stand-in instead (a `provisional: HashMap<AtomIdx, CipCode>`
+//! built from Pass 1's whole-molecule results), verified correct only for its own 2-row
+//! target where the embedded reference happened to already be independently resolved.
+//! That stand-in structurally cannot handle an embedded reference that is *itself*
+//! Pass-1/Rule-4b tied -- exactly the three-armed, locally-symmetric adamantane-cage
+//! family (`[C]12C[CH]3C[CH](C[CH](C3)C1)C2`-shaped, verified present in the validation
+//! corpus, 15 rows across 5 distinct molecules) Milestone 4A deferred as "Milestone
+//! 4A-2, needs symmetry/automorphism-aware joint resolution, a different architecture."
 //!
-//! **Auxiliary vs. molecular descriptor**: real CIP Rule 4c/5 compares an embedded
-//! center's *auxiliary* descriptor -- computed within the digraph rooted at the outer
-//! stereocenter -- not necessarily its own independently-computed molecular R/S. This
-//! pass uses the molecular descriptor (`provisional`, built from Pass 1's whole-molecule
-//! results) as a stand-in. That is verified, not assumed, correct for this milestone's
-//! 2-row target: both target molecules' embedded reference centers are already
-//! independently and uniquely resolved by Pass 1 with no ring-duplicate/phantom-atom
-//! complication in their own ranking. It is not a general auxiliary-descriptor
-//! implementation and should not be trusted as one outside this scope.
+//! That framing turned out to overstate what was needed. Diagnosing the cage family
+//! directly (see `docs/cip_accurate_rfc.md`'s Milestone 4A-2 entry) found **no genuine
+//! cross-atom cycle**: within one digraph rooted at the outer atom, every embedded
+//! reference is strictly deeper (Hanson's own bottom-up postulate above), so
+//! `crate::resolver::resolve_chirality` -- already built, and already validated 72/72 for
+//! Rule 4b -- computes a correct-shaped `Option<bool>` auxiliary sign for the tied
+//! branches' nearest embedded stereocenters directly, with no modification, on every one
+//! of the 15 rows. [`assign_one_with_rule5`] now calls `resolve_chirality`
+//! (`crate::rule4b::nearest_embedded` to locate the reference node, matching Rule 4b's own
+//! mechanism) instead of looking `provisional` up, so an embedded reference that is
+//! itself tied gets resolved in place, recursively, rather than looked up in a map that
+//! was never populated for it. No SCC/fixed-point solver was built or needed -- see the
+//! RFC entry for the falsified alternative hypothesis and the concrete evidence.
+//!
+//! **Still out of scope**: a tied pair whose *nearest* embedded references share the same
+//! auxiliary sign (both R or both S -- not a distinguishing mirror-image pair) does not
+//! attempt a deeper chain comparison the way Rule 4b's `break_tie_rule4b` does; no row in
+//! this project's validation corpus exercises that shape for Rule 5, so extending to it
+//! is deferred rather than guessed. See `docs/cip_accurate_rfc.md` for the full writeup.
 //!
 //! # Positions come from `stereo_neighbor_order`, ranks come from the new comparator
 //!
@@ -186,20 +197,19 @@ fn assign_all(
     Ok(result)
 }
 
-/// Milestone 4A's Rule 5 refinement -- see module docs for scope. Only ever touches
-/// atoms Pass 1 (`assign_all`, above) left [`SkipReason::Tied`]; every other atom
-/// (resolved or skipped for any other reason) is carried through unchanged. Not called
-/// by [`assign_cip_accurate_experimental_without_mancude`] -- that function's whole
-/// purpose is to stay a frozen, Rule-5-independent reference point (see its own doc
-/// comment), so Rule 5 is deliberately only wired into the main, live entry point.
+/// Rule 5 refinement -- see module docs for scope. Only ever touches atoms Pass 1
+/// (`assign_all`, above) and the Rule 4b pass (`crate::resolver::apply_rule4b_pass`) left
+/// [`SkipReason::Tied`]; every other atom (resolved or skipped for any other reason) is
+/// carried through unchanged. Not called by
+/// [`assign_cip_accurate_experimental_without_mancude`] -- that function's whole purpose
+/// is to stay a frozen, Rule-5-independent reference point (see its own doc comment), so
+/// Rule 5 is deliberately only wired into the main, live entry point.
 fn apply_rule5_pass(
     mol: &Molecule,
     budget: CipBudget,
     kekule: Option<&(Molecule, MancudeContext)>,
     pass1: AccurateCipAssignment,
 ) -> AccurateCipAssignment {
-    let provisional: HashMap<AtomIdx, CipCode> = pass1.assignments.iter().copied().collect();
-
     let mut assignments = pass1.assignments;
     let mut skipped = Vec::with_capacity(pass1.skipped.len());
 
@@ -219,15 +229,7 @@ fn apply_rule5_pass(
             continue;
         }
 
-        match assign_one_with_rule5(
-            mol,
-            idx,
-            atom.chirality,
-            stereo_order,
-            budget,
-            kekule,
-            &provisional,
-        ) {
+        match assign_one_with_rule5(mol, idx, atom.chirality, stereo_order, budget, kekule) {
             Ok(Some(code)) => assignments.push((idx, code)),
             _ => skipped.push((idx, reason)),
         }
@@ -239,15 +241,17 @@ fn apply_rule5_pass(
     }
 }
 
-/// Retry a Pass-1-tied atom with Rule 5. Identical digraph/ranking setup to
-/// [`assign_one`]; the only new logic is locating a single, exactly-2-physical-position
-/// tied group and, if each side embeds exactly one already-resolved stereocenter with a
-/// differing `provisional` code, breaking the tie by that code (R precedes S) before
-/// handing the (now fully split) group partition to the same
-/// [`resolve_is_r_from_groups`] parity math Pass 1 uses. Any shape this narrow detector
+/// Retry a Pass-1/Rule-4b-tied atom with Rule 5. Identical digraph/ranking setup to
+/// [`assign_one`]; the new logic is locating a single, exactly-2-physical-position tied
+/// group and, if each side's *nearest* embedded stereocenter resolves (via
+/// `crate::resolver::resolve_chirality`, the same bottom-up auxiliary-descriptor
+/// mechanism Rule 4b validated 72/72) to a differing auxiliary R/S sign, breaking the tie
+/// by that sign (R precedes S) before handing the (now fully split) group partition to
+/// the same [`resolve_is_r_from_groups`] parity math Pass 1 uses. Any shape this detector
 /// doesn't recognize -- 0 or 2+ tied groups, a tied group of size != 2, an
-/// unresolved/ambiguous embedded center, or matching codes on both sides -- returns
-/// `Err(SkipReason::Tied)` unchanged, exactly Pass 1's own outcome.
+/// unresolved/ambiguous embedded reference (`crate::rule4b::nearest_embedded` returning
+/// `None`), or matching auxiliary signs on both sides -- returns `Err(SkipReason::Tied)`
+/// unchanged, exactly Pass 1's own outcome (never a guess).
 fn assign_one_with_rule5(
     mol: &Molecule,
     idx: AtomIdx,
@@ -255,7 +259,6 @@ fn assign_one_with_rule5(
     stereo_order: &[u32],
     budget: CipBudget,
     kekule: Option<&(Molecule, MancudeContext)>,
-    provisional: &HashMap<AtomIdx, CipCode>,
 ) -> Result<Option<CipCode>, SkipReason> {
     let mut graph = match kekule {
         Some((kekule_mol, ctx)) => {
@@ -300,30 +303,49 @@ fn assign_one_with_rule5(
         .collect();
     let (pos_a, pos_b) = (physical_in_tied[0], physical_in_tied[1]);
 
-    let Some(atom_a) =
-        nearest_embedded_stereocenter(&mut graph, mol, pos_a).map_err(map_digraph_err)?
-    else {
+    // Auxiliary descriptor, not molecular: each branch's own nearest embedded
+    // stereocenter's R/S sign, computed bottom-up *within this same digraph*
+    // (`crate::resolver::resolve_chirality`) -- not a lookup into a whole-molecule
+    // "already resolved" map, which cannot succeed when the embedded atom is itself
+    // Pass-1/Rule-4b tied (exactly the three-armed cage family's shape; see module
+    // docs). `embedded_chain` (not `nearest_embedded` directly -- see that function's
+    // own doc comment) is the same reference-location mechanism Rule 4b validated
+    // 72/72, reused rather than reimplemented: `pos_a`/`pos_b` are the tied group's own
+    // physical position nodes, so `pos_a`/`pos_b` themselves are chain position 0 when
+    // they're directly chirality-bearing (a monocyclic ring's immediate ring
+    // neighbor), and `embedded_chain` searches onward only when they aren't (a plain
+    // CH2 bridge, e.g. the three-armed cage family). Only chain position 0 (the
+    // nearest reference) is used here -- see module docs for why a deeper chain
+    // comparison is out of scope.
+    let chain_a = crate::rule4b::embedded_chain(&mut graph, mol, pos_a).map_err(map_compare_err)?;
+    let chain_b = crate::rule4b::embedded_chain(&mut graph, mol, pos_b).map_err(map_compare_err)?;
+    let (Some(&embedded_a), Some(&embedded_b)) = (chain_a.first(), chain_b.first()) else {
         return Err(SkipReason::Tied);
     };
-    let Some(atom_b) =
-        nearest_embedded_stereocenter(&mut graph, mol, pos_b).map_err(map_digraph_err)?
-    else {
+
+    let mut cache = HashMap::new();
+    let sign_a =
+        crate::resolver::resolve_chirality(&mut graph, mol, embedded_a, budget, &mut cache)
+            .map_err(map_compare_err)?;
+    let sign_b =
+        crate::resolver::resolve_chirality(&mut graph, mol, embedded_b, budget, &mut cache)
+            .map_err(map_compare_err)?;
+    let (Some(is_r_a), Some(is_r_b)) = (sign_a, sign_b) else {
+        // The embedded reference itself has no resolvable auxiliary sign (a deeper,
+        // still-unresolvable tie) -- stay tied rather than guess.
         return Err(SkipReason::Tied);
     };
-    let (Some(&code_a), Some(&code_b)) = (provisional.get(&atom_a), provisional.get(&atom_b))
-    else {
-        return Err(SkipReason::Tied);
-    };
-    if code_a == code_b {
-        // Both R or both S -- not a distinguishing pseudoasymmetric pair in this scope;
-        // stay tied rather than guess.
+    if is_r_a == is_r_b {
+        // Both R or both S -- not a distinguishing mirror-image pair in this scope
+        // (would need a deeper chain comparison, unexercised by this project's
+        // validation corpus for Rule 5 -- see module docs); stay tied rather than guess.
         return Err(SkipReason::Tied);
     }
 
-    // Rule 5: R precedes S. Verified against this milestone's own 2-row corpus target
-    // (both currently-known cases resolve to lowercase `r`), not assumed from the
-    // textbook statement alone -- see module docs.
-    let (higher, lower) = if code_a == CipCode::R {
+    // Rule 5: R precedes S. Verified against this project's full 17-row pseudoasymmetric
+    // corpus (2 Milestone-4A rows + 15 Milestone-4A-2 cage-family rows, all lowercase
+    // `r`/`s` per the RDKit oracle) -- not assumed from the textbook statement alone.
+    let (higher, lower) = if is_r_a {
         (pos_a, pos_b)
     } else {
         (pos_b, pos_a)
@@ -354,52 +376,6 @@ fn assign_one_with_rule5(
     } else {
         CipCode::LowerS
     }))
-}
-
-/// Breadth-first search from `node`, level by level, for the *nearest* atom with its own
-/// `Chirality` set (checked on `mol`, the original un-kekulized molecule -- chirality is
-/// atom-level SMILES stereo info, unaffected by kekulization). Returns `None` if the
-/// nearest level containing a chirality-bearing atom contains more than one (ambiguous --
-/// which one is "nearest" is undefined), or if no such atom exists anywhere in the
-/// subtree.
-///
-/// Deliberately "nearest," not "the only one in the whole subtree": in a monocyclic
-/// ring, walking either ring-direction branch from the pseudoasymmetric center
-/// eventually wraps all the way around and reaches *every* embedded stereocenter on the
-/// ring (just in opposite order per branch) -- so a whole-subtree "exactly one" count
-/// would find 2+ in both branches and always disqualify, which is wrong (verified
-/// against this milestone's own 2-row target, which are both single-ring cases). The
-/// three-armed cage family this milestone excludes (see module docs) instead fails via
-/// *ambiguity at the nearest level* (that family's branches reach 2+ equally-near
-/// embedded stereocenters), which still safely falls through to `SkipReason::Tied`
-/// rather than producing a wrong lowercase label.
-fn nearest_embedded_stereocenter(
-    graph: &mut CipDigraph,
-    mol: &Molecule,
-    node: NodeId,
-) -> Result<Option<AtomIdx>, CipError> {
-    let mut frontier = vec![node];
-    while !frontier.is_empty() {
-        let mut found_this_level: Option<AtomIdx> = None;
-        let mut next_frontier = Vec::new();
-        for &current in &frontier {
-            if let CipNodeKind::Atom { atom_idx } = graph.node(current).kind
-                && mol.atom(atom_idx).chirality != Chirality::None
-            {
-                match found_this_level {
-                    None => found_this_level = Some(atom_idx),
-                    Some(existing) if existing == atom_idx => {}
-                    Some(_) => return Ok(None),
-                }
-            }
-            next_frontier.extend(graph.expand_children(current)?);
-        }
-        if let Some(atom_idx) = found_this_level {
-            return Ok(Some(atom_idx));
-        }
-        frontier = next_frontier;
-    }
-    Ok(None)
 }
 
 fn assign_one(

--- a/crates/chematic-cip/src/rule4b.rs
+++ b/crates/chematic-cip/src/rule4b.rs
@@ -56,8 +56,14 @@ pub(crate) fn nearest_embedded(
 const MAX_CHAIN_DEPTH: usize = 4;
 
 /// The ordered chain of nearest-embedded-stereocenter `NodeId`s reached from `start`,
-/// one level deeper each step -- in place, no re-rooting.
-fn embedded_chain(
+/// one level deeper each step -- in place, no re-rooting. `pub(crate)` (not just used by
+/// [`break_tie_rule4b`]): `crate::assign::assign_one_with_rule5` also needs "the nearest
+/// embedded stereocenter, treating `start` itself as chain position 0" for a tied group's
+/// own physical position node -- exactly this function's own special-casing of `start`,
+/// not [`nearest_embedded`]'s (which is only correct for continuing a chain past an
+/// already-found element, never for the first one -- see its own call sites here for why
+/// that distinction matters).
+pub(crate) fn embedded_chain(
     graph: &mut CipDigraph,
     mol: &Molecule,
     start: NodeId,

--- a/crates/chematic-cip/src/tests.rs
+++ b/crates/chematic-cip/src/tests.rs
@@ -1010,3 +1010,79 @@ fn rule5_15_row_cage_family_is_renumbering_invariant_worst_of_30() {
         cases.len()
     );
 }
+
+/// Companion determinism gate for the element-level guard in `assign_one_with_rule5`
+/// (see `assign.rs` module docs, "Element-level guard: phosphorus stays tied"): the
+/// guard is a plain `mol.atom(idx).element == Element::P` check on the *original*
+/// atom identity, so it should stay `SkipReason::Tied` under every renumbering by
+/// construction -- checked here the same way `rule5_15_row_cage_family_is_renumbering_invariant_worst_of_30`
+/// checks the carbon cage family, rather than assumed. Confirms the 2 cyclophosphazene
+/// phosphorus stereocenters from Milestone 4C-1 never flap to a resolved label on any
+/// of 30 renumbering permutations.
+#[test]
+fn rule5_phosphorus_ties_stay_tied_across_renumbering_worst_of_30() {
+    fn next(state: &mut u64) -> u64 {
+        *state ^= *state << 13;
+        *state ^= *state >> 7;
+        *state ^= *state << 17;
+        *state
+    }
+    fn shuffled(n: usize, state: &mut u64) -> Vec<usize> {
+        let mut perm: Vec<usize> = (0..n).collect();
+        for i in (1..n).rev() {
+            let j = (next(state) as usize) % (i + 1);
+            perm.swap(i, j);
+        }
+        perm
+    }
+
+    const PERMUTATIONS: usize = 30;
+    let smi = "CNP1(NC)=N[P@](NC)(N2CC2)=NP(NC)(NC)=N[P@@](NC)(N2CC2)=N1";
+    let mol = chematic_smiles::parse(smi).expect("valid SMILES");
+    let n = mol.atom_count();
+    let mut seed: u64 = 0x9E3779B97F4A7C15;
+    let mut checked = 0usize;
+
+    for trial in 0..PERMUTATIONS {
+        let perm = shuffled(n, &mut seed);
+        let (permuted, old_to_new) = permute_molecule(&mol, &perm);
+
+        let assignment =
+            crate::assign_cip_accurate_experimental(&permuted, CipBudget::default_budget())
+                .expect("assignment succeeds");
+
+        for atom_idx in [6u32, 19u32] {
+            let new_idx = old_to_new[atom_idx as usize];
+            let resolved = assignment
+                .assignments
+                .iter()
+                .any(|(idx, _)| idx.0 == new_idx);
+            assert!(
+                !resolved,
+                "original atom {atom_idx} (trial {trial}, new idx {new_idx}): \
+                 phosphorus must never resolve to a label"
+            );
+            let tied = assignment
+                .skipped
+                .iter()
+                .any(|(idx, reason)| idx.0 == new_idx && *reason == SkipReason::Tied);
+            assert!(
+                tied,
+                "original atom {atom_idx} (trial {trial}, new idx {new_idx}): \
+                 expected SkipReason::Tied under every renumbering, got {:?}",
+                assignment.skipped.iter().find(|(idx, _)| idx.0 == new_idx)
+            );
+            checked += 1;
+        }
+    }
+
+    assert_eq!(
+        checked,
+        PERMUTATIONS * 2,
+        "sanity: both atoms x every permutation checked"
+    );
+    println!(
+        "phosphorus tied-stability under renumbering: {checked}/{checked} stably unresolved \
+         (2 atoms x {PERMUTATIONS} permutations)"
+    );
+}

--- a/crates/chematic-cip/src/tests.rs
+++ b/crates/chematic-cip/src/tests.rs
@@ -871,3 +871,142 @@ fn rule5_resolves_the_15_row_cage_family_mirrored() {
         );
     }
 }
+
+/// Determinism gate for the Milestone 4A-2 fix: `rank_children`'s equivalence classes
+/// come from a `HashMap<usize, Vec<usize>>` (`groups_map` in `compare.rs`), and
+/// `assign_one_with_rule5`'s `physical_in_tied[0]`/`[1]` pick is therefore sensitive, in
+/// principle, to `mol.neighbors()`'s raw adjacency/bond-creation order -- exactly the
+/// class of order-dependence this project has been burned by before (see this repo's
+/// standing "never use atom index or HashMap iteration order as a tie-break" policy).
+/// The fix's `if is_r_a { (pos_a, pos_b) } else { (pos_b, pos_a) }` choice is a genuine
+/// chemical comparison (which branch's auxiliary sign is R), not an index tie-break, so
+/// it should be renumbering-invariant by construction -- but that is an argument, not a
+/// test, until checked here: worst-of-30 atom-renumbering permutations per molecule,
+/// covering all 5 distinct cage molecules (15 target atoms total, 450 checks), using the
+/// same `permute_molecule` helper (which also remaps `stereo_neighbor_order`, without
+/// which no permuted molecule's `@`/`@@` tags could be reinterpreted at all) the existing
+/// Rules-1a/2 renumbering tests use above.
+#[test]
+fn rule5_15_row_cage_family_is_renumbering_invariant_worst_of_30() {
+    let cases: &[(&str, u32)] = &[
+        (
+            "CCCCCCCC/C=C/CCCCCCCC(=O)OCc1cc(=O)c(OC(=O)[C@]23C[C@H]4C[C@H](C[C@H](C4)C2)C3)co1",
+            31,
+        ),
+        (
+            "CCCCCCCC/C=C/CCCCCCCC(=O)OCc1cc(=O)c(OC(=O)[C@]23C[C@H]4C[C@H](C[C@H](C4)C2)C3)co1",
+            33,
+        ),
+        (
+            "CCCCCCCC/C=C/CCCCCCCC(=O)OCc1cc(=O)c(OC(=O)[C@]23C[C@H]4C[C@H](C[C@H](C4)C2)C3)co1",
+            35,
+        ),
+        (
+            "COc1ccccc1N1CCN(CCCCNC(=O)C23C[C@H]4C[C@@H](C2)C[C@@H](C3)C4)CC1",
+            21,
+        ),
+        (
+            "COc1ccccc1N1CCN(CCCCNC(=O)C23C[C@H]4C[C@@H](C2)C[C@@H](C3)C4)CC1",
+            23,
+        ),
+        (
+            "COc1ccccc1N1CCN(CCCCNC(=O)C23C[C@H]4C[C@@H](C2)C[C@@H](C3)C4)CC1",
+            26,
+        ),
+        (
+            "O=C(NCCCCN1CCCC(/C=C\\c2ccccc2)C1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3",
+            23,
+        ),
+        (
+            "O=C(NCCCCN1CCCC(/C=C\\c2ccccc2)C1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3",
+            25,
+        ),
+        (
+            "O=C(NCCCCN1CCCC(/C=C\\c2ccccc2)C1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3",
+            28,
+        ),
+        (
+            "O=C(NCCCCN1CCN(c2cccc3ccccc23)CC1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3",
+            25,
+        ),
+        (
+            "O=C(NCCCCN1CCN(c2cccc3ccccc23)CC1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3",
+            27,
+        ),
+        (
+            "O=C(NCCCCN1CCN(c2cccc3ccccc23)CC1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3",
+            30,
+        ),
+        (
+            "O=c1cc(COC2CCOCC2)occ1OC(=O)[C@]12C[C@H]3C[C@H](C[C@H](C3)C1)C2",
+            20,
+        ),
+        (
+            "O=c1cc(COC2CCOCC2)occ1OC(=O)[C@]12C[C@H]3C[C@H](C[C@H](C3)C1)C2",
+            22,
+        ),
+        (
+            "O=c1cc(COC2CCOCC2)occ1OC(=O)[C@]12C[C@H]3C[C@H](C[C@H](C3)C1)C2",
+            24,
+        ),
+    ];
+
+    // Small inline xorshift PRNG -- no `rand` dev-dependency exists in this crate and
+    // adding one for a single deterministic-shuffle test isn't worth it (see the crate's
+    // own `Cargo.toml`); a fixed seed keeps this test itself reproducible.
+    fn next(state: &mut u64) -> u64 {
+        *state ^= *state << 13;
+        *state ^= *state >> 7;
+        *state ^= *state << 17;
+        *state
+    }
+    fn shuffled(n: usize, state: &mut u64) -> Vec<usize> {
+        let mut perm: Vec<usize> = (0..n).collect();
+        for i in (1..n).rev() {
+            let j = (next(state) as usize) % (i + 1);
+            perm.swap(i, j);
+        }
+        perm
+    }
+
+    const PERMUTATIONS_PER_MOLECULE: usize = 30;
+    let mut checked = 0usize;
+    let mut seed: u64 = 0x9E3779B97F4A7C15;
+
+    for (smi, atom_idx) in cases {
+        let mol = chematic_smiles::parse(smi).expect("valid SMILES");
+        let n = mol.atom_count();
+        for trial in 0..PERMUTATIONS_PER_MOLECULE {
+            let perm = shuffled(n, &mut seed);
+            let (permuted, old_to_new) = permute_molecule(&mol, &perm);
+            let new_idx = old_to_new[*atom_idx as usize];
+
+            let assignment =
+                crate::assign_cip_accurate_experimental(&permuted, CipBudget::default_budget())
+                    .expect("assignment succeeds");
+            let code = assignment
+                .assignments
+                .iter()
+                .find(|(idx, _)| idx.0 == new_idx)
+                .map(|(_, code)| *code);
+            assert_eq!(
+                code,
+                Some(chematic_core::CipCode::LowerS),
+                "{smi} original atom {atom_idx} (trial {trial}, new idx {new_idx}): \
+                 expected LowerS under every renumbering, got {code:?}"
+            );
+            checked += 1;
+        }
+    }
+
+    assert_eq!(
+        checked,
+        cases.len() * PERMUTATIONS_PER_MOLECULE,
+        "sanity: every (molecule, permutation) pair must have been checked"
+    );
+    println!(
+        "rule5 cage-family renumbering invariance: {checked}/{checked} identical \
+         ({} molecule-atoms x {PERMUTATIONS_PER_MOLECULE} permutations)",
+        cases.len()
+    );
+}

--- a/crates/chematic-cip/src/tests.rs
+++ b/crates/chematic-cip/src/tests.rs
@@ -513,6 +513,51 @@ fn rule5_resolves_the_two_verified_milestone_4a_target_rows() {
     }
 }
 
+/// Pseudoasymmetric r/s labels have a genuinely counter-intuitive property, verified
+/// directly against the live RDKit oracle (not assumed from textbook analogy -- this
+/// project's own standing lesson from Milestone 4B-1.5's discarded "S precedes R"
+/// overfit): under a *global* molecular mirror (every `@`/`@@` in the molecule swapped,
+/// including both this center's own tag and the two embedded reference centers that
+/// make it pseudoasymmetric), the lowercase label is **invariant**, not covariant like
+/// ordinary uppercase R/S. `rdCIPLabeler` confirms this directly on both Milestone-4A
+/// target rows (checked, not derived by hand): `orig=r, mirr=r` for both. This is not a
+/// corpus quirk -- swapping which of the two constitutionally-identical branches holds
+/// the `R`/`S` auxiliary descriptor is itself the local mirror image, and it exactly
+/// cancels the center's own tag flip. An earlier version of this test asserted the
+/// *opposite* (mirrored expectation = the flipped label) on the assumption that CIP
+/// labels always invert under mirroring; that assumption was wrong specifically for
+/// pseudoasymmetric centers and was caught by checking the live oracle before trusting
+/// it, not by argument.
+#[test]
+fn rule5_two_row_target_pseudoasymmetric_label_is_mirror_invariant() {
+    use chematic_core::CipCode;
+    let cases: &[(&str, u32)] = &[
+        ("N[C@@]1(C(=O)O)C[C@@H](C(=O)O)[C@@H](C(=O)O)C1", 1),
+        (
+            "CCCCc1cn([C@@H]2[C@@H](C)CCC[C@H]2C)c(=O)n1Cc1ccc(-c2ccccc2-c2nn[nH]n2)nc1",
+            7,
+        ),
+    ];
+    for (smiles, atom_idx) in cases {
+        let mol = chematic_smiles::parse(smiles).expect("valid SMILES");
+        let assignment =
+            crate::assign_cip_accurate_experimental(&mol, crate::CipBudget::default_budget())
+                .expect("assignment succeeds");
+        let code = assignment
+            .assignments
+            .iter()
+            .find(|(idx, _)| idx.0 == *atom_idx)
+            .map(|(_, code)| *code);
+        assert_eq!(
+            code,
+            Some(CipCode::LowerR),
+            "{smiles} atom {atom_idx} (mirrored): expected the SAME lowercase r \
+             (RDKit oracle: mirroring is invariant for pseudoasymmetric centers, not \
+             covariant), got {code:?}"
+        );
+    }
+}
+
 #[test]
 fn diagnose_m4a0_quinic_residual_constitutional_identity() {
     // M4A-0: for each quinic/gallic-ester residual molecule, check whether the two
@@ -608,6 +653,221 @@ fn diagnose_m4a0_quinic_residual_constitutional_identity() {
         println!(
             "{smi} atom {atom_idx}: branch_signature a={sig_a:#x} b={sig_b:#x} equal={}",
             sig_a == sig_b
+        );
+    }
+}
+
+/// Milestone 4A-2: the three-armed, locally-symmetric adamantane-cage pseudoasymmetric
+/// family (`validation/cip_residual_classification_corpus.jsonl`, `engine=accurate`,
+/// `bucket=pseudoasymmetric`, 15 rows across 5 distinct molecules -- every one of them,
+/// not a sample). Each `(smiles, atom_idx, expected)` pair's `expected` is the RDKit
+/// `rdCIPLabeler` oracle label (RDKit 2026.03.3), reproduced via
+/// `scripts/cip_pseudoasymmetric_oracle.py`. Before this milestone's fix, every one of
+/// these 15 atoms was `SkipReason::Tied` (a declined answer) -- see module docs for why
+/// (the embedded reference used for the tiebreak was itself Pass-1/Rule-4b tied, so the
+/// old molecular-descriptor `provisional` lookup could never find it).
+#[test]
+fn rule5_resolves_the_15_row_cage_family() {
+    let cases: &[(&str, u32, chematic_core::CipCode)] = &[
+        (
+            "CCCCCCCC/C=C/CCCCCCCC(=O)OCc1cc(=O)c(OC(=O)[C@]23C[C@H]4C[C@H](C[C@H](C4)C2)C3)co1",
+            31,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "CCCCCCCC/C=C/CCCCCCCC(=O)OCc1cc(=O)c(OC(=O)[C@]23C[C@H]4C[C@H](C[C@H](C4)C2)C3)co1",
+            33,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "CCCCCCCC/C=C/CCCCCCCC(=O)OCc1cc(=O)c(OC(=O)[C@]23C[C@H]4C[C@H](C[C@H](C4)C2)C3)co1",
+            35,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "COc1ccccc1N1CCN(CCCCNC(=O)C23C[C@H]4C[C@@H](C2)C[C@@H](C3)C4)CC1",
+            21,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "COc1ccccc1N1CCN(CCCCNC(=O)C23C[C@H]4C[C@@H](C2)C[C@@H](C3)C4)CC1",
+            23,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "COc1ccccc1N1CCN(CCCCNC(=O)C23C[C@H]4C[C@@H](C2)C[C@@H](C3)C4)CC1",
+            26,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "O=C(NCCCCN1CCCC(/C=C\\c2ccccc2)C1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3",
+            23,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "O=C(NCCCCN1CCCC(/C=C\\c2ccccc2)C1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3",
+            25,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "O=C(NCCCCN1CCCC(/C=C\\c2ccccc2)C1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3",
+            28,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "O=C(NCCCCN1CCN(c2cccc3ccccc23)CC1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3",
+            25,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "O=C(NCCCCN1CCN(c2cccc3ccccc23)CC1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3",
+            27,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "O=C(NCCCCN1CCN(c2cccc3ccccc23)CC1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3",
+            30,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "O=c1cc(COC2CCOCC2)occ1OC(=O)[C@]12C[C@H]3C[C@H](C[C@H](C3)C1)C2",
+            20,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "O=c1cc(COC2CCOCC2)occ1OC(=O)[C@]12C[C@H]3C[C@H](C[C@H](C3)C1)C2",
+            22,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "O=c1cc(COC2CCOCC2)occ1OC(=O)[C@]12C[C@H]3C[C@H](C[C@H](C3)C1)C2",
+            24,
+            chematic_core::CipCode::LowerS,
+        ),
+    ];
+
+    for (smi, atom_idx, expected) in cases {
+        let mol = chematic_smiles::parse(smi).expect("valid SMILES");
+        let assignment = crate::assign_cip_accurate_experimental(&mol, CipBudget::default_budget())
+            .expect("assignment succeeds");
+        let code = assignment
+            .assignments
+            .iter()
+            .find(|(idx, _)| idx.0 == *atom_idx)
+            .map(|(_, code)| *code);
+        assert_eq!(
+            code,
+            Some(*expected),
+            "{smi} atom {atom_idx}: expected {expected:?} (RDKit oracle), got {code:?}"
+        );
+    }
+}
+
+/// Companion control for the 15-row cage family above (see module docs, "Sign
+/// convention: your corpus supplies ~1 bit" concern, and
+/// `rule5_two_row_target_pseudoasymmetric_label_is_mirror_invariant`'s doc comment for
+/// the underlying property this relies on). Every row in the corpus is oracle-labeled
+/// lowercase `s`, which alone can't rule out a same-shape overfit as the one Milestone
+/// 4B-1.5 found and discarded ("S precedes R" scored 8/8 on its own one-sided corpus
+/// and 0/8 on the mirrored set) -- **but** for pseudoasymmetric centers specifically,
+/// checked directly against the live RDKit oracle on all 15 rows (not assumed), a
+/// global molecular mirror (every `@`/`@@` swapped) leaves the lowercase label
+/// **unchanged** (`s` stays `s`), unlike ordinary R/S. This test's expectation is
+/// therefore the *same* label as the original set, not its flip -- an oracle-verified
+/// invariance check, not the mirror-antisymmetry check an uppercase R/S case would need.
+#[test]
+fn rule5_resolves_the_15_row_cage_family_mirrored() {
+    let cases: &[(&str, u32, chematic_core::CipCode)] = &[
+        (
+            "CCCCCCCC/C=C/CCCCCCCC(=O)OCc1cc(=O)c(OC(=O)[C@@]23C[C@@H]4C[C@@H](C[C@@H](C4)C2)C3)co1",
+            31,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "CCCCCCCC/C=C/CCCCCCCC(=O)OCc1cc(=O)c(OC(=O)[C@@]23C[C@@H]4C[C@@H](C[C@@H](C4)C2)C3)co1",
+            33,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "CCCCCCCC/C=C/CCCCCCCC(=O)OCc1cc(=O)c(OC(=O)[C@@]23C[C@@H]4C[C@@H](C[C@@H](C4)C2)C3)co1",
+            35,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "COc1ccccc1N1CCN(CCCCNC(=O)C23C[C@@H]4C[C@H](C2)C[C@H](C3)C4)CC1",
+            21,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "COc1ccccc1N1CCN(CCCCNC(=O)C23C[C@@H]4C[C@H](C2)C[C@H](C3)C4)CC1",
+            23,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "COc1ccccc1N1CCN(CCCCNC(=O)C23C[C@@H]4C[C@H](C2)C[C@H](C3)C4)CC1",
+            26,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "O=C(NCCCCN1CCCC(/C=C\\c2ccccc2)C1)C12C[C@@H]3C[C@H](C1)C[C@H](C2)C3",
+            23,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "O=C(NCCCCN1CCCC(/C=C\\c2ccccc2)C1)C12C[C@@H]3C[C@H](C1)C[C@H](C2)C3",
+            25,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "O=C(NCCCCN1CCCC(/C=C\\c2ccccc2)C1)C12C[C@@H]3C[C@H](C1)C[C@H](C2)C3",
+            28,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "O=C(NCCCCN1CCN(c2cccc3ccccc23)CC1)C12C[C@@H]3C[C@H](C1)C[C@H](C2)C3",
+            25,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "O=C(NCCCCN1CCN(c2cccc3ccccc23)CC1)C12C[C@@H]3C[C@H](C1)C[C@H](C2)C3",
+            27,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "O=C(NCCCCN1CCN(c2cccc3ccccc23)CC1)C12C[C@@H]3C[C@H](C1)C[C@H](C2)C3",
+            30,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "O=c1cc(COC2CCOCC2)occ1OC(=O)[C@@]12C[C@@H]3C[C@@H](C[C@@H](C3)C1)C2",
+            20,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "O=c1cc(COC2CCOCC2)occ1OC(=O)[C@@]12C[C@@H]3C[C@@H](C[C@@H](C3)C1)C2",
+            22,
+            chematic_core::CipCode::LowerS,
+        ),
+        (
+            "O=c1cc(COC2CCOCC2)occ1OC(=O)[C@@]12C[C@@H]3C[C@@H](C[C@@H](C3)C1)C2",
+            24,
+            chematic_core::CipCode::LowerS,
+        ),
+    ];
+
+    for (smi, atom_idx, expected) in cases {
+        let mol = chematic_smiles::parse(smi).expect("valid SMILES");
+        let assignment = crate::assign_cip_accurate_experimental(&mol, CipBudget::default_budget())
+            .expect("assignment succeeds");
+        let code = assignment
+            .assignments
+            .iter()
+            .find(|(idx, _)| idx.0 == *atom_idx)
+            .map(|(_, code)| *code);
+        assert_eq!(
+            code,
+            Some(*expected),
+            "{smi} atom {atom_idx}: expected {expected:?} (mirrored RDKit oracle), got {code:?}"
         );
     }
 }

--- a/docs/cip_accurate_rfc.md
+++ b/docs/cip_accurate_rfc.md
@@ -1584,6 +1584,25 @@ precisely, not just nominally. All
 11 phosphorus rows enumerated with reproduction evidence. No chematic fix was needed to
 reach this — the gate closes on stratification, not remediation.
 
+**Follow-up (Milestone 4A-2's later fix, commit `1950cfa`, and its own follow-up,
+`9dd1ef5`)**: Milestone 4A-2's real fix for the 15-row carbon cage family
+(`assign_one_with_rule5` calling `resolve_chirality` on the tied group's nearest embedded
+reference instead of a `provisional` map lookup) reaches this section's 2 rows via the
+identical code path (same chain-length-1 shape), since the map-lookup limitation that
+made them tie in the first place is exactly what that fix removed. Left unguarded, it
+would resolve these 2 phosphorus atoms to `LowerR` -- but this section's own finding
+above (neither RDKit engine has a representation-stable answer for this molecule) still
+holds unchanged, so a resolved label here has no oracle to verify it against. Commit
+`9dd1ef5` adds an element-level guard in `assign_one_with_rule5` (see its module docs,
+"Element-level guard: phosphorus stays tied"): the auxiliary-resolution path only ever
+emits a label for a carbon stereocenter, so these 2 rows fall back to `SkipReason::Tied`
+again, matching this section's original, still-correct decision. Open question, not
+resolved: this project has zero verified examples of this path being correct for *any*
+non-carbon element, not specifically zero phosphorus examples -- a broader
+"unverified for any non-carbon element" guard may be more honest than the
+phosphorus-specific one actually shipped; flagged for a maintainer decision, not
+expanded unilaterally.
+
 ## Milestone 5A — Accurate CIP wired into the public API, opt-in
 
 With Milestone 4's gate closed, the accurate engine was still reachable only from

--- a/docs/cip_accurate_rfc.md
+++ b/docs/cip_accurate_rfc.md
@@ -709,6 +709,151 @@ correctness argued/verified first — a provisional-map two-pass refinement cann
 this family by construction (no seed), so this is not a parameter tweak on the current
 code, it needs a different mechanism.
 
+**Milestone 4A-2 — RESOLVED** (branch `feat/cip-pseudoasymmetric-rs`, part of the "v0.7
+Accuracy Wave"). The framing above ("needs symmetry/automorphism-aware joint resolution, a
+different architecture") turned out to be **wrong about what was needed**, discovered by
+direct instrumentation before any redesign was attempted (per the standing project
+discipline of checking a hypothesis before building for it):
+
+- **Root cause, verified not assumed.** The 15 rows all share the same connectivity
+  pattern: a 1-substituted adamantane cage (`[C]12C[CH]3C[CH](C[CH](C3)C1)C2`-shaped — 4
+  bridgeheads forming a complete graph K4 via 6 CH2 bridges, one bridgehead bearing the
+  exocyclic substituent, the other 3 the pseudoasymmetric CH centers). At the outer tied
+  atom (e.g. atom31), the two tied branches are genuinely, permanently constitutionally
+  identical under Rules 1a/1b/2 (confirmed by deep manual sphere-by-sphere tracing: the
+  branches remain tied through at least 5 spheres, the point at which the cage's own
+  vertex-transitive symmetry makes further constitutional comparison structurally
+  incapable of ever distinguishing them) — this is a real Rule-5 case, not a comparator
+  bug. `assign_one_with_rule5`'s original Milestone 4A implementation looked up each
+  branch's nearest embedded stereocenter's descriptor in `provisional`, a `HashMap`
+  populated only from Pass 1/Rule 4b's *already-resolved* atoms — but the embedded
+  reference here (e.g. atom33, as seen from atom31) is *itself* one of the three mutually
+  tied pseudoasymmetric atoms, so `provisional.get(&atom33)` was always `None`. This is
+  exactly "no seed to refine from," confirmed directly (not inferred) via a temporary
+  instrumented test calling `crate::resolver::resolve_chirality` directly on the tied
+  group's embedded references: both returned `Some(bool)`, and the two values *always
+  differed*, across all 15 rows — the raw signal Rule 5 needs was available the whole
+  time, just never looked at, because `provisional` was the wrong place to look for it.
+- **No SCC / fixed-point solver needed.** Per Hanson, Musacchio, Mayfield et al. 2018 (*J.
+  Chem. Inf. Model.* 58(9), 1755–1765, already cited in this doc's Milestone 4B-1.5
+  entry): "the descriptor for an auxiliary center does not depend upon any center between
+  it and the root... the path back to the root is always unique." Within *one* digraph
+  rooted at the true outer stereocenter, every embedded reference — however deep, however
+  many times the same underlying atom is revisited via a different ring path — is
+  strictly deeper than its parent by construction (`child_depth = parent_depth + 1`,
+  ring-closures terminate as childless `RingDuplicate` leaves). There is no cross-atom
+  cycle to resolve: `crate::resolver::resolve_chirality`, memoized by `NodeId` (path
+  identity, not atom identity) and already validated 72/72 for Rule 4b
+  (`docs/cip_accurate_rfc.md`'s Milestone 4B-2 entry, this same document), computes a
+  correct-shaped auxiliary sign for every one of the 15 rows' embedded references with
+  **zero modification** — confirmed directly, not assumed, before any production code
+  changed.
+- **The fix**: `crates/chematic-cip/src/assign.rs::assign_one_with_rule5` now locates the
+  nearest embedded reference via `crate::rule4b::embedded_chain(...).first()` (the same
+  chain-construction function Rule 4b's `break_tie_rule4b` uses, made `pub(crate)` for
+  this reuse — **not** `crate::rule4b::nearest_embedded` directly, which searches
+  *past* an already-consumed position and is only correct for chain positions ≥1, a
+  distinction documented in `nearest_embedded`'s own doc comment and initially missed,
+  caught by a real regression against the *original* 2-row Milestone 4A target before
+  being fixed) and calls `crate::resolver::resolve_chirality` on it directly, instead of
+  looking `provisional` (now removed entirely, along with the now-dead
+  `nearest_embedded_stereocenter` helper it required) up.
+- **A genuinely new, oracle-confirmed finding, not assumed from textbook analogy**:
+  pseudoasymmetric r/s labels are **invariant**, not covariant, under a full-molecule
+  mirror (every `@`/`@@` swapped, including the center's own tag and both its embedded
+  references) — verified directly against a live `rdCIPLabeler` on all 15 rows plus both
+  Milestone-4A 2-row targets (18/18 invariant). An initial mirror *negative control*
+  written for this milestone assumed labels always invert under mirroring (the correct
+  assumption for ordinary R/S) and failed against the live implementation; checking the
+  live RDKit oracle on the mirrored SMILES *before* treating that failure as a bug (per
+  this project's own standing lesson from Milestone 4B-1.5's discarded "S precedes R"
+  overfit) showed the "failure" was the test's wrong assumption, not an implementation
+  defect — chematic's own output already matched the oracle's real (invariant) behavior.
+  Both a same-molecule test (`rule5_resolves_the_15_row_cage_family`) and a mirrored
+  positive control (`rule5_resolves_the_15_row_cage_family_mirrored`, asserting the *same*
+  label, not the flipped one) are now permanent regression tests, plus the analogous pair
+  for the original 2-row target
+  (`rule5_two_row_target_pseudoasymmetric_label_is_mirror_invariant`).
+- **RDKit source audit** (pinned commit `8afba32ec539dcb2369bc84549d802aca3f7eb39`,
+  `github.com/rdkit/rdkit`), confirming the design direction against the real
+  implementation rather than memory of "how CIP usually works":
+  - `Code/GraphMol/CIPLabeler/CIPLabeler.cpp:43-47` — the rule cascade actually wired up
+    (`all_rules`) uses `Rule5New`, not the simpler `Rule5` (whose `.h`/`.cpp` are present
+    in the source tree but never included in `all_rules`, i.e. dead/superseded code as of
+    this commit — worth citing so a future reader doesn't mistake `Rule5.cpp`'s plain
+    ordinal comparator for the operative rule).
+  - `Code/GraphMol/CIPLabeler/CIPLabeler.cpp:103-166` (`labelAux`) — for each unresolved
+    center, auxiliary descriptors for every *other* configuration's foci reached in that
+    center's own digraph are computed **farthest-first** (`std::sort(..., farthest)`
+    where `farthest` compares `getDistance() >`, i.e. descending distance/depth), batched
+    by distance, each labeled via the *full* rule cascade (`all_rules`) before the center
+    itself is finally labeled — the literal bottom-up procedure the Hanson paper
+    describes and this crate's `resolve_chirality` already structurally mirrors.
+  - `Code/GraphMol/CIPLabeler/rules/Rule5New.cpp:26-68` — the real Rule 5: at a
+    non-root comparison it's a simple single-reference like/unlike test against a fixed
+    `d_ref` (matching chematic's own single-reference approach for this milestone's
+    scope); at the true digraph root it builds *four* pair lists (R-referenced and
+    S-referenced, for both branches) and returns a magnitude that distinguishes ordinary
+    (±1, R-referenced and S-referenced comparisons agree in sign) from genuinely
+    pseudoasymmetric (±2, they disagree) — the "both-references-max" procedure this RFC's
+    Milestone 4B-2 entry already flagged as deferred for Rule 4b, confirmed still
+    unimplemented here too (not needed: every observed row in this project's corpus
+    decides cleanly at a single reference, chain position 0).
+  - `Code/GraphMol/CIPLabeler/Descriptor.h:24-40` — `R`/`S`/`r`/`s` (and `M`/`P`/`m`/`p`
+    for axial) are distinct enum values, matching `chematic_core::CipCode`'s own
+    `R`/`S`/`LowerR`/`LowerS` typing decision (not collapsed).
+  - `Code/GraphMol/CIPLabeler/Node.h:87,109` (`getAux`/`setAux`) — the auxiliary
+    descriptor is a separate, mutable per-node field (`d_aux`, default `Descriptor::NONE`)
+    distinct from an atom's eventual *primary* label, confirming the
+    auxiliary-vs-molecular distinction this crate's own docs already argued for is a real
+    structural property of RDKit's implementation, not just a plausible-sounding theory.
+  - `Code/GraphMol/CIPLabeler/rules/Pairlist.h:35-46,84-93` (`PairList::ref`/`add`) — only
+    `R`/`S`/`M`/`P`/`seqCis`/`seqTrans` are recognized; a lowercase `r`/`s`/`m`/`p`
+    auxiliary descriptor is **silently excluded** from the pairing sequence entirely
+    (falls to `default: return Descriptor::NONE` / `return false`) — i.e. RDKit's own
+    Rule 4b/5 pairing mechanism does not thread nested pseudoasymmetric descriptors
+    through the pair list at all, it only ever pairs on the uppercase family. This is
+    consistent with (not contradicted by) chematic's own `resolve_chirality` returning a
+    plain `Option<bool>` (uppercase-equivalent) at every recursion level.
+- **Verification.** All 15 rows now resolve, all matching the oracle (`LowerS`);
+  0 regressions on the previously-correct 4160/4186, confirmed two independent ways
+  (`corpus_snapshot.rs` diff + `cip_accurate_full_corpus_report.py` full recompute
+  against a fresh `rdCIPLabeler`, RDKit 2026.03.3): raw agreement 4160/4186 (99.38%) →
+  4175/4186 (99.74%); **oracle-stable agreement 4160/4175 (99.64%) → 4175/4175
+  (100.00%)** — the stable-subset denominator's own residual (exactly these 15 rows) is
+  now fully closed. A **disclosed side effect**, not silently absorbed: the same fix also
+  resolves the 2 previously-`SkipReason::Tied` cyclophosphazene phosphorus rows from
+  Milestone 4C-1 (same chain-length-1-degenerate structural shape), which now return
+  `LowerR` — but neither RDKit CIP engine has a *representation-stable* answer for that
+  specific molecule (Milestone 4C-1's own finding, re-confirmed unchanged), so this new
+  label is **not** verified against any oracle. What *is* checked: chematic's own new
+  label is stable under the same Kekule-respelling test that broke both RDKit engines
+  there (`cip_mode_accurate_pseudoasymmetric_fix_is_kekule_stable_on_the_former_phosphorus_tie`)
+  — self-consistency evidence, not external correctness evidence. The existing test
+  asserting these 2 rows stay `unresolved` was updated to assert the new, disclosed
+  behavior instead of silently going stale.
+- **Performance.** The cage molecules are exactly `docs/cip_accurate_rfc.md`'s own
+  recorded worst-case `needs_pass2_or_3` bucket (already noted in the
+  MANCUDE-Decision-A0 entry above: `36,198` comparisons on the worst adamantane-cage
+  amide) — this fix does not add a new pass or new recursion, it only changes *where*
+  Rule 5's existing lookup gets its embedded reference from, so no new worst-case
+  mechanism is introduced. Full-corpus wall-clock, `corpus_snapshot --candidate`
+  (`~/Downloads/SMILES.csv`, 4,188 rows), this branch vs. `main`
+  (`65ca79b8ee352a0905f92d3f90cf7db91416a6b8`), each built in its own isolated worktree so
+  neither build disturbed the other: `main` `total_ms=470.8 median_us=34.79
+  p95_us=795.83`; this branch `total_ms=464.1 median_us=33.54 p95_us=797.25` — no material
+  change (within run-to-run noise), consistent with only ~29/4,188 stereocenters ever
+  reaching Rule 4b/Rule 5 at all (Milestone MANCUDE-Decision-A0's own CIP-Perf-A0
+  measurement, unaffected by this change). Issue #107's heavy-tail concern is unchanged:
+  this fix touches the *lookup mechanism* inside an already-reached tied-atom code path,
+  not the digraph expansion or comparator recursion that produces the heavy tail.
+- **Scope not attempted, disclosed rather than silently narrowed**: a tied pair whose two
+  branches' *nearest* embedded references resolve to the **same** auxiliary sign (both R
+  or both S) does not fall back to a deeper chain comparison the way Rule 4b's
+  `break_tie_rule4b` does (`embedded_chain`'s later chain positions) — no row in this
+  project's validation corpus exercises that shape for Rule 5, so extending to it would
+  be unverified against any oracle. Left as `SkipReason::Tied` (declined, not guessed).
+
 **Milestone 4A-0 — post-Milestone-4A residual refresh, frozen at `992d18c`.** Per the
 user's explicit instruction not to carry the pre-4A bucket estimates forward (Milestone
 4A's own +2 fix could have shifted which rows remain), the residual was re-derived from


### PR DESCRIPTION
## Update (commits `9dd1ef5` + `fb948b4`): element-level guard closes the phosphorus gap disclosed below

This is a follow-up commit on this same branch, addressing exactly the caveat raised in
"Known limitation / disclosed side effect" further down: the pseudoasymmetric fix's side
effect on 2 cyclophosphazene phosphorus atoms was shipped as "self-consistent but not
oracle-verified." That is not good enough by this project's own fail-closed standard —
an unresolved answer (`Tied`) is the honest state when no oracle can check the answer,
not a resolved-but-unverifiable one.

### Root cause (why the P side effect was wrong to ship as-is)

`assign_one_with_rule5`'s fix (previous commit, `1950cfa`) generalized correctly for the
15-row carbon cage family — every embedded reference there is genuinely resolvable and
oracle-checked. But the exact same code path also reaches the 2 phosphorus atoms from
Milestone 4C-1 (`docs/cip_accurate_rfc.md`), which tie for the *identical* structural
reason (a chain-length-1-degenerate Rule 4b comparison). Unlike the carbon rows, Milestone
4C-1 independently found that **neither** RDKit CIP engine (`rdCIPLabeler` nor legacy
`_CIPCode`) has a representation-stable answer for that specific molecule — both flip
under a chemically neutral Kekulé respelling of the P/N ring. There is therefore no
reliable oracle a resolved phosphorus label could ever be checked against. Shipping a
resolved-but-unverifiable label for those 2 atoms was the actual bug this commit fixes;
`SkipReason::Tied` (declined, not guessed) is the correct, honest state here, matching
this function's own pre-existing convention for every other shape it doesn't recognize.

### The guard's exact structural condition

I looked for a tighter, more chemically-specific condition than a bare element check —
e.g. whether the phosphorus instability traces to "both tied branches' nearest embedded
reference resolve to the *same* underlying atom" (Milestone 4C-1's own diagnosis: atoms
6/19 are each other's nearest embedded reference, reached via the ring's two different
paths — a mutual/circular reference, unlike the carbon cage family where "no genuine
cross-atom cycle" exists). That is a real, more specific structural fact about *why*
chematic's own mechanism used to tie there, but it is **not** established as the general
cause of RDKit's own oracle instability (that instability was found by testing RDKit
directly on the respelled molecule, independently of chematic's internal chain-length
computation) — extending the guard to "mutual embedded reference" would be inventing
false precision that isn't backed by any additional verified example.

What the evidence actually, plainly supports: **this auxiliary-resolution path has 15/15
oracle-verified examples, all carbon, and 0 verified examples for any other element.**
The guard implemented is a per-atom-identity, element-level check in
`assign_one_with_rule5` (`crates/chematic-cip/src/assign.rs`):

```rust
if mol.atom(idx).element == Element::P {
    return Err(SkipReason::Tied);
}
```

placed before any digraph work, keyed on `mol.atom(idx).element` (the *original*,
pre-Kekulé molecule's atom identity — stable across resonance respellings by
construction, verified by the new Kekulé-stability test below). `SkipReason::Tied` is
reused rather than adding a new `SkipReason::OracleUnstable` variant: I checked
`apply_rule5_pass`'s match arm that calls this function —

```rust
match assign_one_with_rule5(mol, idx, atom.chirality, stereo_order, budget, kekule) {
    Ok(Some(code)) => assignments.push((idx, code)),
    _ => skipped.push((idx, reason)),   // `reason` is pass1's own Tied, unconditionally
}
```

— and it already discards whatever `Err` variant `assign_one_with_rule5` returns,
unconditionally re-pushing pass 1's own `reason` (which is always `Tied` on this code
path). A new variant would need extra plumbing through `apply_rule5_pass` and
`chematic-chem`'s `CipUnresolvedReason` adapter for zero externally-visible benefit, so
this is the "otherwise reuse `Tied`" branch of the task's own decision rule — the smaller,
equally-correct change, not a corner cut.

**Scope question, flagged rather than resolved unilaterally**: this project has zero
verified examples of this path being correct for *any* non-carbon element, not
specifically zero *phosphorus* examples — phosphorus is simply the only non-carbon
element the validation corpus happens to exercise here. A broader "unverified for any
non-carbon element" framing may be more honest than "unverified for phosphorus
specifically," and would future-proof against some hypothetical third element reaching
this path with an equally-unverified answer. I did not implement that broader guard —
only the phosphorus-specific one asked for — to avoid expanding scope beyond what was
requested. Raising it here for a maintainer decision.

### Test restructuring (`crates/chematic-chem/src/cip.rs`)

1. `cip_mode_accurate_pseudoasymmetric_fix_now_resolves_former_phosphorus_ties` (asserted
   `LowerR`, resolved) → renamed and rewritten to
   `cip_mode_accurate_pseudoasymmetric_fix_stays_unresolved_for_phosphorus_ties` (asserts
   `unresolved`/`Tied`), with the doc comment rewritten to explain the element-level guard
   as the structural reason, not a molecule-specific carve-out (not a blind revert of the
   pre-#157 assertion text).
2. `cip_mode_accurate_pseudoasymmetric_fix_is_kekule_stable_on_the_former_phosphorus_tie`
   (checked that a *resolved* label didn't flip under Kekulé respelling) → repurposed to
   `cip_mode_accurate_phosphorus_ties_stay_unresolved_kekule_stable`, now checking that the
   guard's "stays unresolved" behavior itself doesn't flap between resolved/unresolved
   across the same respelling (the original test's premise — a resolved label existing —
   no longer holds, so keeping its literal assertion would have made it vacuously pass
   without checking anything).
3. `cip_mode_accurate_does_not_hide_oracle_unstable_answers` (the 9-row Milestone 4C-0
   family, resolved via Pass 1/Rule 4b, never reaches the Rule 5 pass) — **untouched**,
   confirmed still green; this guard only touches `assign_one_with_rule5`.
4. New: `crates/chematic-cip/src/tests.rs::rule5_phosphorus_ties_stay_tied_across_renumbering_worst_of_30`
   — mirrors the existing carbon-cage 450/450 determinism test: both phosphorus atoms ×
   30 renumbering permutations (60/60), confirming the guard doesn't flap between
   resolved/unresolved under atom renumbering (same PRNG-shuffle methodology, independent
   inline copy of the small xorshift helper rather than refactoring the existing one, to
   keep this a minimal, contained change).

Existing 15-row carbon cage tests (`rule5_resolves_the_15_row_cage_family`,
`..._mirrored`, `..._is_renumbering_invariant_worst_of_30`) and the 2-row Milestone 4A
target tests are **unchanged** and still pass.

### Re-derived corpus numbers (independently re-run against `~/Downloads/SMILES.csv`,
sha256 `1c47371dcbe37f4e0a141bf545b72bf238de2761fa3894fa251a552d84728d3e` — same corpus,
same hash as every number in this PR body) — via
`cargo run -p chematic-cip --release --example corpus_snapshot -- --candidate` at two
commits (base `65ca79b`, pre-#157, isolated `git worktree`; and this branch's new HEAD
`9dd1ef5`), then `scripts/cip_accurate_full_corpus_report.py` against a fresh
`rdCIPLabeler` (RDKit `2026.03.3`, independent venv — see Provenance below):

```
input_rows (snapshot union):        4188
baseline_assigned_rows:              4167
candidate_assigned_rows:             4167
oracle_assigned_rows:                4186
oracle_unassigned_rows:              2
excluded_rows (== oracle_unassigned): 2
baseline_correct:                    4160/4186 (99.38%)
candidate_correct:                   4175/4186 (99.74%)
newly_correct:                       15
regressions_from_full_recompute:     0  (Method B)
regressions_from_diff:               0  (Method A -- diff-set only, 15 changed rows: 15 fixes, 0 regressions, 0 neutral)

=== oracle-stable breakdown (candidate engine) ===
Modern RDKit raw agreement:          4175/4186 = 99.74%
Agreement on oracle-stable cases:    4175/4175 = 100.00%
Oracle-unstable cases excluded:      11/4186
```

- **Oracle-stable agreement: 4175/4175 (100.00%)** — unchanged from the pre-guard number
  in the table below, confirmed by rerunning rather than assumed: the 2 phosphorus rows
  were already excluded from this denominator as `oracle-unstable` (Milestone 4C-1) both
  before and after this guard, so reverting them to `Tied` doesn't move this figure either
  way. Checked, not just argued to "net out."
- **Pseudoasymmetric fixes: 15** (carbon cage only) — `newly_correct: 15`.
- **Previously-correct regressions: 0** — both independent methods.
- **Unverified P label additions: 0** — this is the whole point of the guard, and it's
  directly visible in the diff-set size below, not just asserted.
- **Total changed rows vs the pre-#157 baseline (`main`/`65ca79b`): 15, not 17.** The
  report script's diff-set (`regressions_from_diff`'s "N changed rows") is **15**, down
  from the 17 this same comparison reported before this guard existed (15 carbon fixes +
  2 phosphorus rows that no longer show up in the diff at all, because they're `Tied` in
  both the pre-#157 baseline and this branch's new HEAD). **Enumerated, not just
  counted** (diffed the two raw `corpus_snapshot` TSVs directly): all 15 changed rows are
  `skip:tied -> s`, on exactly the 5 cage molecules at exactly the atom indices
  `rule5_resolves_the_15_row_cage_family` already pins (31/33/35, 21/23/26, 23/25/28,
  25/27/30, 20/22/24) — zero phosphorus rows appear in the diff at all, confirmed by
  inspection of the actual changed-row list, not inferred from the aggregate count alone.

### Re-run gates (all re-run after this commit, not carried over from the previous commit)

- `cargo test -p chematic-cip --lib -- rule5`: 6/6 passed, including the new 60/60
  phosphorus-stability-under-renumbering test, in ~138s (dominated by the pre-existing
  450-permutation carbon test).
- `cargo test -p chematic-chem --lib -- cip_mode`: 5/5 passed (both rewritten phosphorus
  tests + the untouched 9-row/E-Z/legacy-parity tests).
- `cargo test -p chematic-cip --test rule4b_production_parity`: 9/9 passed, untouched.
- Full-corpus oracle report: above.
- Performance (`cargo run -p chematic-cip --release --example cage_worst_case_timing`):
  ran on both this branch's new HEAD and the pre-guard commit (`e2fea29`) back-to-back
  under identical (noisy, shared-machine) load to get an apples-to-apples comparison
  rather than trusting the previous commit's numbers under different load: pre-guard
  worst case 156,283us vs post-guard 109,606us on this run — **not slower**, confirming
  the guard (one `Element` equality check per Rule-5-eligible atom) adds no measurable
  overhead. Absolute numbers are ~2x the table further down in this PR body, uniformly
  across all 5 molecules (consistent with shared-machine contention during this session,
  not a per-molecule regression signal — this project's own standing policy, issue #70,
  is that noisy non-Criterion timing isn't regression evidence by itself; the two commits
  were compared back-to-back under the same conditions specifically to control for that).
- `cargo test --workspace --lib` / `--tests`: 0 failures workspace-wide.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo deny --all-features check`, `python3 scripts/check_publish_graph.py`,
  `bash scripts/check.sh`: all clean/pass.

### CI / Security / Bench status (`gh pr checks 157`, HEAD `fb948b4`)

Pushed as `9dd1ef5` (the guard fix) then `fb948b4` (doc-pointer/RFC-note follow-up),
both fast-forward on top of `e2fea29`, no force-push. `gh pr checks 157` at HEAD
`fb948b4`:

| Check | Result |
|---|---|
| Format Check | pass |
| Clippy / Clippy Lints | pass |
| Build Check | pass |
| Test | pass |
| Test (native-inchi) | pass |
| Cargo Audit | pass |
| Cargo Deny | pass |
| Validate CITATION.cff | pass |
| CodeQL (actions/javascript-typescript/python/rust `Analyze`) | pass |
| Python bench regression gate | pass |
| Rust Criterion regression gate | **pending at time of this report** (all 15 other checks pass; this is the only one still running) |

Per this project's standing policy (issue #70, pseudo-replication in the Criterion gate),
a Bench gate failure alone would not be treated as semantic regression evidence, and
nothing was tuned in response to Bench noise. If the Criterion gate comes back red after
this report is read, that is expected to be checked against the same standing policy
before any action is taken, not treated as a blocker by itself.

### A note on this session's environment

Disk space on the shared build machine was exhausted for a period during this task (many
concurrent agent worktrees, each with a multi-GB `target/`) — every `Bash`/tool-write
call failed with `ENOSPC` for a while, including this agent's own attempt to write test
logs. Recovered by deleting only this worktree's own `target/` directory (not touching
any sibling worktree's build state) once shell access returned; work was committed
locally immediately after, before continuing. Noted here for the record, not as an
excuse — all gates above were re-run cleanly after recovery.

---

## Summary

Completes pseudoasymmetric (lowercase `r`/`s`) labeling for the accurate CIP engine's
"three-armed cage" residual: **15/15 rows resolved**, all matching the RDKit oracle.
Milestone 4A-2's own framing ("needs symmetry/automorphism-aware joint resolution, a
different architecture") turned out to overstate what was needed — no SCC/fixed-point
solver was built or needed; see Root cause below.

## Root cause

`assign_one_with_rule5` (Milestone 4A) looked up each tied branch's nearest embedded
stereocenter's descriptor in `provisional: HashMap<AtomIdx, CipCode>`, populated only from
Pass 1/Rule 4b's *already-resolved* atoms. This fails whenever the embedded reference is
itself Pass-1/Rule-4b tied — exactly the three-armed, 1-substituted-adamantane-cage family
(`[C]12C[CH]3C[CH](C[CH](C3)C1)C2`-shaped: 4 bridgeheads forming K4 via 6 CH2 bridges, one
bridgehead bearing the exocyclic substituent, the other 3 the pseudoasymmetric centers).

Direct instrumentation (a temporary test calling `crate::resolver::resolve_chirality`
directly on the tied group's embedded references, removed before this PR) showed the
"no seed" framing was wrong: within one digraph rooted at the outer atom, every embedded
reference is strictly deeper (Hanson, Musacchio, Mayfield et al. 2018, *J. Chem. Inf.
Model.* 58(9), 1755–1765: "the descriptor for an auxiliary center does not depend upon
any center between it and the root... the path back to the root is always unique"). The
already-validated (72/72, Rule 4b) `resolve_chirality` machinery — memoized by `NodeId`
(path identity, not atom identity) — computed a correct-shaped auxiliary sign for every
one of the 15 rows' embedded references with **zero modification**, confirmed *before*
any production code changed.

**The fix** (`crates/chematic-cip/src/assign.rs::assign_one_with_rule5`): locate the
nearest embedded reference via `crate::rule4b::embedded_chain(...).first()` (made
`pub(crate)`) and call `crate::resolver::resolve_chirality` on it directly, instead of a
`provisional` map lookup (now removed, along with the now-dead
`nearest_embedded_stereocenter` helper it required).

One real bug caught mid-implementation, before shipping: my first attempt used
`crate::rule4b::nearest_embedded` directly on the tied group's own position node. That
function searches *past* an already-consumed position (its own doc comment says so) and
is only correct for chain positions ≥1 — using it at position 0 flipped one of the
original 2 verified Milestone-4A target rows from `LowerR` to `LowerS`. Caught by the
existing `rule5_resolves_the_two_verified_milestone_4a_target_rows` regression test
failing, root-caused, and fixed by switching to `embedded_chain(...).first()` (the
function that *does* special-case position 0), which restored that test and fixed all 15
new rows.

## RDKit source audit (pinned commit `8afba32ec539dcb2369bc84549d802aca3f7eb39`, `github.com/rdkit/rdkit`)

- `Code/GraphMol/CIPLabeler/CIPLabeler.cpp:43-47` — the rule cascade actually wired up
  (`all_rules`) uses **`Rule5New`**, not the simpler `Rule5` (whose `.h`/`.cpp` exist in
  the tree but are never included in `all_rules` — dead/superseded code as of this
  commit).
- `Code/GraphMol/CIPLabeler/CIPLabeler.cpp:103-166` (`labelAux`) — for each unresolved
  center, auxiliary descriptors for every other configuration's foci reached in that
  center's own digraph are computed **farthest-first** (`std::sort(..., farthest)` where
  `farthest` compares `getDistance() >`), batched by distance, each labeled via the full
  rule cascade before the center itself is labeled — the literal bottom-up procedure
  Hanson's paper describes, and what `resolve_chirality` already structurally mirrors.
- `Code/GraphMol/CIPLabeler/rules/Rule5New.cpp:26-68` — the real Rule 5: at a non-root
  comparison, a simple single-reference like/unlike test against a fixed `d_ref`
  (matching this PR's single-reference scope); at the true digraph root, it builds *four*
  pair lists (R-referenced and S-referenced, both branches) and returns a magnitude that
  distinguishes ordinary (±1, agree in sign) from genuinely pseudoasymmetric (±2,
  disagree) — the "both-references-max" procedure this project's own RFC already flagged
  as deferred for Rule 4b (Milestone 4B-2). Confirmed still unimplemented here too — not
  needed, since every observed row in this corpus decides cleanly at chain position 0.
- `Code/GraphMol/CIPLabeler/Descriptor.h:24-40` — `R`/`S`/`r`/`s` are distinct enum
  values, matching `chematic_core::CipCode`'s own `R`/`S`/`LowerR`/`LowerS` (not
  collapsed).
- `Code/GraphMol/CIPLabeler/Node.h:87,109` (`getAux`/`setAux`) — the auxiliary descriptor
  is a separate, mutable per-node field (`d_aux`, default `Descriptor::NONE`), distinct
  from an atom's eventual primary label — confirms the auxiliary-vs-molecular distinction
  is a real structural property of RDKit's implementation.
- `Code/GraphMol/CIPLabeler/rules/Pairlist.h:35-46,84-93` (`PairList::ref`/`add`) — only
  `R`/`S`/`M`/`P`/`seqCis`/`seqTrans` are recognized; a lowercase `r`/`s`/`m`/`p`
  auxiliary descriptor is **silently excluded** from the pairing sequence entirely. RDKit
  itself does not thread nested pseudoasymmetric descriptors through the pair list — only
  the uppercase family is paired. Consistent with `resolve_chirality`'s own plain
  `Option<bool>` return.

Full narrative also recorded in `docs/cip_accurate_rfc.md`'s new "Milestone 4A-2 —
RESOLVED" entry (kept alongside, not replacing, the original "deferred" entry).

## Before / after

Full-corpus (`~/Downloads/SMILES.csv`, sha256 `1c47371dcbe37f4e0a141bf545b72bf238de2761fa3894fa251a552d84728d3e`,
4999 rows), via `cargo run -p chematic-cip --release --example corpus_snapshot --
--candidate` run **twice at two different commits** (base `65ca79b8ee352a0905f92d3f90cf7db91416a6b8`
in an isolated `git worktree`, and this branch's HEAD — both in `--candidate` mode, i.e.
both measuring `assign_cip_accurate_experimental`; the report script's own column label
`assign_cip_accurate_experimental_without_mancude` for column 1 is a fixed script default
and does **not** describe what was actually run here, noted so it isn't mistaken for a
baseline-mode claim), then `scripts/cip_accurate_full_corpus_report.py` against a fresh
`rdCIPLabeler` (RDKit 2026.03.3):

| | before (`65ca79b`) | after commit `1950cfa`/`e2fea29` (superseded, see Update above) |
|---|---|---|
| Raw modern-oracle agreement | 4160/4186 (99.38%) | 4175/4186 (99.74%) |
| Oracle-stable agreement | 4160/4175 (99.64%) | 4175/4175 (100.00%) |
| Oracle-unstable (excluded) | 11/4186 | 11/4186 (unchanged) |
| Oracle-unassigned (excluded) | 2 | 2 (unchanged) |

**This table's "17 changed rows" framing (below) is superseded by the Update section at
the top of this PR body — after the phosphorus guard, the diff-set is 15 rows, not 17.**
Kept verbatim here as the original, honest record of what commit `1950cfa` actually did
before the follow-up guard.

- **Success denominator: 15/15** pseudoasymmetric cage-family rows resolved, all matching
  oracle `LowerS`.
- **Regressions: 0**, two independently computed methods
  (`regressions_from_diff`/`regressions_from_full_recompute`): 17 changed rows = 15 fixes
  + 2 neutral, 0 regressions either way. (Superseded: 15 changed rows after the guard —
  see Update above.)
- **Excluded/oracle-unstable denominator: 11/4186**, fully enumerated in
  `validation/cip_oracle_instability.jsonl` (unchanged by this PR).

## Known limitation / disclosed side effect — READ: RESOLVED by the Update section at the top

The same fix also resolves the **2** previously-`SkipReason::Tied` cyclophosphazene
phosphorus atoms from Milestone 4C-1 (identical chain-length-1-degenerate structural
shape). They now return `LowerR`. **Neither RDKit CIP engine has a representation-stable
answer for that specific molecule** (Milestone 4C-0/4C-1's own finding, re-confirmed
unchanged) — this new label is **not verified against any oracle**. What *is* checked:
chematic's own new label is stable under the same Kekule-respelling test that broke both
RDKit engines there
(`cip_mode_accurate_pseudoasymmetric_fix_is_kekule_stable_on_the_former_phosphorus_tie`,
new test) — self-consistency evidence, not external correctness evidence. The pre-existing
test asserting these 2 rows stay `unresolved`
(`cip_mode_accurate_surfaces_unresolved_not_a_guess_for_tied_phosphorus`) was renamed and
rewritten to assert the new, disclosed behavior rather than silently going stale or being
deleted.

**This whole paragraph is superseded**: the follow-up commit `9dd1ef5` (see Update at the
top of this PR body) adds an element-level guard so these 2 atoms stay `Tied` again,
because "self-consistent but not oracle-verified" isn't good enough — kept here verbatim
as the honest original record of what commit `1950cfa` shipped, not silently edited away.

**A second, positive finding worth flagging explicitly, not folding into the headline**:
an initial mirror-image negative control assumed pseudoasymmetric labels invert under a
global molecular mirror (`@`/`@@` swapped everywhere), the correct assumption for ordinary
R/S. It failed. Checking the live RDKit oracle on the mirrored SMILES *before* treating
that as a bug (this project's own standing lesson from Milestone 4B-1.5's discarded "S
precedes R" overfit) showed the failure was the test's wrong assumption:
pseudoasymmetric labels are **mirror-invariant**, confirmed directly on all 15 rows plus
both original Milestone-4A 2-row targets (18/18). Both directions are now permanent tests
(`rule5_resolves_the_15_row_cage_family_mirrored`,
`rule5_two_row_target_pseudoasymmetric_label_is_mirror_invariant`).

**Still out of scope, disclosed rather than silently narrowed**: a tied pair whose two
branches' nearest embedded references resolve to the *same* auxiliary sign (both R or
both S) does not fall back to a deeper chain comparison the way Rule 4b's
`break_tie_rule4b` does. No row in this project's validation corpus exercises that shape
for Rule 5. Left as `SkipReason::Tied` (declined, not guessed) rather than extended on an
unverified assumption.

## Regression-set diff (0 regressions on previously-correct rows)

Confirmed two independent ways (see table above): `regressions_from_diff` (Method A, only
the rows where the two snapshots differ, each independently oracle-checked: 15 fixes,
0 regressions) and `regressions_from_full_recompute` (Method B, independent
full 4186-row oracle re-derivation, not reusing Method A's diff set): 0. (Diff-set size
was 17 before the phosphorus guard, 15 after — see Update above.)

All existing `chematic-cip`/`chematic-chem` test suites pass unchanged (workspace-wide
`cargo test --workspace --lib`/`--tests`, 0 failures), including the 72/72 Rule 4b
production-parity suite (`tests/rule4b_production_parity.rs`, untouched) and every
existing MANCUDE/renumbering/mirror invariance test.

## Determinism (worst-of-30 relabeling)

`rule5_15_row_cage_family_is_renumbering_invariant_worst_of_30` (new test): all 15 target
atoms across the 5 distinct cage molecules × 30 atom-renumbering permutations each —
**450/450 identical** (`LowerS` every time). Motivated by a real, checked concern, not a
formality: `rank_children`'s equivalence classes are built via a
`HashMap<usize, Vec<usize>>`, so `physical_in_tied[0]`/`[1]`'s order is, in principle,
`mol.neighbors()` adjacency-order-sensitive. The fix's `(higher, lower) = if is_r_a {
(pos_a, pos_b) } else { (pos_b, pos_a) }` is a genuine chemical comparison (which
branch's auxiliary sign is R), not an index/HashMap-order tie-break — verified, not just
argued. (See Update above for the companion 60/60 phosphorus-stays-tied determinism test
added by the follow-up commit.)

## Performance (issue #107)

The 5 cage molecules are this crate's own already-documented `needs_pass2_or_3` worst
case (`docs/cip_accurate_rfc.md`'s MANCUDE-Decision-A0 entry: 36,198 comparisons on an
adamantane-cage amide). Best-of-20 wall-clock (`examples/cage_worst_case_timing.rs`, new),
same 5 molecules, `main` (`65ca79b`, isolated worktree) vs this branch:

| molecule (truncated) | before | after |
|---|---|---|
| `CCCCCCCC/C=C/...co1` | 5267 us | 5356 us |
| `COc1ccccc1N1...CC1` | 7955 us | 8013 us |
| `O=C(NCCCCN1CCCC...C3` | 10228 us | 10160 us |
| `O=C(NCCCCN1CCN...C3` (worst) | 54166 us | 53589 us |
| `O=c1cc(COC2...C2` | 4698 us | 4806 us |

No regression (within run-to-run noise; the fix changes which map a final lookup reads,
not digraph expansion or comparator recursion, so the worst-case mechanism issue #107
tracks is unaffected). Full-corpus aggregate (`corpus_snapshot`, 4188 rows, same
before/after commits): `total_ms=470.8 median_us=34.79 p95_us=795.83` → `total_ms=464.1
median_us=33.54 p95_us=797.25` — consistent with only ~29/4188 stereocenters ever
reaching Rule 4b/5 at all (previously measured, unaffected by this change). (See Update
above for the follow-up commit's own back-to-back re-timing, since a full session had
passed and machine load had changed.)

## Corpus provenance

- `~/Downloads/SMILES.csv`: sha256 `1c47371dcbe37f4e0a141bf545b72bf238de2761fa3894fa251a552d84728d3e`
  (matches every prior recorded value in this project's CIP RFC — no corpus drift).
- `validation/cip_residual_classification_corpus.jsonl` (read only, not regenerated —
  historical diagnosis snapshot): sha256 `df07a28558a9feb1c4b5b63114babef9e671b5bdd7f284cee6b66620fda08ff9`
- `validation/cip_m4b2_post_port_residual.jsonl` (read only): sha256 `c541d17254d4d348e146a5e83cd6926db40459cbd070e96684a99b87fa3f19ae`
- `validation/cip_oracle_instability.jsonl` (read only): sha256 `8e541e14290cc716743d97fea9ae69d760f37b16f2a0c12637bdb8f159085e73`
- `validation/cip_label_corpus.jsonl` (read only): sha256 `14ce78b96a24bc66b65fd963ffc7e236e1153f72c006933555335d0bdd61730e`
- `scripts/cip_accurate_full_corpus_report.py` (read + run, unmodified): sha256 `c92aa89569e23c11335e6bed6ae6e1a2ee2044e3dd6ba52a478926b2dae687d4`
- `scripts/cip_ground_truth.py` (read only, unmodified): sha256 `dafbf4c59cc17423304a1b0413d9036286d07366764dde4c76647f095238db75`
- `scripts/cip_residual_classification_audit.py` (read only, unmodified): sha256 `d6983f171566a88ea2aecd8b4b1da97725c6ab5c193e6ad6f3f44cf8110f86fc`

## Positive controls

- `rule5_resolves_the_two_verified_milestone_4a_target_rows` (pre-existing, must stay
  green): confirms the 2-row target still resolves correctly under the new mechanism —
  caught the `nearest_embedded`-vs-`embedded_chain` bug described above before it shipped.
- `rule4b_production_parity.rs` (pre-existing, 9/9, untouched): confirms Rule 4b's 72/72
  parity is unaffected — this PR only touches Rule 5's own pass.
- `diagnose_m4a0_quinic_residual_constitutional_identity` (pre-existing): confirms the
  Rule-4b-territory quinic/gallate rows are unaffected.
- Mirror-image checks on both the 2-row and 15-row targets (18/18 invariant, verified
  against the live oracle, not assumed).

## Provenance / reproducibility record

- Base commit: `65ca79b8ee352a0905f92d3f90cf7db91416a6b8` (main, exact — confirmed via
  `git rev-parse HEAD` at start).
- Head commit (original scope, commit `1950cfa`/`e2fea29`): `e2fea299824d7983c5a4efccb231683da4db1a13`.
- Head commit (phosphorus guard): `9dd1ef5`.
- **Head commit (this branch, current): `fb948b4`** (doc-pointer/RFC-note follow-up on
  top of `9dd1ef5`, no code change).
- RDKit oracle version: `2026.03.3`.
  - Original commit's venv: `/private/tmp/chematic-cipD-venv`.
  - Follow-up guard commit's venv (this update): `/tmp/chematic-cipD-p-fix-venv`
    (`python3 -m venv` + `pip install rdkit==2026.03.3`, independent of the shared repo
    `.venv` and of the original commit's venv, per instructions). `sys.executable`:
    `/private/tmp/chematic-cipD-p-fix-venv/bin/python`. `rdkit.__version__`: `2026.03.3`.
- RDKit pinned source commit: `8afba32ec539dcb2369bc84549d802aca3f7eb39`
  (`github.com/rdkit/rdkit`), fetched via `gh api repos/rdkit/rdkit/contents/...`.
- `git status --short` at completion: clean (all changes committed, HEAD `fb948b4`).
- Oracle script used: `scripts/cip_accurate_full_corpus_report.py` (existing,
  unmodified — sha256 above); no new Python oracle script was written, per "extend,
  don't duplicate."

## Does any default API change?

**No.** `CipMode::LegacyFast` is untouched (verified: `cip_mode_legacy_fast_matches_assign_cip_byte_for_byte`
still passes). `CipMode::Accurate` is still opt-in; only its behavior for
pseudoasymmetric-eligible atoms changes (15 previously-`Tied` carbon atoms now resolve;
the 2 phosphorus atoms disclosed above and "resolved" by commit `1950cfa` are, after the
follow-up guard in `9dd1ef5`, back to `unresolved`/`Tied` — matching their original,
pre-#157 behavior exactly). No Rust/Python/WASM public function signature changed.
`SkipReason` gained no new variant (the guard reuses `Tied`); `provisional`/
`nearest_embedded_stereocenter` were crate-private and remain removed.

## Resource / recursion limits

No new limits added. `resolve_chirality`/`embedded_chain` are pre-existing, already
budget-gated (`CipBudget`) machinery reused as-is; this PR adds no new recursion depth or
node-count path. The phosphorus guard is a single `Element` equality check, evaluated
before any digraph work for a Rule-5-eligible atom — strictly cheaper than the prior
behavior for phosphorus atoms, never more expensive for carbon atoms.

## Merge dependencies

None. This track only touches `chematic-cip` (`assign.rs`, `rule4b.rs`, `tests.rs`, one
new example) and `chematic-chem::cip.rs` (test-only changes). File-disjoint from PR #154,
which only touches `chematic-mol`/`chematic-perception`/`chematic-py::formats,io`/
`chematic-wasm::mol_io`.

## Untrusted-data note

No prompt-injection or out-of-scope instructions were encountered in any fixture, corpus
file, or script read during this work (original commit or this follow-up).

## Completion checks (all run, all green — re-run for the follow-up guard commit `9dd1ef5`,
and `bash scripts/check.sh` re-run again at `fb948b4` after the doc-only commit)

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace --lib        (0 failures)
cargo test --workspace --tests      (0 failures)
cargo deny --all-features check     (advisories ok, bans ok, licenses ok, sources ok)
python3 scripts/check_publish_graph.py   (OK, 18 publishable crates)
bash scripts/check.sh               (All checks passed. -- run at both 9dd1ef5 and fb948b4)
```
Plus the oracle script run documented in the Update section at the top
(`cip_accurate_full_corpus_report.py`).

---

Draft PR — not self-merging. The original scope (all 15 known pseudoasymmetric residual
rows) is complete; the phosphorus side effect this PR body originally disclosed as a known
limitation is now closed by an explicit, evidence-based element-level guard (see Update at
the top), with the "should this be broader than phosphorus" question raised for a
maintainer decision rather than resolved unilaterally. The same-sign-chain-position-0 gap
remains an explicit, disclosed, out-of-scope limitation.
