### PR TITLE
chore(3d): scaffold distance_geometry_v2 module stub for Agent C

### DIFF
--- a/crates/chematic-3d/src/distance_geometry_v2.rs
+++ b/crates/chematic-3d/src/distance_geometry_v2.rs
@@ -1,0 +1,5 @@
+//! Placeholder for the real distance-geometry embedder (3D Breakthrough Program,
+//! Wave 1, Agent C). See `docs/3d_breakthrough_master_plan.md` §1b: this module
+//! is deliberately empty scaffolding — Coordinator added the `pub mod` declaration
+//! so `chematic-3d` keeps compiling while Agent C's own PR fills this file in,
+//! without Agent C needing to touch `lib.rs` (Coordinator-only).

--- a/crates/chematic-3d/src/lib.rs
+++ b/crates/chematic-3d/src/lib.rs
@@ -18,6 +18,7 @@ pub mod descriptors_3d;
 pub mod determine_bonds;
 pub mod dg;
 pub mod dg_fft;
+pub mod distance_geometry_v2;
 pub mod etkdg;
 pub mod etkdg_knowledge;
 pub mod md;


### PR DESCRIPTION
## Summary

Tiny, additive, zero-behavior-change scaffolding for the 3D Breakthrough
Program (see #164, docs/3d_breakthrough_master_plan.md §1b). Adds an empty
`crates/chematic-3d/src/distance_geometry_v2.rs` module and one
`pub mod distance_geometry_v2;` line in `chematic-3d/src/lib.rs`
(Coordinator-only file) so the crate keeps compiling while Wave 1's Agent C
fills the module in with a real distance-geometry embedder, without Agent C
needing to touch a Coordinator-only file itself.

## Why this exists

`etkdg.rs`/`lib.rs` are Coordinator-only per the ownership table (to prevent
merge conflicts across parallel Wave 1 agents). Agent C's PR needs somewhere
to put its new module; this narrow, pre-authorized one-line exception
unblocks it without widening Agent C's file ownership.

## Verification

`cargo check -p chematic-3d` — compiles clean (empty module, no warnings).
Pre-commit hook ran `cargo clippy` on modified crates — clean.

## Base for Wave 1 worktrees

Depends on #164 only in the sense that both are Wave 0/pre-Wave-1 prep; this
PR has no file overlap with #164 and can merge independently. Not
self-merging — awaiting explicit merge authorization, same as #164.