### PR TITLE
feat(mol): read/write real 3D coordinates in MOL/SDF, diagnose dimension/stereo conflicts

### DIFF
--- a/crates/chematic-core/src/coords3d.rs
+++ b/crates/chematic-core/src/coords3d.rs
@@ -1,0 +1,228 @@
+//! Minimal, algorithm-free 3D coordinate storage shared across crates.
+//!
+//! [`Coords3D`] holds one [`Point3`] per atom, indexed by atom insertion
+//! order (`AtomIdx.0` as `usize`). It carries no embedding, force-field, or
+//! alignment logic -- see the 3D Breakthrough Program's master plan
+//! (`docs/3d_breakthrough_master_plan.md`, decision 1a) for why this type
+//! lives in `chematic-core` rather than `chematic-mol` importing
+//! `chematic_3d::coords::Coords3D` directly: `chematic-3d` pulls in
+//! `chematic-ff`/`chematic-chem`/`chematic-fp`/`chematic-smarts` transitively,
+//! an unwanted dependency footprint for `chematic-mol` and every other
+//! `chematic-core` consumer that never touches 3D generation. Every crate
+//! already depends on `chematic-core`, so this requires zero new dependency
+//! edges.
+//!
+//! **Field layout and method names deliberately mirror
+//! `chematic_3d::coords::{Point3, Coords3D}` as closely as possible** (same
+//! `x`/`y`/`z` fields, same `points: Vec<Point3>` layout, same
+//! `new_zeroed`/`get`/`set`/`atom_count` names and panics-on-out-of-range
+//! indexing convention) so that a later Coordinator-authored bridge PR can
+//! make `chematic_3d::coords` re-export this type
+//! (`pub use chematic_core::{Coords3D, Point3};`) with minimal changes to
+//! existing `chematic-3d` call sites. `chematic-3d`'s own `Coords3D` is not
+//! touched by this PR (read-only reference); the two types are reconciled at
+//! Wave 1->2 integration time, not here.
+//!
+//! This module adds exactly one thing `chematic_3d::coords` doesn't have:
+//! `is_finite()` on both types, since `chematic-mol`'s readers need a way to
+//! reject NaN/Inf coordinates as a typed parse error rather than silently
+//! constructing a poisoned conformer.
+
+use crate::molecule::AtomIdx;
+
+/// A 3D point in Cartesian space (Angstrom).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Point3 {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+}
+
+impl Point3 {
+    /// Create a new point.
+    #[inline]
+    pub fn new(x: f64, y: f64, z: f64) -> Self {
+        Self { x, y, z }
+    }
+
+    /// The origin (0, 0, 0).
+    #[inline]
+    pub fn zero() -> Self {
+        Self::new(0.0, 0.0, 0.0)
+    }
+
+    /// `true` when all three components are finite (not NaN, not Infinite).
+    #[inline]
+    pub fn is_finite(&self) -> bool {
+        self.x.is_finite() && self.y.is_finite() && self.z.is_finite()
+    }
+
+    /// Euclidean distance to another point.
+    #[inline]
+    pub fn distance(&self, other: &Self) -> f64 {
+        let dx = self.x - other.x;
+        let dy = self.y - other.y;
+        let dz = self.z - other.z;
+        (dx * dx + dy * dy + dz * dz).sqrt()
+    }
+
+    /// Component-wise addition.
+    #[inline]
+    pub fn add(&self, other: &Self) -> Self {
+        Self::new(self.x + other.x, self.y + other.y, self.z + other.z)
+    }
+
+    /// Component-wise subtraction.
+    #[inline]
+    pub fn sub(&self, other: &Self) -> Self {
+        Self::new(self.x - other.x, self.y - other.y, self.z - other.z)
+    }
+
+    /// Scalar multiplication.
+    #[inline]
+    pub fn scale(&self, s: f64) -> Self {
+        Self::new(self.x * s, self.y * s, self.z * s)
+    }
+
+    /// Dot product.
+    #[inline]
+    pub fn dot(&self, other: &Self) -> f64 {
+        self.x * other.x + self.y * other.y + self.z * other.z
+    }
+
+    /// Cross product.
+    #[inline]
+    pub fn cross(&self, other: &Self) -> Self {
+        Self::new(
+            self.y * other.z - self.z * other.y,
+            self.z * other.x - self.x * other.z,
+            self.x * other.y - self.y * other.x,
+        )
+    }
+
+    /// Euclidean norm (length).
+    #[inline]
+    pub fn norm(&self) -> f64 {
+        (self.x * self.x + self.y * self.y + self.z * self.z).sqrt()
+    }
+
+    /// Normalize to a unit vector.
+    ///
+    /// # Panics
+    /// Panics if the vector has zero length.
+    pub fn normalize(&self) -> Self {
+        let n = self.norm();
+        assert!(n > 0.0, "cannot normalize a zero-length vector");
+        self.scale(1.0 / n)
+    }
+
+    /// Try to normalize to a unit vector, returning `None` if the vector has
+    /// zero length.
+    pub fn try_normalize(&self) -> Option<Self> {
+        let n = self.norm();
+        if n > 0.0 {
+            Some(self.scale(1.0 / n))
+        } else {
+            None
+        }
+    }
+}
+
+/// 3D coordinates for all heavy atoms in a molecule.
+///
+/// Indexed by atom insertion order (`AtomIdx.0` as `usize`). A dumb data
+/// holder only -- no embedding, minimization, or alignment logic (those stay
+/// in `chematic-3d`).
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Coords3D {
+    pub points: Vec<Point3>,
+}
+
+impl Coords3D {
+    /// Create zeroed coordinates for `n` atoms.
+    pub fn new_zeroed(n: usize) -> Self {
+        Self {
+            points: vec![Point3::zero(); n],
+        }
+    }
+
+    /// Get the coordinate of atom `idx`.
+    ///
+    /// # Panics
+    /// Panics if `idx` is out of range (matching `chematic_3d::coords::Coords3D`'s
+    /// existing indexing convention).
+    pub fn get(&self, idx: AtomIdx) -> Point3 {
+        self.points[idx.0 as usize]
+    }
+
+    /// Set the coordinate of atom `idx`.
+    ///
+    /// # Panics
+    /// Panics if `idx` is out of range.
+    pub fn set(&mut self, idx: AtomIdx, p: Point3) {
+        self.points[idx.0 as usize] = p;
+    }
+
+    /// Number of atom coordinate slots.
+    pub fn atom_count(&self) -> usize {
+        self.points.len()
+    }
+
+    /// `true` when every point has all-finite components.
+    pub fn is_finite(&self) -> bool {
+        self.points.iter().all(Point3::is_finite)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_zeroed_has_n_points_at_origin() {
+        let c = Coords3D::new_zeroed(3);
+        assert_eq!(c.atom_count(), 3);
+        for i in 0..3 {
+            assert_eq!(c.get(AtomIdx(i)), Point3::zero());
+        }
+    }
+
+    #[test]
+    fn get_set_roundtrip() {
+        let mut c = Coords3D::new_zeroed(2);
+        c.set(AtomIdx(1), Point3::new(1.0, 2.0, 3.0));
+        assert_eq!(c.get(AtomIdx(1)), Point3::new(1.0, 2.0, 3.0));
+        assert_eq!(c.get(AtomIdx(0)), Point3::zero());
+    }
+
+    #[test]
+    fn is_finite_true_for_normal_coords() {
+        let mut c = Coords3D::new_zeroed(1);
+        c.set(AtomIdx(0), Point3::new(1.0, -2.5, 0.0));
+        assert!(c.is_finite());
+    }
+
+    #[test]
+    fn is_finite_false_for_nan() {
+        let mut c = Coords3D::new_zeroed(1);
+        c.set(AtomIdx(0), Point3::new(f64::NAN, 0.0, 0.0));
+        assert!(!c.is_finite());
+    }
+
+    #[test]
+    fn is_finite_false_for_infinite() {
+        let mut c = Coords3D::new_zeroed(1);
+        c.set(AtomIdx(0), Point3::new(0.0, f64::INFINITY, 0.0));
+        assert!(!c.is_finite());
+    }
+
+    #[test]
+    fn point3_basic_vector_ops() {
+        let a = Point3::new(1.0, 0.0, 0.0);
+        let b = Point3::new(0.0, 1.0, 0.0);
+        assert_eq!(a.cross(&b), Point3::new(0.0, 0.0, 1.0));
+        assert_eq!(a.dot(&b), 0.0);
+        assert_eq!(a.distance(&b), std::f64::consts::SQRT_2);
+        assert_eq!(a.add(&b), Point3::new(1.0, 1.0, 0.0));
+    }
+}

--- a/crates/chematic-core/src/coords3d.rs
+++ b/crates/chematic-core/src/coords3d.rs
@@ -23,10 +23,18 @@
 //! touched by this PR (read-only reference); the two types are reconciled at
 //! Wave 1->2 integration time, not here.
 //!
-//! This module adds exactly one thing `chematic_3d::coords` doesn't have:
-//! `is_finite()` on both types, since `chematic-mol`'s readers need a way to
-//! reject NaN/Inf coordinates as a typed parse error rather than silently
-//! constructing a poisoned conformer.
+//! This module adds two things `chematic_3d::coords` doesn't have:
+//! - `is_finite()` on both types. **Not currently called by this PR's own
+//!   reader code** -- `chematic-mol`'s V2000/V3000 z-coordinate parsers
+//!   validate NaN/Inf with a direct `f64::is_finite()` check on the raw
+//!   parsed value, *before* a `Point3`/`Coords3D` is ever constructed (see
+//!   `mol2000.rs`/`mol3000.rs`), so these methods have zero non-test callers
+//!   today. Provided for future consumers (e.g. Wave 2 work that may
+//!   construct a `Coords3D` from elsewhere and want to validate it after the
+//!   fact) rather than because this PR's own code needs them.
+//! - `Default`/`PartialEq` derives on `Coords3D` (`chematic_3d::coords::Coords3D`
+//!   derives only `Debug, Clone`) -- needed for this crate's own tests and
+//!   generally harmless additions for a plain data holder.
 
 use crate::molecule::AtomIdx;
 

--- a/crates/chematic-core/src/lib.rs
+++ b/crates/chematic-core/src/lib.rs
@@ -16,6 +16,7 @@
 
 pub mod atom;
 pub mod bond;
+pub mod coords3d;
 pub mod element;
 pub mod kekulization;
 pub mod molecule;
@@ -25,6 +26,7 @@ pub mod valence;
 // Re-export the most commonly used types at crate root.
 pub use atom::{Atom, Chirality, CipCode};
 pub use bond::{BondEntry, BondOrder};
+pub use coords3d::{Coords3D, Point3};
 pub use element::Element;
 pub use kekulization::{KekuleError, KekuleResult, apply_kekule, kekulize};
 pub use molecule::{AtomIdx, BondIdx, MolError, Molecule, MoleculeBuilder, STEREO_H_SENTINEL};

--- a/crates/chematic-mol/src/lib.rs
+++ b/crates/chematic-mol/src/lib.rs
@@ -43,14 +43,20 @@ pub use gaussian::{GaussianError, GaussianLogResult, parse_gaussian_log, parse_g
 pub use ket::{KetError, parse_ket, parse_ket_3d, write_ket, write_ket_3d};
 pub use mol2_tripos::{Mol2Error, parse_mol2, write_mol2};
 pub use mol2000::{
-    MolMetadata, MolReadReport, parse_mol, parse_mol_with_coords, parse_sdf_with_coords,
-    read_mol_with_diagnostics, read_sdf_with_diagnostics, write_mol, write_mol_with_coords,
-    write_sdf, write_sdf_record, write_sdf_record_v3000, write_sdf_with_charges,
+    CoordinateDimension, GeometryRank, MolMetadata, MolReadReport, Stereo3DDiagnostic, parse_mol,
+    parse_mol_with_coords, parse_sdf_with_coords, read_mol_with_diagnostics,
+    read_sdf_with_diagnostics, write_mol, write_mol_with_conformer, write_mol_with_coords,
+    write_sdf, write_sdf_record, write_sdf_record_v3000, write_sdf_record_with_conformer,
+    write_sdf_with_charges,
 };
 pub use mol3000::{
     parse_mol_v3000, parse_mol_v3000_with_coords, read_mol_v3000_with_diagnostics, write_mol_v3000,
+    write_mol_v3000_with_conformer,
 };
 pub use moljson::{MolJsonError, parse_moljson, write_moljson};
 pub use pdbqt::{PdbqtError, autodock_atom_type, parse_pdbqt, write_pdbqt};
 pub use rxn::{RxnParseError, parse_rxn_file, write_rxn_file};
-pub use sdf::{SdfFileReader, SdfReader, SdfRecord, SdfRecordReader};
+pub use sdf::{
+    ConformerEnsemble, SdfFileReader, SdfReader, SdfRecord, SdfRecordReader,
+    read_sdf_conformer_ensembles,
+};

--- a/crates/chematic-mol/src/mol2000.rs
+++ b/crates/chematic-mol/src/mol2000.rs
@@ -9,7 +9,10 @@
 //!   Lines 5+natoms..5+natoms+nbonds — bond block (one line per bond)
 //!   "M  END" — molecule terminator
 
-use chematic_core::{Atom, AtomIdx, BondIdx, BondOrder, Element, Molecule, MoleculeBuilder};
+use chematic_core::{
+    Atom, AtomIdx, BondIdx, BondOrder, Chirality, Coords3D, Element, Molecule, MoleculeBuilder,
+    Point3, STEREO_H_SENTINEL,
+};
 use chematic_perception::{
     EzDirectionDiagnostic, StereoDiagnostic, apply_ez_directions_from_2d_ex,
     apply_local_parity_from_wedges_with_diagnostics,
@@ -46,6 +49,249 @@ impl MolMetadata {
     }
 }
 
+/// The MOL header's own declared dimensionality -- the literal `2D`/`3D`
+/// tag a writer stamps in columns 20..22 (0-indexed) of header line 2 (the
+/// "program/date" line, MDL Ctfile spec), e.g. RDKit's
+/// `"     RDKit          3D"`. Empirically confirmed against a live RDKit
+/// `2026.03.3` oracle for both V2000 and V3000 (identical column in both).
+///
+/// This is the file's own CLAIM, independent of what the atom block's
+/// actual `(x, y, z)` values look like -- see [`GeometryRank`] for the
+/// observed side, and [`Stereo3DDiagnostic`] for whether the two agree.
+/// `Unknown` is the common case: most real-world writers (including every
+/// hand-written fixture already in this crate's own test suite) leave line
+/// 2 blank or shorter than 22 columns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CoordinateDimension {
+    TwoD,
+    ThreeD,
+    #[default]
+    Unknown,
+}
+
+/// What the atom block's actual `(x, y, z)` values look like, independent of
+/// what the header declares. Deliberately kept separate from
+/// [`CoordinateDimension`] (the file's claim) -- collapsing "does this file
+/// have 3D data" to one boolean would conflate "header says 3D but is
+/// mislabeled" with "header says 3D and the molecule is just, correctly,
+/// flat" (e.g. benzene from a real conformer generator).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GeometryRank {
+    /// No atoms at all -- not enough information to say anything.
+    Indeterminate,
+    /// Every atom's z is within [`Z_EPS`] of exactly 0.0 -- the trivial flat
+    /// case, indistinguishable from "no z data was ever written".
+    FlatZero,
+    /// Not all-zero-z, but every point still lies within [`COPLANAR_EPS`] of
+    /// a single best-fit plane (which need not be the z=0 plane, and need
+    /// not be axis-aligned) -- includes fewer-than-3-atom records, which
+    /// are trivially coplanar. A genuinely flat molecule (e.g. benzene)
+    /// legitimately lands here; on its own this is not evidence of a bug.
+    Coplanar,
+    /// At least one point lies measurably off the best-fit plane through
+    /// the rest -- genuinely three-dimensional.
+    ThreeD,
+}
+
+/// Coordinate magnitude below which a z value is treated as exactly zero.
+const Z_EPS: f64 = 1e-4;
+/// Maximum perpendicular deviation (Angstrom) from a best-fit plane still
+/// classified as [`GeometryRank::Coplanar`]. Chosen well above float noise
+/// and well below a real 3D ring pucker (~0.2-0.5 A for e.g. cyclohexane).
+const COPLANAR_EPS: f64 = 1e-2;
+/// Minimum cross-product norm (Angstrom^2) accepted as "not collinear" when
+/// searching for a plane-defining pair of vectors.
+const COLLINEAR_EPS: f64 = 1e-6;
+/// Minimum |signed volume| (Angstrom^3) treated as a reliable, non-degenerate
+/// tetrahedral sign in [`wedge_vs_3d_conflicts`].
+const VOLUME_EPS: f64 = 1e-6;
+
+/// Classify a point cloud's [`GeometryRank`]. See that type's docs for the
+/// four cases.
+pub(crate) fn classify_geometry_rank(points: &[Point3]) -> GeometryRank {
+    if points.is_empty() {
+        return GeometryRank::Indeterminate;
+    }
+    if points.iter().all(|p| p.z.abs() < Z_EPS) {
+        return GeometryRank::FlatZero;
+    }
+    if points.len() < 3 {
+        return GeometryRank::Coplanar;
+    }
+    // Find a non-degenerate plane-defining pair of vectors from point 0.
+    // ponytail: fixing the origin at point 0 makes this O(n) instead of
+    // O(n^3); it misses only the vanishingly rare pathological case where
+    // point 0 is collinear with every other point yet some other, unrelated
+    // triple isn't -- not worth a full O(n^3) search for real molecular
+    // input up to `MAX_ATOMS`.
+    let origin = points[0];
+    let mut normal: Option<Point3> = None;
+    'outer: for (j, pj) in points.iter().enumerate().skip(1) {
+        let v1 = pj.sub(&origin);
+        for pk in points.iter().skip(j + 1) {
+            let v2 = pk.sub(&origin);
+            let n = v1.cross(&v2);
+            if n.norm() > COLLINEAR_EPS {
+                normal = Some(n);
+                break 'outer;
+            }
+        }
+    }
+    let Some(n) = normal else {
+        // Every point is collinear with point 0 -- trivially coplanar.
+        return GeometryRank::Coplanar;
+    };
+    let n = n.normalize();
+    let max_dev = points
+        .iter()
+        .map(|p| p.sub(&origin).dot(&n).abs())
+        .fold(0.0_f64, f64::max);
+    if max_dev < COPLANAR_EPS {
+        GeometryRank::Coplanar
+    } else {
+        GeometryRank::ThreeD
+    }
+}
+
+/// Parse the dimensional-code field (columns 20..22, 0-indexed) from a MOL
+/// header's line 2. Returns [`CoordinateDimension::Unknown`] when the line
+/// is shorter than 22 columns, blank in that field, or contains anything
+/// other than the literal `2D`/`3D` tokens -- never an error (this field is
+/// legacy/optional and most writers, including this crate's own 2D writer,
+/// never populate it).
+pub(crate) fn parse_dimension_code(line2: &str) -> CoordinateDimension {
+    match line2.get(20..22).map(str::trim) {
+        Some("2D") => CoordinateDimension::TwoD,
+        Some("3D") => CoordinateDimension::ThreeD,
+        _ => CoordinateDimension::Unknown,
+    }
+}
+
+/// One 3D-geometry-related diagnostic surfaced while parsing a MOL/SDF
+/// record -- see [`MolReadReport::stereo3d_diagnostics`].
+///
+/// An empty `stereo3d_diagnostics` vec does NOT mean "3D stereo was verified
+/// correct" -- it means there was nothing to check (no wedge/hash bond was
+/// present at any center, and the header/geometry dimensionality agreed),
+/// mirroring how `stereo_diagnostics`/`ez_diagnostics` are only ever
+/// populated when something was actually declared and rejected. A record
+/// with genuine 3D coordinates and zero declared stereo is common and
+/// entirely valid -- it produces no diagnostics, which must not be read as
+/// "stereo check passed".
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Stereo3DDiagnostic {
+    /// The header declares `2D`, but the atom block's actual z values are
+    /// not all (near-)zero.
+    DeclaredTwoDButNonzeroZ { observed: GeometryRank },
+    /// The header declares `3D`, but the observed geometry is flat -- either
+    /// every z is exactly 0 ([`GeometryRank::FlatZero`]) or all points lie
+    /// on a single, possibly tilted, plane ([`GeometryRank::Coplanar`]). The
+    /// two are reported distinctly via the payload: "every z is literally
+    /// 0" is near-certainly a 2D file mislabeled 3D, while a real but
+    /// planar/degenerate 3D geometry (e.g. benzene) is not on its own a bug.
+    DeclaredThreeDButFlat { observed: GeometryRank },
+    /// A wedge/hash bond was present at `atom`, and its 2D-perceived local
+    /// parity (`Atom.chirality`, computed on this record's own `(x, y)` by
+    /// the unmodified [`apply_local_parity_from_wedges_with_diagnostics`]
+    /// pathway) disagrees with the parity read directly off the atom's real
+    /// 3D geometry (`from_3d_geometry`). Named for what is actually being
+    /// compared: for a genuinely-3D record, `(x, y)` alone is not a
+    /// meaningful 2D depiction, so this is "the wedge disagrees with the
+    /// shape", not "the declared stereo failed verification". When a wedge
+    /// and nonzero-z geometry coexist and *agree*, nothing is emitted here
+    /// -- 3D geometry is treated as the higher-fidelity signal, but it is
+    /// never written back to `Atom.chirality` (which stays exactly what the
+    /// 2D wedge pathway produced); only genuine disagreement is surfaced.
+    WedgeVs3DParityConflict {
+        atom: AtomIdx,
+        wedge_2d: Chirality,
+        from_3d_geometry: Chirality,
+    },
+}
+
+/// Signed volume of the tetrahedron `(p1-p4, p2-p4, p3-p4)` from real 3D
+/// coordinates. An independent, deliberately tiny (single determinant)
+/// re-implementation of the same triple product
+/// `chematic_perception::stereo2d_local` uses internally on a synthetic
+/// wedge-derived z -- that helper is `pub(crate)` there and its z is not a
+/// real coordinate, so it cannot be reused directly from this crate.
+fn signed_volume3(p1: Point3, p2: Point3, p3: Point3, p4: Point3) -> f64 {
+    let a = p1.sub(&p4);
+    let b = p2.sub(&p4);
+    let c = p3.sub(&p4);
+    a.x * (b.y * c.z - b.z * c.y) - a.y * (b.x * c.z - b.z * c.x) + a.z * (b.x * c.y - b.y * c.x)
+}
+
+/// Compare every wedge/hash-perceived tetrahedral parity against the same
+/// atom's real 3D geometry, using the exact sign convention
+/// `chematic_perception::stereo2d_local::local_parity_from_wedges`
+/// establishes (mirrored here from its doc comments, not re-derived): apex =
+/// first neighbor in `stereo_neighbor_order`, viewed = the rest (in order),
+/// for a 4-explicit-neighbor center; pivot = the center atom itself (no
+/// synthetic H position needed -- the triple product of the 3 real bond
+/// vectors from the center already carries full parity) for a 3-heavy +
+/// implicit-H center. Only ever consulted when a wedge/hash bond was
+/// actually present (`atom.chirality != Chirality::None`), so this never
+/// fires on the common case of a real 3D SDF record with no wedge notation
+/// at all.
+pub(crate) fn wedge_vs_3d_conflicts(
+    mol: &Molecule,
+    conformer: &Coords3D,
+) -> Vec<Stereo3DDiagnostic> {
+    let mut out = Vec::new();
+    let get = |a: u32| conformer.points.get(a as usize).copied();
+
+    for (idx, atom) in mol.atoms() {
+        if atom.chirality == Chirality::None {
+            continue;
+        }
+        let Some(order) = mol.stereo_neighbor_order(idx) else {
+            continue;
+        };
+
+        let computed = if order.len() == 4 && order[3] == STEREO_H_SENTINEL {
+            // 3 heavy neighbors + 1 implicit H: pivot = center.
+            match (get(order[0]), get(order[1]), get(order[2]), get(idx.0)) {
+                (Some(p0), Some(p1), Some(p2), Some(center)) => {
+                    let v = signed_volume3(p0, p1, p2, center);
+                    match v {
+                        v if v.abs() < VOLUME_EPS => None,
+                        v if v < 0.0 => Some(Chirality::Clockwise),
+                        _ => Some(Chirality::CounterClockwise),
+                    }
+                }
+                _ => None,
+            }
+        } else if order.len() == 4 {
+            // 4 explicit neighbors: apex = order[0], viewed = order[1..4].
+            match (get(order[0]), get(order[1]), get(order[2]), get(order[3])) {
+                (Some(p0), Some(p1), Some(p2), Some(p3)) => {
+                    let v = signed_volume3(p1, p2, p3, p0);
+                    match v {
+                        v if v.abs() < VOLUME_EPS => None,
+                        v if v < 0.0 => Some(Chirality::CounterClockwise),
+                        _ => Some(Chirality::Clockwise),
+                    }
+                }
+                _ => None,
+            }
+        } else {
+            None
+        };
+
+        if let Some(computed) = computed
+            && computed != atom.chirality
+        {
+            out.push(Stereo3DDiagnostic::WedgeVs3DParityConflict {
+                atom: idx,
+                wedge_2d: atom.chirality,
+                from_3d_geometry: computed,
+            });
+        }
+    }
+    out
+}
+
 /// Result of parsing a MOL/SDF record with stereo-perception diagnostics.
 ///
 /// `stereo_diagnostics` is empty unless a wedge/hash bond was actually
