### PR TITLE
docs: sync CHANGELOG/READMEs with recent merges, fix MolJSON citation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `chematic-inchi`
+
+- **Accurate-CIP dedup preflight** (issue #161): `compare_with_accurate_cip_preflight`/
+  `compare_molecules_with_accurate_cip_preflight`/
+  `deduplicate_verified_with_accurate_cip_preflight` retry a legacy-CIP-unresolved
+  specified tetrahedral stereocentre via `CipMode::Accurate` and, if it resolves,
+  use that to recover verified-comparison capability — without ever letting the
+  accurate engine's answer leak into the generated InChI string itself (which
+  would silently reopen the 4663/4664 false-duplicate bug fixed previously).
+  Additive only: `compare`/`compare_molecules`/`deduplicate_verified`/
+  `identity_verify` are byte-for-byte unchanged. On the project's 5,000-molecule
+  reference corpus: `verification_unavailable` 15 → 6 (9 recovered, 0 newly
+  unavailable). Fails closed (`IdentityDiagnostic`) if the accurate engine
+  ties/budgets-out/errors on any flagged atom, or if two flagged atoms in the
+  same molecule share a `morgan_ranks` value (ambiguous correspondence — costs
+  real recall on 3/12 audited molecules, a known, quantified, unfixed
+  limitation).
+- **Indexed graph relation API**: `compare_indexed_graph_relation`, with mode
+  controlled by two independent, orthogonal axes —
+  `GraphStrictness::{RawGraphExact, ChemicalGraphExact}` (literal bond-order/
+  aromatic-flag equality vs. Kekulize-first chemical equality) and
+  `AtomMapPolicy::{Include, Ignore}` (whether reaction atom-mapping numbers are
+  part of molecule identity) — combinable freely via `IndexedGraphRelationMode`
+  rather than a flat preset enum. Requires matching atom-index correspondence
+  between the two molecules (e.g. conformer/ensemble grouping, MOL/SDF
+  round-trip checks) — not a general graph-isomorphism search; named
+  accordingly rather than as "exact graph identity" to avoid overclaiming.
+  `ChemicalGraphExact` does not yet recognize two independently-Kekulized
+  structures representing different valid resonance forms of the same
+  aromatic system as equivalent (degrades to an honest mismatch or
+  inconclusive result, never a false match).
+
 ### Added — `chematic-mcp`
 
 - **MCP 2026-07-28 tools-only stateless stdio server**, alongside unchanged

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,9 +1,10 @@
 cff-version: 1.2.0
 title: chematic
-message: "If you use this software, please cite it as below."
+message: "If you use Chematic in academic work, please cite it as below."
 type: software
 authors:
-  - name: kent-tokyo
+  - family-names: "Tanabe"
+    given-names: "Kentaro"
 repository-code: https://github.com/kent-tokyo/chematic
 url: https://kent-tokyo.github.io/chematic/
 abstract: >-

