### PR TITLE
fix(inchi): correct explicit-graph-H isotope tallying and stereo0D drop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Unit tests with native-inchi feature
         run: cargo test -p chematic-inchi --features native-inchi --lib --quiet
       - name: Integration tests with native-inchi feature
-        run: cargo test -p chematic-inchi --features native-inchi --test standard_inchi --quiet
+        run: cargo test -p chematic-inchi --features native-inchi --quiet
 
   clippy:
     name: Clippy

--- a/crates/chematic-inchi/src/native/convert.rs
+++ b/crates/chematic-inchi/src/native/convert.rs
@@ -97,12 +97,28 @@ pub fn mol_to_inchi_atoms(
         let Some((code, sorted_nbrs)) = tetrahedral_stereo_neighbors(mol, aidx) else {
             continue;
         };
-        // A valid tetrahedral stereocentre has 4 distinct substituents, so at
-        // most one can be hydrogen (of any isotope) -- `.find()` is safe here.
-        let h_sub = sorted_nbrs
+        // Usually at most one substituent is hydrogen (bracket-H or a real
+        // graph H atom), since a tetrahedral stereocentre needs 4 CIP-distinct
+        // groups and two *ordinary* hydrogens would tie. But two isotopically
+        // distinct hydrogens (e.g. a centre bearing both `[2H]` and `[3H]`, or
+        // bracket-H plus an explicit `[2H]`) DO rank differently under CIP
+        // rule 2 (mass) and are a legitimate stereocentre -- confirmed
+        // reachable and RDKit-stereogenic (see `two_h_like_substituents_*`
+        // tests below). This mechanism only has ONE manufactured-atom slot
+        // per centre, so it cannot represent two independently-indexed H
+        // substituents; register at most one (`h_subs.len() == 1`) and leave
+        // multi-H centres unregistered so Phase 5's existing "no mapping ->
+        // ok=false -> drop the descriptor" path applies -- safe (same
+        // behaviour as any other unsupported case in this file) rather than
+        // silently emitting a corrupted Stereo0D with a duplicated index.
+        let mut h_subs = sorted_nbrs
             .iter()
-            .find(|&&nb| nb.0 == u32::MAX || mol.atom(nb).element.atomic_number() == 1);
-        if let Some(&nb) = h_sub {
+            .copied()
+            .filter(|&nb| nb.0 == u32::MAX || mol.atom(nb).element.atomic_number() == 1);
+        let first = h_subs.next();
+        let is_single = first.is_some() && h_subs.next().is_none();
+        if is_single {
+            let nb = first.unwrap();
             // Index = number of heavy atoms + number of H atoms added so far.
             let h_idx = (heavy_order.len() + stereo_h.len()) as i16;
             let source = if nb.0 == u32::MAX {
@@ -476,6 +492,55 @@ mod tests {
             atoms[0].num_iso_h,
             [0, 0, 4, 0],
             "4 explicit D atoms must tally into bucket 2 (D), not bucket 0 (ordinary)"
+        );
+    }
+
+    /// A stereocentre with TWO isotopically-distinct H-like substituents
+    /// (here D and T, which DO rank differently under CIP rule 2 and so form
+    /// a real stereocentre -- confirmed reachable and RDKit-stereogenic) has
+    /// no single manufactured-atom slot that can hold both. Must NOT emit a
+    /// Stereo0D with a duplicated neighbor index (that would be silently
+    /// wrong); must instead safely drop the descriptor while keeping the
+    /// isotope counts on the heavy atom itself fully correct.
+    #[test]
+    fn two_h_like_substituents_on_one_centre_drops_stereo_not_corrupts_it() {
+        let mol = parse("[C@](Br)(F)([2H])[3H]").unwrap();
+        let (atoms, stereo) = mol_to_inchi_atoms(&mol).unwrap();
+        assert_eq!(
+            atoms.len(),
+            3,
+            "no manufactured atom for either H: 3 heavy atoms only (C, Br, F)"
+        );
+        assert!(
+            stereo.is_empty(),
+            "ambiguous double-H-slot centre must be dropped, not emitted with a duplicated index"
+        );
+        // The D and T themselves must still be correctly isotope-tallied on
+        // the heavy carbon -- only the stereo *descriptor* is unsupported.
+        assert_eq!(
+            atoms[0].num_iso_h,
+            [0, 0, 1, 1],
+            "D and T must still tally correctly even though stereo is dropped"
+        );
+    }
+
+    /// Same guard, but for bracket-H (sentinel) + an explicit isotopic H on
+    /// the same centre -- also two H-like substituents, also must drop
+    /// cleanly rather than duplicate an index.
+    #[test]
+    fn bracket_h_plus_explicit_isotope_h_drops_stereo_not_corrupts_it() {
+        let mol = parse("[C@H](Br)([2H])F").unwrap();
+        let (atoms, stereo) = mol_to_inchi_atoms(&mol).unwrap();
+        assert_eq!(
+            atoms.len(),
+            3,
+            "no manufactured atom: 3 heavy atoms (C, Br, F)"
+        );
+        assert!(stereo.is_empty(), "must be dropped, not corrupted");
+        assert_eq!(
+            atoms[0].num_iso_h,
+            [1, 0, 1, 0],
+            "bracket-H implicit count (bucket 0 = 1) + explicit D (bucket 2 = 1)"
         );
     }
 }

--- a/crates/chematic-inchi/src/native/convert.rs
+++ b/crates/chematic-inchi/src/native/convert.rs
@@ -13,6 +13,36 @@ pub enum ConvertError {
     KekulizationFailed(String),
 }
 
+/// Where a manufactured "H" InChI atom (added only so a tetrahedral stereocentre's
+/// hydrogen substituent has an index `Stereo0D` can reference -- `heavy_order`/
+/// `inchi_idx` never include H, so it has no index of its own otherwise) traces
+/// back to the source molecule.
+///
+/// * `Sentinel` -- bracket-H notation (`[C@H]`, `[C@@H]`, ...): the H is not a
+///   graph atom at all, just an implicit count on the bracket atom, so it is
+///   always isotopically ordinary.
+/// * `Explicit(AtomIdx)` -- a real graph H atom (`[H]`, `[2H]`, `[3H]`, ...)
+///   that IS present in `mol`; its isotope (if any) must be forwarded onto the
+///   manufactured atom so the `/i` layer is correct.
+#[derive(Clone, Copy)]
+enum StereoHSource {
+    Sentinel,
+    Explicit(AtomIdx),
+}
+
+/// Isotope of an explicit hydrogen atom -> the `num_iso_h[]` bucket it tallies
+/// into (`inchi_api.h`: `[0]` ordinary, `[1]` explicit 1H/protium, `[2]` 2H/D,
+/// `[3]` 3H/T). Anything other than 1/2/3 is not a real H isotope; fall back to
+/// ordinary rather than panicking or silently mis-bucketing.
+fn h_isotope_bucket(isotope: Option<u16>) -> usize {
+    match isotope {
+        Some(1) => 1,
+        Some(2) => 2,
+        Some(3) => 3,
+        _ => 0,
+    }
+}
+
 /// Convert a `Molecule` into the atom + stereo lists required by the IUPAC InChI C API.
 ///
 /// Aromatic bonds are Kekulized first. Tetrahedral stereo is derived from CIP R/S codes:
@@ -50,28 +80,55 @@ pub fn mol_to_inchi_atoms(
 
     // --- Phase 2: gather stereo info & find centres that need explicit H -----
     // tetrahedral_stereo_neighbors returns CIP code + 4 neighbors sorted by
-    // DECREASING CIP priority. AtomIdx(u32::MAX) is the virtual-H sentinel.
+    // DECREASING CIP priority. AtomIdx(u32::MAX) is the virtual-H sentinel
+    // (bracket-H, e.g. `[C@H]`); a real graph H atom (e.g. `[C@](Br)(Cl)(F)[H]`
+    // or an isotope thereof) shows up here as its own real AtomIdx instead,
+    // since chematic-chem's stereo_neighbors reads it straight out of the
+    // molecule graph. Either way, H is never in `heavy_order`/`inchi_idx`
+    // (Phase 1 deliberately excludes it), so neither can be referenced by
+    // Stereo0D without a manufactured stand-in atom (Phase 4).
     //
     // stereo_data: (center_aidx, CipCode, [p4, p3, p2, p1])
-    // stereo_h: center_aidx → InChI index of the explicit H we will add
+    // stereo_h: (center_aidx, InChI index of the manufactured H atom, its source)
     let mut stereo_data: Vec<(AtomIdx, CipCode, [AtomIdx; 4])> = Vec::new();
-    let mut stereo_h: Vec<(AtomIdx, i16)> = Vec::new(); // ordered by heavy_order
+    let mut stereo_h: Vec<(AtomIdx, i16, StereoHSource)> = Vec::new(); // ordered by heavy_order
 
     for &aidx in &heavy_order {
         let Some((code, sorted_nbrs)) = tetrahedral_stereo_neighbors(mol, aidx) else {
             continue;
         };
-        let needs_explicit_h = sorted_nbrs.iter().any(|&nb| nb.0 == u32::MAX);
-        if needs_explicit_h {
+        // A valid tetrahedral stereocentre has 4 distinct substituents, so at
+        // most one can be hydrogen (of any isotope) -- `.find()` is safe here.
+        let h_sub = sorted_nbrs
+            .iter()
+            .find(|&&nb| nb.0 == u32::MAX || mol.atom(nb).element.atomic_number() == 1);
+        if let Some(&nb) = h_sub {
             // Index = number of heavy atoms + number of H atoms added so far.
             let h_idx = (heavy_order.len() + stereo_h.len()) as i16;
-            stereo_h.push((aidx, h_idx));
+            let source = if nb.0 == u32::MAX {
+                StereoHSource::Sentinel
+            } else {
+                StereoHSource::Explicit(nb)
+            };
+            stereo_h.push((aidx, h_idx, source));
         }
         stereo_data.push((aidx, code, sorted_nbrs));
     }
 
-    // Build lookup: center_aidx → explicit-H InChI index
-    let h_idx_for: HashMap<AtomIdx, i16> = stereo_h.iter().copied().collect();
+    // Build lookups: center_aidx → manufactured-H InChI index, and
+    // center_aidx → which num_iso_h[] bucket that manufactured H "steals"
+    // from (so it isn't ALSO tallied via the count-based H-layer below).
+    let h_idx_for: HashMap<AtomIdx, i16> = stereo_h.iter().map(|&(c, i, _)| (c, i)).collect();
+    let h_bucket_for: HashMap<AtomIdx, usize> = stereo_h
+        .iter()
+        .map(|&(c, _, source)| {
+            let bucket = match source {
+                StereoHSource::Sentinel => 0,
+                StereoHSource::Explicit(h_aidx) => h_isotope_bucket(mol.atom(h_aidx).isotope),
+            };
+            (c, bucket)
+        })
+        .collect();
 
     // --- Phase 3: build InchiAtom list (heavy atoms) -------------------------
     let mut c_atoms: Vec<InchiAtom> = Vec::with_capacity(heavy_order.len() + stereo_h.len());
@@ -109,21 +166,31 @@ pub fn mol_to_inchi_atoms(
         }
         ca.num_bonds = nb;
 
-        // H count: total implicit + explicit-in-graph H.
-        let explicit_h: u8 = mol
-            .neighbors(aidx)
-            .filter(|(ni, _)| mol.atom(*ni).element.atomic_number() == 1)
-            .count() as u8;
-        let implicit_h = mol.implicit_hydrogen_count(aidx);
-        let total_h = implicit_h + explicit_h;
-        // If we're adding an explicit H atom for this stereo centre, subtract one
-        // so the library doesn't double-count.
-        let h_for_inchi = if h_idx_for.contains_key(&aidx) {
-            total_h.saturating_sub(1)
-        } else {
-            total_h
-        };
-        ca.num_iso_h[0] = h_for_inchi as i8;
+        // H count: implicit + explicit-in-graph H, bucketed by isotope.
+        // num_iso_h[0]=ordinary (no isotope tag), [1]=explicit 1H(protium),
+        // [2]=explicit 2H(D), [3]=explicit 3H(T) -- see inchi_api.h. Implicit
+        // H is never isotope-tagged (isotopes must be written explicitly in
+        // the source graph), so it always tallies into bucket 0.
+        let mut iso_h = [0u8; 4];
+        for (nb, _) in mol.neighbors(aidx) {
+            if mol.atom(nb).element.atomic_number() != 1 {
+                continue;
+            }
+            let bucket = h_isotope_bucket(mol.atom(nb).isotope);
+            iso_h[bucket] = iso_h[bucket].saturating_add(1);
+        }
+        iso_h[0] = iso_h[0].saturating_add(mol.implicit_hydrogen_count(aidx));
+        // If this centre's stereo H-substituent is represented by a manufactured
+        // InChI atom instead (Phase 4), don't ALSO count it here.
+        if let Some(&bucket) = h_bucket_for.get(&aidx) {
+            iso_h[bucket] = iso_h[bucket].saturating_sub(1);
+        }
+        ca.num_iso_h = [
+            iso_h[0] as i8,
+            iso_h[1] as i8,
+            iso_h[2] as i8,
+            iso_h[3] as i8,
+        ];
 
         if let Some(mass) = atom.isotope {
             ca.isotopic_mass = mass as i16;
@@ -135,7 +202,7 @@ pub fn mol_to_inchi_atoms(
 
     // --- Phase 4: add explicit H atoms in the same order as stereo_h ---------
     // Iterate in stereo_h order (which matches heavy_order) to guarantee indices.
-    for &(center_aidx, h_inchi_idx) in &stereo_h {
+    for &(center_aidx, h_inchi_idx, source) in &stereo_h {
         debug_assert_eq!(h_inchi_idx as usize, c_atoms.len());
         let center_inchi = *inchi_idx.get(&center_aidx).unwrap();
         let mut h_atom = InchiAtom::default();
@@ -144,6 +211,14 @@ pub fn mol_to_inchi_atoms(
         h_atom.num_bonds = 1;
         h_atom.neighbor[0] = center_inchi;
         h_atom.bond_type[0] = 1;
+        // A real graph H atom (not the bracket-H sentinel) may itself carry an
+        // isotope (`[2H]`, `[3H]`) -- forward it onto the manufactured atom,
+        // same as the heavy-atom isotope path below (`ca.isotopic_mass`).
+        if let StereoHSource::Explicit(h_aidx) = source
+            && let Some(mass) = mol.atom(h_aidx).isotope
+        {
+            h_atom.isotopic_mass = mass as i16;
+        }
         c_atoms.push(h_atom);
     }
 
@@ -161,7 +236,11 @@ pub fn mol_to_inchi_atoms(
         let mut ok = true;
         let mut arr = [0i16; 4];
         for (i, &nb) in sorted_nbrs.iter().enumerate() {
-            arr[i] = if nb.0 == u32::MAX {
+            // Sentinel (bracket-H) or a real graph H atom: neither has an
+            // entry in `inchi_idx` (H is never a heavy atom), so both route
+            // through the manufactured stand-in atom from Phase 4 instead.
+            let is_h = nb.0 == u32::MAX || mol.atom(nb).element.atomic_number() == 1;
+            arr[i] = if is_h {
                 match h_idx_for.get(center_aidx) {
                     Some(&h) => h,
                     None => {
@@ -268,4 +347,135 @@ pub fn mol_to_inchi_atoms(
     }
 
     Ok((c_atoms, stereo))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mol_to_inchi_atoms;
+    use chematic_smiles::parse;
+
+    /// Structural check (not just final-string matching): a real explicit
+    /// graph H atom that is a stereocentre's substituent must NOT be folded
+    /// into the heavy-atom numbering. The only correct way to give it a
+    /// Stereo0D-referenceable index is via a manufactured extra atom appended
+    /// AFTER all heavy atoms (Phase 4) -- so `c_atoms.len()` must be exactly
+    /// `heavy_atom_count + 1`, and that manufactured atom must be the last
+    /// entry, elname "H".
+    #[test]
+    fn explicit_h_stereo_substituent_is_manufactured_not_folded_into_heavy_atoms() {
+        // [C@](Br)(Cl)(F)[H]: 4 heavy atoms (C, Br, Cl, F) + 1 manufactured H.
+        let mol = parse("[C@](Br)(Cl)(F)[H]").unwrap();
+        let (atoms, stereo) = mol_to_inchi_atoms(&mol).unwrap();
+        assert_eq!(
+            atoms.len(),
+            5,
+            "expected 4 heavy atoms + 1 manufactured H atom, got {}",
+            atoms.len()
+        );
+        let last = atoms.last().unwrap();
+        assert_eq!(last.elname[0] as u8 as char, 'H');
+        assert_eq!(
+            last.num_bonds, 1,
+            "manufactured H atom must have exactly 1 bond (back to its centre)"
+        );
+        // Stereo0D must reference the manufactured atom (index 4), not any
+        // heavy-atom index or the sentinel value itself.
+        assert_eq!(stereo.len(), 1);
+        assert!(
+            stereo[0].neighbor.contains(&4),
+            "Stereo0D neighbor list must reference the manufactured H atom's index (4): {:?}",
+            stereo[0].neighbor
+        );
+    }
+
+    /// Same structural check for an isotopically-labeled explicit H substituent:
+    /// the manufactured atom must carry the isotope (D=2), not the centre atom's
+    /// own isotopic_mass field, and must still not be folded into heavy atoms.
+    #[test]
+    fn explicit_deuterium_stereo_substituent_isotope_on_manufactured_atom() {
+        let mol = parse("[C@](Br)(Cl)(F)[2H]").unwrap();
+        let (atoms, _stereo) = mol_to_inchi_atoms(&mol).unwrap();
+        assert_eq!(atoms.len(), 5);
+        let centre = &atoms[0];
+        assert_eq!(
+            centre.isotopic_mass, 0,
+            "the heavy stereocentre atom itself must not carry the H's isotope"
+        );
+        assert_eq!(
+            centre.num_iso_h,
+            [0, 0, 0, 0],
+            "the D substituent must be represented via the manufactured atom, not double-counted in num_iso_h"
+        );
+        let manufactured = atoms.last().unwrap();
+        assert_eq!(manufactured.elname[0] as u8 as char, 'H');
+        assert_eq!(
+            manufactured.isotopic_mass, 2,
+            "manufactured atom must carry the D isotope mass"
+        );
+    }
+
+    /// Two independent stereocentres, each with its own explicit-graph-H
+    /// substituent (D and T respectively): two manufactured atoms must be
+    /// appended, with distinct indices, each carrying its own isotope, and
+    /// each Stereo0D descriptor must reference its OWN manufactured atom
+    /// (not the other centre's).
+    #[test]
+    fn two_stereocenters_each_get_their_own_manufactured_atom() {
+        let mol = parse("[C@](Br)(Cl)([2H])[C@@]([3H])(F)I").unwrap();
+        let (atoms, stereo) = mol_to_inchi_atoms(&mol).unwrap();
+        // 6 heavy atoms (C,Br,Cl,C,F,I) + 2 manufactured H atoms.
+        assert_eq!(
+            atoms.len(),
+            8,
+            "expected 6 heavy atoms + 2 manufactured H atoms"
+        );
+        let manufactured = &atoms[6..8];
+        let masses: Vec<i16> = manufactured.iter().map(|a| a.isotopic_mass).collect();
+        assert_eq!(
+            masses,
+            vec![2, 3],
+            "manufactured atoms must carry D then T in stereo_h/heavy_order traversal order"
+        );
+        assert_eq!(stereo.len(), 2);
+        // Each descriptor must reference exactly one manufactured index (6 or 7),
+        // and the two descriptors must reference DIFFERENT indices.
+        let referenced: Vec<i16> = stereo
+            .iter()
+            .map(|s| {
+                let hits: Vec<i16> = s
+                    .neighbor
+                    .iter()
+                    .copied()
+                    .filter(|&n| n == 6 || n == 7)
+                    .collect();
+                assert_eq!(
+                    hits.len(),
+                    1,
+                    "each stereocentre must reference exactly one manufactured atom: {:?}",
+                    s.neighbor
+                );
+                hits[0]
+            })
+            .collect();
+        assert_ne!(
+            referenced[0], referenced[1],
+            "the two centres must reference DIFFERENT manufactured atoms, not cross-talk"
+        );
+    }
+
+    /// Non-stereo explicit isotopic H (bug 1 in isolation, no stereocentre
+    /// involved at all): methane-d4 must tally 4 deuteriums into num_iso_h[2],
+    /// not num_iso_h[0], and must not manufacture any extra atom (no stereo).
+    #[test]
+    fn methane_d4_isotope_tally_no_stereo() {
+        let mol = parse("[2H]C([2H])([2H])[2H]").unwrap();
+        let (atoms, stereo) = mol_to_inchi_atoms(&mol).unwrap();
+        assert_eq!(atoms.len(), 1, "no stereocentre => no manufactured atom");
+        assert!(stereo.is_empty());
+        assert_eq!(
+            atoms[0].num_iso_h,
+            [0, 0, 4, 0],
+            "4 explicit D atoms must tally into bucket 2 (D), not bucket 0 (ordinary)"
+        );
+    }
 }

--- a/crates/chematic-inchi/tests/explicit_h_stereo.rs
+++ b/crates/chematic-inchi/tests/explicit_h_stereo.rs
@@ -1,0 +1,203 @@
+//! Regression tests for two bugs in explicit-graph-hydrogen handling
+//! (`crates/chematic-inchi/src/native/convert.rs`):
+//!
+//! 1. Isotope-tallying bug: an explicit graph H atom (`[2H]`, `[3H]`, as opposed
+//!    to bracket-H notation like `[C@H]`) had its `isotope` field ignored when
+//!    tallying `num_iso_h` -- every explicit H was counted as ordinary H
+//!    regardless of isotope, so no `/i` layer was ever produced for D/T.
+//! 2. Stereo0D-drop bug: when a tetrahedral stereocentre's 4th substituent is a
+//!    real explicit graph H atom (any isotope, including plain `[H]`), the
+//!    whole stereo descriptor silently disappeared -- no `/t` layer for either
+//!    enantiomer, making them InChI-indistinguishable.
+//!
+//! Expected values below were independently verified against RDKit
+//! (`rdkit==2026.03.3`, isolated venv) via `Chem.MolToInchi`, confirmed
+//! byte-exact -- see the PR body for the generation script and the venv path.
+
+#![cfg(feature = "native-inchi")]
+
+use chematic_inchi::standard_inchi;
+use chematic_smiles::parse;
+
+// (label, SMILES, expected standard InChI -- RDKit 2026.03.3 byte-exact)
+const FIXTURES: &[(&str, &str, &str)] = &[
+    (
+        "plain_H_R",
+        "[C@](Br)(Cl)(F)[H]",
+        "InChI=1S/CHBrClF/c2-1(3)4/h1H/t1-/m1/s1",
+    ),
+    (
+        "plain_H_S",
+        "[C@@](Br)(Cl)(F)[H]",
+        "InChI=1S/CHBrClF/c2-1(3)4/h1H/t1-/m0/s1",
+    ),
+    (
+        "D_R",
+        "[C@](Br)(Cl)(F)[2H]",
+        "InChI=1S/CHBrClF/c2-1(3)4/h1H/t1-/m1/s1/i1D",
+    ),
+    (
+        "D_S",
+        "[C@@](Br)(Cl)(F)[2H]",
+        "InChI=1S/CHBrClF/c2-1(3)4/h1H/t1-/m0/s1/i1D",
+    ),
+    (
+        "T_R",
+        "[C@](Br)(Cl)(F)[3H]",
+        "InChI=1S/CHBrClF/c2-1(3)4/h1H/t1-/m1/s1/i1T",
+    ),
+    (
+        "T_S",
+        "[C@@](Br)(Cl)(F)[3H]",
+        "InChI=1S/CHBrClF/c2-1(3)4/h1H/t1-/m0/s1/i1T",
+    ),
+    // bracket-H control: already-working common case, must stay unchanged.
+    (
+        "bracketH_control",
+        "[C@H](Br)(Cl)F",
+        "InChI=1S/CHBrClF/c2-1(3)4/h1H/t1-/m0/s1",
+    ),
+    (
+        "bracketH_control_mirror",
+        "[C@@H](Br)(Cl)F",
+        "InChI=1S/CHBrClF/c2-1(3)4/h1H/t1-/m1/s1",
+    ),
+    // heavy-atom isotope control: different code path (isotopic_mass on a
+    // heavy atom), must stay unchanged.
+    (
+        "heavy_isotope_control",
+        "[13CH3]C",
+        "InChI=1S/C2H6/c1-2/h1-2H3/i1+1",
+    ),
+    // combined charge + isotope + stereo.
+    (
+        "combined_charge_isotope_stereo_R",
+        "[NH3+][C@](Br)([2H])C(=O)[O-]",
+        "InChI=1S/C2H4BrNO2/c3-1(4)2(5)6/h1H,4H2,(H,5,6)/t1-/m1/s1/i1D",
+    ),
+    (
+        "combined_charge_isotope_stereo_S",
+        "[NH3+][C@@](Br)([2H])C(=O)[O-]",
+        "InChI=1S/C2H4BrNO2/c3-1(4)2(5)6/h1H,4H2,(H,5,6)/t1-/m0/s1/i1D",
+    ),
+    // Atom-renumbering invariance: same absolute configuration as plain_H_R
+    // (RDKit-confirmed: full reversal of a 4-element neighbor list is an even
+    // permutation, so the descriptor is preserved), atoms declared in a
+    // different order (H first, Cl/Br/F re-slotted).
+    (
+        "plain_H_R_renumbered",
+        "[H][C@](Cl)(Br)F",
+        "InChI=1S/CHBrClF/c2-1(3)4/h1H/t1-/m1/s1",
+    ),
+    // Bond-declaration-order-reversal invariance: full reversal of the
+    // substituent list order (Br,Cl,F,H -> H,F,Cl,Br), also RDKit-confirmed
+    // to be the same configuration as plain_H_R.
+    (
+        "plain_H_R_bond_reversed",
+        "[C@]([H])(F)(Cl)Br",
+        "InChI=1S/CHBrClF/c2-1(3)4/h1H/t1-/m1/s1",
+    ),
+    // Explicit protium ([1H]): a distinct isotope tag from plain (untagged) H,
+    // even though 1 is hydrogen's natural/most-abundant mass number -- InChI
+    // still emits a dedicated /i layer for an explicitly-declared isotope.
+    (
+        "protium_R",
+        "[C@](Br)(Cl)(F)[1H]",
+        "InChI=1S/CHBrClF/c2-1(3)4/h1H/t1-/m1/s1/i1H",
+    ),
+    (
+        "protium_S",
+        "[C@@](Br)(Cl)(F)[1H]",
+        "InChI=1S/CHBrClF/c2-1(3)4/h1H/t1-/m0/s1/i1H",
+    ),
+    // Two independent stereocentres in one molecule, each with its own
+    // explicit-graph-H substituent of a different isotope (D and T) -- checks
+    // that the two manufactured Stereo0D stand-in atoms don't collide/cross-talk.
+    (
+        "two_stereocenters_D_T",
+        "[C@](Br)(Cl)([2H])[C@@]([3H])(F)I",
+        "InChI=1S/C2H2BrClFI/c3-1(4)2(5)6/h1-2H/t1-,2-/m0/s1/i1D,2T",
+    ),
+    (
+        "two_stereocenters_D_T_mirror",
+        "[C@@](Br)(Cl)([2H])[C@]([3H])(F)I",
+        "InChI=1S/C2H2BrClFI/c3-1(4)2(5)6/h1-2H/t1-,2-/m1/s1/i1D,2T",
+    ),
+];
+
+#[test]
+fn explicit_h_fixtures_match_rdkit_byte_exact() {
+    let mut failures = Vec::new();
+    for &(label, smiles, expected) in FIXTURES {
+        let mol = parse(smiles).unwrap_or_else(|e| panic!("parse {smiles:?}: {e}"));
+        let got =
+            standard_inchi(&mol).unwrap_or_else(|e| panic!("standard_inchi({smiles:?}): {e}"));
+        if got != expected {
+            failures.push(format!(
+                "[{label}] SMILES {smiles:?}\n  got:      {got}\n  expected: {expected}"
+            ));
+        }
+    }
+    if !failures.is_empty() {
+        panic!(
+            "{}/{} fixtures mismatched RDKit reference:\n{}",
+            failures.len(),
+            FIXTURES.len(),
+            failures.join("\n\n")
+        );
+    }
+}
+
+/// Core bug-2 acceptance criterion: the enantiomer pairs must differ. Before
+/// the fix, ALL of these collapsed to the identical InChI string (no /t layer
+/// at all), making enantiomers indistinguishable.
+#[test]
+fn explicit_h_enantiomer_pairs_differ() {
+    let pairs: &[(&str, &str)] = &[
+        ("[C@](Br)(Cl)(F)[H]", "[C@@](Br)(Cl)(F)[H]"),
+        ("[C@](Br)(Cl)(F)[2H]", "[C@@](Br)(Cl)(F)[2H]"),
+        ("[C@](Br)(Cl)(F)[3H]", "[C@@](Br)(Cl)(F)[3H]"),
+        (
+            "[NH3+][C@](Br)([2H])C(=O)[O-]",
+            "[NH3+][C@@](Br)([2H])C(=O)[O-]",
+        ),
+    ];
+    for &(r_smi, s_smi) in pairs {
+        let r_mol = parse(r_smi).unwrap();
+        let s_mol = parse(s_smi).unwrap();
+        let r_inchi = standard_inchi(&r_mol).unwrap();
+        let s_inchi = standard_inchi(&s_mol).unwrap();
+        assert_ne!(
+            r_inchi, s_inchi,
+            "enantiomers {r_smi:?} / {s_smi:?} must produce different InChI strings"
+        );
+        // And both must actually carry a /t (tetrahedral stereo) layer -- the
+        // failure mode was silently DROPPING the layer, not producing a wrong one.
+        assert!(
+            r_inchi.contains("/t"),
+            "expected a /t layer in {r_inchi:?} (from {r_smi:?})"
+        );
+        assert!(
+            s_inchi.contains("/t"),
+            "expected a /t layer in {s_inchi:?} (from {s_smi:?})"
+        );
+    }
+}
+
+/// Core bug-1 acceptance criterion: D/T must produce an /i layer distinct
+/// from plain H and from each other.
+#[test]
+fn explicit_h_isotope_layers_distinguished() {
+    let plain = standard_inchi(&parse("[C@](Br)(Cl)(F)[H]").unwrap()).unwrap();
+    let d = standard_inchi(&parse("[C@](Br)(Cl)(F)[2H]").unwrap()).unwrap();
+    let t = standard_inchi(&parse("[C@](Br)(Cl)(F)[3H]").unwrap()).unwrap();
+    assert!(
+        !plain.contains("/i"),
+        "plain H must have no /i layer: {plain}"
+    );
+    assert!(d.contains("/i1D"), "D must have an /i1D layer: {d}");
+    assert!(t.contains("/i1T"), "T must have an /i1T layer: {t}");
+    assert_ne!(d, t);
+    assert_ne!(d, plain);
+    assert_ne!(t, plain);
+}


### PR DESCRIPTION
## Summary

Fixes two real bugs in `chematic-inchi`'s native (IUPAC-standard) InChI conversion (`crates/chematic-inchi/src/native/convert.rs`, `mol_to_inchi_atoms`, feature-gated behind `native-inchi`), plus a third edge case found while verifying the fix. This is a prerequisite for PR #156 (verified canonical dedup) — **PR #156 depends on this PR merging first**; per instructions I did not read or reference #156's code, only note the dependency direction.

### Recording (start + completion)

- Base commit: `65ca79b8ee352a0905f92d3f90cf7db91416a6b8` (main at session start; `git merge-base HEAD main` still resolves to this exact SHA — my branch's fork point is unchanged even though `main` has since advanced by one unrelated commit, `45b9277` "chore: refine umbrella crate's crates.io categories (#155)", which touches no files this PR touches)
- Head commit: `c0deae4e23403c3dcfc0d07889ab5ea8a86bd777`
- RDKit version: `2026.03.3` (installed in an isolated venv, not the shared repo `.venv`)
- RDKit venv Python executable: `/tmp/chematic-inchih-venv/bin/python`
- RDKit pinned source commit (for the record, per instructions; not source-audited this time — RDKit was used purely as the byte-exact cross-check oracle via `Chem.MolToInchi`): `8afba32ec539dcb2369bc84549d802aca3f7eb39`
- `git status --short` at completion: clean (no uncommitted changes)
- SHA-256 of touched/generated files:
  - `crates/chematic-inchi/src/native/convert.rs`: `4f9a2844e211c83ae77a05ad374fde6005f0f6fad5659f1cb6570b340fdf1f94`
  - `crates/chematic-inchi/tests/explicit_h_stereo.rs`: `965a23e6c231ee10b73f856e9c4daa95c90d73b891f67d709f3243dc55d2c401`
  - `.github/workflows/ci.yml`: `18b21ebb8a671c2a61d9d6ad9fc5991e23ee455bda053f21590878018be75dd9`
  - RDKit cross-check script (`rdkit_fixtures.py`, not committed — lives in the session scratchpad, reproducible from the SMILES list below): `e4213f887c73242483082994a043f81ec34de06ccde8e8dd7becc8acf37b3acb`

## Root cause (confirmed by reading, not assumed)

`mol_to_inchi_atoms` (Phase 1) deliberately excludes hydrogen from `heavy_order`/`inchi_idx` — H is never a "heavy" atom, by design. `chematic-chem`'s `tetrahedral_stereo_neighbors`/`stereo_neighbors` (`crates/chematic-chem/src/cip.rs`) returns a stereocentre's 4 CIP-sorted substituents, using the sentinel `AtomIdx(u32::MAX)` **only** for the bracket-H case (`[C@H]`, where H is not a graph atom at all, just an implicit count). For a **real graph H atom** (`[C@](Br)(Cl)(F)[H]`, `[2H]`, `[3H]`, ...) it returns that atom's own real `AtomIdx` instead, since it's read straight out of the molecule graph.

1. **Isotope-tallying bug**: Phase 3's H-count tally (`ca.num_iso_h[0]`) counted every explicit graph H neighbor as ordinary H regardless of its `atom.isotope` field — `[2H]`/`[3H]` were never bucketed into `num_iso_h[2]`/`[3]`, so no `/i` layer was ever produced for isotopically-labeled explicit H.
2. **Stereo0D-drop bug**: Phase 5's neighbor-index lookup checked `nb.0 == u32::MAX` (the sentinel) to route through the manufactured-stand-in-atom mechanism (Phase 4, already correct for bracket-H); a **real** graph H atom's real `AtomIdx` fails that check, falls through to `inchi_idx.get(&nb)`, which is `None` (H is never in `inchi_idx`) — so `ok = false` and the whole Stereo0D descriptor is silently dropped via `continue`. Both enantiomers of e.g. `[C@](Br)(Cl)(F)[H]` collapsed to the identical InChI string with no `/t` layer at all.

**Third mechanism found while verifying (not in the original two-bug diagnosis, found via advisor review before opening this PR):** a stereocentre can legitimately have **two** isotopically-distinct H-like substituents (e.g. one `[2H]` and one `[3H]` on the same carbon, or bracket-H plus an explicit `[2H]`) — CIP rule 2 (mass) ranks them differently, so `tetrahedral_stereo_neighbors` correctly returns `Some(...)` for these (confirmed reachable, confirmed RDKit-stereogenic). My first-pass fix only registered **one** manufactured stand-in atom per centre (`.find()`), so both H-like slots resolved to the *same* manufactured index — a **corrupted** Stereo0D with a duplicated neighbor index, not merely a dropped one. Fixed with a guard: register a manufactured atom only when *exactly one* H-like substituent is found; otherwise leave the centre unregistered so the existing "no mapping → `ok = false` → drop the descriptor" path applies (same conservative failure mode this file already uses elsewhere). Verified: formula/connectivity/isotope layers stay fully correct and byte-exact against RDKit for this case — only the `/t` layer is absent. **Known limitation**: stereocentres with two simultaneous H-like substituents do not get a `/t` layer (RDKit does emit one). This combination was not in the required fixture list; supporting it would need extending the mechanism to manufacture two independently-indexed stand-in atoms per centre, which I judged out of scope for this fix (flagging per the honesty requirement rather than declaring a narrower victory).

## The fix

`StereoHSource` enum (`Sentinel` | `Explicit(AtomIdx)`) tracks where each manufactured stand-in H atom traces back to. Detection in Phase 2 now matches a real graph H atom exactly like the existing sentinel case (`nb.0 == u32::MAX || mol.atom(nb).element.atomic_number() == 1`), guarded to register only when exactly one such substituent exists. Phase 3's isotope tally is bucketed by `h_isotope_bucket(atom.isotope)` instead of always bucket 0. Phase 4 forwards the real H atom's isotope onto the manufactured atom's `isotopic_mass` field (mirroring the existing heavy-atom isotope path). Phase 5 routes a real graph H neighbor through the same manufactured-atom lookup as the sentinel case.

**No default API changed** — this is entirely inside `crates/chematic-inchi/src/native/convert.rs`, feature-gated behind `native-inchi`, not touching any public signature.

**On "must not be assigned their own InChI heavy-atom index"**: this is satisfied because the *source* graph's real H atom is never added to `heavy_order`/`inchi_idx`/the `/c` connectivity layer (Phase 1 excludes H unconditionally, unchanged) — verified structurally by `atoms.len() == heavy_atom_count + 1` in the new unit tests, not just by matching final strings. The Stereo0D reference is instead a **freshly manufactured** atom entry appended after all heavy atoms (identical mechanism to the pre-existing, unchanged bracket-H path), which the InChI C library's own terminal-H-removal preprocessing folds back in. A literal reading of "must not get an index at all" would also forbid the pre-existing bracket-H mechanism this task requires left unchanged, so I read it as "must not be counted among the heavy atoms," which the tests verify directly.

## Fixtures — before/after, byte-exact against RDKit 2026.03.3

All SMILES verified independently by parsing with RDKit itself (`Chem.MolFromSmiles` + `Chem.MolToInchi`) before writing any Rust code.

| Fixture | SMILES | Before (buggy) | After (this PR) | RDKit reference | Match |
|---|---|---|---|---|---|
| plain H, R | `[C@](Br)(Cl)(F)[H]` | `...c2-1(3)4/h1H` (no /t) | `...t1-/m1/s1` | `...t1-/m1/s1` | Y |
| plain H, S | `[C@@](Br)(Cl)(F)[H]` | same as R (bug!) | `...t1-/m0/s1` | `...t1-/m0/s1` | Y |
| D, R | `[C@](Br)(Cl)(F)[2H]` | no /t, no /i | `...t1-/m1/s1/i1D` | `...t1-/m1/s1/i1D` | Y |
| D, S | `[C@@](Br)(Cl)(F)[2H]` | same as D-R (bug!) | `...t1-/m0/s1/i1D` | `...t1-/m0/s1/i1D` | Y |
| T, R | `[C@](Br)(Cl)(F)[3H]` | no /t, no /i | `...t1-/m1/s1/i1T` | `...t1-/m1/s1/i1T` | Y |
| T, S | `[C@@](Br)(Cl)(F)[3H]` | same as T-R (bug!) | `...t1-/m0/s1/i1T` | `...t1-/m0/s1/i1T` | Y |
| protium, R | `[C@](Br)(Cl)(F)[1H]` | no /t, no /i | `...t1-/m1/s1/i1H` | `...t1-/m1/s1/i1H` | Y |
| protium, S | `[C@@](Br)(Cl)(F)[1H]` | same as protium-R (bug!) | `...t1-/m0/s1/i1H` | `...t1-/m0/s1/i1H` | Y |
| bracket-H control, R | `[C@H](Br)(Cl)F` | already correct | unchanged | `...t1-/m0/s1` | Y |
| bracket-H control, S | `[C@@H](Br)(Cl)F` | already correct | unchanged | `...t1-/m1/s1` | Y |
| heavy-isotope control | `[13CH3]C` | already correct | unchanged | `...i1+1` | Y |
| combined charge+isotope+stereo, R | `[NH3+][C@](Br)([2H])C(=O)[O-]` | no /t | `...t1-/m1/s1/i1D` | `...t1-/m1/s1/i1D` | Y |
| combined charge+isotope+stereo, S | `[NH3+][C@@](Br)([2H])C(=O)[O-]` | same as R (bug!) | `...t1-/m0/s1/i1D` | `...t1-/m0/s1/i1D` | Y |
| atom-renumbering invariance | `[H][C@](Cl)(Br)F` | no /t | `...t1-/m1/s1` (matches plain-H-R) | same | Y |
| bond-order-reversal invariance | `[C@]([H])(F)(Cl)Br` | no /t | `...t1-/m1/s1` (matches plain-H-R) | same | Y |
| two stereocentres, D+T | `[C@](Br)(Cl)([2H])[C@@]([3H])(F)I` | no /t | `...t1-,2-/m0/s1/i1D,2T` | same | Y |
| two stereocentres, D+T mirror | `[C@@](Br)(Cl)([2H])[C@]([3H])(F)I` | same as above (bug!) | `...t1-,2-/m1/s1/i1D,2T` | same | Y |
| **known limitation**: two H-like subs, one centre | `[C@](Br)(F)([2H])[3H]` | no /t (dropped) | no /t (dropped, but safely -- formula/isotope layers correct) | **has** `/t1-/m0/s1` | N (documented gap) |
| **known limitation**: bracket-H + explicit D | `[C@H](Br)([2H])F` | no /t (dropped) | no /t (dropped, but safely) | **has** `/t1-/m1/s1` | N (documented gap) |

**Success/failure denominators**: 17/17 required + gap-closing fixtures byte-exact against RDKit. 2/2 additional edge-case fixtures (found during advisor review, not in the required list) produce a safe partial result (all non-stereo layers byte-exact, `/t` layer absent) rather than a corrupted one — explicitly **not** claimed as fixed, documented as a known limitation.

## Acceptance criteria checklist

- [x] Enantiomer pairs' native InChI strings differ (core bug 2) -- verified for all 4 required pairs plus the 2-stereocentre pair, via a dedicated `assert_ne!` test.
- [x] Byte-exact match against RDKit's `Chem.MolToInchi` for every required fixture (17/17).
- [x] D/T `/i` layer byte-exact against RDKit.
- [x] Zero regressions on the existing `chematic-inchi` native-inchi suite: 25/25 tests before, 25/25 after (identical pass set, diffed byte-for-byte).
- [x] Explicit-H atoms never assigned their own InChI heavy-atom index -- verified structurally (`atoms.len() == heavy_atom_count + 1`, not string matching) in `explicit_h_stereo_substituent_is_manufactured_not_folded_into_heavy_atoms` and related unit tests.
- [x] Full completion checks green (see below).
- [x] Corpus smoke test (`corpus_smoke_issue_11`, `~/Downloads/SMILES.csv`, 4999 molecules): **before** 4998 ok / 1 kekulization-skip / 0 lib-errors; **after** 4998 ok / 1 kekulization-skip / 0 lib-errors -- identical, confirming zero new errors/crashes introduced across the full corpus (this smoke test only checks for crashes/lib-errors, not byte-level correctness, so it doesn't quantify the actual bug fix -- the fixture table above does that).

## Regression detail

`cargo test -p chematic-inchi --features native-inchi` (before fix, base commit): 3+3+3+16 = 25 integration tests, all pass; no unit tests existed yet in `convert.rs` at that point.

After fix: lib tests 102 (96 pre-existing + 6 new in `native::convert::tests`), integration tests 3+3+3+3(new `explicit_h_stereo.rs`)+16 = 28, all pass. The 25 pre-existing integration tests are byte-identical pass/fail before and after (diffed the sorted `test result`/`test ...` lines from both runs -- zero diff).

## CI coverage gap found and fixed

`.github/workflows/ci.yml`'s `test-native-inchi` job ran `cargo test -p chematic-inchi --features native-inchi --test standard_inchi --quiet` -- scoped to exactly one integration test binary by name. This would have **silently skipped** the new `tests/explicit_h_stereo.rs` file (CI would show green without ever running the new fixtures). Widened to `cargo test -p chematic-inchi --features native-inchi --quiet` (drops the `--test` filter, runs all integration tests + doctests in the crate -- a strict superset, verified locally to still pass). This is the only change outside `crates/chematic-inchi/`.

## Completion checks (all run locally, in order)

```
cargo fmt --all -- --check                            -> exit 0
cargo clippy --workspace --all-targets -- -D warnings -> exit 0
cargo test --workspace --lib                          -> exit 0 (19/19 test binaries ok)
cargo test --workspace --tests                        -> exit 0 (41/41 test binaries ok)
cargo deny --all-features check                       -> exit 0 (advisories ok, bans ok, licenses ok, sources ok; pre-existing duplicate-crate warnings unrelated to this PR)
python3 scripts/check_publish_graph.py                -> exit 0 (18 publishable crates, graph OK)
bash scripts/check.sh                                 -> exit 0, "All checks passed."
cargo test -p chematic-inchi --features native-inchi  -> exit 0 (102 lib + 28 integration tests, all ok)
RDKit cross-check script (17 fixtures)                -> 17/17 byte-exact
```

## CI / Security status (GitHub Actions)

See follow-up comment for `gh pr checks` results after push.

## Known limitations

1. A stereocentre with two simultaneous H-like substituents (isotopically distinct, e.g. D+T on one carbon, or bracket-H + explicit D) does not get a `/t` layer -- safely dropped (all other layers remain correct and byte-exact), not corrupted. RDKit does emit a `/t` layer for these. Not in the required fixture list; flagged here per the honesty requirement rather than silently shipping a narrower fix as if complete.
2. RDKit's own InChI-writing source was not audited for this PR -- RDKit was used strictly as the byte-exact cross-check oracle (pinned commit `8afba32ec539dcb2369bc84549d802aca3f7eb39` recorded per instructions), consistent with this being IUPAC-InChI-API-conformance work rather than a source-audit task.

## Merge dependency

**PR #156 (verified canonical dedup) depends on this PR merging first.** I did not read or reference #156's code or branch (`feat/verified-canonical-dedup`) per instructions -- noting the dependency direction only.
