### PR TITLE
chore(3d): bridge chematic-3d::coords to chematic_core::{Point3, Coords3D}

### DIFF
--- a/crates/chematic-3d/src/coords.rs
+++ b/crates/chematic-3d/src/coords.rs
@@ -1,126 +1,19 @@
 //! 3D coordinate types for molecular structures.
+//!
+//! `Point3`/`Coords3D` are now defined once in `chematic_core::coords3d` and
+//! re-exported here as a compatibility surface, per the 3D Breakthrough
+//! Program's Coords3D unification (`docs/3d_breakthrough_master_plan.md`,
+//! decision 1a and the Wave 1->2 integration note in
+//! `chematic_core::coords3d`'s own doc comment). Every existing
+//! `crate::coords::{Point3, Coords3D}` / `chematic_3d::{Point3, Coords3D}`
+//! call site in this workspace keeps compiling unchanged: the two types were
+//! kept field-for-field and method-for-method identical (same `x`/`y`/`z`
+//! layout, same `points: Vec<Point3>` layout, same `new_zeroed`/`get`/`set`/
+//! `atom_count` names and panics-on-out-of-range indexing convention) exactly
+//! so this bridge could be a plain re-export with zero call-site changes.
+//!
+//! The `chematic-core` type is a strict superset (adds `is_finite()` on both
+//! types, `Default`/`PartialEq` on `Coords3D`) so nothing that worked before
+//! this bridge can stop working after it.
 
-use chematic_core::AtomIdx;
-
-/// A 3D point in Cartesian space (angstroms).
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Point3 {
-    pub x: f64,
-    pub y: f64,
-    pub z: f64,
-}
-
-impl Point3 {
-    /// Create a new point.
-    #[inline]
-    pub fn new(x: f64, y: f64, z: f64) -> Self {
-        Self { x, y, z }
-    }
-
-    /// The origin (0, 0, 0).
-    #[inline]
-    pub fn zero() -> Self {
-        Self::new(0.0, 0.0, 0.0)
-    }
-
-    /// Euclidean distance to another point.
-    #[inline]
-    pub fn distance(&self, other: &Self) -> f64 {
-        let dx = self.x - other.x;
-        let dy = self.y - other.y;
-        let dz = self.z - other.z;
-        (dx * dx + dy * dy + dz * dz).sqrt()
-    }
-
-    /// Component-wise addition.
-    #[inline]
-    pub fn add(&self, other: &Self) -> Self {
-        Self::new(self.x + other.x, self.y + other.y, self.z + other.z)
-    }
-
-    /// Component-wise subtraction.
-    #[inline]
-    pub fn sub(&self, other: &Self) -> Self {
-        Self::new(self.x - other.x, self.y - other.y, self.z - other.z)
-    }
-
-    /// Scalar multiplication.
-    #[inline]
-    pub fn scale(&self, s: f64) -> Self {
-        Self::new(self.x * s, self.y * s, self.z * s)
-    }
-
-    /// Dot product.
-    #[inline]
-    pub fn dot(&self, other: &Self) -> f64 {
-        self.x * other.x + self.y * other.y + self.z * other.z
-    }
-
-    /// Cross product.
-    #[inline]
-    pub fn cross(&self, other: &Self) -> Self {
-        Self::new(
-            self.y * other.z - self.z * other.y,
-            self.z * other.x - self.x * other.z,
-            self.x * other.y - self.y * other.x,
-        )
-    }
-
-    /// Euclidean norm (length).
-    #[inline]
-    pub fn norm(&self) -> f64 {
-        (self.x * self.x + self.y * self.y + self.z * self.z).sqrt()
-    }
-
-    /// Normalize to a unit vector.
-    ///
-    /// # Panics
-    /// Panics if the vector has zero length.
-    pub fn normalize(&self) -> Self {
-        let n = self.norm();
-        assert!(n > 0.0, "cannot normalize a zero-length vector");
-        self.scale(1.0 / n)
-    }
-
-    /// Try to normalize to a unit vector, returning None if the vector has zero length.
-    pub fn try_normalize(&self) -> Option<Self> {
-        let n = self.norm();
-        if n > 0.0 {
-            Some(self.scale(1.0 / n))
-        } else {
-            None
-        }
-    }
-}
-
-/// 3D coordinates for all heavy atoms in a molecule.
-///
-/// Indexed by atom insertion order (`AtomIdx.0` as `usize`).
-#[derive(Debug, Clone)]
-pub struct Coords3D {
-    pub points: Vec<Point3>,
-}
-
-impl Coords3D {
-    /// Create zeroed coordinates for `n` atoms.
-    pub fn new_zeroed(n: usize) -> Self {
-        Self {
-            points: vec![Point3::zero(); n],
-        }
-    }
-
-    /// Get the coordinate of atom `idx`.
-    pub fn get(&self, idx: AtomIdx) -> Point3 {
-        self.points[idx.0 as usize]
-    }
-
-    /// Set the coordinate of atom `idx`.
-    pub fn set(&mut self, idx: AtomIdx, p: Point3) {
-        self.points[idx.0 as usize] = p;
-    }
-
-    /// Number of atom coordinate slots.
-    pub fn atom_count(&self) -> usize {
-        self.points.len()
-    }
-}
+pub use chematic_core::{Coords3D, Point3};


### PR DESCRIPTION
## Summary
- Part of the 3D Breakthrough Program's Coords3D unification (`docs/3d_breakthrough_master_plan.md`, decision 1a).
- `crates/chematic-3d/src/coords.rs` is now a thin `pub use chematic_core::{Coords3D, Point3};` re-export instead of a separate, field/method-identical type definition (added in PR #168 by Agent A specifically to enable this bridge).
- Zero call-site changes required anywhere in the workspace: field layout (`x`/`y`/`z`, `points: Vec<Point3>`) and method names (`new_zeroed`/`get`/`set`/`atom_count`, same panics-on-out-of-range convention) are identical between the two types. Only non-`chematic-3d` construction site (`chematic-py/src/formats.rs`'s `flat_to_coords3d`, a struct literal) still compiles unchanged.
- `chematic-core` type is a strict superset (adds `is_finite()` on both types, `Default`/`PartialEq` on `Coords3D`), so nothing that worked before this bridge can stop working after it.
- No new dependency edge: `chematic-3d` already depends on `chematic-core`.

## Why this order
Per the program's merge-order requirement, this bridge must land before Agent C's (`#167`) and Agent F's (`#169`) PRs merge, since both touch `chematic-3d` coordinate code and must rebase onto the unified type rather than the old one.

## Test plan
- [x] `cargo check -p chematic-3d --all-targets`
- [x] `cargo check --workspace --all-targets` (all crates incl. chematic-py/wasm/mcp)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib --quiet` — all lib test binaries green, 0 failures