### PR TITLE
feat(inchi): accurate-CIP dedup preflight (#161) + exact graph identity API

### DIFF
--- a/crates/chematic-inchi/src/dedup.rs
+++ b/crates/chematic-inchi/src/dedup.rs
@@ -127,7 +127,7 @@
 
 #[cfg(feature = "native-inchi")]
 use chematic_core::AtomIdx;
-use chematic_core::Molecule;
+use chematic_core::{CipCode, Molecule};
 use chematic_smiles::canonical_smiles;
 use std::collections::HashMap;
 
@@ -648,6 +648,449 @@ pub fn deduplicate_verified(mols: &[Molecule], policy: IdentityPolicy) -> Verifi
     }
 }
 
+// ─── Typed identity diagnostics (shared) ───────────────────────────────────
+
+/// Typed reason a [`crate::dedup`] identity claim could not be made at full
+/// strength (or had to fall back to a weaker one). Shared by the
+/// accurate-CIP dedup preflight (issue #161, see
+/// [`compare_molecules_with_accurate_cip_preflight`]) and (in a later
+/// commit) the exact-graph-identity API -- never a free-form string, so
+/// callers can match on it instead of parsing text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdentityDiagnostic {
+    /// The accurate CIP engine (`CipMode::Accurate`) explicitly tied on a
+    /// centre the legacy engine also could not rank -- a genuine CIP-ranking
+    /// limit shared by both chematic engines (see issue #161's "case B":
+    /// tricyclic-cage bridgeheads, corpus idx 443/590, where RDKit's own
+    /// `rdCIPLabeler` agrees no label exists either).
+    AccurateCipTied,
+    /// The accurate CIP engine exceeded its recursion/size budget for a
+    /// centre the legacy engine also could not rank.
+    AccurateCipBudgetExceeded,
+    /// The accurate CIP engine itself returned an error (not a tie/budget
+    /// outcome). Never pooled with the tie/budget classes above -- an engine
+    /// failure is a different thing from an explicit "no answer" (see
+    /// `docs/`'s standing rule against pooling a fallible path's failures
+    /// into another class's rate).
+    AccurateCipEngineError,
+    /// Two or more legacy-CIP-unresolved centres in the SAME molecule land on
+    /// the same `chematic_smiles::morgan_ranks` value -- their identity
+    /// cannot be safely attributed to a specific centre when compared
+    /// against another molecule, so the accurate-CIP recovery is not applied
+    /// and the comparison fails closed instead of risking a mispaired
+    /// centre.
+    AmbiguousStereoRankCorrespondence,
+}
+
+// ─── Accurate-CIP dedup preflight (issue #161) ─────────────────────────────
+//
+// PR #156 shipped `has_unresolved_specified_tetrahedral_stereo`: a specified
+// tetrahedral stereocentre (`@`/`@@`) that the LEGACY CIP engine
+// (`chematic_chem::assign_cip`) cannot rank a substituent order for makes
+// `identity_verify` fail closed to `VerificationUnavailable`, because
+// `crate::native::convert::mol_to_inchi_atoms` depends on that exact same
+// ranking to build the InChI Stereo0D descriptor for that atom -- when it
+// fails, native InChI silently emits either an undefined `?` parity (if
+// other centres in the molecule succeeded) or omits the whole `/t` layer (if
+// none did), and two genuine diastereomers can then collapse onto the same
+// string (the corpus 4663/4664 pair PR #156 fixed).
+//
+// PR #156's own full 5,000-molecule-corpus audit
+// (`validation/results/dedup_stereo_guard_corpus_audit.jsonl`) found this
+// guard newly fires on 14 molecules beyond that pair, classified into case A
+// (legacy ties, `CipMode::Accurate` resolves with a label an independent
+// RDKit 2026.03.3 oracle agrees with exactly -- 10 molecules / 26 atoms) and
+// case B (genuinely unresolvable by *both* chematic engines and by RDKit's
+// own modern CIP labeler -- 2 molecules / 2 atoms, tricyclic-cage
+// bridgeheads).
+//
+// This PR independently RE-RAN that classification against current HEAD
+// (not trusted on faith -- see the fixtures in
+// `tests/accurate_cip_preflight.rs` and the PR body for the full
+// re-derivation) and a **fresh** 5,000-molecule corpus, and found it has
+// partially drifted for two unrelated reasons: (1) one of the original 12
+// molecules (audit idx=4412) no longer triggers the guard at all -- an
+// upstream `chematic-chem`/`chematic-cip` CIP-ranking change since the audit
+// ran, unrelated to this PR; (2) three of the original 10 "case A" molecules
+// share a THIRD failure mode the original audit did not anticipate: a
+// 3-fold-symmetric substituent (an adamantane-cage-like scaffold) whose
+// legacy-unresolved centres all land on the same `morgan_ranks` value, which
+// `accurate_stereo_supplement`'s cross-molecule correspondence deliberately
+// refuses to pair (see that function's own doc comment) -- these 3
+// molecules' individual centres ARE correctly resolved by the accurate
+// engine (RDKit-confirmed, 9/9 atoms), but stay `VerificationUnavailable`
+// under this preflight rather than risk a mispaired guess. Net effect on a
+// fresh corpus rerun: `verification_unavailable` shrinks from 15 to 6 (9
+// molecules recovered, 0 molecules newly made unavailable -- the "shrink,
+// never widen" invariant this PR must preserve, confirmed empirically over
+// the whole corpus, not just the audited 12). Full denominators, the
+// RDKit-cross-check table, and dataset provenance are in the PR body.
+//
+// Importantly, resolving a centre via the accurate engine does NOT change
+// what `crate::native::standard_inchi` itself emits for that atom -- that
+// generation path still depends on the legacy ranking (issue #161
+// deliberately scopes out "switch native InChI generation to the accurate
+// engine wholesale," since that would change `standard_inchi`'s output for
+// every caller, not just `dedup`, and the accurate engine's own
+// budget/tied-result semantics would need threading through the whole
+// Stereo0D pipeline -- a separate, larger proposal). So merely "unblocking"
+// the guard and generating `standard_inchi` as normal would silently
+// reintroduce the exact 4663/4664 bug: both molecules would still collapse
+// onto the same `?`-bearing string. Instead, the accurate engine's resolved
+// codes for exactly the previously-unresolved centres are folded into the
+// COMPARISON KEY as a supplement (never into the generated InChI string
+// itself, and never into the InChIKey C library call -- see
+// `verified_identity_key_with_supplement`), keyed by
+// `chematic_smiles::morgan_ranks` (a purely constitutional, stereo-blind
+// isomorphism invariant) so the supplement is meaningfully comparable
+// between two molecules that share a skeleton but differ in stereo, without
+// needing native InChI's own canonical atom numbering.
+//
+// This is deliberately a NEW, separate set of entry points
+// (`*_with_accurate_cip_preflight`), not a parameter threaded into
+// `identity_verify`/`compare`/`compare_molecules`/`deduplicate_verified`:
+// every existing call through those stays byte-for-byte unchanged (verified
+// by `preflight_is_opt_in_existing_paths_unchanged` below), matching the
+// "opt-in, two-tier" framing issue #161 itself proposed.
+
+/// Recover legacy-CIP-unresolved specified tetrahedral centres via
+/// `CipMode::Accurate` (issue #161). Returns the accurate CIP code for every
+/// atom `crate::native::unresolved_specified_tetrahedral_stereo_atoms`
+/// flagged, keyed by that atom's `chematic_smiles::morgan_ranks` value.
+///
+/// Fails closed (`Err`) -- never partially recovers -- if the accurate
+/// engine ties, exceeds its budget, or errors on ANY flagged atom, or if two
+/// flagged atoms in this SAME molecule share a morgan-rank value (their
+/// cross-molecule correspondence would be ambiguous -- see the module-level
+/// docs above).
+#[cfg(feature = "native-inchi")]
+fn accurate_stereo_supplement(mol: &Molecule) -> Result<Vec<(u64, CipCode)>, IdentityDiagnostic> {
+    let unresolved = crate::native::unresolved_specified_tetrahedral_stereo_atoms(mol);
+    if unresolved.is_empty() {
+        return Ok(Vec::new());
+    }
+    let accurate = chematic_chem::assign_cip_with_mode(mol, chematic_chem::CipMode::Accurate)
+        .map_err(|_| IdentityDiagnostic::AccurateCipEngineError)?;
+    let ranks = chematic_smiles::morgan_ranks(mol);
+
+    let mut supplement: Vec<(u64, CipCode)> = Vec::with_capacity(unresolved.len());
+    let mut seen_ranks: std::collections::HashSet<u64> = std::collections::HashSet::new();
+    for atom in unresolved {
+        if let Some((_, reason)) = accurate.unresolved.iter().find(|(i, _)| *i == atom) {
+            return Err(match reason {
+                chematic_chem::CipUnresolvedReason::Tied => IdentityDiagnostic::AccurateCipTied,
+                chematic_chem::CipUnresolvedReason::BudgetExceeded => {
+                    IdentityDiagnostic::AccurateCipBudgetExceeded
+                }
+            });
+        }
+        let Some(code) = accurate.get(atom) else {
+            // The accurate engine never touched this atom at all -- shouldn't
+            // happen for a specified tetrahedral centre, but fail closed
+            // defensively rather than silently skip it.
+            return Err(IdentityDiagnostic::AccurateCipEngineError);
+        };
+        let rank = ranks[atom.0 as usize];
+        if !seen_ranks.insert(rank) {
+            return Err(IdentityDiagnostic::AmbiguousStereoRankCorrespondence);
+        }
+        supplement.push((rank, code));
+    }
+    supplement.sort_by_key(|&(r, _)| r);
+    Ok(supplement)
+}
+
+/// Parallel to [`Verify`], for the accurate-CIP-preflight entry points only.
+/// `Ok` additionally carries the (possibly empty) stereo supplement
+/// recovered by [`accurate_stereo_supplement`].
+#[cfg_attr(not(feature = "native-inchi"), allow(dead_code))]
+enum PreflightVerify {
+    Ok(String, Vec<(u64, CipCode)>),
+    Invalid,
+    Unavailable,
+}
+
+/// Like [`identity_verify`], but retries a legacy-CIP-unresolved specified
+/// tetrahedral stereocentre via the accurate CIP engine before giving up
+/// (issue #161), instead of failing closed immediately.
+#[cfg(feature = "native-inchi")]
+fn identity_verify_with_accurate_preflight(
+    mol: &Molecule,
+    policy: IdentityPolicy,
+) -> PreflightVerify {
+    if crate::native::has_unrepresentable_multi_h_stereocenter(mol) {
+        return PreflightVerify::Unavailable;
+    }
+
+    let (result, supplement) = match policy {
+        IdentityPolicy::StandardInchiString | IdentityPolicy::StandardInchiKey => {
+            if crate::native::has_unresolved_specified_tetrahedral_stereo(mol) {
+                match accurate_stereo_supplement(mol) {
+                    Err(_) => return PreflightVerify::Unavailable,
+                    Ok(supplement) => (crate::native::standard_inchi(mol), supplement),
+                }
+            } else {
+                (crate::native::standard_inchi(mol), Vec::new())
+            }
+        }
+        IdentityPolicy::StereoIgnored => {
+            // Deliberately not guarded (same rationale as `identity_verify`):
+            // ignoring stereo entirely is this policy's contract.
+            (crate::native::standard_inchi_no_stereo(mol), Vec::new())
+        }
+        IdentityPolicy::IsotopeIgnored => {
+            let mut cleared = mol.clone();
+            for i in 0..cleared.atom_count() {
+                cleared.set_isotope(AtomIdx(i as u32), None);
+            }
+            if crate::native::has_unresolved_specified_tetrahedral_stereo(&cleared) {
+                match accurate_stereo_supplement(&cleared) {
+                    Err(_) => return PreflightVerify::Unavailable,
+                    Ok(supplement) => (crate::native::standard_inchi(&cleared), supplement),
+                }
+            } else {
+                (crate::native::standard_inchi(&cleared), Vec::new())
+            }
+        }
+    };
+    match result {
+        Ok(s) => PreflightVerify::Ok(s, supplement),
+        Err(crate::native::InchiError::InvalidInput(_)) => PreflightVerify::Invalid,
+        Err(_) => PreflightVerify::Unavailable,
+    }
+}
+
+#[cfg(not(feature = "native-inchi"))]
+fn identity_verify_with_accurate_preflight(
+    _mol: &Molecule,
+    _policy: IdentityPolicy,
+) -> PreflightVerify {
+    PreflightVerify::Unavailable
+}
+
+/// Reduce a raw native InChI string plus an accurate-CIP stereo supplement to
+/// the actual comparison key. Reuses [`verified_identity_key`] unchanged for
+/// the base key (so `IdentityPolicy::StandardInchiKey`'s InChIKey C-library
+/// call always receives a clean, real InChI string -- the supplement is
+/// appended only to the final *comparison* key, never fed back into any
+/// native call).
+#[cfg(feature = "native-inchi")]
+fn verified_identity_key_with_supplement(
+    inchi: &str,
+    supplement: &[(u64, CipCode)],
+    policy: IdentityPolicy,
+) -> Result<String, ()> {
+    let base = verified_identity_key(inchi, policy)?;
+    if supplement.is_empty() {
+        return Ok(base);
+    }
+    use std::fmt::Write;
+    let mut key = base;
+    // A marker that cannot appear inside a real InChI string or InChIKey
+    // (both use restricted character sets), so this can never collide with
+    // an unmodified base key from a molecule that didn't need the
+    // supplement.
+    key.push_str("|accurate_cip_stereo_supplement=");
+    for (rank, code) in supplement {
+        let _ = write!(key, "{rank}:{code:?};");
+    }
+    Ok(key)
+}
+
+#[cfg(not(feature = "native-inchi"))]
+fn verified_identity_key_with_supplement(
+    _inchi: &str,
+    _supplement: &[(u64, CipCode)],
+    _policy: IdentityPolicy,
+) -> Result<String, ()> {
+    Err(())
+}
+
+/// Compare two molecules under `policy`, retrying a legacy-CIP-unresolved
+/// specified tetrahedral stereocentre via the accurate CIP engine before
+/// giving up (issue #161). Given explicit candidate keys, like [`compare`].
+///
+/// This SHRINKS `VerificationUnavailable`'s trigger rate relative to
+/// [`compare`] (9 of the 15 molecules a fresh 5,000-molecule corpus rerun
+/// finds newly guarded by PR #156, beyond the original 4663/4664 pair,
+/// recover verified-comparison capability -- see the module docs above and
+/// the PR body for the full re-derivation) and never weakens the guard: a centre unresolved
+/// by *both* engines still fails closed exactly as before, and a resolved
+/// centre's accurate-CIP code is folded into the comparison key rather than
+/// silently trusted via a regenerated (still `?`-bearing) InChI string, so
+/// the original 4663/4664 false-`VerifiedDuplicate` stays fixed (see
+/// `accurate_preflight_never_reopens_the_4663_4664_false_duplicate` below).
+pub fn compare_with_accurate_cip_preflight(
+    key_a: &str,
+    mol_a: &Molecule,
+    key_b: &str,
+    mol_b: &Molecule,
+    policy: IdentityPolicy,
+) -> DedupRelation {
+    let (raw_a, supp_a, raw_b, supp_b) = match (
+        identity_verify_with_accurate_preflight(mol_a, policy),
+        identity_verify_with_accurate_preflight(mol_b, policy),
+    ) {
+        (PreflightVerify::Invalid, _) | (_, PreflightVerify::Invalid) => {
+            return DedupRelation::InvalidMolecule;
+        }
+        (PreflightVerify::Unavailable, _) | (_, PreflightVerify::Unavailable) => {
+            return DedupRelation::VerificationUnavailable;
+        }
+        (PreflightVerify::Ok(a, sa), PreflightVerify::Ok(b, sb)) => (a, sa, b, sb),
+    };
+
+    let (ident_a, ident_b) = match (
+        verified_identity_key_with_supplement(&raw_a, &supp_a, policy),
+        verified_identity_key_with_supplement(&raw_b, &supp_b, policy),
+    ) {
+        (Ok(a), Ok(b)) => (a, b),
+        _ => return DedupRelation::VerificationUnavailable,
+    };
+    let same_identity = ident_a == ident_b;
+    let same_key = key_a == key_b;
+
+    match (same_identity, same_key) {
+        (true, true) => DedupRelation::VerifiedDuplicate,
+        (true, false) => DedupRelation::CanonicalSplit,
+        (false, true) => DedupRelation::CanonicalCollision,
+        (false, false) => DedupRelation::Distinct,
+    }
+}
+
+/// [`compare_with_accurate_cip_preflight`], computing each molecule's own
+/// [`chematic_smiles::canonical_smiles`] as the fast candidate key -- the
+/// accurate-CIP-preflight counterpart to [`compare_molecules`].
+pub fn compare_molecules_with_accurate_cip_preflight(
+    mol_a: &Molecule,
+    mol_b: &Molecule,
+    policy: IdentityPolicy,
+) -> DedupRelation {
+    let key_a = canonical_smiles(mol_a);
+    let key_b = canonical_smiles(mol_b);
+    compare_with_accurate_cip_preflight(&key_a, mol_a, &key_b, mol_b, policy)
+}
+
+/// [`deduplicate_verified`], with the accurate-CIP preflight (issue #161)
+/// applied to every molecule instead of failing closed on the first
+/// legacy-CIP-unresolved specified tetrahedral centre. Same algorithm/
+/// complexity/output-ordering guarantees as [`deduplicate_verified`] -- see
+/// that function's docs.
+pub fn deduplicate_verified_with_accurate_cip_preflight(
+    mols: &[Molecule],
+    policy: IdentityPolicy,
+) -> VerifiedDedupReport {
+    let n = mols.len();
+    let mut canonical_key: Vec<String> = Vec::with_capacity(n);
+    let mut verified_key: Vec<Option<String>> = Vec::with_capacity(n);
+    let mut verification_unavailable: Vec<usize> = Vec::new();
+    let mut invalid_molecules: Vec<usize> = Vec::new();
+
+    for (i, m) in mols.iter().enumerate() {
+        canonical_key.push(canonical_smiles(m));
+        match identity_verify_with_accurate_preflight(m, policy) {
+            PreflightVerify::Invalid => {
+                invalid_molecules.push(i);
+                verified_key.push(None);
+            }
+            PreflightVerify::Unavailable => {
+                verification_unavailable.push(i);
+                verified_key.push(None);
+            }
+            PreflightVerify::Ok(raw, supplement) => {
+                match verified_identity_key_with_supplement(&raw, &supplement, policy) {
+                    Ok(k) => verified_key.push(Some(k)),
+                    Err(()) => {
+                        verification_unavailable.push(i);
+                        verified_key.push(None);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut by_verified: HashMap<&str, Vec<usize>> = HashMap::new();
+    for (i, k) in verified_key.iter().enumerate() {
+        if let Some(k) = k {
+            by_verified.entry(k.as_str()).or_default().push(i);
+        }
+    }
+
+    let mut groups: Vec<VerifiedGroup> = Vec::new();
+    let mut canonical_splits: Vec<CanonicalSplit> = Vec::new();
+    for members in by_verified.into_values() {
+        if members.len() < 2 {
+            continue;
+        }
+        let mut members = members;
+        members.sort_unstable();
+
+        let mut by_canon_within: HashMap<&str, Vec<usize>> = HashMap::new();
+        for &i in &members {
+            by_canon_within
+                .entry(canonical_key[i].as_str())
+                .or_default()
+                .push(i);
+        }
+        groups.push(VerifiedGroup {
+            members: members.clone(),
+        });
+        if by_canon_within.len() > 1 {
+            let mut canonical_subgroups: Vec<Vec<usize>> = by_canon_within.into_values().collect();
+            canonical_subgroups.sort_by_key(|g| g[0]);
+            canonical_splits.push(CanonicalSplit {
+                members,
+                canonical_subgroups,
+            });
+        }
+    }
+
+    let mut by_canonical: HashMap<&str, Vec<usize>> = HashMap::new();
+    for i in 0..n {
+        if verified_key[i].is_some() {
+            by_canonical
+                .entry(canonical_key[i].as_str())
+                .or_default()
+                .push(i);
+        }
+    }
+
+    let mut canonical_collisions: Vec<CanonicalCollision> = Vec::new();
+    for mut members in by_canonical.into_values() {
+        if members.len() < 2 {
+            continue;
+        }
+        members.sort_unstable();
+        let mut by_ident_within: HashMap<&str, Vec<usize>> = HashMap::new();
+        for &i in &members {
+            let k = verified_key[i].as_deref().expect("filtered to Some above");
+            by_ident_within.entry(k).or_default().push(i);
+        }
+        if by_ident_within.len() > 1 {
+            let mut verified_subgroups: Vec<Vec<usize>> = by_ident_within.into_values().collect();
+            verified_subgroups.sort_by_key(|g| g[0]);
+            canonical_collisions.push(CanonicalCollision {
+                canonical_key_members: members,
+                verified_subgroups,
+            });
+        }
+    }
+
+    groups.sort_by_key(|g| g.members[0]);
+    canonical_splits.sort_by_key(|s| s.members[0]);
+    canonical_collisions.sort_by_key(|c| c.canonical_key_members[0]);
+    verification_unavailable.sort_unstable();
+    invalid_molecules.sort_unstable();
+
+    VerifiedDedupReport {
+        groups,
+        canonical_splits,
+        canonical_collisions,
+        verification_unavailable,
+        invalid_molecules,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -687,5 +1130,123 @@ mod tests {
         let report = deduplicate_verified(&mols, IdentityPolicy::StandardInchiString);
         assert!(report.groups.is_empty());
         assert_eq!(report.verification_unavailable, vec![0, 1]);
+    }
+
+    // ── Accurate-CIP preflight (issue #161) ────────────────────────────────
+
+    /// The original 4663/4664 diastereomer pair PR #156 fixed must NEVER
+    /// become `VerifiedDuplicate` under the accurate-CIP preflight either --
+    /// per `validation/results/dedup_stereo_guard_corpus_audit.jsonl`, the
+    /// accurate engine resolves both previously-unresolved centres (atoms 13
+    /// and 32) for both molecules, but to genuinely DIFFERENT codes (4663:
+    /// S,R; 4664: R,S) -- so the stereo supplement must differ and the pair
+    /// must resolve to something other than `VerifiedDuplicate`. This is the
+    /// single most important regression guard in this file: a design that
+    /// merely relaxed the guard (without folding the accurate codes into the
+    /// comparison key) would silently reopen this exact false merge.
+    #[cfg(feature = "native-inchi")]
+    #[test]
+    fn accurate_preflight_never_reopens_the_4663_4664_false_duplicate() {
+        use chematic_smiles::parse;
+        let a = parse(
+            "O=C(Oc1c(O)cc(C(=O)O[C@@H]2C[C@](O)(C(=O)O)C[C@@H](OC(=O)c3cc(O)c(O)c(O)c3)[C@H]2OC(=O)c2cc(O)c(O)c(O)c2)cc1O)c1cc(O)c(O)c(O)c1",
+        )
+        .unwrap();
+        let b = parse(
+            "O=C(Oc1c(O)cc(C(=O)O[C@@H]2C[C@@](O)(C(=O)O)C[C@@H](OC(=O)c3cc(O)c(O)c(O)c3)[C@@H]2OC(=O)c2cc(O)c(O)c(O)c2)cc1O)c1cc(O)c(O)c(O)c1",
+        )
+        .unwrap();
+
+        // Reference: the plain (legacy-only) path already reports this as
+        // unavailable (PR #156's fix, unchanged).
+        assert_eq!(
+            compare_molecules(&a, &b, IdentityPolicy::StandardInchiString),
+            DedupRelation::VerificationUnavailable,
+            "sanity: PR #156's fix must still fail closed on the plain path"
+        );
+
+        let with_preflight = compare_molecules_with_accurate_cip_preflight(
+            &a,
+            &b,
+            IdentityPolicy::StandardInchiString,
+        );
+        assert_ne!(
+            with_preflight,
+            DedupRelation::VerifiedDuplicate,
+            "accurate-CIP preflight must never claim these two real diastereomers \
+             are the same molecule: {with_preflight:?}"
+        );
+    }
+
+    /// Case B from the corpus audit (tricyclic-cage bridgehead, corpus
+    /// idx=443/590): unresolved by *both* chematic CIP engines (and by
+    /// RDKit's own modern CIP labeler) -- must stay `VerificationUnavailable`
+    /// even with the preflight engaged, never silently promoted.
+    #[cfg(feature = "native-inchi")]
+    #[test]
+    fn accurate_preflight_still_fails_closed_on_genuine_ties() {
+        use chematic_smiles::parse;
+        let idx_443 = parse(
+            "CCCCCCCC/C=C/CCCCCCCC(=O)OCc1cc(=O)c(OC(=O)[C@]23C[C@H]4C[C@H](C[C@H](C4)C2)C3)co1",
+        )
+        .unwrap();
+        assert_eq!(
+            compare_molecules_with_accurate_cip_preflight(
+                &idx_443,
+                &idx_443,
+                IdentityPolicy::StandardInchiString
+            ),
+            DedupRelation::VerificationUnavailable,
+            "genuine tricyclic-cage tie (case B) must still fail closed under the preflight"
+        );
+    }
+
+    /// Case A from the corpus audit (corpus idx=1567): legacy fails on the
+    /// ring-fusion atom, accurate resolves it to a plain 'R' agreeing with
+    /// RDKit -- the preflight must recover verified-comparison capability
+    /// here (comparing the molecule against itself must no longer be
+    /// `VerificationUnavailable`).
+    #[cfg(feature = "native-inchi")]
+    #[test]
+    fn accurate_preflight_recovers_case_a_self_comparison() {
+        use chematic_smiles::parse;
+        let mol = parse("NS(=O)(=O)OC[C@@]12CCCC[C@@H]1CCC2").unwrap();
+        assert_eq!(
+            compare_molecules(&mol, &mol, IdentityPolicy::StandardInchiString),
+            DedupRelation::VerificationUnavailable,
+            "sanity: plain path is unavailable for this legacy-unresolved centre"
+        );
+        assert_eq!(
+            compare_molecules_with_accurate_cip_preflight(
+                &mol,
+                &mol,
+                IdentityPolicy::StandardInchiString
+            ),
+            DedupRelation::VerifiedDuplicate,
+            "accurate-CIP preflight should recover a molecule compared against itself"
+        );
+    }
+
+    /// Every EXISTING public entry point (`compare`, `compare_molecules`,
+    /// `deduplicate_verified`) must be completely unaffected by the new
+    /// preflight machinery existing in this file -- verified here by
+    /// checking a molecule with no stereo ambiguity at all behaves
+    /// identically either way, and (above) that the guarded molecules'
+    /// PLAIN-path behavior is unchanged from PR #156.
+    #[test]
+    fn preflight_is_opt_in_existing_paths_unchanged() {
+        use chematic_smiles::parse;
+        let a = parse("CCO").unwrap();
+        let b = parse("OCC").unwrap();
+        assert_eq!(
+            compare_molecules(&a, &b, IdentityPolicy::StandardInchiString),
+            compare_molecules_with_accurate_cip_preflight(
+                &a,
+                &b,
+                IdentityPolicy::StandardInchiString
+            ),
+            "an ordinary molecule with no legacy-CIP-unresolved centre must behave \
+             identically under both entry points"
+        );
     }
 }

--- a/crates/chematic-inchi/src/dedup.rs
+++ b/crates/chematic-inchi/src/dedup.rs
@@ -826,6 +826,10 @@ fn accurate_stereo_supplement(mol: &Molecule) -> Result<Vec<(u64, CipCode)>, Ide
         }
         supplement.push((rank, code));
     }
+    // ponytail: `sort_by_key` on rank alone is a total, deterministic order
+    // here specifically because every rank in `supplement` is already unique
+    // by construction -- any duplicate would have returned `Err` at the
+    // `seen_ranks.insert` check above before reaching this line.
     supplement.sort_by_key(|&(r, _)| r);
     Ok(supplement)
 }
@@ -1729,6 +1733,29 @@ mod tests {
             ),
             DedupRelation::VerificationUnavailable,
             "genuine tricyclic-cage tie (case B) must still fail closed under the preflight"
+        );
+    }
+
+    /// One of the 3 "case A blocked by tied rank" molecules (corpus
+    /// idx=1609): a 3-fold-symmetric adamantane-cage substituent where all 3
+    /// legacy-unresolved centres share one `morgan_ranks` value. This directly
+    /// exercises `accurate_stereo_supplement` (not just the outcome via
+    /// `compare_molecules_with_accurate_cip_preflight`) to confirm the
+    /// *mechanism* is really the rank-collision guard firing --
+    /// `AmbiguousStereoRankCorrespondence` -- and not some other failure path
+    /// (e.g. the accurate engine tying or erroring on these atoms, which
+    /// would make the module doc comment's causal claim wrong).
+    #[cfg(feature = "native-inchi")]
+    #[test]
+    fn accurate_stereo_supplement_blocks_via_rank_collision_not_some_other_path() {
+        use chematic_smiles::parse;
+        let mol =
+            parse("O=C(NCCCCN1CCN(c2cccc3ccccc23)CC1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3").unwrap();
+        assert_eq!(
+            accurate_stereo_supplement(&mol),
+            Err(IdentityDiagnostic::AmbiguousStereoRankCorrespondence),
+            "idx=1609 must be blocked specifically by the rank-collision guard, \
+             not by AccurateCipTied/AccurateCipBudgetExceeded/AccurateCipEngineError"
         );
     }
 

--- a/crates/chematic-inchi/src/dedup.rs
+++ b/crates/chematic-inchi/src/dedup.rs
@@ -125,9 +125,7 @@
 //! the underlying conversion behavior, and this module's own
 //! `two_h_like_substituents_*` fixtures for the guard itself.
 
-#[cfg(feature = "native-inchi")]
-use chematic_core::AtomIdx;
-use chematic_core::{CipCode, Molecule};
+use chematic_core::{AtomIdx, BondOrder, Chirality, CipCode, Molecule, apply_kekule, kekulize};
 use chematic_smiles::canonical_smiles;
 use std::collections::HashMap;
 
@@ -653,8 +651,8 @@ pub fn deduplicate_verified(mols: &[Molecule], policy: IdentityPolicy) -> Verifi
 /// Typed reason a [`crate::dedup`] identity claim could not be made at full
 /// strength (or had to fall back to a weaker one). Shared by the
 /// accurate-CIP dedup preflight (issue #161, see
-/// [`compare_molecules_with_accurate_cip_preflight`]) and (in a later
-/// commit) the exact-graph-identity API -- never a free-form string, so
+/// [`compare_molecules_with_accurate_cip_preflight`]) and the exact-graph-
+/// identity API ([`IdentityEvidence`]) -- never a free-form string, so
 /// callers can match on it instead of parsing text.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IdentityDiagnostic {
@@ -680,6 +678,38 @@ pub enum IdentityDiagnostic {
     /// and the comparison fails closed instead of risking a mispaired
     /// centre.
     AmbiguousStereoRankCorrespondence,
+    /// Native InChI is unavailable: the `native-inchi` feature is disabled,
+    /// or the C library failed for a reason unrelated to CIP ranking
+    /// (kekulization limit, library error).
+    NativeInchiUnavailable,
+    /// The molecule has no valid InChI at all (e.g. zero heavy atoms).
+    InvalidMolecule,
+    /// [`compare_graph_identity`]'s bounded structural comparator only
+    /// establishes atom correspondence by matching raw input index (see that
+    /// function's module docs) -- the two molecules' bond structure did not
+    /// line up completely under that direct index correspondence, so no
+    /// conclusive relation was reached. A real, literal graph-isomorphism
+    /// search (atom orders free to differ) is out of scope for this API's
+    /// current version -- see the module docs for the full reasoning.
+    AtomOrderCorrespondenceNotEstablished,
+    /// A specified tetrahedral stereocentre's raw SMILES/MOL neighbor order
+    /// (`Molecule::stereo_neighbor_order`) was missing, or not exactly 4
+    /// entries, on at least one side -- its parity could not be expressed in
+    /// the canonical (index-sorted) reference frame [`compare_graph_identity`]
+    /// compares in, so that specific centre's contribution to the relation is
+    /// unverified.
+    TetrahedralParityNotRepresented,
+    /// [`GraphStrictness::ChemicalGraphExact`] could not Kekulize one (or
+    /// both) of the input molecules' aromatic bonds (the same limitation
+    /// `crate::native::standard_inchi` already surfaces as
+    /// `InchiError::KekulizationFailed` for some fused/bridgehead-heteroatom
+    /// ring systems) -- comparing an un-Kekulizable aromatic structure
+    /// literally against the other input would risk a false `Distinct` (the
+    /// aromatic-order bonds simply would not match a Kekulized structure's
+    /// Single/Double spelling, for a reason that has nothing to do with
+    /// whether the molecules are actually the same), so the comparison
+    /// fails closed to "inconclusive" instead.
+    ChemicalGraphKekulizationFailed,
 }
 
 // ─── Accurate-CIP dedup preflight (issue #161) ─────────────────────────────
@@ -1091,6 +1121,507 @@ pub fn deduplicate_verified_with_accurate_cip_preflight(
     }
 }
 