--- a/README.md
+++ b/README.md
@@ -398,17 +398,17 @@ See the [full WASM API reference](https://kent-tokyo.github.io/chematic/) for al
 | `chematic-smarts`     | SMARTS, VF2, MCS with chirality matching; **SmartsCache** (LRU compilation cache, 5–20×); **named_pattern()** library (20 functional group patterns); **atom map `:N` in SMARTS** (`[O;D1;H0:3]` — stored as metadata, not a match criterion); **`[kN]` ring-size primitive**; **VF2 early-exit** when query > target atom count; **`find_matches_with_rings`** — share SSSR across multi-pattern batches | 142   |
 | `chematic-3d`         | 3D coordinate generation, distance geometry constraints, ETKDG KB (40 torsion patterns, adaptive noise), force-field minimization, shape descriptors, ConformerEnsemble with RMSD pruning, PDB/XYZ; **GETAWAY HATS-matrix** (full 19-dim implementation); **`whim_getaway_combined()`** now 29-dim | 265    |
 | `chematic-rxn`        | Reaction SMILES/SMIRKS, `run_reactants`/`run_reactants_strict`; **`retro_disconnect()`** — 60 retro-SMIRKS templates (AmideBond/Ester/Ether/CNBond/CCBond/CSBond) + SA Score ranking; **parity-aware `@`/`@@` SMIRKS stereo filtering**; **E/Z double-bond stereo filtering** in `run_reactants` (`ez_stereo_outward`, `smirks_ez_stereo_ok`) | 137    |
-| `chematic-inchi`      | InChI/InChIKey: pure-Rust approximation (WASM) **+ IUPAC-standard** via `native-inchi` feature (vendored C lib 1.07.5, bit-exact); **parse_inchi** reader; **verified canonical-SMILES dedup** (`dedup::{group_candidates, deduplicate_verified}`, fail-closed on legacy-CIP-unresolved specified tetrahedral stereo) | 96 (+16*)    |
+| `chematic-inchi`      | InChI/InChIKey: pure-Rust approximation (WASM) **+ IUPAC-standard** via `native-inchi` feature (vendored C lib 1.07.5, bit-exact); **parse_inchi** reader; **verified canonical-SMILES dedup** (`dedup::{group_candidates, deduplicate_verified}`, fail-closed on legacy-CIP-unresolved specified tetrahedral stereo); **accurate-CIP dedup preflight** (issue #161) recovering verified-comparison capability on legacy-CIP-unresolved stereocentres; **indexed graph relation API** (`compare_indexed_graph_relation`, orthogonal `GraphStrictness`/`AtomMapPolicy` axes) | 108 (+16*)    |
 | `chematic-cip`        | Opt-in accurate CIP engine (`assign_cip_accurate_experimental`, hierarchical digraph, Rules 1a/1b/2/4b/5, RDKit-compatible MANCUDE fractional atomic numbers) — the default `assign_cip()`/`CipMode::LegacyFast` is unchanged | —     |
 | `chematic-wasm`       | **130+ WASM exports** — npm: `@kent-tokyo/chematic` (published `0.7.0`, in sync with crates.io/PyPI); pKa/ADMET/BBB/Caco-2/hERG/CYP3A4; `smiles_to_pdbqt`, `minimize_uff_json` | 211   |
 | `chematic-iupac`      | Local IUPAC name generation — **25+ compound classes**: alkanes, cycloalkanes, alkenes/alkynes, alcohols, amines, halides, aldehydes, ketones, acids, esters, amides, **piperidine, morpholine, piperazine, naphthalene, sulfides** | 47    |
-| `chematic-mcp`        | **MCP (Model Context Protocol) server** — AI agent integration; **20 tools**: parse_smiles, calc_properties, ecfp4, tanimoto, smarts_match, canonical_smiles, find_mcs, generate_3d, pains_check, brenk_check, sa_score, admet_profile, boiled_egg, lipinski_check, name_to_smiles, retrosynthesis, smiles_to_moljson, moljson_to_smiles, representation_router, **molecule_context_pack** | 31    |
+| `chematic-mcp`        | **MCP (Model Context Protocol) server** — AI agent integration; **20 tools**: parse_smiles, calc_properties, ecfp4, tanimoto, smarts_match, canonical_smiles, find_mcs, generate_3d, pains_check, brenk_check, sa_score, admet_profile, boiled_egg, lipinski_check, name_to_smiles, retrosynthesis, smiles_to_moljson, moljson_to_smiles, representation_router, **molecule_context_pack**; dual-era protocol (legacy `2024-11-05` + modern `2026-07-28` stateless dialect), `structuredContent`/`outputSchema` on all 20 tools | 82    |
 | `chematic-py`         | PyO3 Python bindings (`pip install chematic`); 300+ API endpoints: `from_smiles()`, `Mol.descriptors()`, `Mol.minimize_dreiding()`, `from_cxsmiles()`, `from_rxn_file()`/`to_rxn_file()`, `parse_sdf_with_coords()`, `Mol.ring_families()`, `tanimoto_matrix()`, `iter_sdf()`, `SimilarityIndex`; **`mol.to_pdf()`/`mol.to_eps()`** (depict); **`from_cjson()`/`mol.to_cjson()`** (ChemicalJSON); **`mol.schultz_mti`, `mol.gutman_mti`, `mol.vabc`, `mol.gravitational_index`**; **`bulk.substructure_match(smarts, mols)`** (parallel VF2 on pre-parsed Mol objects); **`mol.describe()`** (LLM/MCP-ready natural-language summary); **`mol.diff(other)`** (element + descriptor diff); Sprint 18–27 coverage | 300+  |
 | `chematic-ewald`      | PME Ewald summation, B-spline interpolation (cubic, phase-corrected)                                     | 16    |
 | `chematic`            | Umbrella crate with feature flags (all sub-crates, incl. `iupac`, `inchi`)                              | 1     |
 
 ```
-cargo test --workspace --lib --quiet                                          # 2,746 tests, all passing (2026-07-26)
+cargo test --workspace --lib --quiet                                          # 2,812 tests, all passing (2026-07-27)
 cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +16 IUPAC-exact InChI tests
 ```
 
@@ -616,7 +616,7 @@ chematic/
 
 ```bash
 cargo build --workspace                                                   # build all crates
-cargo test --workspace --lib --quiet                                      # 2,746 lib tests
+cargo test --workspace --lib --quiet                                      # 2,812 lib tests
 cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +16 InChI tests
 cargo clippy --workspace -- -D warnings                                   # lints (zero warnings)
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -265,15 +265,15 @@ const picks = JSON.parse(maxmin_picks_ecfp4_json('["CC","c1ccccc1","CCO","CCCC"]
 | `chematic-smarts`      | SMARTS、VF2、MCS；**SmartsCache** (LRU 5–20×)；**named_pattern()** (20 パターン)；**SMARTS 内アトムマップ `:N`** (`[O;D1;H0:3]` 形式 — メタデータとして保存、マッチング条件には不使用) | 142     |
 | `chematic-3d`          | 3D 座標生成、ETKDG KB (40 パターン、adaptive noise)、力場最小化、形状記述子、ConformerEnsemble、PDB/XYZ | 265     |
 | `chematic-rxn`         | 反応 SMILES/SMIRKS、`run_reactants`/`run_reactants_strict`；**`retro_disconnect()`** — 60 retro-SMIRKS テンプレート (AmideBond/Ester/Ether/CNBond/CCBond/CSBond) + SA Score ランク付き | 137      |
-| `chematic-inchi`       | InChI/InChIKey：純 Rust 近似（WASM 対応）**+ `native-inchi` feature で IUPAC 標準準拠**（C ライブラリ 1.07.5 vendored、ビット完全一致）；**parse_inchi** 読み込み；**検証付きcanonical SMILES重複排除**（`dedup`モジュール、legacy CIPで未解決の指定済みtetrahedral stereoに対してfail-closed） | 96 (+16*)   |
+| `chematic-inchi`       | InChI/InChIKey：純 Rust 近似（WASM 対応）**+ `native-inchi` feature で IUPAC 標準準拠**（C ライブラリ 1.07.5 vendored、ビット完全一致）；**parse_inchi** 読み込み；**検証付きcanonical SMILES重複排除**（`dedup`モジュール、legacy CIPで未解決の指定済みtetrahedral stereoに対してfail-closed）；**accurate-CIP dedup preflight**（issue #161、legacy CIPで未解決のstereocentreに対して検証capabilityを回復）；**indexed graph relation API**（`compare_indexed_graph_relation`、直交する`GraphStrictness`/`AtomMapPolicy`軸） | 108 (+16*)   |
 | `chematic-cip`         | opt-inの高精度CIPエンジン（`assign_cip_accurate_experimental`、階層的digraph、Rules 1a/1b/2/4b/5、RDKit互換MANCUDE分数原子番号）— デフォルトの`assign_cip()`/`CipMode::LegacyFast`は変更なし | —       |
 | `chematic-wasm`        | **130+ WASM エクスポート** — npm: `@kent-tokyo/chematic`（`0.7.0`公開済み、crates.io/PyPIと同期）；**pKa/ADMET/BBB/Caco-2/hERG/CYP3A4** WASM API | 211     |
 | `chematic-iupac`       | ローカル IUPAC 命名（Pure Rust・オフライン）— **25+ 化合物クラス**：アルカン、シクロアルカン、アルコール、アミン、ハロアルカン、ケトン、酸、エステル、アミド、**ピペリジン、モルホリン、ピペラジン、ナフタレン、スルフィド** | 47      |
-| `chematic-mcp`         | **MCP (Model Context Protocol) サーバー** — AI エージェント統合；**20 ツール**：parse_smiles, calc_properties, ecfp4, tanimoto, smarts_match, canonical_smiles, find_mcs, generate_3d, pains_check, brenk_check, sa_score, admet_profile, boiled_egg, lipinski_check, name_to_smiles, retrosynthesis, smiles_to_moljson, moljson_to_smiles, representation_router, molecule_context_pack | 31      |
+| `chematic-mcp`         | **MCP (Model Context Protocol) サーバー** — AI エージェント統合；**20 ツール**：parse_smiles, calc_properties, ecfp4, tanimoto, smarts_match, canonical_smiles, find_mcs, generate_3d, pains_check, brenk_check, sa_score, admet_profile, boiled_egg, lipinski_check, name_to_smiles, retrosynthesis, smiles_to_moljson, moljson_to_smiles, representation_router, molecule_context_pack；dual-eraプロトコル（レガシー`2024-11-05` + モダン`2026-07-28`ステートレス方言）、全20ツールに`structuredContent`/`outputSchema` | 82      |
 | `chematic`             | フィーチャーフラグ付きアンブレラクレート（統合クレート）                                                                                                  | 1       |
 
 ```
-cargo test --workspace --lib --quiet                                               # 2,746 ライブラリテスト、全パス（2026-07-26 時点）
+cargo test --workspace --lib --quiet                                               # 2,812 ライブラリテスト、全パス（2026-07-27 時点）
 cargo test -p chematic-inchi --features native-inchi --test standard_inchi         # +16 IUPAC 標準 InChI 統合テスト
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -233,15 +233,15 @@ const picks = JSON.parse(maxmin_picks_ecfp4_json('["CC","c1ccccc1","CCO","CCCC"]
 | `chematic-smarts`     | SMARTS、VF2、MCS；**SmartsCache**（LRU 5–20×）；**named_pattern()** 库（20 种模式）；**SMARTS 原子映射 `:N`**（`[O;D1;H0:3]` — 作为元数据存储，不用于匹配） | 142    |
 | `chematic-3d`         | 3D 坐标生成、ETKDG KB（40 种模式，自适应噪声）、力场最小化、形状描述符、ConformerEnsemble、PDB/XYZ | 265    |
 | `chematic-rxn`        | 反应 SMILES/SMIRKS、`run_reactants`/`run_reactants_strict`；**`retro_disconnect()`** — 60 个 retro-SMIRKS 模板（AmideBond/Ester/Ether/CNBond/CCBond/CSBond）+ SA 分数排序 | 137     |
-| `chematic-inchi`      | InChI/InChIKey：纯 Rust 近似（WASM 兼容）**+ `native-inchi` feature 提供 IUPAC 标准**（vendored C 库 1.07.5，逐位一致）；**parse_inchi** 读取；**带验证的 canonical SMILES 去重**（`dedup` 模块，遇到 legacy CIP 无法解析的指定四面体立体中心时安全失败） | 96 (+16*)   |
+| `chematic-inchi`      | InChI/InChIKey：纯 Rust 近似（WASM 兼容）**+ `native-inchi` feature 提供 IUPAC 标准**（vendored C 库 1.07.5，逐位一致）；**parse_inchi** 读取；**带验证的 canonical SMILES 去重**（`dedup` 模块，遇到 legacy CIP 无法解析的指定四面体立体中心时安全失败）；**accurate-CIP 去重预检**（issue #161，为 legacy CIP 无法解析的立体中心恢复已验证比较能力）；**indexed graph relation API**（`compare_indexed_graph_relation`，正交的 `GraphStrictness`/`AtomMapPolicy` 轴） | 108 (+16*)   |
 | `chematic-cip`        | opt-in 高精度 CIP 引擎（`assign_cip_accurate_experimental`，层次化 digraph，Rules 1a/1b/2/4b/5，RDKit 兼容 MANCUDE 分数原子序数）— 默认的 `assign_cip()`/`CipMode::LegacyFast` 未变更 | —    |
 | `chematic-wasm`       | **130+ WASM 导出** — npm：`@kent-tokyo/chematic`（已发布 `0.7.0`，与 crates.io/PyPI 同步）；**pKa/ADMET/BBB/Caco-2/hERG/CYP3A4** WASM API | 211    |
 | `chematic-iupac`      | 本地 IUPAC 命名（纯 Rust·离线）— **25+ 化合物类**：烷烃、环烷烃、醇、胺、卤代烃、酮、酸、酯、酰胺、**哌啶、吗啉、哌嗪、萘、硫醚** | 47     |
-| `chematic-mcp`        | **MCP（模型上下文协议）服务器** — AI 代理集成；**20 个工具**：parse_smiles, calc_properties, ecfp4, tanimoto, smarts_match, canonical_smiles, find_mcs, generate_3d, pains_check, brenk_check, sa_score, admet_profile, boiled_egg, lipinski_check, name_to_smiles, retrosynthesis, smiles_to_moljson, moljson_to_smiles, representation_router, molecule_context_pack | 31     |
+| `chematic-mcp`        | **MCP（模型上下文协议）服务器** — AI 代理集成；**20 个工具**：parse_smiles, calc_properties, ecfp4, tanimoto, smarts_match, canonical_smiles, find_mcs, generate_3d, pains_check, brenk_check, sa_score, admet_profile, boiled_egg, lipinski_check, name_to_smiles, retrosynthesis, smiles_to_moljson, moljson_to_smiles, representation_router, molecule_context_pack；dual-era 协议（旧版 `2024-11-05` + 现代 `2026-07-28` 无状态方言）、全部 20 个工具均支持 `structuredContent`/`outputSchema` | 82     |
 | `chematic`            | 带功能标志的伞形 crate                                                                                   | 1      |
 
 ```
-cargo test --workspace --lib --quiet                                               # 2,746 个库测试，全部通过（截至 2026-07-26）
+cargo test --workspace --lib --quiet                                               # 2,812 个库测试，全部通过（截至 2026-07-27）
 cargo test -p chematic-inchi --features native-inchi --test standard_inchi         # +16 IUPAC 标准 InChI 集成测试
 ```
 

--- a/crates/chematic-mol/src/moljson.rs
+++ b/crates/chematic-mol/src/moljson.rs
@@ -23,8 +23,11 @@
 //! ```
 //!
 //! ## References
-//! - Guo et al. "Molecular Representations for Large Language Models" (2026)
-//! - oxpig/MolJSON: <https://github.com/oxpig/MolJSON>
+//! - Nicholas T. Runcie, Fergus Imrie, Charlotte M. Deane, "Molecular
+//!   Representations for Large Language Models," arXiv:2605.01822, 2026.
+//! - Official schema and reference implementation: oxpig/MolJSON
+//!   <https://github.com/oxpig/MolJSON> (reference implementation licensed
+//!   BSD-3-Clause).
 
 #![forbid(unsafe_code)]
 


### PR DESCRIPTION
## Summary
- CHANGELOG `[Unreleased]`: document the accurate-CIP dedup preflight (issue #161, #178) and indexed graph relation API (#181) — both merged without their own CHANGELOG entries.
- README.md/README_ja.md/README_zh.md: update `chematic-inchi` (96→108) and `chematic-mcp` (31→82) test counts and feature descriptions to match #178/#181/#182; refresh the workspace lib test count (2,746→2,812, re-measured 2026-07-27).
- `moljson.rs`: correct the MolJSON citation from "Guo et al." to the actual authors (Runcie, Imrie, Deane, arXiv:2605.01822) per the official `oxpig/MolJSON` repository's own citation request.
- `CITATION.cff`: replace the GitHub-username-only author entry with a proper `family-names`/`given-names` person entry, and clarify the citation message is for academic use.

## Test plan
- [x] `bash scripts/check.sh` — all checks passed
- [x] `cargo test --workspace --lib --quiet` re-measured directly: 2,812 tests passed
- [x] `cffconvert --validate` — citation metadata valid per schema 1.2.0