@@ -59,6 +305,15 @@ impl MolMetadata {
 /// symmetric-substituent alkenes are never stereogenic in the first place)
 /// had its direction rejected -- see
 /// [`chematic_perception::EzDirectionDiagnostic`].
+///
+/// `conformer` is `Some` exactly when the atom block's real z values are not
+/// all (near-)zero (i.e. `geometry_rank` is [`GeometryRank::Coplanar`] or
+/// [`GeometryRank::ThreeD`]) -- this is "does this file actually have a 3D
+/// conformer", independent of `coordinate_dimension` (the header's own,
+/// possibly wrong or absent, claim). `coordinate_dimension` and
+/// `geometry_rank` are always populated; `stereo3d_diagnostics` cross-checks
+/// the two and checks any wedge/hash-declared stereo against real geometry
+/// -- see [`Stereo3DDiagnostic`].
 #[derive(Clone)]
 pub struct MolReadReport {
     pub mol: Molecule,
@@ -66,6 +321,10 @@ pub struct MolReadReport {
     pub coords: Vec<(f64, f64)>,
     pub stereo_diagnostics: Vec<StereoDiagnostic>,
     pub ez_diagnostics: Vec<EzDirectionDiagnostic>,
+    pub conformer: Option<Coords3D>,
+    pub coordinate_dimension: CoordinateDimension,
+    pub geometry_rank: GeometryRank,
+    pub stereo3d_diagnostics: Vec<Stereo3DDiagnostic>,
 }
 
 // ---------------------------------------------------------------------------
@@ -145,7 +404,11 @@ pub fn read_mol_with_diagnostics(input: &str) -> Result<MolReadReport, MolParseE
     // -- Header block: lines 1–3 -------------------------------------------
 
     let name = next_line()?.1.to_string();
-    next_line()?; // line 2: program/date — discarded
+    // Line 2 (program/date info) is mostly discarded, except for the
+    // dimensional-code field (columns 20..22, "2D"/"3D") -- see
+    // `parse_dimension_code`. Empirically confirmed against a live RDKit
+    // 2026.03.3 oracle: `"     RDKit          3D"`/`"...2D"`.
+    let (_, line2_raw) = next_line()?;
     let comment = next_line()?.1.to_string();
 
     let metadata = MolMetadata { name, comment };
@@ -194,6 +457,7 @@ pub fn read_mol_with_diagnostics(input: &str) -> Result<MolReadReport, MolParseE
 
     let mut builder = MoleculeBuilder::new();
     let mut coords: Vec<(f64, f64)> = Vec::with_capacity(natoms);
+    let mut raw_z: Vec<f64> = Vec::with_capacity(natoms);
     let make_atom_err = |ln: usize, d: String| MolParseError::InvalidAtomLine {
         line: ln,
         detail: d,
@@ -212,6 +476,42 @@ pub fn read_mol_with_diagnostics(input: &str) -> Result<MolReadReport, MolParseE
             .and_then(|s| s.trim().parse().ok())
             .unwrap_or(0.0);
         coords.push((x, y));
+
+        // Z coordinate (bytes 20-29): previously silently discarded
+        // entirely -- root cause of the 3D-coordinate-loss bug this PR
+        // fixes (nothing downstream ever read this field). Unlike x/y
+        // above, a present-but-garbled or non-finite z is a typed error
+        // rather than a silent 0.0 default: nothing today reads z, so a
+        // malformed value can only be file corruption, and silently
+        // matching x/y's leniency would manufacture a fake flat conformer
+        // out of garbage input instead of surfacing it. A genuinely
+        // *missing* z field (line too short, or blank) still defaults to
+        // 0.0, same as x/y -- most real 2D-only writers pad it with zeros,
+        // but some don't, and a short 2D line is not corruption.
+        let z: f64 = match atom_line.get(20..30) {
+            None => 0.0,
+            Some(raw) => {
+                let trimmed = raw.trim();
+                if trimmed.is_empty() {
+                    0.0
+                } else {
+                    let val: f64 = trimmed.parse().map_err(|_| {
+                        make_atom_err(
+                            raw_lineno,
+                            format!("cannot parse z coordinate from '{trimmed}'"),
+                        )
+                    })?;
+                    if !val.is_finite() {
+                        return Err(make_atom_err(
+                            raw_lineno,
+                            format!("z coordinate is not finite (NaN/Infinite): '{trimmed}'"),
+                        ));
+                    }
+                    val
+                }
+            }
+        };
+        raw_z.push(z);
 
         // Element symbol: bytes 31–33 (3 chars, left-padded with a space in
         // the spec, but writers vary; trim both ends).
@@ -339,12 +639,46 @@ pub fn read_mol_with_diagnostics(input: &str) -> Result<MolReadReport, MolParseE
     let ez_diagnostics =
         apply_ez_directions_from_2d_ex(&mut mol, &coords, &explicitly_unspecified_ez);
 
+    let coordinate_dimension = parse_dimension_code(line2_raw);
+    let points: Vec<Point3> = coords
+        .iter()
+        .zip(raw_z.iter())
+        .map(|(&(x, y), &z)| Point3::new(x, y, z))
+        .collect();
+    let geometry_rank = classify_geometry_rank(&points);
+    let conformer = match geometry_rank {
+        GeometryRank::Coplanar | GeometryRank::ThreeD => Some(Coords3D { points }),
+        GeometryRank::FlatZero | GeometryRank::Indeterminate => None,
+    };
+
+    let mut stereo3d_diagnostics = Vec::new();
+    match (coordinate_dimension, geometry_rank) {
+        (CoordinateDimension::TwoD, GeometryRank::Coplanar | GeometryRank::ThreeD) => {
+            stereo3d_diagnostics.push(Stereo3DDiagnostic::DeclaredTwoDButNonzeroZ {
+                observed: geometry_rank,
+            });
+        }
+        (CoordinateDimension::ThreeD, GeometryRank::FlatZero | GeometryRank::Coplanar) => {
+            stereo3d_diagnostics.push(Stereo3DDiagnostic::DeclaredThreeDButFlat {
+                observed: geometry_rank,
+            });
+        }
+        _ => {}
+    }
+    if let Some(ref conf) = conformer {
+        stereo3d_diagnostics.extend(wedge_vs_3d_conflicts(&mol, conf));
+    }
+
     Ok(MolReadReport {
         mol,
         metadata,
         coords,
         stereo_diagnostics,
         ez_diagnostics,
+        conformer,
+        coordinate_dimension,
+        geometry_rank,
+        stereo3d_diagnostics,
     })
 }
 
@@ -521,6 +855,78 @@ pub fn write_mol_with_coords(
     out
 }
 
+/// Serialize `mol` to MOL V2000 format using `conformer`'s real 3D
+/// coordinates, stamping the header's line-2 dimensional code as `3D`.
+///
+/// This is the writer counterpart of [`read_mol_with_diagnostics`]'s new 3D
+/// support -- round-tripping this output back through the reader reproduces
+/// [`CoordinateDimension::ThreeD`] and never manufactures a fresh
+/// [`Stereo3DDiagnostic::WedgeVs3DParityConflict`] on its own output: no
+/// wedge/hash stereo field is ever emitted here (always `0`), matching the
+/// fact that a real 3D geometry makes a 2D wedge symbol redundant at best,
+/// contradictory at worst -- see [`write_mol_with_coords`] (unchanged, still
+/// the 2D writer) for the wedge-preserving counterpart. Atoms beyond
+/// `conformer.atom_count()` receive `(0.0, 0.0, 0.0)`.
+pub fn write_mol_with_conformer(
+    mol: &Molecule,
+    metadata: &MolMetadata,
+    conformer: &Coords3D,
+) -> String {
+    let mut out = String::new();
+
+    out.push_str(&metadata.name);
+    out.push('\n');
+    // Columns 0..10 "  chematic" match the 2D writer exactly; columns
+    // 10..20 are the (blank) date field; columns 20..22 carry the "3D"
+    // dimensional code -- the same column `parse_dimension_code` reads,
+    // empirically confirmed against RDKit 2026.03.3's own `MolToMolBlock`.
+    out.push_str("  chematic          3D\n");
+    out.push_str(&metadata.comment);
+    out.push('\n');
+
+    let natoms = mol.atom_count();
+    let nbonds = mol.bond_count();
+    out.push_str(&format!(
+        "{:>3}{:>3}  0  0  0  0  0  0  0  0999 V2000\n",
+        natoms, nbonds
+    ));
+
+    for (idx, atom) in mol.atoms() {
+        let sym = atom.element.symbol();
+        let charge_code = encode_charge(atom.charge);
+        let p = conformer
+            .points
+            .get(idx.0 as usize)
+            .copied()
+            .unwrap_or(Point3::zero());
+        out.push_str(&format!(
+            "{:>10.4}{:>10.4}{:>10.4} {:<3} 0{:>3}  0  0  0  0  0  0  0  0  0\n",
+            p.x, p.y, p.z, sym, charge_code,
+        ));
+    }
+
+    for (_idx, bond) in mol.bonds() {
+        let a1 = bond.atom1.0 + 1;
+        let a2 = bond.atom2.0 + 1;
+        let btype = match bond.order {
+            BondOrder::Single | BondOrder::Up | BondOrder::Down | BondOrder::Dative => 1,
+            BondOrder::Double => 2,
+            BondOrder::Triple => 3,
+            BondOrder::Aromatic => 4,
+            BondOrder::QuerySingleOrDouble => 5,
+            BondOrder::QuerySingleOrAromatic => 6,
+            BondOrder::QueryDoubleOrAromatic => 7,
+            BondOrder::QueryAny | BondOrder::Zero => 8,
+            BondOrder::Quadruple => 4,
+        };
+        // Stereo field is always 0 -- see doc comment above.
+        out.push_str(&format!("{:>3}{:>3}{:>3}{:>3}\n", a1, a2, btype, 0));
+    }
+
+    out.push_str("M  END\n");
+    out
+}
+
 // ---------------------------------------------------------------------------
 // SDF writer
 // ---------------------------------------------------------------------------
@@ -603,6 +1009,29 @@ pub fn write_sdf_record_v3000(
     props: &std::collections::HashMap<String, String>,
 ) -> String {
     let mut out = crate::mol3000::write_mol_v3000(mol, meta, coords);
+    for (k, v) in props {
+        if !k.starts_with('_') {
+            out.push_str(&format!("> <{k}>\n{v}\n\n"));
+        }
+    }
+    out.push_str("$$$$\n");
+    out
+}
+
+/// Like [`write_sdf_record`] but writes `conformer`'s real 3D coordinates
+/// (V2000, via [`write_mol_with_conformer`]) instead of a 2D `(x, y)` slice
+/// -- the 3D counterpart for a single SDF record. To write several
+/// conformers of the same molecule as separate, repeated records (readable
+/// back as one [`crate::sdf::ConformerEnsemble`] by
+/// [`crate::sdf::read_sdf_conformer_ensembles`]), call this once per
+/// conformer and concatenate the results.
+pub fn write_sdf_record_with_conformer(
+    mol: &Molecule,
+    meta: &MolMetadata,
+    conformer: &Coords3D,
+    props: &std::collections::HashMap<String, String>,
+) -> String {
+    let mut out = write_mol_with_conformer(mol, meta, conformer);
     for (k, v) in props {
         if !k.starts_with('_') {
             out.push_str(&format!("> <{k}>\n{v}\n\n"));

--- a/crates/chematic-mol/src/mol3000.rs
+++ b/crates/chematic-mol/src/mol3000.rs
@@ -7,15 +7,17 @@
 //! Reference: MDL/Dassault Systèmes CTfile Formats specification, V3000 section.
 
 use chematic_core::{
-    Atom, AtomIdx, BondIdx, BondOrder, Element, Molecule, MoleculeBuilder, StereoGroup,
-    StereoGroupKind,
+    Atom, AtomIdx, BondIdx, BondOrder, Coords3D, Element, Molecule, MoleculeBuilder, Point3,
+    StereoGroup, StereoGroupKind,
 };
 use chematic_perception::{
     apply_ez_directions_from_2d_ex, apply_local_parity_from_wedges_with_diagnostics,
 };
 
 use crate::error::MolParseError;
-use crate::mol2000::{MolMetadata, MolReadReport};
+use crate::mol2000::{
+    CoordinateDimension, GeometryRank, MolMetadata, MolReadReport, Stereo3DDiagnostic,
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -152,7 +154,11 @@ pub fn read_mol_v3000_with_diagnostics(input: &str) -> Result<MolReadReport, Mol
     // -- Header lines 1–3 ----------------------------------------------------
 
     let name = all_lines[0].1.to_string();
-    // Line 2 (program/date) is read but discarded.
+    // Line 2 (program/date) is mostly discarded, except for the
+    // dimensional-code field (columns 20..22, "2D"/"3D") -- same column as
+    // V2000's header (see `crate::mol2000::parse_dimension_code`); V3000
+    // keeps the identical 3-line header before its own counts line.
+    let line2_raw = all_lines[1].1;
     let comment = all_lines[2].1.to_string();
 
     let metadata = MolMetadata { name, comment };
@@ -193,6 +199,9 @@ pub fn read_mol_v3000_with_diagnostics(input: &str) -> Result<MolReadReport, Mol
 
     // Collect (x, y) coordinates in the order atoms are added to builder.
     let mut coords: Vec<(f64, f64)> = Vec::new();
+    // Real z coordinates, parallel to `coords` -- previously discarded
+    // entirely (root cause of the 3D-coordinate-loss bug this PR fixes).
+    let mut raw_z: Vec<f64> = Vec::new();
 
     enum State {
         BeforeCtab,
@@ -301,9 +310,36 @@ pub fn read_mol_v3000_with_diagnostics(input: &str) -> Result<MolReadReport, Mol
                         line: lnum,
                     })?;
 
-                // Parse x, y coordinates (tokens[2] and tokens[3]).
+                // Parse x, y coordinates (tokens[2] and tokens[3]) --
+                // unchanged, still lenient (a malformed x/y silently
+                // defaults to 0.0, matching pre-existing behavior).
                 let x: f64 = tokens[2].parse().unwrap_or(0.0);
                 let y: f64 = tokens[3].parse().unwrap_or(0.0);
+
+                // z coordinate (tokens[4]): previously silently discarded
+                // entirely -- root cause of the 3D-coordinate-loss bug this
+                // PR fixes. Unlike x/y above, a garbled or non-finite z is a
+                // typed error rather than a silent 0.0 default: nothing
+                // downstream reads z today, so a malformed value can only be
+                // file corruption. The token always exists syntactically
+                // (the `tokens.len() < 6` check above already guarantees
+                // it), so unlike V2000's "line too short" leniency, there is
+                // no "missing field" case here to default instead of error.
+                let z: f64 = tokens[4]
+                    .parse()
+                    .map_err(|_| MolParseError::InvalidAtomLine {
+                        line: lnum,
+                        detail: format!("cannot parse z coordinate from '{}'", tokens[4]),
+                    })?;
+                if !z.is_finite() {
+                    return Err(MolParseError::InvalidAtomLine {
+                        line: lnum,
+                        detail: format!(
+                            "z coordinate is not finite (NaN/Infinite): '{}'",
+                            tokens[4]
+                        ),
+                    });
+                }
 
                 // Atom-map number (positional field 6, 0 = no mapping).
                 let aamap_raw = tokens[5].parse::<u16>().unwrap_or(0);
@@ -337,6 +373,7 @@ pub fn read_mol_v3000_with_diagnostics(input: &str) -> Result<MolReadReport, Mol
                 let builder_idx = builder.add_atom(atom);
                 atom_idx_map.push((v3k_idx, builder_idx));
                 coords.push((x, y));
+                raw_z.push(z);
             }
 
             State::AfterAtomBlock => {
@@ -489,12 +526,49 @@ pub fn read_mol_v3000_with_diagnostics(input: &str) -> Result<MolReadReport, Mol
     let ez_diagnostics =
         apply_ez_directions_from_2d_ex(&mut mol, &coords, &explicitly_unspecified_ez);
 
+    // Same 3D bookkeeping as `mol2000.rs::read_mol_with_diagnostics` -- see
+    // that function's comments for the full rationale (kept in one place,
+    // reused via `pub(crate)` helpers, not re-derived here).
+    let coordinate_dimension = crate::mol2000::parse_dimension_code(line2_raw);
+    let points: Vec<Point3> = coords
+        .iter()
+        .zip(raw_z.iter())
+        .map(|(&(x, y), &z)| Point3::new(x, y, z))
+        .collect();
+    let geometry_rank = crate::mol2000::classify_geometry_rank(&points);
+    let conformer = match geometry_rank {
+        GeometryRank::Coplanar | GeometryRank::ThreeD => Some(Coords3D { points }),
+        GeometryRank::FlatZero | GeometryRank::Indeterminate => None,
+    };
+
+    let mut stereo3d_diagnostics = Vec::new();
+    match (coordinate_dimension, geometry_rank) {
+        (CoordinateDimension::TwoD, GeometryRank::Coplanar | GeometryRank::ThreeD) => {
+            stereo3d_diagnostics.push(Stereo3DDiagnostic::DeclaredTwoDButNonzeroZ {
+                observed: geometry_rank,
+            });
+        }
+        (CoordinateDimension::ThreeD, GeometryRank::FlatZero | GeometryRank::Coplanar) => {
+            stereo3d_diagnostics.push(Stereo3DDiagnostic::DeclaredThreeDButFlat {
+                observed: geometry_rank,
+            });
+        }
+        _ => {}
+    }
+    if let Some(ref conf) = conformer {
+        stereo3d_diagnostics.extend(crate::mol2000::wedge_vs_3d_conflicts(&mol, conf));
+    }
+
     Ok(MolReadReport {
         mol,
         metadata,
         coords,
         stereo_diagnostics,
         ez_diagnostics,
+        conformer,
+        coordinate_dimension,
+        geometry_rank,
+        stereo3d_diagnostics,
     })
 }
 
@@ -1066,6 +1140,116 @@ pub fn write_mol_v3000(mol: &Molecule, metadata: &MolMetadata, coords: &[(f64, f
                 .atom_indices
                 .iter()
                 .map(|ai| (ai.0 + 1).to_string()) // 0-based → 1-based
+                .collect();
+            out.push_str(&format!("M  V30 {key} ATOMS=({n} {})\n", idxs.join(" ")));
+        }
+        out.push_str("M  V30 END COLLECTION\n");
+    }
+
+    out.push_str("M  V30 END CTAB\n");
+    out.push_str("M  END\n");
+
+    out
+}
+
+/// Serialize `mol` to MOL V3000 (Extended Ctab) format using `conformer`'s
+/// real 3D coordinates, stamping the header's line-2 dimensional code as
+/// `3D` -- the V3000 counterpart of
+/// [`crate::mol2000::write_mol_with_conformer`]. As with that function, no
+/// wedge/hash `CFG` is ever emitted on a bond line here: a real 3D geometry
+/// makes a 2D wedge symbol redundant at best, and round-tripping this output
+/// back through [`read_mol_v3000_with_diagnostics`] must not manufacture a
+/// fresh [`crate::mol2000::Stereo3DDiagnostic::WedgeVs3DParityConflict`] on
+/// its own output. Enhanced stereo groups (`COLLECTION`/`STEABS`/`STEOR`/
+/// `STEAND`) are unaffected -- they label which atoms form a stereo group,
+/// not a direction, and remain meaningful for a 3D record.
+pub fn write_mol_v3000_with_conformer(
+    mol: &Molecule,
+    metadata: &MolMetadata,
+    conformer: &Coords3D,
+) -> String {
+    let natoms = mol.atom_count();
+    let nbonds = mol.bond_count();
+
+    let mut out = String::new();
+
+    out.push_str(&metadata.name);
+    out.push('\n');
+    // Same column convention as `mol2000::write_mol_with_conformer`.
+    out.push_str("  chematic          3D\n");
+    out.push_str(&metadata.comment);
+    out.push('\n');
+
+    out.push_str("  0  0  0  0  0  0  0  0  0  0999 V3000\n");
+
+    out.push_str("M  V30 BEGIN CTAB\n");
+    out.push_str(&format!("M  V30 COUNTS {natoms} {nbonds} 0 0 0\n"));
+
+    out.push_str("M  V30 BEGIN ATOM\n");
+    for (idx, atom) in mol.atoms() {
+        let p = conformer
+            .points
+            .get(idx.0 as usize)
+            .copied()
+            .unwrap_or(Point3::zero());
+        let sym = atom.element.symbol();
+        let atom_map = atom.atom_map.unwrap_or(0);
+        let i = idx.0 + 1;
+
+        let mut line = format!(
+            "M  V30 {i} {sym} {:.4} {:.4} {:.4} {atom_map}",
+            p.x, p.y, p.z
+        );
+        if atom.charge != 0 {
+            line.push_str(&format!(" CHG={}", atom.charge));
+        }
+        if let Some(iso) = atom.isotope {
+            line.push_str(&format!(" MASS={iso}"));
+        }
+        if let Some(h) = atom.hydrogen_count {
+            line.push_str(&format!(" HCOUNT={h}"));
+        }
+        out.push_str(&line);
+        out.push('\n');
+    }
+    out.push_str("M  V30 END ATOM\n");
+
+    out.push_str("M  V30 BEGIN BOND\n");
+    for (bidx, bond) in mol.bonds() {
+        let a1 = bond.atom1.0 + 1;
+        let a2 = bond.atom2.0 + 1;
+        let order = match bond.order {
+            BondOrder::Zero => 0,
+            BondOrder::Single | BondOrder::Up | BondOrder::Down | BondOrder::Dative => 1,
+            BondOrder::Double => 2,
+            BondOrder::Triple => 3,
+            BondOrder::Aromatic => 4,
+            BondOrder::QuerySingleOrDouble => 5,
+            BondOrder::QuerySingleOrAromatic => 6,
+            BondOrder::QueryDoubleOrAromatic => 7,
+            BondOrder::QueryAny => 8,
+            BondOrder::Quadruple => 4,
+        };
+        let i = bidx.0 + 1;
+        // No wedge/hash CFG here -- see doc comment above.
+        out.push_str(&format!("M  V30 {i} {order} {a1} {a2}\n"));
+    }
+    out.push_str("M  V30 END BOND\n");
+
+    let groups = mol.stereo_groups();
+    if !groups.is_empty() {
+        out.push_str("M  V30 BEGIN COLLECTION\n");
+        for group in groups {
+            let key = match &group.kind {
+                StereoGroupKind::Absolute => "MDLV30/STEABS".to_string(),
+                StereoGroupKind::Or(n) => format!("MDLV30/STEOR{n}"),
+                StereoGroupKind::And(n) => format!("MDLV30/STEAND{n}"),
+            };
+            let n = group.atom_indices.len();
+            let idxs: Vec<String> = group
+                .atom_indices
+                .iter()
+                .map(|ai| (ai.0 + 1).to_string())
                 .collect();
             out.push_str(&format!("M  V30 {key} ATOMS=({n} {})\n", idxs.join(" ")));
         }

--- a/crates/chematic-mol/src/sdf.rs
+++ b/crates/chematic-mol/src/sdf.rs
@@ -4,11 +4,14 @@
 //! delimiter lines.  Data-field sections between `M  END` and `$$$$` are
 //! accepted but ignored.
 
-use chematic_core::Molecule;
+use chematic_core::{Coords3D, Molecule};
 use chematic_perception::{EzDirectionDiagnostic, StereoDiagnostic};
 
 use crate::error::MolParseError;
-use crate::mol2000::{MolMetadata, parse_mol, read_mol_with_diagnostics};
+use crate::mol2000::{
+    CoordinateDimension, GeometryRank, MolMetadata, Stereo3DDiagnostic, parse_mol,
+    read_mol_with_diagnostics,
+};
 
 /// Iterator over molecules in an SDF string.
 ///
@@ -122,6 +125,20 @@ pub struct SdfRecord {
     /// [`chematic_perception::EzDirectionDiagnostic`]). Empty unless a
     /// stereogenic double bond's direction was rejected.
     pub ez_diagnostics: Vec<EzDirectionDiagnostic>,
+    /// Real 3D coordinates, `Some` exactly when the record's atom block has
+    /// non-(near-)zero z values -- see [`crate::mol2000::MolReadReport::conformer`].
+    pub conformer: Option<Coords3D>,
+    /// The record's own header-declared dimensionality (line 2's "2D"/"3D"
+    /// tag). `Unknown` is the common case -- most writers never populate it.
+    pub coordinate_dimension: CoordinateDimension,
+    /// What the record's actual coordinates look like, independent of
+    /// `coordinate_dimension` -- see [`crate::mol2000::GeometryRank`].
+    pub geometry_rank: GeometryRank,
+    /// 3D-geometry-related diagnostics for this record (dimension-vs-geometry
+    /// mismatches, wedge-vs-3D-geometry parity conflicts). See
+    /// [`crate::mol2000::Stereo3DDiagnostic`] -- empty does not mean
+    /// "verified correct", it means nothing was declared to check.
+    pub stereo3d_diagnostics: Vec<Stereo3DDiagnostic>,
 }
 
 /// Iterator over SDF records that also captures SD data fields.
@@ -205,6 +222,10 @@ impl<'a> Iterator for SdfRecordReader<'a> {
             properties,
             stereo_diagnostics: report.stereo_diagnostics,
             ez_diagnostics: report.ez_diagnostics,
+            conformer: report.conformer,
+            coordinate_dimension: report.coordinate_dimension,
+            geometry_rank: report.geometry_rank,
+            stereo3d_diagnostics: report.stereo3d_diagnostics,
         }))
     }
 }
@@ -254,6 +275,105 @@ fn parse_sd_field_header(line: &str) -> Option<String> {
     let rest = rest.trim();
     let inner = rest.strip_prefix('<')?.strip_suffix('>')?;
     Some(inner.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Conformer ensembles — bundle records sharing the same molecular graph
+// ---------------------------------------------------------------------------
+
+/// One group of SDF records that share the same molecular graph (see
+/// [`same_graph_identity`]) and each carry a real 3D conformer.
+///
+/// Records with no 3D conformer (`conformer.is_none()`, i.e. flagged 2D or
+/// flat -- see [`crate::mol2000::MolReadReport::conformer`]) are not part of
+/// any ensemble: this supplier is specifically about bundling repeated 3D
+/// conformers of "the same" molecule (e.g. `EmbedMultipleConfs` +
+/// `MolToMolBlock` per conformer, written as consecutive SDF records).
+pub struct ConformerEnsemble {
+    /// The molecular graph shared by every member (the first record's
+    /// `mol`; every other member's `mol` is checked equal by
+    /// [`same_graph_identity`] and then discarded, not stored again).
+    pub mol: Molecule,
+    /// Metadata from the first record in the group.
+    pub metadata: MolMetadata,
+    /// One conformer per member record, in file order.
+    pub conformers: Vec<Coords3D>,
+}
+
+/// Deliberately simple identity check: same atom count/order, same
+/// per-index `(element, charge, isotope)`, same bond list `(atom1, atom2,
+/// order)` in index order.
+///
+/// This is order-sensitive structural equality, NOT graph isomorphism or
+/// canonical-SMILES equality -- and that is intentional, not a shortcut
+/// taken for lack of time: it is correct for the actual use case this
+/// supplier targets (the same molecule written N times with different
+/// coordinates by the same embedding tool, which never reorders atoms or
+/// bonds between calls -- confirmed against RDKit's own
+/// `EmbedMultipleConfs` + per-conformer `MolToMolBlock`, see this crate's
+/// fixture tests). A more rigorous, reordering-tolerant identity layer is a
+/// separate, parallel workstream in the 3D Breakthrough Program (Agent B);
+/// this one is intentionally not that, and the Coordinator is expected to
+/// reconcile the two later.
+fn same_graph_identity(a: &Molecule, b: &Molecule) -> bool {
+    if a.atom_count() != b.atom_count() || a.bond_count() != b.bond_count() {
+        return false;
+    }
+    for ((_, atom_a), (_, atom_b)) in a.atoms().zip(b.atoms()) {
+        if atom_a.element != atom_b.element
+            || atom_a.charge != atom_b.charge
+            || atom_a.isotope != atom_b.isotope
+        {
+            return false;
+        }
+    }
+    for ((_, bond_a), (_, bond_b)) in a.bonds().zip(b.bonds()) {
+        if bond_a.atom1 != bond_b.atom1
+            || bond_a.atom2 != bond_b.atom2
+            || bond_a.order != bond_b.order
+        {
+            return false;
+        }
+    }
+    true
+}
+
+/// Parse an SDF string and group records that share the same molecular graph
+/// (see [`same_graph_identity`]) and each carry a real 3D conformer into
+/// [`ConformerEnsemble`]s.
+///
+/// Records with no 3D conformer are silently omitted from the result (this
+/// is specifically a *3D conformer* ensemble supplier, not a general SDF
+/// grouping utility). Grouping is order-independent within the file (a
+/// record is compared against every existing group's representative, not
+/// just its immediate predecessor), matching how real multi-conformer SDF
+/// exports are usually -- but not always -- written consecutively.
+///
+/// Stops and returns an error on the first parse failure, same as
+/// [`read_sdf_with_diagnostics`].
+pub fn read_sdf_conformer_ensembles(input: &str) -> Result<Vec<ConformerEnsemble>, MolParseError> {
+    let reports = crate::mol2000::read_sdf_with_diagnostics(input)?;
+    let mut ensembles: Vec<ConformerEnsemble> = Vec::new();
+
+    for report in reports {
+        let Some(conformer) = report.conformer else {
+            continue;
+        };
+        if let Some(existing) = ensembles
+            .iter_mut()
+            .find(|e| same_graph_identity(&e.mol, &report.mol))
+        {
+            existing.conformers.push(conformer);
+        } else {
+            ensembles.push(ConformerEnsemble {
+                mol: report.mol,
+                metadata: report.metadata,
+                conformers: vec![conformer],
+            });
+        }
+    }
+
+    Ok(ensembles)
 }
 
 // ---------------------------------------------------------------------------
@@ -343,6 +463,10 @@ impl<R: std::io::BufRead> Iterator for SdfFileReader<R> {
             properties,
             stereo_diagnostics: report.stereo_diagnostics,
             ez_diagnostics: report.ez_diagnostics,
+            conformer: report.conformer,
+            coordinate_dimension: report.coordinate_dimension,
+            geometry_rank: report.geometry_rank,
+            stereo3d_diagnostics: report.stereo3d_diagnostics,
         }))
     }
 }