+// ─── Exact graph identity (GraphIdentityMode / IdentityEvidence) ──────────
+//
+// A separate, standalone identity API -- not a fifth `IdentityPolicy`
+// variant (that enum, and `identity_verify`/`verified_identity_key`, are
+// matched exhaustively by callers with no wildcard arm; adding a variant
+// would be a breaking change -- see `ALL_POLICIES` in
+// `tests/dedup_fixtures.rs`). This is the "true exact graph identity"
+// follow-up the module docs above flagged as out of scope for the original
+// four InChI-normalization-based policies: no tautomer/mobile-H
+// normalization at all, literal element/isotope/charge/aromaticity/bond-
+// order/tetrahedral-parity/E-Z/fragment-composition equality.
+//
+// **Canonical SMILES is never used as the proof here** (same standing rule
+// as the rest of this module): [`compare_graph_identity`] establishes atom
+// correspondence via direct input-index matching plus a bond-set check, and
+// verifies every attribute in-place -- never via a canonical string.
+//
+// # Scope boundary: atom ordering
+//
+// This first version's structural comparator only recognizes two molecules
+// as the same graph when they share **the same atom indexing** (`Molecule`
+// index `i` in one input corresponds to index `i` in the other) -- it is not
+// a general-purpose graph-isomorphism search over arbitrary atom
+// permutations. This is not a corner deliberately cut for convenience: a
+// real isomorphism search needs an isomorphism-library dependency (this
+// crate has none -- `chematic-smarts`'s VF2 implementation is not on
+// `chematic-inchi`'s dependency graph, and adding it is outside this PR's
+// file-ownership scope, see `Cargo.toml`), or a from-scratch bounded
+// backtracking matcher with its own correctness-testing burden. The
+// motivating real-world consumer named in this program (conformer/ensemble
+// grouping over records that share one connection table) already satisfies
+// same-indexing by construction, so this scope boundary does not block that
+// use case. When atom ordering doesn't line up, [`IdentityEvidence::graph_relation`]
+// is `None` (never a guess) with [`IdentityDiagnostic::AtomOrderCorrespondenceNotEstablished`],
+// and the native-InChI corroboration fields are still populated when
+// possible so the caller has *some* signal. A full isomorphism search is a
+// natural follow-up, not attempted here.
+//
+// # Scope boundary: enhanced stereo
+//
+// The task brief for this API asked for "enhanced stereo (if representable)"
+// to be part of what's compared. `chematic-core`/`chematic-perception` have
+// no enhanced-stereochemistry representation today (no `StereoGroup`
+// AND/OR/ABS-style relative/absolute grouping over multiple centres beyond
+// plain per-atom `Chirality` -- confirmed by grep across both crates before
+// writing this module). Building a new enhanced-stereo model as a side
+// effect of this task would be exactly the kind of unrequested, speculative
+// abstraction this codebase's own conventions warn against; this is
+// documented here as a real scope boundary, not silently ignored.
+//
+// # Scope boundary: `GraphStrictness::ChemicalGraphExact` and resonance forms
+//
+// See that variant's own doc comment: Kekulization normalizes "aromatic-
+// flagged" vs. "one particular already-Kekulized" spelling of the same ring,
+// but does not recognize two independently-written, already-Kekulized
+// alternative resonance structures of the same aromatic system as
+// equivalent (that needs Hückel aromaticity perception, which is not on this
+// crate's dependency graph either).
+
+/// How strictly [`compare_graph_identity`] treats bond-order/aromaticity
+/// spelling. Orthogonal to [`AtomMapPolicy`] -- see [`GraphIdentityMode`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphStrictness {
+    /// Literal bond-order and `aromatic`-flag equality. Two molecules that
+    /// differ only in Kekulé vs. aromatic-order spelling for the same ring
+    /// system (e.g. one writer emits `Aromatic`-order bonds, another emits
+    /// the same ring pre-Kekulized as alternating Single/Double) are **not**
+    /// identical here -- the strictest, most literal "same graph as written."
+    RawGraphExact,
+    /// Chemically-meaningful equality: any input molecule with `Aromatic`-
+    /// order bonds is Kekulized first, via the same deterministic algorithm
+    /// (`chematic_core::kekulize`/`apply_kekule`) this crate's native InChI
+    /// conversion already relies on -- **not** canonical-SMILES string
+    /// equality (see this module's standing rule). The `aromatic` flag
+    /// itself is then excluded from atom comparison: Kekulization does not
+    /// clear it (see `apply_kekule`'s own doc comment), so comparing it
+    /// post-Kekulization would silently reintroduce the exact spelling-
+    /// sensitivity this mode exists to remove.
+    ///
+    /// Known limitation (see the module docs above): two independently-
+    /// written, already-Kekulized structures representing *different* valid
+    /// resonance forms of the same aromatic system (e.g. two of
+    /// naphthalene's several valid Kekulé structures) are not recognized as
+    /// equivalent here -- that needs Hückel aromaticity perception, not on
+    /// this crate's dependency graph. Never a false
+    /// [`GraphRelation::Identical`] either way: worst case this degrades to
+    /// an honest mismatch or, if Kekulization itself fails, an inconclusive
+    /// result (see [`IdentityDiagnostic::ChemicalGraphKekulizationFailed`]).
+    ChemicalGraphExact,
+}
+
+/// Whether [`compare_graph_identity`] treats reaction atom-mapping numbers
+/// (`Atom::atom_map`, the `:1` in `[CH4:1]`) as part of the molecule's
+/// identity. Orthogonal to [`GraphStrictness`] -- any combination of the two
+/// axes is valid, see [`GraphIdentityMode`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AtomMapPolicy {
+    /// Atom-mapping numbers must correspond exactly (`None` only matches
+    /// `None`; `Some(n)` only matches the literal same `n`) at every atom
+    /// under the discovered correspondence.
+    Include,
+    /// Atom-mapping numbers are not compared at all -- appropriate for
+    /// almost every caller outside reaction-atom-mapping bookkeeping (e.g.
+    /// conformer/ensemble grouping, MOL/SDF round-trip checks, ordinary
+    /// dedup: none of these contexts carry or care about reaction atom
+    /// maps).
+    Ignore,
+}
+
+/// Mode for [`compare_graph_identity`]: two independent, orthogonal axes
+/// (see [`GraphStrictness`] / [`AtomMapPolicy`]) rather than one flat,
+/// 3-or-4-variant enum -- a caller can freely combine either strictness with
+/// either atom-map policy (e.g. `ChemicalGraphExact` + ignore atom maps, or
+/// `RawGraphExact` + include atom maps) instead of being limited to whatever
+/// preset combinations a flat enum happened to name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GraphIdentityMode {
+    pub graph_strictness: GraphStrictness,
+    pub atom_maps: AtomMapPolicy,
+}
+
+/// A conclusive exact-graph-identity relation between two molecules (see
+/// [`compare_graph_identity`]). Two values only -- both mean "the search
+/// examined every dimension `graph_strictness`/`atom_maps` requires and
+/// reached a decisive answer." When the search cannot reach one (atom
+/// ordering doesn't line up, a stereocentre's parity can't be represented,
+/// Kekulization failed, ...), [`IdentityEvidence::graph_relation`] is `None`
+/// instead -- never a third "maybe" value smuggled into this enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphRelation {
+    Identical,
+    Distinct,
+}
+
+/// Evidence produced by [`compare_graph_identity`] for one pair of
+/// molecules.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdentityEvidence {
+    /// The conclusive structural relation, if the bounded comparator reached
+    /// one. `None` means "inconclusive" -- never "distinct" or "identical"
+    /// by omission. Always check `diagnostics` for why.
+    pub graph_relation: Option<GraphRelation>,
+    /// The shared native standard InChI string for both molecules, IF native
+    /// InChI generation succeeded independently for both AND their full
+    /// (stereo-inclusive) strings agree. Supplementary corroboration only:
+    /// per this module's standing rule, `graph_relation` is never derived
+    /// from this field alone -- native InChI performs its own IUPAC-defined
+    /// tautomer/mobile-H normalization, a different (weaker) question than
+    /// literal graph identity (see the module-level docs' `IdentityPolicy`
+    /// discussion of the same distinction).
+    pub standard_inchi: Option<String>,
+    /// The shared standard InChIKey, under the same "both succeeded and
+    /// agreed" condition as `standard_inchi`.
+    pub inchikey: Option<String>,
+    /// Typed reasons for anything short of a fully conclusive, fully
+    /// corroborated result.
+    pub diagnostics: Vec<IdentityDiagnostic>,
+}
+
+/// Structural bond-order class used by [`compare_graph_identity`]'s
+/// comparisons: `Up`/`Down`/`Dative` normalize to the same class as `Single`
+/// (mirroring `crate::native::convert::mol_to_inchi_atoms`'s own
+/// `bond_type` mapping) since their directional/donor-acceptor meaning is
+/// verified separately (E/Z via [`directed_bond_marker`], not via this raw
+/// class); everything else keeps its own distinct class.
+fn structural_bond_order(order: BondOrder) -> u8 {
+    match order {
+        BondOrder::Single | BondOrder::Up | BondOrder::Down | BondOrder::Dative => 1,
+        BondOrder::Double => 2,
+        BondOrder::Triple => 3,
+        BondOrder::Quadruple => 4,
+        BondOrder::Aromatic => 5,
+        BondOrder::Zero => 6,
+        BondOrder::QueryAny => 7,
+        BondOrder::QuerySingleOrDouble => 8,
+        BondOrder::QuerySingleOrAromatic => 9,
+        BondOrder::QueryDoubleOrAromatic => 10,
+    }
+}
+
+/// Cheap, atom-order-independent composition signature: fragment sizes,
+/// atom multiset (element/isotope/charge/aromatic-per-`strictness`), bond
+/// multiset (structural order + endpoint elements). A mismatch here is
+/// conclusive (`GraphRelation::Distinct`) regardless of atom ordering --
+/// this is a real graph invariant, not canonical-SMILES string equality.
+#[derive(PartialEq, Eq)]
+struct CompositionSignature {
+    fragment_sizes: Vec<usize>,
+    atom_multiset: Vec<(u8, Option<u16>, i8, bool)>,
+    bond_multiset: Vec<(u8, u8, u8)>,
+}
+
+fn composition_signature(mol: &Molecule, strictness: GraphStrictness) -> CompositionSignature {
+    let mut fragment_sizes: Vec<usize> = mol.fragments().iter().map(|f| f.atom_count()).collect();
+    fragment_sizes.sort_unstable();
+
+    let mut atom_multiset: Vec<(u8, Option<u16>, i8, bool)> = mol
+        .atoms()
+        .map(|(_, a)| {
+            let aromatic = match strictness {
+                GraphStrictness::RawGraphExact => a.aromatic,
+                GraphStrictness::ChemicalGraphExact => false,
+            };
+            (a.element.atomic_number(), a.isotope, a.charge, aromatic)
+        })
+        .collect();
+    atom_multiset.sort_unstable();
+
+    let mut bond_multiset: Vec<(u8, u8, u8)> = mol
+        .bonds()
+        .map(|(_, b)| {
+            let e1 = mol.atom(b.atom1).element.atomic_number();
+            let e2 = mol.atom(b.atom2).element.atomic_number();
+            (structural_bond_order(b.order), e1.min(e2), e1.max(e2))
+        })
+        .collect();
+    bond_multiset.sort_unstable();
+
+    CompositionSignature {
+        fragment_sizes,
+        atom_multiset,
+        bond_multiset,
+    }
+}
+
+/// Attempt to Kekulize `mol` for [`GraphStrictness::ChemicalGraphExact`].
+/// `Ok(None)` = no aromatic bonds present (nothing to do, compare `mol`
+/// as-is); `Ok(Some(k))` = Kekulized working copy; `Err(())` = Kekulization
+/// failed (caller must not fall back to comparing the un-Kekulized aromatic
+/// form literally against the other input -- see
+/// [`IdentityDiagnostic::ChemicalGraphKekulizationFailed`]'s doc comment for
+/// why that would risk a false `Distinct`).
+fn kekulize_for_comparison(mol: &Molecule) -> Result<Option<Molecule>, ()> {
+    if !mol.bonds().any(|(_, b)| b.order == BondOrder::Aromatic) {
+        return Ok(None);
+    }
+    match kekulize(mol) {
+        Ok(k) => Ok(Some(apply_kekule(mol, &k))),
+        Err(_) => Err(()),
+    }
+}
+
+/// Permutation parity (`true` = even) needed to sort `list` into ascending
+/// order, via inversion counting. `list` always has exactly 4, pairwise-
+/// distinct entries here (`STEREO_H_SENTINEL` counts as its own, always-
+/// largest value) -- see [`canonical_tetrahedral_parity`].
+fn is_even_permutation(list: &[u32]) -> bool {
+    let mut inversions = 0usize;
+    for i in 0..list.len() {
+        for j in (i + 1)..list.len() {
+            if list[i] > list[j] {
+                inversions += 1;
+            }
+        }
+    }
+    inversions.is_multiple_of(2)
+}
+
+/// Canonical signed tetrahedral parity for atom `idx`, expressed in a common
+/// reference frame (ascending raw `AtomIdx` order) so it is directly
+/// comparable across two molecules that share the same atom indexing --
+/// pure combinatorial permutation parity, no CIP engine involved (unlike
+/// [`accurate_stereo_supplement`] above, which exists for a different
+/// purpose: recovering a *specific* dedup guard's trigger rate, not general
+/// graph-identity comparison). `None` if the atom isn't a well-formed
+/// tetrahedral centre in chematic's own representation here (no chirality
+/// specified, no recorded neighbor order, or not exactly 4 neighbors).
+fn canonical_tetrahedral_parity(mol: &Molecule, idx: AtomIdx) -> Option<bool> {
+    let atom = mol.atom(idx);
+    let chirality_is_even = match atom.chirality {
+        Chirality::Clockwise => true,
+        Chirality::CounterClockwise => false,
+        Chirality::None => return None,
+    };
+    let order = mol.stereo_neighbor_order(idx)?;
+    if order.len() != 4 {
+        return None;
+    }
+    let sorted_is_even = is_even_permutation(order);
+    Some(chirality_is_even == sorted_is_even)
+}
+
+/// Directed wedge/hash marker for the bond from `from` to `to`: `Some(true)`
+/// = "up" traversed in that direction, `Some(false)` = "down", `None` = no
+/// `Up`/`Down` direction stored for this bond. Mirrors
+/// `crate::native::convert::mol_to_inchi_atoms`'s own `is_up` convention
+/// exactly (same `atom1`-relative sign rule) rather than inventing a new
+/// one.
+fn directed_bond_marker(mol: &Molecule, from: AtomIdx, to: AtomIdx) -> Option<bool> {
+    let (bidx, bond) = mol.bond_between(from, to)?;
+    let effective = mol.bond_direction(bidx).unwrap_or(bond.order);
+    match effective {
+        BondOrder::Up => Some(bond.atom1 == from),
+        BondOrder::Down => Some(bond.atom1 == to),
+        _ => None,
+    }
+}
+
+/// Outcome of [`same_structure_under_identity`].
+enum StructuralComparison {
+    Identical,
+    Distinct,
+    Inconclusive(IdentityDiagnostic),
+}
+
+/// The identity-atom-index-correspondence structural comparator (see this
+/// module's "scope boundary: atom ordering" docs above). `a`/`b` are assumed
+/// to already be [`GraphStrictness`]-normalized (Kekulized if
+/// `ChemicalGraphExact`) by the caller.
+fn same_structure_under_identity(
+    a: &Molecule,
+    b: &Molecule,
+    mode: GraphIdentityMode,
+) -> StructuralComparison {
+    if a.atom_count() != b.atom_count() {
+        return StructuralComparison::Distinct;
+    }
+    let n = a.atom_count();
+
+    let bond_key = |bd: &chematic_core::BondEntry| -> (u32, u32, u8) {
+        let (x, y) = (bd.atom1.0, bd.atom2.0);
+        (x.min(y), x.max(y), structural_bond_order(bd.order))
+    };
+    let bonds_a: std::collections::HashSet<(u32, u32, u8)> =
+        a.bonds().map(|(_, bd)| bond_key(bd)).collect();
+    let bonds_b: std::collections::HashSet<(u32, u32, u8)> =
+        b.bonds().map(|(_, bd)| bond_key(bd)).collect();
+    if bonds_a != bonds_b {
+        return StructuralComparison::Inconclusive(
+            IdentityDiagnostic::AtomOrderCorrespondenceNotEstablished,
+        );
+    }
+
+    for i in 0..n {
+        let idx = AtomIdx(i as u32);
+        let (aa, ab) = (a.atom(idx), b.atom(idx));
+        let (aromatic_a, aromatic_b) = match mode.graph_strictness {
+            GraphStrictness::RawGraphExact => (aa.aromatic, ab.aromatic),
+            GraphStrictness::ChemicalGraphExact => (false, false),
+        };
+        if aa.element != ab.element
+            || aa.isotope != ab.isotope
+            || aa.charge != ab.charge
+            || aromatic_a != aromatic_b
+        {
+            return StructuralComparison::Distinct;
+        }
+        if mode.atom_maps == AtomMapPolicy::Include && aa.atom_map != ab.atom_map {
+            return StructuralComparison::Distinct;
+        }
+    }
+
+    let mut inconclusive = false;
+    for i in 0..n {
+        let idx = AtomIdx(i as u32);
+        match (
+            canonical_tetrahedral_parity(a, idx),
+            canonical_tetrahedral_parity(b, idx),
+        ) {
+            (None, None) => {}
+            (Some(pa), Some(pb)) => {
+                if pa != pb {
+                    return StructuralComparison::Distinct;
+                }
+            }
+            _ => inconclusive = true,
+        }
+    }
+
+    for (_, bd) in a.bonds() {
+        if bd.order != BondOrder::Double {
+            continue;
+        }
+        for from in [bd.atom1, bd.atom2] {
+            let to_end = if from == bd.atom1 { bd.atom2 } else { bd.atom1 };
+            for (nb, _) in a.neighbors(from) {
+                if nb == to_end {
+                    continue;
+                }
+                let da = directed_bond_marker(a, from, nb);
+                let db = directed_bond_marker(b, from, nb);
+                if da != db {
+                    return StructuralComparison::Distinct;
+                }
+            }
+        }
+    }
+
+    if inconclusive {
+        StructuralComparison::Inconclusive(IdentityDiagnostic::TetrahedralParityNotRepresented)
+    } else {
+        StructuralComparison::Identical
+    }
+}
+
+/// Independent native-InChI corroboration for [`IdentityEvidence`] (see that
+/// struct's docs): each molecule's own full-stereo standard InChI
+/// ([`identity_verify`] under [`IdentityPolicy::StandardInchiString`],
+/// unchanged/legacy-only -- this corroboration signal deliberately does not
+/// pull in the accurate-CIP preflight, keeping the two features decoupled),
+/// populated only when both succeed AND agree.
+fn shared_native_inchi_evidence(
+    mol_a: &Molecule,
+    mol_b: &Molecule,
+    diagnostics: &mut Vec<IdentityDiagnostic>,
+) -> (Option<String>, Option<String>) {
+    let (ra, rb) = match (
+        identity_verify(mol_a, IdentityPolicy::StandardInchiString),
+        identity_verify(mol_b, IdentityPolicy::StandardInchiString),
+    ) {
+        (Verify::Ok(ra), Verify::Ok(rb)) => (ra, rb),
+        (Verify::Invalid, _) | (_, Verify::Invalid) => {
+            diagnostics.push(IdentityDiagnostic::InvalidMolecule);
+            return (None, None);
+        }
+        _ => {
+            diagnostics.push(IdentityDiagnostic::NativeInchiUnavailable);
+            return (None, None);
+        }
+    };
+    if ra != rb {
+        return (None, None);
+    }
+    let key = inchi_key(&ra).ok();
+    (Some(ra), key)
+}
+
+/// Compare two molecules for exact graph identity under `mode` (see the
+/// module docs above for the full rationale, scope boundaries, and why
+/// canonical SMILES is never the proof).
+pub fn compare_graph_identity(
+    mol_a: &Molecule,
+    mol_b: &Molecule,
+    mode: GraphIdentityMode,
+) -> IdentityEvidence {
+    let mut diagnostics: Vec<IdentityDiagnostic> = Vec::new();
+
+    let (working_a, working_b) = match mode.graph_strictness {
+        GraphStrictness::RawGraphExact => (None, None),
+        GraphStrictness::ChemicalGraphExact => {
+            match (
+                kekulize_for_comparison(mol_a),
+                kekulize_for_comparison(mol_b),
+            ) {
+                (Ok(a), Ok(b)) => (a, b),
+                _ => {
+                    diagnostics.push(IdentityDiagnostic::ChemicalGraphKekulizationFailed);
+                    let (inchi, key) = shared_native_inchi_evidence(mol_a, mol_b, &mut diagnostics);
+                    return IdentityEvidence {
+                        graph_relation: None,
+                        standard_inchi: inchi,
+                        inchikey: key,
+                        diagnostics,
+                    };
+                }
+            }
+        }
+    };
+    let ref_a = working_a.as_ref().unwrap_or(mol_a);
+    let ref_b = working_b.as_ref().unwrap_or(mol_b);
+
+    if composition_signature(ref_a, mode.graph_strictness)
+        != composition_signature(ref_b, mode.graph_strictness)
+    {
+        return IdentityEvidence {
+            graph_relation: Some(GraphRelation::Distinct),
+            standard_inchi: None,
+            inchikey: None,
+            diagnostics,
+        };
+    }
+
+    match same_structure_under_identity(ref_a, ref_b, mode) {
+        StructuralComparison::Distinct => IdentityEvidence {
+            graph_relation: Some(GraphRelation::Distinct),
+            standard_inchi: None,
+            inchikey: None,
+            diagnostics,
+        },
+        StructuralComparison::Inconclusive(reason) => {
+            diagnostics.push(reason);
+            let (inchi, key) = shared_native_inchi_evidence(mol_a, mol_b, &mut diagnostics);
+            IdentityEvidence {
+                graph_relation: None,
+                standard_inchi: inchi,
+                inchikey: key,
+                diagnostics,
+            }
+        }
+        StructuralComparison::Identical => {
+            let (inchi, key) = shared_native_inchi_evidence(mol_a, mol_b, &mut diagnostics);
+            IdentityEvidence {
+                graph_relation: Some(GraphRelation::Identical),
+                standard_inchi: inchi,
+                inchikey: key,
+                diagnostics,
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1248,5 +1779,179 @@ mod tests {
             "an ordinary molecule with no legacy-CIP-unresolved centre must behave \
              identically under both entry points"
         );
+    }
+
+    // ── Exact graph identity ────────────────────────────────────────────────
+
+    #[test]
+    fn graph_identity_same_molecule_is_identical() {
+        use chematic_smiles::parse;
+        let a = parse("CC(=O)Oc1ccccc1C(=O)O").unwrap();
+        let b = parse("CC(=O)Oc1ccccc1C(=O)O").unwrap();
+        let mode = GraphIdentityMode {
+            graph_strictness: GraphStrictness::RawGraphExact,
+            atom_maps: AtomMapPolicy::Ignore,
+        };
+        let evidence = compare_graph_identity(&a, &b, mode);
+        assert_eq!(evidence.graph_relation, Some(GraphRelation::Identical));
+    }
+
+    #[test]
+    fn graph_identity_different_formula_is_distinct() {
+        use chematic_smiles::parse;
+        let a = parse("CCO").unwrap();
+        let b = parse("CCN").unwrap();
+        let mode = GraphIdentityMode {
+            graph_strictness: GraphStrictness::RawGraphExact,
+            atom_maps: AtomMapPolicy::Ignore,
+        };
+        let evidence = compare_graph_identity(&a, &b, mode);
+        assert_eq!(evidence.graph_relation, Some(GraphRelation::Distinct));
+    }
+
+    /// Enantiomers: same atom order, same connectivity, opposite tetrahedral
+    /// parity -- must be `Distinct` under exact graph identity (unlike
+    /// `IdentityPolicy::StereoIgnored`, which deliberately collapses them).
+    #[test]
+    fn graph_identity_enantiomers_are_distinct() {
+        use chematic_smiles::parse;
+        let l = parse("N[C@@H](C)C(=O)O").unwrap();
+        let d = parse("N[C@H](C)C(=O)O").unwrap();
+        let mode = GraphIdentityMode {
+            graph_strictness: GraphStrictness::RawGraphExact,
+            atom_maps: AtomMapPolicy::Ignore,
+        };
+        let evidence = compare_graph_identity(&l, &d, mode);
+        assert_eq!(evidence.graph_relation, Some(GraphRelation::Distinct));
+    }
+
+    /// E/Z isomers: same atom order/connectivity, opposite double-bond
+    /// direction markers -- must be `Distinct`.
+    #[test]
+    fn graph_identity_ez_isomers_are_distinct() {
+        use chematic_smiles::parse;
+        let e = parse("C/C=C/C").unwrap();
+        let z = parse("C/C=C\\C").unwrap();
+        let mode = GraphIdentityMode {
+            graph_strictness: GraphStrictness::RawGraphExact,
+            atom_maps: AtomMapPolicy::Ignore,
+        };
+        let evidence = compare_graph_identity(&e, &z, mode);
+        assert_eq!(evidence.graph_relation, Some(GraphRelation::Distinct));
+    }
+
+    /// `RawGraphExact` treats aromatic-order-spelled benzene and an explicit
+    /// Kekulé respelling as literally different bond orders.
+    #[test]
+    fn graph_identity_raw_graph_exact_distinguishes_aromatic_spelling() {
+        use chematic_smiles::parse;
+        let aromatic = parse("c1ccccc1").unwrap();
+        let kekule = parse("C1=CC=CC=C1").unwrap();
+        let mode = GraphIdentityMode {
+            graph_strictness: GraphStrictness::RawGraphExact,
+            atom_maps: AtomMapPolicy::Ignore,
+        };
+        let evidence = compare_graph_identity(&aromatic, &kekule, mode);
+        assert_ne!(
+            evidence.graph_relation,
+            Some(GraphRelation::Identical),
+            "RawGraphExact must not equate aromatic-order and Kekule-order spelling"
+        );
+    }
+
+    /// `AtomMapPolicy::Include` must distinguish molecules that otherwise
+    /// have identical structure but different atom-mapping numbers;
+    /// `AtomMapPolicy::Ignore` must not.
+    #[test]
+    fn graph_identity_atom_map_policy_is_respected() {
+        use chematic_smiles::parse;
+        let mapped_a = parse("[CH4:1]").unwrap();
+        let mapped_b = parse("[CH4:2]").unwrap();
+
+        let include = GraphIdentityMode {
+            graph_strictness: GraphStrictness::RawGraphExact,
+            atom_maps: AtomMapPolicy::Include,
+        };
+        let ignore = GraphIdentityMode {
+            graph_strictness: GraphStrictness::RawGraphExact,
+            atom_maps: AtomMapPolicy::Ignore,
+        };
+
+        assert_eq!(
+            compare_graph_identity(&mapped_a, &mapped_b, include).graph_relation,
+            Some(GraphRelation::Distinct)
+        );
+        assert_eq!(
+            compare_graph_identity(&mapped_a, &mapped_b, ignore).graph_relation,
+            Some(GraphRelation::Identical)
+        );
+    }
+
+    /// When atom ordering genuinely doesn't line up between the two inputs
+    /// (a real respelling that starts the traversal from a different atom),
+    /// the bounded index-correspondence comparator must report `None`
+    /// (inconclusive) rather than a guess in either direction.
+    #[test]
+    fn graph_identity_reordered_atoms_is_inconclusive_not_a_guess() {
+        use chematic_smiles::{parse, random_smiles};
+        let mol = parse("CC(=O)Oc1ccccc1C(=O)O").unwrap();
+        let mode = GraphIdentityMode {
+            graph_strictness: GraphStrictness::RawGraphExact,
+            atom_maps: AtomMapPolicy::Ignore,
+        };
+        // Find a random respelling seed that actually reorders atoms (not
+        // every seed necessarily does, for a small/symmetric molecule) --
+        // try a handful of seeds and require at least one exercises the
+        // inconclusive path.
+        let mut saw_inconclusive = false;
+        for seed in 0..8u64 {
+            let respelled = parse(&random_smiles(&mol, seed)).unwrap();
+            let evidence = compare_graph_identity(&mol, &respelled, mode);
+            if evidence.graph_relation.is_none() {
+                assert!(
+                    evidence
+                        .diagnostics
+                        .contains(&IdentityDiagnostic::AtomOrderCorrespondenceNotEstablished),
+                    "{:?}",
+                    evidence.diagnostics
+                );
+                saw_inconclusive = true;
+            } else {
+                // A seed that happens to preserve index order entirely is
+                // fine too (still not a WRONG answer) -- just not the case
+                // this test is trying to exercise.
+                assert_eq!(evidence.graph_relation, Some(GraphRelation::Identical));
+            }
+        }
+        assert!(
+            saw_inconclusive,
+            "expected at least one random-respelling seed to reorder atoms for this molecule"
+        );
+    }
+
+    /// Never a false `Identical` and never a false `Distinct`: for a batch of
+    /// known-distinct small molecules compared pairwise under
+    /// `ChemicalGraphExact`, nothing spuriously collapses.
+    #[test]
+    fn graph_identity_chemical_graph_exact_no_false_positives() {
+        use chematic_smiles::parse;
+        let mols = ["CCO", "CCN", "CCC", "c1ccccc1", "CC(=O)O"]
+            .iter()
+            .map(|s| parse(s).unwrap())
+            .collect::<Vec<_>>();
+        let mode = GraphIdentityMode {
+            graph_strictness: GraphStrictness::ChemicalGraphExact,
+            atom_maps: AtomMapPolicy::Ignore,
+        };
+        for i in 0..mols.len() {
+            for j in (i + 1)..mols.len() {
+                let evidence = compare_graph_identity(&mols[i], &mols[j], mode);
+                assert_ne!(
+                    evidence.graph_relation,
+                    Some(GraphRelation::Identical),
+                    "{i} vs {j} must not be Identical"
+                );
+            }
+        }
     }
 }

--- a/crates/chematic-inchi/src/native/convert.rs
+++ b/crates/chematic-inchi/src/native/convert.rs
@@ -108,12 +108,26 @@ pub(crate) fn has_unrepresentable_multi_h_stereocenter(mol: &Molecule) -> bool {
 /// not silently widen its net if a future non-tetrahedral `Chirality`
 /// variant (e.g. an eventual axial/allenic chirality) is added.
 pub(crate) fn has_unresolved_specified_tetrahedral_stereo(mol: &Molecule) -> bool {
-    mol.atoms().any(|(idx, atom)| {
-        matches!(
-            atom.chirality,
-            Chirality::CounterClockwise | Chirality::Clockwise
-        ) && tetrahedral_stereo_neighbors(mol, idx).is_none()
-    })
+    !unresolved_specified_tetrahedral_stereo_atoms(mol).is_empty()
+}
+
+/// Same predicate as [`has_unresolved_specified_tetrahedral_stereo`], but
+/// returns the actual atom indices instead of a bare bool.
+///
+/// Added for issue #161: `crate::dedup`'s accurate-CIP preflight needs to
+/// know exactly *which* centres the legacy engine failed to rank (to re-check
+/// each one individually via `CipMode::Accurate`), not just whether any
+/// exist. Ascending order (same order as [`Molecule::atoms`]).
+pub(crate) fn unresolved_specified_tetrahedral_stereo_atoms(mol: &Molecule) -> Vec<AtomIdx> {
+    mol.atoms()
+        .filter(|(idx, atom)| {
+            matches!(
+                atom.chirality,
+                Chirality::CounterClockwise | Chirality::Clockwise
+            ) && tetrahedral_stereo_neighbors(mol, *idx).is_none()
+        })
+        .map(|(idx, _)| idx)
+        .collect()
 }
 
 /// Convert a `Molecule` into the atom + stereo lists required by the IUPAC InChI C API.

--- a/crates/chematic-inchi/src/native/mod.rs
+++ b/crates/chematic-inchi/src/native/mod.rs
@@ -17,6 +17,7 @@ use std::os::raw::c_char;
 use convert::ConvertError;
 pub(crate) use convert::{
     has_unrepresentable_multi_h_stereocenter, has_unresolved_specified_tetrahedral_stereo,
+    unresolved_specified_tetrahedral_stereo_atoms,
 };
 
 use ffi::{FreeStdINCHI, GetStdINCHI, GetStdINCHIKeyFromStdINCHI, InchiInput, InchiOutput};

--- a/crates/chematic-inchi/tests/accurate_cip_preflight.rs
+++ b/crates/chematic-inchi/tests/accurate_cip_preflight.rs
@@ -1,0 +1,242 @@
+//! Corpus regression fixture for issue #161 (accurate-CIP dedup preflight).
+//!
+//! The 12 molecules below (SMILES quoted verbatim) are taken from
+//! `validation/results/dedup_stereo_guard_corpus_audit.jsonl` /
+//! `_summary.json` -- PR #156's own full 5,000-molecule corpus audit of
+//! every molecule `has_unresolved_specified_tetrahedral_stereo` newly fails
+//! closed. That audit's own classification (case A = legacy fails, accurate
+//! resolves; case B = both chematic engines tie, matching RDKit's own
+//! `rdCIPLabeler`'s inability to assign a label either) is **not** taken on
+//! faith here: re-running these exact molecules against the current
+//! `chematic-inchi`/`chematic-chem`/`chematic-cip` HEAD (this file does not
+//! re-parse the mutable `~/Downloads/SMILES.csv` at test time -- no
+//! JSON-parsing dev-dependency is available to this crate under its
+//! file-ownership scope for this PR, so these SMILES are pinned literals,
+//! same approach as `examples/dedup_stereo_guard_diagnosis.rs`) found the
+//! classification has partially drifted since the audit ran, for two
+//! independent, unrelated reasons documented at each constant below. See the
+//! PR body for the full re-derivation, the independent live RDKit 2026.03.3
+//! cross-check (own isolated venv), and the fresh, current 5,000-molecule
+//! corpus rerun this file's groupings are consistent with.
+//!
+//! Requires the `native-inchi` feature.
+
+#![cfg(feature = "native-inchi")]
+
+use chematic_inchi::dedup::{
+    DedupRelation, IdentityPolicy, compare_molecules, compare_molecules_with_accurate_cip_preflight,
+};
+use chematic_smiles::parse;
+
+fn mol(smiles: &str) -> chematic_core::Molecule {
+    parse(smiles).unwrap_or_else(|e| panic!("parse {smiles:?}: {e}"))
+}
+
+/// 6 of the audit's original 10 "case A" molecules: legacy CIP fails to
+/// rank at least one specified tetrahedral centre, `CipMode::Accurate`
+/// resolves every such centre, and the accurate-CIP preflight fully
+/// recovers verified-comparison capability. Each recovered atom's code was
+/// independently re-checked against a live RDKit 2026.03.3 oracle
+/// (`rdCIPLabeler` + `FindMolChiralCenters(includeUnassigned=True,
+/// useLegacyImplementation=False)`, own isolated venv) -- 15/15 atoms agree
+/// exactly (see the PR body for the full table).
+const CASE_A_FULLY_RECOVERED: &[(usize, &str)] = &[
+    (
+        196,
+        "CCCCc1cn([C@H]2[C@H](C)CCC[C@@H]2C)c(=O)n1Cc1ccc(-c2ccccc2-c2nn[nH]n2)nc1",
+    ),
+    (1567, "NS(=O)(=O)OC[C@@]12CCCC[C@@H]1CCC2"),
+    (
+        4047,
+        "O=C(Oc1c(O)cc(C(=O)O[C@H]2[C@H](OC(=O)c3cc(O)c(O)c(O)c3)C[C@](O)(C(=O)O)C[C@H]2OC(=O)c2cc(O)c(O)c(O)c2)cc1O)c1cc(O)c(O)c(O)c1",
+    ),
+    (
+        4413,
+        "O=C(O[C@H]1[C@H](O)C[C@](O)(C(=O)O)C[C@H]1O)c1cc(O)c(O)c(O)c1",
+    ),
+    (
+        4509,
+        "O=C(O[C@@H]1C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@@H](OC(=O)c2cc(O)c(O)c(O)c2)[C@H]1OC(=O)c1cc(O)c(O)c(O)c1)c1cc(O)c(O)c(O)c1",
+    ),
+    (4745, "N[C@]1(C(=O)O)C[C@H](C(=O)O)[C@H](C(=O)O)C1"),
+];
+
+/// The 2 "case B" molecules from the audit: tricyclic-cage bridgeheads,
+/// unresolved by *both* chematic CIP engines. Re-confirmed directly against
+/// a live RDKit 2026.03.3 oracle in this PR's own venv: RDKit's own modern
+/// CIP labeler leaves the exact same bridgehead atom unlabeled
+/// (`Tet_CCW`/`None` -- defined parity, no CIP descriptor) -- a genuine,
+/// shared CIP-ranking limit, not fixable by this preflight.
+const CASE_B_GENUINE_TIE: &[(usize, &str)] = &[
+    (
+        443,
+        "CCCCCCCC/C=C/CCCCCCCC(=O)OCc1cc(=O)c(OC(=O)[C@]23C[C@H]4C[C@H](C[C@H](C4)C2)C3)co1",
+    ),
+    (
+        590,
+        "O=c1cc(COC2CCOCC2)occ1OC(=O)[C@]12C[C@H]3C[C@H](C[C@H](C3)C1)C2",
+    ),
+];
+
+/// 3 of the audit's original 10 "case A" molecules that this preflight's
+/// implementation does **not** recover, for a reason the audit itself did
+/// not anticipate: each has a 3-fold-symmetric substituent (an
+/// adamantane-cage-like scaffold) whose 3 legacy-unresolved stereocentres
+/// all land on the SAME `chematic_smiles::morgan_ranks` value. The accurate
+/// CIP engine resolves all 3 individually (each independently re-confirmed
+/// against RDKit's `rdCIPLabeler` here: 9/9 atoms agree, all labeled `s`),
+/// but `accurate_stereo_supplement`'s cross-molecule correspondence
+/// mechanism deliberately fails closed on ANY rank collision among flagged
+/// atoms in the same molecule (`IdentityDiagnostic::AmbiguousStereoRankCorrespondence`)
+/// -- see that function's doc comment in `src/dedup.rs` for why a bijection
+/// can't be safely assumed here without a real automorphism-consistency
+/// check (out of scope for this PR, flagged as a follow-up). This is a
+/// deliberate, conservative recall/safety trade-off, not a bug: it never
+/// produces a wrong answer, it simply declines to recover these 3
+/// molecules rather than risk mispairing a symmetric stereocentre.
+const CASE_A_BLOCKED_BY_TIED_RANK: &[(usize, &str)] = &[
+    (
+        1609,
+        "O=C(NCCCCN1CCN(c2cccc3ccccc23)CC1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3",
+    ),
+    (
+        1643,
+        "COc1ccccc1N1CCN(CCCCNC(=O)C23C[C@H]4C[C@@H](C2)C[C@@H](C3)C4)CC1",
+    ),
+    (
+        4178,
+        "O=C(NCCCCN1CCCC(/C=C\\c2ccccc2)C1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3",
+    ),
+];
+
+/// The audit's original idx=4412 molecule: at the time of the audit, legacy
+/// CIP failed to rank one of its centres; at this PR's HEAD, legacy CIP now
+/// resolves all of its specified centres (an upstream `chematic-chem`/
+/// `chematic-cip` change since the audit ran -- `has_unresolved_specified_
+/// tetrahedral_stereo` no longer fires on it at all). Kept here, tested
+/// separately, purely so this file's molecule list is traceable 1:1 against
+/// the audit's original 12 -- not part of the "recovered by this preflight"
+/// count, since the plain (legacy-only) path already succeeds for it.
+const NO_LONGER_APPLICABLE: &str = "O=C(O[C@H]1[C@H](O)C[C@](OC(=O)c2cc(O)c(O)c(O)c2)(C(=O)O)C[C@@H](OC(=O)c2cc(O)c(O)c(O)c2)[C@H]1OC(=O)c1cc(O)c(O)c(O)c1)c1cc(O)c(O)c(O)c1";
+
+/// For every audited molecule where the guard still fires at all (case A
+/// fully-recovered, case A blocked-by-tied-rank, and case B alike), the
+/// PLAIN (legacy-only) path is unchanged from PR #156's shipped behavior:
+/// comparing the molecule against itself is `VerificationUnavailable`. This
+/// is the "before" half of issue #161's before/after claim.
+#[test]
+fn plain_path_unchanged_unavailable_for_every_still_applicable_audited_molecule() {
+    for &(idx, smiles) in CASE_A_FULLY_RECOVERED
+        .iter()
+        .chain(CASE_B_GENUINE_TIE)
+        .chain(CASE_A_BLOCKED_BY_TIED_RANK)
+    {
+        let m = mol(smiles);
+        assert_eq!(
+            compare_molecules(&m, &m, IdentityPolicy::StandardInchiString),
+            DedupRelation::VerificationUnavailable,
+            "idx={idx}: plain path must still fail closed (PR #156 unchanged)"
+        );
+    }
+}
+
+/// `idx=4412` (see `NO_LONGER_APPLICABLE`'s doc comment): the plain path
+/// ALREADY succeeds on it at this PR's HEAD, unrelated to this PR's
+/// changes. Documented here as an explicit, tested observation rather than
+/// silently dropped from the fixture list.
+#[test]
+fn idx_4412_no_longer_triggers_the_guard_at_all_upstream_drift() {
+    let m = mol(NO_LONGER_APPLICABLE);
+    assert_eq!(
+        compare_molecules(&m, &m, IdentityPolicy::StandardInchiString),
+        DedupRelation::VerifiedDuplicate,
+        "if this starts failing, chematic-chem/chematic-cip's CIP ranking regressed \
+         back to the audit-time behavior -- update this fixture's category, don't just \
+         change the assertion"
+    );
+}
+
+/// Case A (fully recovered): the accurate-CIP preflight recovers
+/// verified-comparison capability -- a molecule compared against itself
+/// becomes `VerifiedDuplicate` instead of `VerificationUnavailable`.
+#[test]
+fn case_a_fully_recovered_molecules_become_verified_duplicate_under_preflight() {
+    for &(idx, smiles) in CASE_A_FULLY_RECOVERED {
+        let m = mol(smiles);
+        assert_eq!(
+            compare_molecules_with_accurate_cip_preflight(
+                &m,
+                &m,
+                IdentityPolicy::StandardInchiString
+            ),
+            DedupRelation::VerifiedDuplicate,
+            "idx={idx}: case A molecule should recover under the accurate-CIP preflight"
+        );
+    }
+}
+
+/// Case B: even with the preflight engaged, a genuine tie in *both* chematic
+/// engines (matching RDKit's own inability to label the same centre) must
+/// stay `VerificationUnavailable` -- never silently promoted.
+#[test]
+fn case_b_molecules_still_fail_closed_under_preflight() {
+    for &(idx, smiles) in CASE_B_GENUINE_TIE {
+        let m = mol(smiles);
+        assert_eq!(
+            compare_molecules_with_accurate_cip_preflight(
+                &m,
+                &m,
+                IdentityPolicy::StandardInchiString
+            ),
+            DedupRelation::VerificationUnavailable,
+            "idx={idx}: genuine tie (case B) must still fail closed under the preflight"
+        );
+    }
+}
+
+/// Case A blocked by tied morgan-rank correspondence: must ALSO still fail
+/// closed under the preflight (this is the conservative, safe direction --
+/// see `CASE_A_BLOCKED_BY_TIED_RANK`'s doc comment). A future, more capable
+/// correspondence mechanism might recover these; this preflight must never
+/// promote them via a mispaired guess in the meantime.
+#[test]
+fn case_a_blocked_by_tied_rank_still_fails_closed_under_preflight() {
+    for &(idx, smiles) in CASE_A_BLOCKED_BY_TIED_RANK {
+        let m = mol(smiles);
+        assert_eq!(
+            compare_molecules_with_accurate_cip_preflight(
+                &m,
+                &m,
+                IdentityPolicy::StandardInchiString
+            ),
+            DedupRelation::VerificationUnavailable,
+            "idx={idx}: tied-morgan-rank case must stay VerificationUnavailable, never a guess"
+        );
+    }
+}
+
+/// `IdentityPolicy::StandardInchiKey` and `IdentityPolicy::IsotopeIgnored`
+/// are the other two policies the corpus audit found this guard fires
+/// under (`StereoIgnored` deliberately does not check the guard at all --
+/// see the module docs) -- spot-check one fully-recovered case-A molecule
+/// under each to confirm the preflight isn't accidentally
+/// `StandardInchiString`-only.
+#[test]
+fn case_a_recovery_also_applies_under_standard_inchi_key_and_isotope_ignored() {
+    let m = mol("NS(=O)(=O)OC[C@@]12CCCC[C@@H]1CCC2");
+    for policy in [
+        IdentityPolicy::StandardInchiKey,
+        IdentityPolicy::IsotopeIgnored,
+    ] {
+        assert_eq!(
+            compare_molecules(&m, &m, policy),
+            DedupRelation::VerificationUnavailable,
+            "sanity ({policy:?}): plain path unavailable"
+        );
+        assert_eq!(
+            compare_molecules_with_accurate_cip_preflight(&m, &m, policy),
+            DedupRelation::VerifiedDuplicate,
+            "{policy:?}: should recover under the accurate-CIP preflight"
+        );
+    }
+}

--- a/crates/chematic-inchi/tests/graph_identity.rs
+++ b/crates/chematic-inchi/tests/graph_identity.rs
@@ -1,0 +1,267 @@
+//! End-to-end fixtures for `chematic_inchi::dedup`'s exact-graph-identity API
+//! (`GraphIdentityMode`/`IdentityEvidence`/`compare_graph_identity`).
+//!
+//! Unlike `IdentityPolicy`'s four native-InChI-backed policies, this API's
+//! structural comparator (`same_structure_under_identity` in `src/dedup.rs`)
+//! does not require the `native-inchi` feature at all -- it never uses
+//! canonical SMILES or native InChI as the actual proof of identity (only as
+//! optional corroborating evidence in `IdentityEvidence::standard_inchi`/
+//! `inchikey`, which are simply `None` without the feature). So, unlike
+//! `tests/dedup_fixtures.rs` and `tests/accurate_cip_preflight.rs`, this file
+//! runs in both feature configurations.
+
+use chematic_inchi::dedup::{
+    AtomMapPolicy, GraphIdentityMode, GraphRelation, GraphStrictness, IdentityDiagnostic,
+    compare_graph_identity,
+};
+use chematic_smiles::{parse, random_smiles};
+
+fn mol(smiles: &str) -> chematic_core::Molecule {
+    parse(smiles).unwrap_or_else(|e| panic!("parse {smiles:?}: {e}"))
+}
+
+const RAW_IGNORE: GraphIdentityMode = GraphIdentityMode {
+    graph_strictness: GraphStrictness::RawGraphExact,
+    atom_maps: AtomMapPolicy::Ignore,
+};
+const CHEMICAL_IGNORE: GraphIdentityMode = GraphIdentityMode {
+    graph_strictness: GraphStrictness::ChemicalGraphExact,
+    atom_maps: AtomMapPolicy::Ignore,
+};
+
+#[test]
+fn same_molecule_twice_is_identical_under_both_strictness_modes() {
+    for mode in [RAW_IGNORE, CHEMICAL_IGNORE] {
+        let a = mol("CC(=O)Oc1ccccc1C(=O)O");
+        let b = mol("CC(=O)Oc1ccccc1C(=O)O");
+        let evidence = compare_graph_identity(&a, &b, mode);
+        assert_eq!(
+            evidence.graph_relation,
+            Some(GraphRelation::Identical),
+            "{mode:?}"
+        );
+        // `diagnostics` may carry a `NativeInchiUnavailable` note when this
+        // crate is built without the `native-inchi` feature (the InChI
+        // corroboration fields are simply unavailable, not an error in the
+        // structural comparator itself) -- not asserted empty here.
+    }
+}
+
+#[test]
+fn different_element_is_distinct() {
+    let a = mol("CCO");
+    let b = mol("CCN");
+    let evidence = compare_graph_identity(&a, &b, RAW_IGNORE);
+    assert_eq!(evidence.graph_relation, Some(GraphRelation::Distinct));
+}
+
+#[test]
+fn different_charge_is_distinct() {
+    let a = mol("[NH4+]");
+    let b = mol("[NH3]");
+    let evidence = compare_graph_identity(&a, &b, RAW_IGNORE);
+    assert_eq!(evidence.graph_relation, Some(GraphRelation::Distinct));
+}
+
+#[test]
+fn different_isotope_is_distinct() {
+    let a = mol("[13CH4]");
+    let b = mol("C");
+    let evidence = compare_graph_identity(&a, &b, RAW_IGNORE);
+    assert_eq!(evidence.graph_relation, Some(GraphRelation::Distinct));
+}
+
+#[test]
+fn different_fragment_composition_is_distinct() {
+    // Same total heavy-atom multiset, different fragmentation (one molecule
+    // vs. two salt fragments) -- must not collide.
+    let a = mol("CCCC"); // butane, 1 fragment
+    let b = mol("CC.CC"); // two ethane fragments
+    let evidence = compare_graph_identity(&a, &b, RAW_IGNORE);
+    assert_eq!(evidence.graph_relation, Some(GraphRelation::Distinct));
+}
+
+#[test]
+fn enantiomers_are_distinct_not_collapsed() {
+    let l = mol("N[C@@H](C)C(=O)O");
+    let d = mol("N[C@H](C)C(=O)O");
+    for mode in [RAW_IGNORE, CHEMICAL_IGNORE] {
+        let evidence = compare_graph_identity(&l, &d, mode);
+        assert_eq!(
+            evidence.graph_relation,
+            Some(GraphRelation::Distinct),
+            "{mode:?}"
+        );
+    }
+}
+
+#[test]
+fn diastereomers_are_distinct() {
+    // Tartaric acid: (2R,3R) vs meso (2R,3S).
+    let rr = mol("OC(=O)[C@H](O)[C@H](O)C(=O)O");
+    let meso = mol("OC(=O)[C@H](O)[C@@H](O)C(=O)O");
+    let evidence = compare_graph_identity(&rr, &meso, RAW_IGNORE);
+    assert_eq!(evidence.graph_relation, Some(GraphRelation::Distinct));
+}
+
+#[test]
+fn ez_isomers_are_distinct() {
+    let e = mol("C/C=C/C");
+    let z = mol("C/C=C\\C");
+    let evidence = compare_graph_identity(&e, &z, RAW_IGNORE);
+    assert_eq!(evidence.graph_relation, Some(GraphRelation::Distinct));
+}
+
+#[test]
+fn ez_same_configuration_written_differently_is_identical() {
+    // (E)-but-2-ene, two equivalent ways to write the same E configuration
+    // (marker on the other side of the double bond).
+    let a = mol("C/C=C/C");
+    let b = mol("C/C=C/C");
+    let evidence = compare_graph_identity(&a, &b, RAW_IGNORE);
+    assert_eq!(evidence.graph_relation, Some(GraphRelation::Identical));
+}
+
+#[test]
+fn raw_graph_exact_distinguishes_aromatic_vs_kekule_spelling() {
+    let aromatic = mol("c1ccccc1");
+    let kekule = mol("C1=CC=CC=C1");
+    let evidence = compare_graph_identity(&aromatic, &kekule, RAW_IGNORE);
+    assert_ne!(
+        evidence.graph_relation,
+        Some(GraphRelation::Identical),
+        "RawGraphExact must not equate aromatic-order and Kekule-order spelling: {evidence:?}"
+    );
+}
+
+#[test]
+fn chemical_graph_exact_equates_aromatic_vs_same_kekule_spelling() {
+    // `kekulize()` is deterministic given the same underlying graph -- so an
+    // aromatic-flagged benzene and an explicit Kekule respelling that
+    // happens to already match `kekulize()`'s own chosen alternation must
+    // compare Identical under ChemicalGraphExact.
+    let aromatic = mol("c1ccccc1");
+    let kekule = mol("C1=CC=CC=C1");
+    let evidence = compare_graph_identity(&aromatic, &kekule, CHEMICAL_IGNORE);
+    assert_eq!(
+        evidence.graph_relation,
+        Some(GraphRelation::Identical),
+        "{evidence:?}"
+    );
+}
+
+#[test]
+fn chemical_graph_exact_never_false_positive_across_distinct_small_molecules() {
+    let smiles = ["CCO", "CCN", "CCC", "c1ccccc1", "CC(=O)O", "c1ccncc1"];
+    let mols: Vec<_> = smiles.iter().map(|s| mol(s)).collect();
+    for i in 0..mols.len() {
+        for j in (i + 1)..mols.len() {
+            let evidence = compare_graph_identity(&mols[i], &mols[j], CHEMICAL_IGNORE);
+            assert_ne!(
+                evidence.graph_relation,
+                Some(GraphRelation::Identical),
+                "{} vs {}",
+                smiles[i],
+                smiles[j],
+            );
+        }
+    }
+}
+
+#[test]
+fn atom_map_include_distinguishes_include_ignores_dont() {
+    let a = mol("[CH4:1]");
+    let b = mol("[CH4:2]");
+    let include = GraphIdentityMode {
+        graph_strictness: GraphStrictness::RawGraphExact,
+        atom_maps: AtomMapPolicy::Include,
+    };
+    assert_eq!(
+        compare_graph_identity(&a, &b, include).graph_relation,
+        Some(GraphRelation::Distinct)
+    );
+    assert_eq!(
+        compare_graph_identity(&a, &b, RAW_IGNORE).graph_relation,
+        Some(GraphRelation::Identical)
+    );
+}
+
+#[test]
+fn atom_map_axis_is_orthogonal_to_strictness_axis() {
+    // Same molecule, different atom maps, aromatic vs Kekule spelling: all
+    // 4 combinations of the two axes must be independently selectable and
+    // give the expected, axis-specific answer.
+    let a = mol("[cH:1]1ccccc1");
+    let b_same_map_kekule = mol("[CH:1]1=CC=CC=C1");
+
+    let raw_include = GraphIdentityMode {
+        graph_strictness: GraphStrictness::RawGraphExact,
+        atom_maps: AtomMapPolicy::Include,
+    };
+    let chemical_include = GraphIdentityMode {
+        graph_strictness: GraphStrictness::ChemicalGraphExact,
+        atom_maps: AtomMapPolicy::Include,
+    };
+
+    // RawGraphExact still distinguishes the aromatic/Kekule spelling
+    // regardless of atom-map policy.
+    assert_ne!(
+        compare_graph_identity(&a, &b_same_map_kekule, raw_include).graph_relation,
+        Some(GraphRelation::Identical)
+    );
+    // ChemicalGraphExact + Include atom maps: same map number, same
+    // chemistry once Kekulized -- Identical.
+    assert_eq!(
+        compare_graph_identity(&a, &b_same_map_kekule, chemical_include).graph_relation,
+        Some(GraphRelation::Identical)
+    );
+}
+
+#[test]
+fn reordered_atoms_are_inconclusive_never_a_wrong_guess() {
+    let base = mol("CC(=O)Oc1ccccc1C(=O)O");
+    let mut saw_inconclusive = false;
+    for seed in 0..8u64 {
+        let respelled = mol(&random_smiles(&base, seed));
+        let evidence = compare_graph_identity(&base, &respelled, RAW_IGNORE);
+        match evidence.graph_relation {
+            None => {
+                assert!(
+                    evidence
+                        .diagnostics
+                        .contains(&IdentityDiagnostic::AtomOrderCorrespondenceNotEstablished),
+                    "{:?}",
+                    evidence.diagnostics
+                );
+                saw_inconclusive = true;
+            }
+            Some(GraphRelation::Identical) => {} // a seed that happened to preserve index order -- still not wrong
+            Some(GraphRelation::Distinct) => {
+                panic!(
+                    "a respelling of the SAME molecule must never be reported Distinct: seed={seed}"
+                )
+            }
+        }
+    }
+    assert!(
+        saw_inconclusive,
+        "expected at least one seed to actually reorder atoms for this molecule"
+    );
+}
+
+#[test]
+fn evidence_never_claims_identical_and_distinct_diagnostics_simultaneously() {
+    // Sanity/shape check: whenever `graph_relation` is `Some`, it is
+    // decisive -- no lingering "why inconclusive" diagnostic should be
+    // attached to a conclusive result (those diagnostics are reserved for
+    // `graph_relation: None`).
+    let a = mol("CCO");
+    let b = mol("CCN");
+    let evidence = compare_graph_identity(&a, &b, RAW_IGNORE);
+    assert_eq!(evidence.graph_relation, Some(GraphRelation::Distinct));
+    assert!(
+        !evidence
+            .diagnostics
+            .contains(&IdentityDiagnostic::AtomOrderCorrespondenceNotEstablished)
+    );
+}


### PR DESCRIPTION
## Summary

Two deliverables from the 3D Breakthrough Program's Agent B brief, both scoped to `crates/chematic-inchi/src/dedup.rs` + `crates/chematic-inchi/src/native/**` + new `crates/chematic-inchi/tests/**` files only (no other file touched):

1. **Closes issue #161** — an accurate-CIP preflight for the verified-dedup fail-closed guard shipped in PR #156.
2. **New, standalone "exact graph identity" API** (`GraphIdentityMode` / `GraphRelation` / `IdentityEvidence` / `compare_graph_identity`) for conformer/ensemble grouping, MOL/SDF round-tripping, and dedup to share (Coordinator wires this into Agent A's SDF-ensemble supplier at Wave 2 integration).

- Base SHA: `9f9f459` (`main`, v0.7.0)
- Head SHA: `d0c9fbd`
- Commits (3, each independently reviewable):
  - `c2db0ea` `feat(inchi): add accurate-CIP dedup preflight (issue #161)`
  - `768e4cb` `feat(identity): add exact graph relation API`
  - `d0c9fbd` `test(inchi): directly assert the rank-collision guard's failure reason` — added after a pre-PR self-review pass; see "Known limitation" in §1 below for what it closes
- Files touched (exactly, nothing else):
  - `crates/chematic-inchi/src/dedup.rs`
  - `crates/chematic-inchi/src/native/convert.rs`
  - `crates/chematic-inchi/src/native/mod.rs`
  - `crates/chematic-inchi/tests/accurate_cip_preflight.rs` (new)
  - `crates/chematic-inchi/tests/graph_identity.rs` (new)

**Deviation from the coordinator's suggested 3-commit shape**, flagged as instructed: the coordinator suggested a 3rd commit `test(validation): add identity differential corpus`. My file-ownership scope for this PR is exactly `dedup.rs` + `native/**` + new files under `tests/**` — I have no permission to add anything under `validation/` (that directory isn't in my allow-list, and isn't the crate I own). I folded the RDKit-oracle-backed fixture/regression tests into the same commit as the feature they validate instead (`tests/accurate_cip_preflight.rs` → commit 1, `tests/graph_identity.rs` → commit 2). The 3rd commit that does exist (`d0c9fbd`) is unrelated to that suggestion — it's a small review-driven fix (see below), not the validation-corpus commit the coordinator meant. Each commit is still independently buildable/lintable/testable (verified below) and maps to one conceptual change.

---

## 1. Issue #161 close-out: accurate-CIP dedup preflight

### Root cause (why a naive guard relaxation is unsafe)

PR #156's `has_unresolved_specified_tetrahedral_stereo` guard fails `identity_verify` closed whenever the **legacy** CIP engine (`chematic_chem::assign_cip`) can't rank a specified tetrahedral stereocentre's substituents — because `crate::native::convert::mol_to_inchi_atoms` depends on that *exact same* ranking function (`tetrahedral_stereo_neighbors`) to build the InChI `Stereo0D` descriptor. When ranking fails, native InChI generation doesn't just decline gracefully — empirically (audit data below), it emits either a literal `?` (undefined parity) if *some* centre in the molecule succeeded, or omits the whole `/t` layer if *none* did:

```
idx=196 chematic:  .../t19-,20+,26?          (2/3 centres resolved, 1 shows '?')
idx=443 chematic:  ...no /t layer at all      (0/4 centres resolved)
```

Issue #161 proposed: "re-check a legacy-unresolved centre via `CipMode::Accurate`; if it resolves, treat the centre as ranked instead of failing closed." Taken literally (just relax the guard, then call `standard_inchi()` as before), this is **unsafe**: `standard_inchi()`'s own Stereo0D construction still depends on the *legacy* ranking regardless of what the accurate engine says, so it would still emit the same `?`/missing-`/t` output for that centre — reopening the exact 4663/4664 false-`VerifiedDuplicate` PR #156 fixed. Issue #161 itself anticipates this ("this does NOT mean switching native InChI generation to the accurate engine wholesale").

### Design: fold the accurate code into the comparison key, not into `standard_inchi()`

New, **additive-only** entry points — the existing `compare` / `compare_molecules` / `deduplicate_verified` / `identity_verify` / `verified_identity_key` are untouched (verified byte-for-byte via `preflight_is_opt_in_existing_paths_unchanged`):

```rust
pub fn compare_with_accurate_cip_preflight(key_a, mol_a, key_b, mol_b, policy) -> DedupRelation
pub fn compare_molecules_with_accurate_cip_preflight(mol_a, mol_b, policy) -> DedupRelation
pub fn deduplicate_verified_with_accurate_cip_preflight(mols, policy) -> VerifiedDedupReport
```

For each specified stereocentre the legacy engine can't rank, `accurate_stereo_supplement` re-checks via `chematic_chem::assign_cip_with_mode(mol, CipMode::Accurate)`. If the accurate engine resolves it (not `Tied`/`BudgetExceeded`/error), its code is folded into the **comparison key** — never into the generated InChI string, and never into the `InChIKey` C-library call (`verified_identity_key_with_supplement` reuses the existing, unmodified `verified_identity_key` for the base key, then appends the supplement afterward, so `StandardInchiKey`'s FFI call always still receives a clean, real InChI string).

Cross-molecule correspondence for the supplement uses `chematic_smiles::morgan_ranks` (a purely constitutional, stereo-blind isomorphism invariant, already used/tested elsewhere in this codebase) rather than InChI's own canonical numbering (which would require parsing `AuxInfo`, out of scope) or a full atom-mapping search. **Fails closed** (keeps `VerificationUnavailable`) if the accurate engine ties/budgets-out/errors on *any* flagged atom, or — a case the original audit didn't anticipate — if **two or more flagged atoms in the same molecule land on the same morgan-rank value** (their cross-molecule correspondence would be ambiguous; see limitation below).

### Before/after, re-derived fresh (not trusted from the old audit)

PR #156's own audit (`validation/results/dedup_stereo_guard_corpus_audit.jsonl`) is the fixture starting point issue #161 names — but I did **not** take its 10/12 recovery number on faith. Re-running the exact same 12 audited molecules (pinned literal SMILES, not re-read from the mutable corpus file) against current HEAD found the classification has **partially drifted since the audit ran**, for two independent, unrelated reasons:

| Reason | Molecules affected |
|---|---|
| Upstream `chematic-chem`/`chematic-cip` CIP-ranking change since the audit ran — legacy now resolves this molecule's centres, guard doesn't fire at all any more | 1 (audit idx=4412) |
| A 3-fold-symmetric substituent (adamantane-cage-like) whose legacy-unresolved centres all land on the **same morgan rank** — the accurate engine resolves each individually, but my correspondence guard (above) declines to pair them | 3 (audit idx=1609, 1643, 4178) |

I then independently re-ran the **full 5,000-molecule corpus** (`~/Downloads/SMILES.csv`, current local snapshot — see "Dataset provenance" below for why this differs from the audit's own numbering) through `deduplicate_verified` vs. `deduplicate_verified_with_accurate_cip_preflight`:

| Metric | Plain (`compare`/`deduplicate_verified`, unchanged) | With accurate-CIP preflight |
|---|---|---|
| `verification_unavailable` (of 5,000) | **15** | **6** |
| Recovered (→ `VerifiedDuplicate`) | — | **9** |
| Newly made unavailable | — | **0** (safety invariant, confirmed empirically over the whole corpus) |

The 6 remaining `VerificationUnavailable` molecules, fully explained (not left as an unattributed residual):

| Count | Reason |
|---|---|
| 1 | Pre-existing native-InChI `KekulizationFailed` (unrelated to this guard entirely — a fused/bridgehead heteroaromatic ring chematic can't Kekulize; same molecule the original audit's own scope note excluded at idx=2149) |
| 2 | Genuine CIP tie in **both** chematic engines (tricyclic-cage bridgeheads) |
| 3 | Correctly resolved by the accurate engine, but blocked by the tied-morgan-rank correspondence guard (see limitation below) |

### Independent RDKit 2026.03.3 cross-check (own isolated venv, never the shared `.venv`)

- Isolated venv: `/private/tmp/claude-501/-Users-k-tanabe-Documents-Documents-oss-rust-chematic/9934aa14-7af8-40c0-850a-54a336991cb0/scratchpad/dedup_b_venv`, built from `/opt/homebrew/bin/python3.13` (a clean system interpreter, **not** the repo's shared `.venv` at `/Users/k_tanabe/Documents/Documents/oss_rust/chematic/.venv`, and not any other agent's worktree venv). `pip install "rdkit==2026.03.3"` → confirmed `Chem.rdBase.rdkitVersion == "2026.03.3"`, matching the version pin in this task's brief.
- All **9 recovered** molecules' accurate-CIP codes (15 atoms total) cross-checked against `rdCIPLabeler.AssignCIPLabels` + `Chem.FindMolChiralCenters(includeUnassigned=True, useLegacyImplementation=False)`: **15/15 agree exactly** (R/S/r/s, full denominators, no pooling of a subset as if it were the whole set).
- The 2 genuine-tie molecules: RDKit's own modern CIP labeler independently confirms `Tet_CCW`/no label at the exact same bridgehead atom — a real, shared CIP-ranking limit in both engines, not a chematic defect.
- The 3 tied-morgan-rank-blocked molecules: RDKit assigns `s` to all 9 atoms (3 molecules × 3 symmetric centres), matching chematic's accurate engine exactly — confirming these ARE individually correct, and that the recall cost is purely from my conservative correspondence guard, not from an underlying CIP error.

### Known limitation: tied-morgan-rank correspondence (real, quantified, not swept under the rug)

`accurate_stereo_supplement` fails closed whenever two-or-more legacy-unresolved centres in the *same* molecule share a `morgan_ranks` value (constitutionally symmetric positions, e.g. a 3-fold-symmetric cage substituent). This is **safe by construction under the guard**: a spurious match would require two flagged atoms with swapped codes colliding on one rank key, and the `seen_ranks.insert` check returns `Err(AmbiguousStereoRankCorrespondence)` on exactly that collision before any code is pushed to the supplement — not asserted as a proof, but directly observed: commit `d0c9fbd`'s `accurate_stereo_supplement_blocks_via_rank_collision_not_some_other_path` calls the private function directly on idx=1609 and asserts the *exact* `Err` variant, ruling out `AccurateCipTied`/`AccurateCipBudgetExceeded`/`AccurateCipEngineError` as the real cause (a prior version of this PR only checked the outcome via `compare_molecules_with_accurate_cip_preflight`, which couldn't distinguish "blocked by the rank guard" from "blocked by some other path" — caught in self-review before opening this PR). This costs real recall — 3/12 audited molecules, 3/15 corpus molecules stay `VerificationUnavailable` even though every individual centre is correctly resolved and RDKit-confirmed. A rank-tie-aware correspondence mechanism that additionally proves automorphism-consistency (not just "same label multiset") could recover these safely, but that's a nontrivial, separate piece of work — flagged as a follow-up, not attempted here given the risk of getting the automorphism argument subtly wrong under time pressure.

### Dataset provenance note (a real, orthogonal finding, not excuse-making)

`~/Downloads/SMILES.csv` (5,000 lines, no header) is the same path PR #156's own audit used, but **not byte-identical to whatever produced that audit's JSONL** — the file on this machine has drifted (most of the audit's `corpus_index`-N molecules now sit at position N+1 in the current file; a handful of positions near the audit's idx≈4412 contain genuinely different molecules, not just a shift). This is exactly the kind of "don't trust old numbers/artifacts on faith" situation this project has hit before (see the Wave 0 master plan's own re-verification of `etkdg_vs_rdkit_gap.py`). My headline 5,000-molecule numbers above are from **this PR's own fresh run against the file as it exists now**, not backfilled from the old audit; my 12-molecule fixture uses **pinned literal SMILES** (not re-read from the mutable CSV), so it is reproducible regardless of future corpus-file drift.

---

## 2. New API: exact graph identity (`GraphIdentityMode` / `IdentityEvidence`)

### Shape

```rust
pub struct GraphIdentityMode {
    pub graph_strictness: GraphStrictness,  // RawGraphExact | ChemicalGraphExact
    pub atom_maps: AtomMapPolicy,           // Include | Ignore
}
pub enum GraphRelation { Identical, Distinct }
pub struct IdentityEvidence {
    pub graph_relation: Option<GraphRelation>,
    pub standard_inchi: Option<String>,
    pub inchikey: Option<String>,
    pub diagnostics: Vec<IdentityDiagnostic>,
}
pub fn compare_graph_identity(mol_a: &Molecule, mol_b: &Molecule, mode: GraphIdentityMode) -> IdentityEvidence
```

### Two orthogonal axes, not one flat enum (per the coordinator's design-review refinement)

- **`GraphStrictness`** — how strictly bond order/aromaticity spelling is compared:
  - `RawGraphExact`: literal bond-order/`aromatic`-flag equality. Aromatic-order-spelled benzene ≠ an explicit Kekulé respelling of the same ring under this mode (by design — this is the strictest, most literal notion of "same graph as written").
  - `ChemicalGraphExact`: any input with `Aromatic`-order bonds is Kekulized first via `chematic_core::kekulize`/`apply_kekule` — the same algorithm this crate's own native InChI conversion already uses (not a new one written for this PR), rather than assuming its determinism generalizes; only directly confirmed for the fixtures this PR actually exercises (e.g. `graph_identity_raw_graph_exact_distinguishes_aromatic_spelling`'s benzene case), not proven in general — and the `aromatic` flag itself is excluded from atom comparison (Kekulization never clears it, so comparing it post-Kekulization would silently reintroduce the exact spelling-sensitivity this mode exists to remove). **Never implemented via canonical-SMILES string equality** — this module's standing rule (canonical SMILES is a fast pre-filter elsewhere in this file, never the proof) applies here too.
- **`AtomMapPolicy`** — `Include`/`Ignore` reaction atom-mapping numbers (`Atom::atom_map`), fully independent of the strictness axis. All 4 combinations are independently selectable and tested (`graph_identity_atom_map_policy_is_respected`, `atom_map_axis_is_orthogonal_to_strictness_axis`).

### How identity is actually verified (never canonical SMILES)

1. **Cheap, atom-order-independent composition pre-check**: fragment sizes, element/isotope/charge/aromaticity multiset, bond-order multiset. A mismatch here is conclusive `Distinct` regardless of atom ordering — a real graph invariant, not a string comparison.
2. **Direct input-index correspondence + full bond-set check**: if atom `i` in molecule A is assumed to correspond to atom `i` in molecule B, does *every* bond line up (not just counts)? If yes, every remaining atom/bond attribute is verified directly at each position — conclusive either way. If the bond sets don't line up under this direct correspondence, the result is **`None` (inconclusive)**, never a guess.
3. **Tetrahedral parity**: a from-scratch, self-contained *permutation-parity* comparison (`canonical_tetrahedral_parity`) over `Molecule::stereo_neighbor_order`, expressed in a common ascending-index reference frame — no CIP engine involved at all (this is deliberately a different, lower-level tool than the accurate-CIP preflight above; graph identity needs pure combinatorial parity, not chemical priority ranking).
4. **E/Z**: directed `Up`/`Down` bond-marker comparison (`directed_bond_marker`), mirroring `crate::native::convert::mol_to_inchi_atoms`'s own `is_up` sign convention exactly (not a new one), checked over every adjacent atom pair — no reference-substituent-choice ambiguity, since every pair is checked directly rather than picking one.
5. `standard_inchi`/`inchikey` in `IdentityEvidence` are **independent corroborating evidence only** (each molecule's own full-stereo native InChI, populated only when both succeed and literally agree) — never the basis for `graph_relation` itself. Native InChI's own tautomer/mobile-H normalization is a different, weaker question than literal graph identity (same distinction this module's `IdentityPolicy` docs already make).

### Scope boundaries (documented, not silently cut)

- **Atom ordering**: the structural comparator only recognizes identity when the two molecules share the same atom indexing (index `i` ↔ index `i`) — not a general graph-isomorphism search over arbitrary permutations. A real isomorphism search needs either `chematic-smarts`'s VF2 (not on `chematic-inchi`'s dependency graph — adding it means editing `Cargo.toml`, outside this PR's file-ownership scope) or a from-scratch bounded backtracking matcher with its own correctness-testing burden I judged too risky to build and verify within this PR's budget. The task's own stated real-world consumer (conformer/ensemble grouping over records sharing one connection table) already satisfies same-indexing by construction, so this boundary doesn't block that use case. When ordering doesn't line up, `graph_relation` is `None` with `IdentityDiagnostic::AtomOrderCorrespondenceNotEstablished` — verified never to silently guess `Identical` or `Distinct` (`graph_identity_reordered_atoms_is_inconclusive_not_a_guess`, using `random_smiles` respellings).
- **`ChemicalGraphExact` and alternative resonance structures**: Kekulizing normalizes "aromatic-flagged" vs. "one particular already-Kekulized" spelling, but two *independently-written*, already-Kekulized alternative resonance structures of the same aromatic system (e.g. two different valid Kekulé structures of naphthalene) are not recognized as equivalent — that needs Hückel aromaticity perception (`chematic_perception::apply_aromaticity`), which is also not on `chematic-inchi`'s dependency graph. Never a false `Identical` either way (`ChemicalGraphKekulizationFailed` fails closed to inconclusive if Kekulization itself errors).
- **Enhanced stereochemistry**: the task brief asked for "enhanced stereo (if representable)" to be compared. Grepped `chematic-core`/`chematic-perception` before writing this module: neither has any AND/OR/ABS-style relative-stereo-group representation beyond plain per-atom `Chirality` today. Documented as a real scope boundary; no new enhanced-stereo model was invented as a side effect of this task.

---

## Commands run

```bash
# Isolated venv (own scratchpad, never the shared repo .venv):
/opt/homebrew/bin/python3.13 -m venv <scratchpad>/dedup_b_venv
<scratchpad>/dedup_b_venv/bin/pip install "rdkit==2026.03.3"

cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo build -p chematic-inchi [--features native-inchi]
cargo test  -p chematic-inchi [--features native-inchi] --lib --quiet
cargo test  -p chematic-inchi --features native-inchi --test dedup_fixtures --quiet
cargo test  -p chematic-inchi --features native-inchi --test accurate_cip_preflight --quiet
cargo test  -p chematic-inchi [--features native-inchi] --test graph_identity --quiet
cargo test  --workspace --tests --quiet --exclude chematic-py     # rest of the workspace, unaffected
cargo deny --all-features check
python3 scripts/check_publish_graph.py
```

`chematic-py` cannot be built/tested via plain `cargo build`/`cargo test` in this environment at all (fails at the link stage — missing `libpython` symbols) regardless of this PR's changes; `CLAUDE.md` itself documents that it requires `maturin develop`, which this task explicitly forbids running against the shared `.venv`. `cargo clippy` (type-check only, no final link) succeeds for `chematic-py` and every other crate workspace-wide. I did not build/install/touch the shared `.venv` at any point.

## Confirmation: shared `.venv` never touched

All RDKit oracle work ran through `/private/tmp/claude-501/.../scratchpad/dedup_b_venv`, built from a clean system Python (`/opt/homebrew/bin/python3.13`), never `/Users/k_tanabe/Documents/Documents/oss_rust/chematic/.venv` and never `maturin develop`/`pip install -e`/`pytest` against chematic's own Python bindings.

## Known limitations / follow-ups (not filed as GitHub issues — described here for the Coordinator to triage)

1. Tied-morgan-rank correspondence guard (3/12 audited, 3/15 fresh-corpus molecules stay conservatively unavailable) — see above.
2. `GraphIdentityMode`'s atom-order-identity-only scope — a real isomorphism search is a natural, separate follow-up once file ownership allows a `chematic-smarts` dependency edge (or a from-scratch matcher is independently designed/reviewed).
3. `ChemicalGraphExact` doesn't recognize alternative Kekulé resonance structures without Hückel perception access.
4. Enhanced stereochemistry comparison: blocked entirely on `chematic-core`/`chematic-perception` not having a representation yet.

## Merge blockers / open questions for the Coordinator

- Please independently review the tied-morgan-rank recall trade-off (limitation 1) — I judged "fail closed, ship less recall" as correct given this codebase's own stated fail-closed philosophy, but it's a judgment call worth a second opinion.
- `GraphIdentityMode`/`IdentityEvidence` is new, unintegrated API — Coordinator wires it into Agent A's SDF-ensemble supplier at Wave 2 per the master plan; no code in this PR depends on Agent A's work or vice versa.
- Not self-merging, per instructions.
- Side note for the Coordinator, not specific to this PR: the shared scratchpad directory (`/private/tmp/claude-501/.../scratchpad/`) is program-wide, not per-agent — I found a pre-existing `pr_body.md` there from a different agent's work and used a distinctly-named `pr_body_agent_b.md` instead to avoid clobbering it. Worth a heads-up to the other agents/coordinator if nobody's flagged this already.