--- a/crates/chematic-mol/tests/conformer_3d_io.rs
+++ b/crates/chematic-mol/tests/conformer_3d_io.rs
@@ -1,0 +1,756 @@
+//! Integration tests for 3D conformer support in the MOL/SDF readers and
+//! writers (3D Breakthrough Program, Agent A -- see
+//! `docs/3d_breakthrough_master_plan.md` section 1a/3).
+//!
+//! Every MOL-block fixture below is real RDKit `2026.03.3` output (pinned
+//! commit `8afba32ec539dcb2369bc84549d802aca3f7eb39`, same oracle this
+//! codebase's other stereo work cites), generated via `AllChem.EmbedMolecule`
+//! / `Chem.MolToMolBlock` / `Chem.MolToV3KMolBlock` in an independent venv
+//! that never touched the shared repo `.venv` -- see the PR body for the
+//! exact generation script. A handful of fixtures are a single, explicitly
+//! called-out-in-comments digit edit of that real output (e.g. flipping a
+//! wedge's stereo field from Up to Down while leaving every coordinate
+//! untouched) to construct a deliberate, otherwise-unobtainable conflict
+//! case -- never hand-invented geometry. The hand-authored (non-RDKit)
+//! fixtures further down (typed-error inputs, the blank-z fixture) are
+//! byte-exact-column-constructed, not eyeballed, matching this crate's own
+//! `mol2000.rs` column layout exactly.
+
+use chematic_core::AtomIdx;
+use chematic_mol::mol2000::{
+    CoordinateDimension, GeometryRank, Stereo3DDiagnostic, read_mol_with_diagnostics,
+    write_mol_with_conformer,
+};
+use chematic_mol::mol3000::{read_mol_v3000_with_diagnostics, write_mol_v3000_with_conformer};
+use chematic_mol::sdf::read_sdf_conformer_ensembles;
+
+const ETHANOL_2D: &str = r#"
+     RDKit          2D
+
+  3  2  0  0  0  0  0  0  0  0999 V2000
+   -1.2990   -0.2500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    0.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.2990   -0.2500    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  2  3  1  0
+M  END
+"#;
+const ETHANOL_3D: &str = r#"
+     RDKit          3D
+
+  3  2  0  0  0  0  0  0  0  0999 V2000
+    0.8716    0.1993    0.1351 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.4606   -0.5156    0.0446 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.3264    0.1817   -0.8391 O   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  2  3  1  0
+M  END
+"#;
+const BROMO_3D: &str = r#"
+     RDKit          3D
+
+  5  4  0  0  0  0  0  0  0  0999 V2000
+   -0.0403    0.0604    0.0996 C   0  0  2  0  0  0  0  0  0  0  0  0
+   -1.3475   -1.2822   -0.4144 Br  0  0  0  0  0  0  0  0  0  0  0  0
+   -0.1635    0.3239    1.4269 F   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.3256    1.5434   -0.8199 Cl  0  0  0  0  0  0  0  0  0  0  0  0
+    1.8768   -0.6454   -0.2923 I   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  1  3  1  1
+  1  4  1  0
+  1  5  1  0
+M  END
+"#;
+const L_ALANINE_3D: &str = r#"
+     RDKit          3D
+
+  6  5  0  0  0  0  0  0  0  0999 V2000
+   -1.0297   -1.3503    0.2491 N   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.2785   -0.2519   -0.4000 C   0  0  1  0  0  0  0  0  0  0  0  0
+   -0.9835    1.0686   -0.1221 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.1645   -0.2214    0.1141 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.6568   -0.9800    0.9364 O   0  0  0  0  0  0  0  0  0  0  0  0
+    1.9163    0.7368   -0.4623 O   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  2  3  1  1
+  2  4  1  0
+  4  5  2  0
+  4  6  1  0
+M  END
+"#;
+const D_ALANINE_3D: &str = r#"
+     RDKit          3D
+
+  6  5  0  0  0  0  0  0  0  0999 V2000
+   -0.9715   -1.2914   -0.4126 N   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.2432   -0.2182    0.2939 C   0  0  2  0  0  0  0  0  0  0  0  0
+   -0.8799    1.1176   -0.0660 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.2483   -0.2786   -0.0635 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.8615   -1.2706   -0.4330 O   0  0  0  0  0  0  0  0  0  0  0  0
+    1.9119    0.8740    0.1545 O   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  2  3  1  6
+  2  4  1  0
+  4  5  2  0
+  4  6  1  0
+M  END
+"#;
+const BENZENE_3D_FLAT: &str = r#"
+     RDKit          3D
+
+  6  6  0  0  0  0  0  0  0  0999 V2000
+   -0.3032   -1.3614   -0.0088 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.3305   -0.4183    0.0150 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.0274    0.9431    0.0238 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.3032    1.3614    0.0088 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.3305    0.4183   -0.0150 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.0274   -0.9431   -0.0238 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  2  3  2  0
+  3  4  1  0
+  4  5  2  0
+  5  6  1  0
+  6  1  2  0
+M  END
+"#;
+const CHLORO_BROMO_ETHENE_E_3D: &str = r#"
+     RDKit          3D
+
+  4  3  0  0  0  0  0  0  0  0999 V2000
+   -2.1393    0.3274    0.0050 Cl  0  0  0  0  0  0  0  0  0  0  0  0
+   -0.5726   -0.3650    0.0053 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.5376    0.3710   -0.0052 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.2494   -0.3408   -0.0053 Br  0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  2  3  2  0
+  3  4  1  0
+M  END
+"#;
+const CHLORO_BROMO_ETHENE_Z_3D: &str = r#"
+     RDKit          3D
+
+  4  3  0  0  0  0  0  0  0  0999 V2000
+   -1.5710    1.2629    0.2063 Cl  0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6474   -0.1530   -0.0660 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.6148   -0.1877   -0.4942 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.6973    1.2603   -0.9051 Br  0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  2  3  2  0
+  3  4  1  0
+M  END
+"#;
+const BUTANE_ENSEMBLE_SDF: &str = r#"butane
+     RDKit          3D
+
+  4  3  0  0  0  0  0  0  0  0999 V2000
+    1.8617   -0.0700    0.3396 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.5248    0.4625   -0.1172 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.5372   -0.4649    0.4905 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.8695    0.0995    0.0112 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  2  3  1  0
+  3  4  1  0
+M  END
+$$$$
+butane
+     RDKit          3D
+
+  4  3  0  0  0  0  0  0  0  0999 V2000
+   -1.9282    0.0037    0.1782 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.5239    0.4481   -0.0991 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.5235   -0.5632    0.3245 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.8763    0.0475   -0.0281 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  2  3  1  0
+  3  4  1  0
+M  END
+$$$$
+butane
+     RDKit          3D
+
+  4  3  0  0  0  0  0  0  0  0999 V2000
+   -1.5291   -0.5136   -0.1631 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6384    0.6532   -0.4387 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.6203    0.6882    0.3875 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.4982   -0.4940    0.2014 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  2  3  1  0
+  3  4  1  0
+M  END
+$$$$
+"#;
+const BROMO_3D_V3K: &str = r#"
+     RDKit          3D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 4 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -0.080022 0.044032 0.115420 0 CFG=2
+M  V30 2 Br -1.355208 -1.285319 -0.433136 0
+M  V30 3 F -0.162340 0.349268 1.452720 0
+M  V30 4 Cl -0.307369 1.530691 -0.821563 0
+M  V30 5 I 1.904939 -0.638672 -0.313441 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 1 3 CFG=1
+M  V30 3 1 1 4
+M  V30 4 1 1 5
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+"#;
+const ENHANCED_STEREO_3D_V3K: &str = r#"enhanced_stereo_3d
+  chematic
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 4 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -0.080022 0.044032 0.115420 0
+M  V30 2 Br -1.355208 -1.285319 -0.433136 0
+M  V30 3 F -0.162340 0.349268 1.452720 0
+M  V30 4 Cl -0.307369 1.530691 -0.821563 0
+M  V30 5 I 1.904939 -0.638672 -0.313441 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 1 3
+M  V30 3 1 1 4
+M  V30 4 1 1 5
+M  V30 END BOND
+M  V30 BEGIN COLLECTION
+M  V30 MDLV30/STEABS ATOMS=(1 1)
+M  V30 END COLLECTION
+M  V30 END CTAB
+M  END
+"#;
+
+// Hand-authored, byte-exact-column-constructed (not RDKit output, not
+// eyeballed -- see the generator script referenced in the PR body).
+const NAN_Z_MOL: &str = r#"bad
+  chematic
+
+  1  0  0  0  0  0  0  0  0  0  0 V2000
+    0.0000    0.0000       NaN C   0  0  0  0  0  0  0  0  0  0  0
+M  END
+"#;
+const INF_Z_MOL: &str = r#"bad
+  chematic
+
+  1  0  0  0  0  0  0  0  0  0  0 V2000
+    0.0000    0.0000     1e400 C   0  0  0  0  0  0  0  0  0  0  0
+M  END
+"#;
+const GARBLED_Z_MOL: &str = r#"bad
+  chematic
+
+  1  0  0  0  0  0  0  0  0  0  0 V2000
+    0.0000    0.0000    !!!!!! C   0  0  0  0  0  0  0  0  0  0  0
+M  END
+"#;
+const BLANK_Z_MOL: &str = r#"blank_z
+  chematic
+
+  1  0  0  0  0  0  0  0  0  0  0 V2000
+    0.0000    0.0000           C   0  0  0  0  0  0  0  0  0  0  0
+M  END
+"#;
+
+// ---------------------------------------------------------------------------
+// Root cause regression: Z coordinate is actually read now (was silently
+// discarded entirely before this PR -- see PR body).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn v2000_3d_flagged_file_populates_conformer_with_real_z() {
+    let report = read_mol_with_diagnostics(ETHANOL_3D).expect("parse");
+    let conformer = report.conformer.expect("3D file must produce a conformer");
+    assert_eq!(conformer.atom_count(), 3);
+    // Spot-check against the literal RDKit-authored z values (not 0.0, the
+    // pre-fix silent-discard behavior).
+    assert!((conformer.points[0].z - 0.1351).abs() < 1e-6);
+    assert!((conformer.points[1].z - 0.0446).abs() < 1e-6);
+    assert!((conformer.points[2].z - (-0.8391)).abs() < 1e-6);
+}
+
+#[test]
+fn v2000_2d_flagged_file_has_no_conformer_and_flatzero_rank() {
+    let report = read_mol_with_diagnostics(ETHANOL_2D).expect("parse");
+    assert!(report.conformer.is_none());
+    assert_eq!(report.geometry_rank, GeometryRank::FlatZero);
+    assert_eq!(report.coordinate_dimension, CoordinateDimension::TwoD);
+    assert!(report.stereo3d_diagnostics.is_empty());
+}
+
+#[test]
+fn v3000_3d_flagged_file_populates_conformer_with_real_z() {
+    let report = read_mol_v3000_with_diagnostics(BROMO_3D_V3K).expect("parse");
+    let conformer = report
+        .conformer
+        .expect("3D V3000 file must produce a conformer");
+    assert_eq!(conformer.atom_count(), 5);
+    assert!((conformer.points[0].z - 0.115420).abs() < 1e-6);
+    assert!((conformer.points[2].z - 1.452720).abs() < 1e-6);
+    assert_eq!(report.coordinate_dimension, CoordinateDimension::ThreeD);
+}
+
+// ---------------------------------------------------------------------------
+// GeometryRank: distinguishing FlatZero / Coplanar / ThreeD (not one boolean)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn geometry_rank_threed_for_nonplanar_molecule() {
+    // L-alanine's real embedded conformer is genuinely non-planar (6 atoms,
+    // sp3 stereocenter) -- independently confirmed via a best-fit-plane
+    // residual check in the venv (~2.08 A max deviation, see PR body).
+    let report = read_mol_with_diagnostics(L_ALANINE_3D).expect("parse");
+    assert_eq!(report.geometry_rank, GeometryRank::ThreeD);
+    assert_eq!(report.coordinate_dimension, CoordinateDimension::ThreeD);
+    // Declared and observed agree -- no dimension-mismatch diagnostic.
+    assert!(!report.stereo3d_diagnostics.iter().any(|d| matches!(
+        d,
+        Stereo3DDiagnostic::DeclaredTwoDButNonzeroZ { .. }
+            | Stereo3DDiagnostic::DeclaredThreeDButFlat { .. }
+    )));
+}
+
+#[test]
+fn geometry_rank_coplanar_for_a_real_but_flat_3d_embedding() {
+    // Benzene's real embedded conformer is genuinely 3D-generated but the
+    // molecule itself is flat -- this must NOT be conflated with "every z
+    // is exactly 0" (FlatZero): independently confirmed via a best-fit-plane
+    // residual check in the venv (~2.9e-6 A, see PR body) -- Coplanar, not
+    // FlatZero (z values are small but nonzero).
+    let report = read_mol_with_diagnostics(BENZENE_3D_FLAT).expect("parse");
+    assert_eq!(report.geometry_rank, GeometryRank::Coplanar);
+    assert_eq!(report.coordinate_dimension, CoordinateDimension::ThreeD);
+    // A real, physically-flat 3D molecule is not a bug -- but it IS still
+    // surfaced distinctly via the payload (Coplanar, not FlatZero), per the
+    // Coordinator's "don't collapse to one boolean" requirement.
+    assert!(report.stereo3d_diagnostics.iter().any(|d| matches!(
+        d,
+        Stereo3DDiagnostic::DeclaredThreeDButFlat {
+            observed: GeometryRank::Coplanar
+        }
+    )));
+}
+
+// ---------------------------------------------------------------------------
+// Header-vs-geometry dimension mismatch (cases 1/2/3 from the Coordinator's
+// review, each independently identifiable via the diagnostic payload)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn declared_2d_but_nonzero_z_is_diagnosed() {
+    // Same real RDKit 3D coordinates as ETHANOL_3D, header dimensional code
+    // hand-edited from "3D" to "2D" (single substring replace, geometry
+    // untouched) -- case 1.
+    let hacked = ETHANOL_3D.replacen("          3D", "          2D", 1);
+    let report = read_mol_with_diagnostics(&hacked).expect("parse");
+    assert_eq!(report.coordinate_dimension, CoordinateDimension::TwoD);
+    assert!(
+        report.conformer.is_some(),
+        "real z data must still be captured"
+    );
+    assert!(
+        report
+            .stereo3d_diagnostics
+            .iter()
+            .any(|d| matches!(d, Stereo3DDiagnostic::DeclaredTwoDButNonzeroZ { .. }))
+    );
+}
+
+#[test]
+fn declared_3d_but_every_z_exactly_zero_is_diagnosed_as_flatzero() {
+    // Same real RDKit 2D coordinates as ETHANOL_2D (z is 0.0000 for every
+    // atom), header dimensional code hand-edited from "2D" to "3D" -- case 3,
+    // the "every z is literally 0" sub-case.
+    let hacked = ETHANOL_2D.replacen("          2D", "          3D", 1);
+    let report = read_mol_with_diagnostics(&hacked).expect("parse");
+    assert_eq!(report.coordinate_dimension, CoordinateDimension::ThreeD);
+    assert!(
+        report.conformer.is_none(),
+        "all-zero z is not a real conformer"
+    );
+    assert!(report.stereo3d_diagnostics.iter().any(|d| matches!(
+        d,
+        Stereo3DDiagnostic::DeclaredThreeDButFlat {
+            observed: GeometryRank::FlatZero
+        }
+    )));
+}
+
+// ---------------------------------------------------------------------------
+// Wedge vs. 3D geometry: tetrahedral (4 explicit neighbors)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn wedge_agrees_with_3d_geometry_for_real_rdkit_output_no_conflict() {
+    // BROMO_3D is RDKit's OWN real, self-consistent output: the wedge on the
+    // C-F bond and the real 3D geometry both encode the SAME actual
+    // stereocenter. Zero conflicts expected.
+    let report = read_mol_with_diagnostics(BROMO_3D).expect("parse");
+    assert!(report.conformer.is_some());
+    assert_ne!(
+        report.mol.atom(AtomIdx(0)).chirality,
+        chematic_core::Chirality::None,
+        "wedge must have been perceived"
+    );
+    assert!(
+        !report
+            .stereo3d_diagnostics
+            .iter()
+            .any(|d| matches!(d, Stereo3DDiagnostic::WedgeVs3DParityConflict { .. })),
+        "a real, self-consistent RDKit record must not conflict with itself: {:?}",
+        report.stereo3d_diagnostics
+    );
+}
+
+#[test]
+fn wedge_disagrees_with_3d_geometry_conflict_fires() {
+    // Same real geometry as BROMO_3D, wedge stereo field flipped from Up (1)
+    // to Down (6) on the C-F bond line -- the ONLY edit, geometry untouched.
+    // This can only disagree with the (unchanged) real 3D geometry.
+    let hacked = BROMO_3D.replacen("  1  3  1  1\n", "  1  3  1  6\n", 1);
+    assert_ne!(
+        hacked, BROMO_3D,
+        "the wedge line must actually have been edited"
+    );
+    let report = read_mol_with_diagnostics(&hacked).expect("parse");
+    assert!(report.conformer.is_some());
+    let conflicts: Vec<_> = report
+        .stereo3d_diagnostics
+        .iter()
+        .filter(|d| matches!(d, Stereo3DDiagnostic::WedgeVs3DParityConflict { .. }))
+        .collect();
+    assert_eq!(
+        conflicts.len(),
+        1,
+        "flipping only the wedge must produce exactly one conflict: {:?}",
+        report.stereo3d_diagnostics
+    );
+}
+
+#[test]
+fn v3000_wedge_agrees_with_3d_geometry_no_conflict() {
+    let report = read_mol_v3000_with_diagnostics(BROMO_3D_V3K).expect("parse");
+    assert!(report.conformer.is_some());
+    assert!(
+        !report
+            .stereo3d_diagnostics
+            .iter()
+            .any(|d| matches!(d, Stereo3DDiagnostic::WedgeVs3DParityConflict { .. }))
+    );
+}
+
+#[test]
+fn v3000_wedge_disagrees_with_3d_geometry_conflict_fires() {
+    // Flip CFG=1 (Up) to CFG=3 (Down) on the C-F bond line only.
+    let hacked = BROMO_3D_V3K.replacen("CFG=1", "CFG=3", 1);
+    assert_ne!(hacked, BROMO_3D_V3K);
+    let report = read_mol_v3000_with_diagnostics(&hacked).expect("parse");
+    assert!(
+        report
+            .stereo3d_diagnostics
+            .iter()
+            .any(|d| matches!(d, Stereo3DDiagnostic::WedgeVs3DParityConflict { .. }))
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Wedge vs. 3D geometry: implicit-H stereocenter (3 heavy neighbors + 1 H)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn implicit_h_stereocenter_wedge_agrees_with_3d_geometry_l_alanine() {
+    // L-alanine's alpha carbon is a real 3-heavy-neighbor + implicit-H
+    // stereocenter (N, CH3, COOH heavy substituents + 1 implicit H) --
+    // RDKit's own real wedge (C(alpha)-CH3, stereo=1) and its own real 3D
+    // embedding of the SAME molecule must agree.
+    let report = read_mol_with_diagnostics(L_ALANINE_3D).expect("parse");
+    let alpha_c = AtomIdx(1); // 0-indexed: N=0, C(alpha)=1, CH3=2, C(=O)=3, O=4, O=5
+    assert_ne!(
+        report.mol.atom(alpha_c).chirality,
+        chematic_core::Chirality::None
+    );
+    assert_eq!(
+        report.mol.stereo_neighbor_order(alpha_c).map(|o| o.len()),
+        Some(4),
+        "3 heavy neighbors + 1 implicit-H sentinel"
+    );
+    assert!(
+        !report
+            .stereo3d_diagnostics
+            .iter()
+            .any(|d| matches!(d, Stereo3DDiagnostic::WedgeVs3DParityConflict { .. })),
+        "{:?}",
+        report.stereo3d_diagnostics
+    );
+}
+
+#[test]
+fn implicit_h_stereocenter_wedge_disagrees_conflict_fires() {
+    // Same real L-alanine geometry, wedge flipped Up(1) -> Down(6) on the
+    // C(alpha)-CH3 bond line only.
+    let hacked = L_ALANINE_3D.replacen("  2  3  1  1\n", "  2  3  1  6\n", 1);
+    assert_ne!(hacked, L_ALANINE_3D);
+    let report = read_mol_with_diagnostics(&hacked).expect("parse");
+    let conflicts: Vec<_> = report
+        .stereo3d_diagnostics
+        .iter()
+        .filter(|d| matches!(d, Stereo3DDiagnostic::WedgeVs3DParityConflict { .. }))
+        .collect();
+    assert_eq!(conflicts.len(), 1, "{:?}", report.stereo3d_diagnostics);
+}
+
+#[test]
+fn implicit_h_stereocenter_d_alanine_also_self_consistent() {
+    // The other enantiomer, independently embedded by RDKit -- its own
+    // (different) wedge and its own (different, mirror-image) geometry must
+    // still agree with each other.
+    let report = read_mol_with_diagnostics(D_ALANINE_3D).expect("parse");
+    assert!(
+        !report
+            .stereo3d_diagnostics
+            .iter()
+            .any(|d| matches!(d, Stereo3DDiagnostic::WedgeVs3DParityConflict { .. }))
+    );
+    // And the two enantiomers' wedge-perceived local parity must actually
+    // differ (sanity check that this isn't vacuously true because neither
+    // wedge was perceived at all).
+    let l_report = read_mol_with_diagnostics(L_ALANINE_3D).expect("parse");
+    assert_ne!(
+        l_report.mol.atom(AtomIdx(1)).chirality,
+        report.mol.atom(AtomIdx(1)).chirality
+    );
+}
+
+// ---------------------------------------------------------------------------
+// E/Z fixtures: parse cleanly, real conformer, no false tetrahedral
+// diagnostics (E/Z-vs-3D verification itself is deferred -- see PR body).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ez_fixtures_parse_with_real_conformer_and_no_tetrahedral_false_positive() {
+    for block in [CHLORO_BROMO_ETHENE_E_3D, CHLORO_BROMO_ETHENE_Z_3D] {
+        let report = read_mol_with_diagnostics(block).expect("parse");
+        assert!(report.conformer.is_some());
+        assert!(
+            !report
+                .stereo3d_diagnostics
+                .iter()
+                .any(|d| matches!(d, Stereo3DDiagnostic::WedgeVs3DParityConflict { .. }))
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Enhanced stereo group + 3D conformer coexist
+// ---------------------------------------------------------------------------
+
+#[test]
+fn enhanced_stereo_group_coexists_with_3d_conformer() {
+    let report = read_mol_v3000_with_diagnostics(ENHANCED_STEREO_3D_V3K).expect("parse");
+    assert!(report.conformer.is_some());
+    assert_eq!(report.geometry_rank, GeometryRank::ThreeD);
+    let groups = report.mol.stereo_groups();
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0].kind, chematic_core::StereoGroupKind::Absolute);
+    assert_eq!(groups[0].atom_indices, vec![AtomIdx(0)]);
+}
+
+// ---------------------------------------------------------------------------
+// Multiple conformers: repeated SDF records for the same molecule
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sdf_conformer_ensemble_groups_repeated_records_of_same_molecule() {
+    let ensembles = read_sdf_conformer_ensembles(BUTANE_ENSEMBLE_SDF).expect("parse");
+    assert_eq!(
+        ensembles.len(),
+        1,
+        "all 3 records are the same molecular graph"
+    );
+    assert_eq!(ensembles[0].mol.atom_count(), 4);
+    assert_eq!(ensembles[0].conformers.len(), 3);
+    // The 3 conformers are geometrically distinct (different embeddings).
+    let p0 = ensembles[0].conformers[0].points[0];
+    let p1 = ensembles[0].conformers[1].points[0];
+    assert!(
+        p0.distance(&p1) > 0.1,
+        "different conformers should have different coordinates"
+    );
+}
+
+#[test]
+fn sdf_conformer_ensemble_omits_records_with_no_conformer() {
+    // ETHANOL_2D/ETHANOL_3D both have a blank name line (RDKit's default for
+    // an unnamed molecule) -- give each a real name here. This sidesteps a
+    // separate, pre-existing bug in the shared SDF-block-splitting helpers
+    // (`read_sdf_with_diagnostics` et al.'s leading-blank-line-skip strips a
+    // legitimately-blank *first* line of a record, not just stray blank
+    // lines between records), found incidentally while building this
+    // fixture and reported as a known limitation in the PR body rather than
+    // fixed here (unrelated to 3D coordinates; affects any blank-named 2D
+    // SDF file too).
+    let ethanol_2d_named = ETHANOL_2D.replacen('\n', "ethanol2d\n", 1);
+    let ethanol_3d_named = ETHANOL_3D.replacen('\n', "ethanol3d\n", 1);
+    let sdf = format!("{ethanol_2d_named}$$$$\n{ethanol_3d_named}$$$$\n");
+    let ensembles = read_sdf_conformer_ensembles(&sdf).expect("parse");
+    // ethanol_2d has no conformer (flat); ethanol_3d does -- exactly one
+    // ensemble, with exactly one conformer (from the 3D record only).
+    assert_eq!(ensembles.len(), 1);
+    assert_eq!(ensembles[0].conformers.len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Typed errors: NaN/Inf/unparseable z, never a silent default or a panic
+// ---------------------------------------------------------------------------
+
+#[test]
+fn v2000_nan_z_is_a_typed_error_not_silent_default() {
+    let result = read_mol_with_diagnostics(NAN_Z_MOL);
+    assert!(matches!(
+        result,
+        Err(chematic_mol::MolParseError::InvalidAtomLine { .. })
+    ));
+}
+
+#[test]
+fn v2000_infinite_z_from_overflow_is_a_typed_error() {
+    // "1e400" is valid float *syntax* that overflows to +inf -- not a parse
+    // failure by Rust's own rules, but not a finite coordinate either.
+    let result = read_mol_with_diagnostics(INF_Z_MOL);
+    assert!(matches!(
+        result,
+        Err(chematic_mol::MolParseError::InvalidAtomLine { .. })
+    ));
+}
+
+#[test]
+fn v2000_garbled_z_text_is_a_typed_error() {
+    let result = read_mol_with_diagnostics(GARBLED_Z_MOL);
+    assert!(matches!(
+        result,
+        Err(chematic_mol::MolParseError::InvalidAtomLine { .. })
+    ));
+}
+
+#[test]
+fn v2000_blank_z_field_still_defaults_to_zero_not_an_error() {
+    // The z field's 10 columns are present but blank (all spaces) -- a
+    // genuinely *missing* value, not corruption, same leniency as x/y.
+    let report = read_mol_with_diagnostics(BLANK_Z_MOL).expect("blank z must not error");
+    assert_eq!(report.geometry_rank, GeometryRank::FlatZero);
+}
+
+#[test]
+fn v3000_nan_z_is_a_typed_error() {
+    let bad = "\
+bad
+  chematic
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 1 0 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.0 0.0 NaN 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+";
+    let result = read_mol_v3000_with_diagnostics(bad);
+    assert!(matches!(
+        result,
+        Err(chematic_mol::MolParseError::InvalidAtomLine { .. })
+    ));
+}
+
+#[test]
+fn v3000_garbled_z_is_a_typed_error() {
+    let bad = "\
+bad
+  chematic
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 1 0 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.0 0.0 garbage 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+";
+    let result = read_mol_v3000_with_diagnostics(bad);
+    assert!(matches!(
+        result,
+        Err(chematic_mol::MolParseError::InvalidAtomLine { .. })
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// 3D writers: round-trip, never manufacture a fresh conflict on own output
+// ---------------------------------------------------------------------------
+
+#[test]
+fn v2000_write_mol_with_conformer_round_trips_as_threed() {
+    let original = read_mol_with_diagnostics(L_ALANINE_3D).expect("parse");
+    let conformer = original.conformer.clone().expect("has conformer");
+    let block = write_mol_with_conformer(&original.mol, &original.metadata, &conformer);
+    assert!(
+        block.contains("          3D"),
+        "writer must stamp the 3D dimensional code"
+    );
+
+    let reparsed = read_mol_with_diagnostics(&block).expect("re-parse own output");
+    assert_eq!(reparsed.coordinate_dimension, CoordinateDimension::ThreeD);
+    assert_eq!(reparsed.geometry_rank, GeometryRank::ThreeD);
+    assert!(
+        reparsed.stereo3d_diagnostics.is_empty(),
+        "writer must never manufacture a fresh conflict on its own round-trip output: {:?}",
+        reparsed.stereo3d_diagnostics
+    );
+    // Coordinates survive round-trip within the writer's {:.4} precision.
+    for (p_before, p_after) in conformer
+        .points
+        .iter()
+        .zip(reparsed.conformer.unwrap().points.iter())
+    {
+        assert!((p_before.x - p_after.x).abs() < 1e-3);
+        assert!((p_before.y - p_after.y).abs() < 1e-3);
+        assert!((p_before.z - p_after.z).abs() < 1e-3);
+    }
+}
+
+#[test]
+fn v3000_write_mol_v3000_with_conformer_round_trips_as_threed() {
+    let original = read_mol_v3000_with_diagnostics(BROMO_3D_V3K).expect("parse");
+    let conformer = original.conformer.clone().expect("has conformer");
+    let block = write_mol_v3000_with_conformer(&original.mol, &original.metadata, &conformer);
+    assert!(block.contains("          3D"));
+
+    let reparsed = read_mol_v3000_with_diagnostics(&block).expect("re-parse own output");
+    assert_eq!(reparsed.coordinate_dimension, CoordinateDimension::ThreeD);
+    assert!(
+        reparsed.stereo3d_diagnostics.is_empty(),
+        "{:?}",
+        reparsed.stereo3d_diagnostics
+    );
+}
+
+#[test]
+fn v2000_2d_writer_is_completely_unaffected_by_3d_additions() {
+    // Regression guard: the existing 2D writer's output must not change at
+    // all as a side effect of this PR (additive-only constraint).
+    use chematic_mol::mol2000::write_mol_with_coords;
+    let (mol, meta, coords) = chematic_mol::parse_mol_with_coords(ETHANOL_2D).expect("parse");
+    let written = write_mol_with_coords(&mol, &meta, &coords);
+    assert!(!written.contains("3D"));
+    assert!(!written.contains("2D"));
+}


### PR DESCRIPTION
## Summary

3D Breakthrough Program, Agent A. Wires real 3D coordinate support into the MOL/SDF I/O layer (`chematic-mol`), additively, per `docs/3d_breakthrough_master_plan.md` sections 1a/3.

- **Base SHA**: `bcb45e7` (origin/main, includes Wave 0's master-plan merge #164 and the `distance_geometry_v2` module-stub #166)
- **Head SHA**: `c3725b8` (this branch, rebased onto the base above)
- **Files touched**: `crates/chematic-core/src/coords3d.rs` (new), `crates/chematic-core/src/lib.rs` (+2 lines — Coordinator-ratified, see below), `crates/chematic-mol/src/mol2000.rs`, `crates/chematic-mol/src/mol3000.rs`, `crates/chematic-mol/src/sdf.rs`, `crates/chematic-mol/tests/conformer_3d_io.rs` (new), and **`crates/chematic-mol/src/lib.rs`** (root re-exports — added after independent verification found the gap; `lib.rs` was not on the strict per-agent list but is not Coordinator-only either). Nothing else touched — confirmed via `git diff --stat` against base.

**Update after independent Coordinator verification** (see PR discussion): fixed a mislabeled test-count claim, corrected the `is_finite()` justification, added the root re-exports in `chematic-mol/src/lib.rs`, added a semver-relevant behavior-change note below, and filed #171 for a pre-existing, unrelated SDF-reader bug found (not fixed) during this work. Details in the relevant sections below.

## Root cause of the Z-coordinate-discard bug

- `crates/chematic-mol/src/mol2000.rs` (pre-PR): the atom-line parser read only `atom_line.get(0..10)` (x) and `atom_line.get(10..20)` (y) into `coords: Vec<(f64, f64)>`. Bytes `20..30` (z, MDL Ctfile fixed-width layout) were never read anywhere in the function.
- `crates/chematic-mol/src/mol3000.rs` (pre-PR): the V3000 atom-line parser read `tokens[2]`/`tokens[3]` (x/y) but never `tokens[4]` (z).
- Both silently threw the byte/token away — no error, no field to put it in (`MolReadReport`/`SdfRecord` had no 3D-coordinate field at all), and no way for a caller to tell "this file had a Z I discarded" from "this file never had a Z".

## Architecture: `chematic_core::{Coords3D, Point3}`

Per the master plan's decision 1a plus the Coordinator's follow-up review during this task:
- `Point3 { x, y, z }` and `Coords3D { points: Vec<Point3> }` added to new `crates/chematic-core/src/coords3d.rs`, deliberately mirroring `chematic_3d::coords::{Point3, Coords3D}`'s field names, method names (`new_zeroed`/`get`/`set`/`atom_count`), and panic-on-out-of-range indexing convention, so a later Coordinator bridge PR can do `pub use chematic_core::{Coords3D, Point3};` inside `chematic_3d::coords` with minimal call-site changes.
- Two additions beyond what `chematic_3d::coords`'s type has:
  - `is_finite()` on both `Point3` and `Coords3D`. **Not called by this PR's own reader code** — `mol2000.rs`/`mol3000.rs` validate NaN/Inf with a direct `f64::is_finite()` check on the raw parsed value (`mol2000.rs:504`, `mol3000.rs:334`), before a `Point3`/`Coords3D` is ever constructed, so these methods currently have zero non-test callers. They're provided for future consumers (e.g. Wave 2 code that constructs a `Coords3D` from elsewhere and wants to validate it after the fact), not because this PR's own logic needs them — corrected from an earlier, inaccurate framing of these as load-bearing.
  - `Default`/`PartialEq` derives on `Coords3D` (`chematic_3d::coords::Coords3D` derives only `Debug, Clone`) — needed for this crate's own unit tests, harmless additions for a plain data holder.
- `chematic-3d/src/coords.rs` was read-only reference for this PR — not edited, not touched.
- Zero new dependency edges: `python3 scripts/check_publish_graph.py` passes (18 publishable crates, same safe order as before).

**`chematic-core/src/lib.rs` +2-line deviation — Coordinator-ratified.** I added `pub mod coords3d;` **and** `pub use coords3d::{Coords3D, Point3};` (2 lines, not the literal 1 originally specified), needed for `chematic_core::Coords3D`/`Point3` to resolve at root the way the Coordinator's own bridge-PR sketch (`pub use chematic_core::{Coords3D, Point3};`) assumes. Independently verified and approved: narrow, matches the file's existing re-export pattern, and `chematic-core/src/lib.rs` isn't on the strict Coordinator-only list.

**New: root re-exports added to `crates/chematic-mol/src/lib.rs`.** Independent verification found a real usability gap — `MolReadReport`/`SdfRecord` were already root-exported from `chematic_mol`, but their new field types (`CoordinateDimension`, `GeometryRank`, `Stereo3DDiagnostic`, plus the new writer functions and `ConformerEnsemble`/`read_sdf_conformer_ensembles`) were not, so a caller could read `.coordinate_dimension` but couldn't name the type without reaching into `chematic_mol::mol2000::*` directly. Added the missing `pub use` lines, matching the existing pattern. `chematic-mol/src/lib.rs` was not on the strict per-agent file list (only `mol2000.rs`/`mol3000.rs`/`sdf.rs` were assigned specifically) but isn't Coordinator-only either, so this PR now also touches that file — a 12-line, additive-only re-export change, re-verified (fmt/clippy/tests all still green, see Verification).

## Before / after behavior

| | Before | After |
|---|---|---|
| V2000/V3000 z coordinate | silently discarded | parsed into `MolReadReport.conformer: Option<Coords3D>` |
| Malformed z (NaN/Inf/unparseable) | silently discarded (never read at all) | typed `MolParseError::InvalidAtomLine` |
| Missing/blank z field | n/a | still defaults to `0.0` (unchanged leniency, matches x/y) |
| File's own 2D/3D header claim | never read | `MolReadReport.coordinate_dimension: CoordinateDimension` (line-2 columns 20..22, empirically confirmed against RDKit `2026.03.3`'s own `"...RDKit          3D"` output) |
| Whether coordinates are actually flat/coplanar/3D | not tracked | `MolReadReport.geometry_rank: GeometryRank` (`FlatZero`/`Coplanar`/`ThreeD`/`Indeterminate`) — kept **separate** from `coordinate_dimension` per Coordinator review (a real, physically-flat 3D-embedded molecule like benzene must not be conflated with "every z is exactly 0, probably a mislabeled 2D file") |
| Wedge/hash-declared stereo vs. real 3D geometry | never compared | `Stereo3DDiagnostic::WedgeVs3DParityConflict` (tetrahedral, including the 3-heavy + implicit-H case) |
| Writing a 3D conformer to MOL/SDF | impossible (`write_mol_with_coords` always writes `z=0.0`) | new `write_mol_with_conformer` / `write_mol_v3000_with_conformer` / `write_sdf_record_with_conformer` (never write a wedge/hash field — a real 3D geometry makes 2D wedge notation redundant-at-best) |
| Multiple conformers of one molecule across SDF records | no concept | new `read_sdf_conformer_ensembles` groups same-graph records into `ConformerEnsemble { mol, metadata, conformers: Vec<Coords3D> }` |
| Existing `parse_mol`/`parse_mol_with_coords`/`parse_mol_v3000`/`parse_mol_v3000_with_coords`, `write_mol`/`write_mol_with_coords`/`write_mol_v3000`, `SdfReader`/`SdfRecordReader`/`SdfFileReader` | — | **unchanged signatures, unchanged behavior** — verified by full pre-existing test suite still passing (see Verification) |

## Design notes: how each `CoordinateDimension` x `GeometryRank` case is distinguished (Coordinator review)

The Coordinator flagged that collapsing 3D detection to one boolean was the most dangerous simplification. Final design tracks 3 independent signals — `coordinate_dimension` (header claim), `geometry_rank` (observed shape), and `stereo3d_diagnostics` (declared-vs-geometry stereo agreement) — never merged:

1. Header says 2D, coords have nonzero Z -> `Stereo3DDiagnostic::DeclaredTwoDButNonzeroZ { observed: GeometryRank }` (payload is `Coplanar` or `ThreeD`). Test: `declared_2d_but_nonzero_z_is_diagnosed`.
2. Header says 3D, but all points coplanar (not exactly z=0) -> `DeclaredThreeDButFlat { observed: GeometryRank::Coplanar }`. Test: `geometry_rank_coplanar_for_a_real_but_flat_3d_embedding` (real RDKit-embedded benzene, max plane residual ~2.9e-6 A, independently confirmed in the venv -- genuinely flat molecule, not a bug, but still surfaced distinctly from case 3).
3. Header says 3D, every Z exactly 0 -> `DeclaredThreeDButFlat { observed: GeometryRank::FlatZero }`. Test: `declared_3d_but_every_z_exactly_zero_is_diagnosed_as_flatzero`.
4. Genuine 3D coords, no stereo descriptor at all -> zero `Stereo3DDiagnostic` entries, documented explicitly (on the type and in this PR) as "nothing to check," never "verified correct" -- same discipline as the existing `stereo_diagnostics`/`ez_diagnostics` fields. Test: `ez_fixtures_parse_with_real_conformer_and_no_tetrahedral_false_positive` exercises this (real 3D E/Z fixtures, no wedge anywhere, zero tetrahedral diagnostics).
5. Explicit wedge contradicts 3D geometry -> `WedgeVs3DParityConflict`. Tests: `wedge_disagrees_with_3d_geometry_conflict_fires` (tetrahedral-4), `implicit_h_stereocenter_wedge_disagrees_conflict_fires` (3-heavy + implicit-H), both V2000 and the V3000 CFG equivalent.
6. Wedge + nonzero-Z coexist and **agree** -> nothing emitted (3D geometry is the higher-fidelity signal but is never written back to `Atom.chirality`, which is untouched -- this is stated explicitly in `WedgeVs3DParityConflict`'s doc comment). Tests: `wedge_agrees_with_3d_geometry_for_real_rdkit_output_no_conflict`, `implicit_h_stereocenter_wedge_agrees_with_3d_geometry_l_alanine`, `v3000_wedge_agrees_with_3d_geometry_no_conflict`.

## Stereo-vs-3D verification: scope and the one deliberate omission (E/Z)

- **Tetrahedral (implemented, both 4-explicit-neighbor and 3-heavy+implicit-H)**: `wedge_vs_3d_conflicts` reuses the *exact* CIP-independent sign convention `chematic_perception::stereo2d_local::local_parity_from_wedges` already established (apex = first neighbor in `stereo_neighbor_order` for the 4-explicit case; pivot = the center atom itself, no synthetic H position needed, for the 3-heavy+implicit-H case) -- computed on real 3D coordinates instead of a synthetic wedge-derived z. This required **no CIP dependency and no `chematic-3d` dependency**: it reuses `Atom.chirality`/`Molecule::stereo_neighbor_order`, both already produced by the unmodified 2D pathway, as the "declared" side of the comparison.
- **E/Z-vs-3D verification is deliberately deferred, not implemented.** Rationale: MOL/SDF has no wedge-like declaration channel for E/Z independent of the coordinates themselves (unlike tetrahedral parity, which has a real, separate wedge/hash notation). For a genuinely-3D record, the file's "2D projection" (x,y only) of a real 3D structure is an arbitrary-plane artifact, not an independent declaration -- computing an "E/Z from (x,y)" and diffing it against "E/Z from (x,y,z)" would produce noisy, non-actionable diagnostics on legitimately-correct 3D structures (rotating a real 3D structure can make its xy-projection show either cis or trans with no actual conflict). The one place a real declared E/Z channel exists (`chematic_perception::stereo2d_ez_direction`'s `bond_direction` side-channel, which stores `Up`/`Down` on a chosen carrier bond via an axis-referenced sign convention, `direction_for_up`) is `pub(crate)`-private inside `chematic-perception`, not on my file-ownership list, and reimplementing its sign convention independently in `chematic-mol` risks silent drift between two copies of subtle, CIP-adjacent logic. Scoped out per the task's own permission to document rather than risk a wrong "verified" diagnostic. E/Z fixtures (both E and Z, real RDKit 3D embeddings) are still included in the test suite to confirm they at least parse cleanly and produce zero false-positive tetrahedral diagnostics.
- **V2000 legacy atom-parity field (`sss`, bytes 39..42) not read.** This is the MDL-legacy "atom stereo parity" field some writers populate from 3D geometry directly (as an alternative "declared" 3D-stereo channel to wedges). Not implemented -- RDKit's own writer doesn't reliably populate it in the general case either, and decoding its atom-block-order-dependent convention correctly would be a second, separate research effort. Documented as a known limitation, not silently skipped.
- **Implicit-H stereocenters are covered**, per the task's explicit ask -- not skipped, not approximated with a synthetic H position: the 3-heavy + implicit-H sign convention above needs only the center atom's own real 3D position plus its 3 real heavy-neighbor positions (all present in the conformer), so no virtual-H heuristic was needed at all.

## Typed errors added

All routed through the **existing** `MolParseError` enum (not touched, per file ownership -- `crates/chematic-mol/src/error.rs` is not on my file list):
- `InvalidAtomLine` for a present-but-unparseable z (V2000 and V3000).
- `InvalidAtomLine` for a present-but-non-finite z (NaN, or `Inf` from float-overflow syntax like `1e400` -- valid Rust float *syntax*, not a parse failure by Rust's own rules, but not a finite coordinate).
- A genuinely **missing/blank** z (line too short in V2000, or a blank-but-present 10-column field) still silently defaults to `0.0` -- unchanged, matches x/y's existing leniency. This distinction (missing vs. garbled) was called out explicitly by the pre-work reviewer and is regression-tested (`v2000_blank_z_field_still_defaults_to_zero_not_an_error`).
- Atom-count-mismatch-between-header-and-block: V3000 already had this (`"expected {N} atoms, found {M}"`, pre-existing, unmodified). V2000's format has no independent second signal to cross-check against (the counts line's `natoms` field is the *only* source of truth for how many lines to consume -- there's no `END ATOM` marker as in V3000), so there's nothing new to add there; the existing `UnexpectedEnd` on a too-short file already covers the truncation case.

## Behavior change (semver-relevant -- for Coordinator's CHANGELOG; `CHANGELOG.md` is Coordinator-only, not edited by this PR)

`read_mol_with_diagnostics`/`read_mol_v3000_with_diagnostics` -- and therefore everything downstream that calls them (`parse_mol`, `parse_mol_with_coords`, `parse_mol_v3000`, `parse_mol_v3000_with_coords`, `SdfReader`, `SdfRecordReader`, `SdfFileReader`) -- now return `Err(MolParseError::InvalidAtomLine)` on input that previously parsed successfully: a garbled or non-finite (NaN/Inf) **z**-coordinate field. Before this PR, z was never read at all, so any text in that column silently had no effect. x/y are unaffected and keep their pre-existing lenient-default-to-`0.0` behavior for backward compatibility -- only z gained the new strictness, since nothing downstream ever consumed it before, so there is no legitimate prior behavior to preserve there. Confirmed nothing in the existing pre-PR test corpus (238 tests, see Verification) trips this. Suggested CHANGELOG line:

> **Changed** (semver-minor, additive elsewhere): MOL/SDF readers now reject a garbled or non-finite (NaN/Infinite) Z-coordinate field with a typed `MolParseError::InvalidAtomLine` instead of silently ignoring it (Z was never read/validated before). X/Y coordinates keep their existing lenient defaulting.

## Verification

Independent Python venv (never touched the shared repo `.venv`, confirmed -- see below): scratchpad-local `venv_agentA`, `rdkit==2026.3.3` (pinned commit `8afba32ec539dcb2369bc84549d802aca3f7eb39`, same pin `scripts/stereo2d_diagnosis.py`/`docs/etkdg_3d_gap_rfc.md` use).

**Fixture set** (`crates/chematic-mol/tests/conformer_3d_io.rs`, 27 tests, denominators below):
- 2D-flag+2D-coords, 3D-flag+3D-coords (V2000 and V3000): ethanol, both flags -- real RDKit `AllChem.EmbedMolecule`/`Chem.MolToMolBlock`/`Chem.MolToV3KMolBlock` output.
- 3D-flag+flat(Z=0)-coords / 2D-flag+nonzero-Z: hand-edited (single substring replace of the header's dimensional-code field only, geometry byte-identical to the real RDKit fixture) -- 2/2 tests pass.
- Tetrahedral R/S: `[C@]`/`[C@@](Br)(F)(Cl)I`, real RDKit embeddings, both orientations -- 2/2 self-consistency tests pass, plus 2/2 deliberate-conflict tests (single-digit wedge-field flip, geometry untouched) pass, V2000 and V3000 both.
- Implicit-H R/S: L-alanine / D-alanine, real RDKit embeddings (RDKit's own wedge notation on the alpha-carbon-to-methyl bond, exactly the 3-heavy+implicit-H case) -- 3/3 self-consistency + cross-enantiomer tests pass, plus 1/1 deliberate-conflict test passes.
- E/Z: `Cl/C=C/Br` and `Cl/C=C\Br`, real RDKit embeddings -- parse cleanly, zero false-positive tetrahedral diagnostics (E/Z-vs-3D itself deferred, see above).
- Enhanced-stereo-group case: hand-constructed V3000 block (real 3D coordinates from the bromochlorofluoroiodomethane fixture + a `STEABS` `COLLECTION` block) -- confirms `stereo_groups()` and `conformer` coexist correctly.
- Multiple conformers: `AllChem.EmbedMultipleConfs` (3 conformers of butane) written as 3 separate real SDF records -> `read_sdf_conformer_ensembles` groups them into exactly 1 `ConformerEnsemble` with 3 conformers, denominator 1/1.
- Typed-error fixtures (NaN/Inf/garbled/blank z, V2000 and V3000): 7/7 pass, hand-authored with a byte-exact-column-constructing Python helper (not eyeballed) to avoid off-by-one column bugs.
- Round-trip (write 3D -> reparse): V2000 and V3000, both confirm `coordinate_dimension == ThreeD`, zero new `stereo3d_diagnostics`, coordinates preserved within writer precision (+/-1e-3 A, the `{:.4}` format's rounding).
- **27/27 pass.**

**Corrected test-count framing** (an earlier version of this PR body mislabeled the post-PR total as "pre-existing" -- fixed after independent verification):
- **Pre-existing** (`origin/main`, `chematic-mol` + `chematic-core` `--lib`): **238 tests** (99 core + 139 mol).
- Independently re-confirmed via a `comm`-diff of sorted `--list` test names between `origin/main` and this branch: **0 removed/renamed**, **6 added** (all in `chematic-core`'s new `coords3d::tests::*`).
- **New in this PR**: +6 `chematic-core` lib tests (`coords3d::tests`) + 27 `chematic-mol` integration tests (`conformer_3d_io`, a separate test binary, not part of `--lib`) = **33 new tests**.
- **Total on this branch**: 238 + 33 = **271** across `chematic-mol` + `chematic-core` (`--lib` + `conformer_3d_io`). The `244/244` figure in the command list below is `105 core lib (99+6) + 139 mol lib (unchanged)` -- a real, passing number, just not "pre-existing."

**Commands run** (from repo root):
```bash
cargo fmt --all -- --check                                    # pass
cargo clippy --workspace --all-targets -- -D warnings          # pass (full workspace, ~2 min)
cargo build --workspace --exclude chematic-py                  # pass (chematic-py needs maturin
                                                                 #  to link its PyO3 cdylib; this
                                                                 #  fails identically on unmodified
                                                                 #  origin/main -- confirmed, pre-existing,
                                                                 #  not caused by this PR)
python3 scripts/check_publish_graph.py                          # pass, 18 publishable crates, zero new edges
cargo test -p chematic-mol -p chematic-core --lib --quiet       # 244/244 pass -- see denominators below,
                                                                 #  this total is NOT "244 pre-existing"
cargo test -p chematic-mol --test conformer_3d_io               # 27/27 new integration tests pass
cargo test --workspace --lib --quiet                            # pass, every crate 0 failed
                                                                 #  (this ran slowly due to concurrent
                                                                 #  Wave-1 sibling-agent builds sharing
                                                                 #  the cargo registry/package cache in
                                                                 #  this multi-agent environment, but
                                                                 #  completed clean, exit code 0)
```

**RDKit fixture generation**: SMILES -> `AllChem.EmbedMolecule`/`EmbedMultipleConfs` -> `Chem.MolToMolBlock`/`Chem.MolToV3KMolBlock`, `randomSeed=0xF00D` (same seed convention as `docs/etkdg_3d_gap_rfc.md`), `AllChem.MMFFOptimizeMolecule` post-embed. The generator scripts live in the independent venv's scratch dir, not committed (the fixtures themselves are baked into the Rust test file as string constants).

## Known limitations / deferred (honest, not silent)

1. **E/Z-vs-3D-geometry verification is not implemented** (see rationale above) -- tetrahedral-only for now.
2. **V2000 legacy atom-parity field (`sss`) is not read** -- deferred, documented.
3. ~~No root re-export of the new public items~~ **Fixed**: `CoordinateDimension`, `GeometryRank`, `Stereo3DDiagnostic`, `write_mol_with_conformer`, `write_mol_v3000_with_conformer`, `write_sdf_record_with_conformer`, `ConformerEnsemble`, `read_sdf_conformer_ensembles` are now all re-exported at `chematic_mol::` root (`crates/chematic-mol/src/lib.rs`), matching the existing pattern for `MolReadReport`/`SdfRecord`. `lib.rs` is not on the strict per-agent list but isn't Coordinator-only, so added directly per independent verification's finding.
4. **`same_graph_identity` (the SDF conformer-ensemble grouping check) is deliberately simple**: order-sensitive structural equality (same atom/bond count, same per-index element/charge/isotope, same per-index bond endpoints/order) -- not full graph isomorphism or canonical-SMILES equality. This is correct for the concrete case this program's task described (the same molecule written N times by the same embedding tool, which never reorders atoms/bonds between calls) and is explicitly **not** meant to replace Agent B's more rigorous, parallel identity-layer work; Coordinator is expected to reconcile the two.
5. ~~Found, not fixed: a pre-existing, unrelated bug in the shared SDF-block-splitting helpers~~ **Filed as issue #171**: `read_sdf_with_diagnostics`/`SdfReader`/`SdfRecordReader`'s "skip leading blank lines" preprocessing strips a legitimately-blank *first* line of a record (a molecule with no name, which RDKit's own `Chem.MolToMolBlock` produces routinely), not just stray blank lines between records -- root-caused to `mol2000.rs:715`, `sdf.rs:40`, `sdf.rs:163`, with a confirmed partial historical workaround already in `chematic-py/src/formats.rs:248` (since v0.4.10) that this PR's own new reader inherits the same exposure to. Found incidentally while building the multi-conformer-ensemble fixture; worked around in the one test that would otherwise hit it (`sdf_conformer_ensemble_omits_records_with_no_conformer`, by giving the fixture molecules real names) rather than fixed here, per scope discipline (general SDF delimiter-handling, unrelated to 3D coordinates). See https://github.com/kent-tokyo/chematic/issues/171 for the full repro and proposed fix.
6. **Conformer selection on write is caller-driven, no selector API**: `write_mol_with_conformer`/`write_mol_v3000_with_conformer`/`write_sdf_record_with_conformer` each take a single `&Coords3D`; picking which conformer out of a `ConformerEnsemble.conformers: Vec<Coords3D>` to write is left to the caller (index it themselves) -- deliberately, per this task's own "keep it simple" instruction.
7. **Coordinate epsilons are fixed constants**, not configurable: `Z_EPS = 1e-4` A (flat-vs-nonzero), `COPLANAR_EPS = 1e-2` A (plane-residual, chosen well above float noise and well below a real ring pucker ~0.2-0.5 A), `COLLINEAR_EPS = 1e-6` A^2 (plane-defining-vector-pair search), `VOLUME_EPS = 1e-6` A^3 (degenerate tetrahedron cutoff for the wedge-vs-3D check). Not exposed as parameters.
8. **`classify_geometry_rank`'s plane-fit search fixes the origin at point 0** (O(n) instead of O(n^3)) -- misses only the vanishingly rare pathological case where point 0 happens to be collinear with every other point yet some other, unrelated triple isn't. Documented at the call site; not expected to matter for real molecular input.

## Confirmation: shared `.venv` never touched

All RDKit oracle work ran through an independent venv created fresh in the scratchpad directory (`python3 -m venv`, `pip install rdkit==2026.3.3`), never inside the repo. No `maturin develop`, `pip install -e`, or `pytest` was run against the shared repo `.venv` at any point in this task.

## Merge blockers / open questions for the Coordinator

All items raised by independent verification have been addressed on this branch (pushed):
1. Test-count claim corrected (238 pre-existing, 0 removed/renamed, 33 new, 271 total) -- was mislabeled.
2. `is_finite()` justification corrected (not currently called by this PR's own reader code); `Default`/`PartialEq` derives now mentioned.
3. Semver-relevant behavior-change note added (new `Err` on garbled/non-finite z) with a suggested CHANGELOG line for the Coordinator to add to `CHANGELOG.md` (not edited here, per file ownership).
4. `chematic-core/src/lib.rs` +2-line deviation -- ratified, no action needed.
5. Root re-exports added to `crates/chematic-mol/src/lib.rs` for the new public items.
6. Pre-existing SDF blank-name-line bug filed as https://github.com/kent-tokyo/chematic/issues/171 (not fixed here, per scope discipline).

No open questions remain from my side. Not self-merging, per program rules -- this is still a draft PR, timing of the actual merge is the Coordinator's call per the program's dependency order (Coords3D bridge PR).
