### PR TITLE
fix(rxn): eliminate redundant canonical-SMILES write in run_reactants hot path (partial fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet — everything below `[0.7.1]` has shipped._
+
+## [0.7.1] — 2026-07-27
+
 ### Added — `chematic-inchi`
 
 - **Accurate-CIP dedup preflight** (issue #161): `compare_with_accurate_cip_preflight`/
@@ -93,24 +97,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`canonical_smiles()` wrote its winning individualize-refine branch's
   string, then wrote it again.** `winning_individualized_ranks` (shared by
-  `canonical_smiles`/`canonical_atom_order`) already had to call
+  `canonical_smiles`/`canonical_atom_order`, extracted by `c219ee7` so
+  `canonical_atom_order` would share the same tie-break) already had to call
   `CanonicalWriter::write_all()` on every candidate branch to find the
   lexicographically smallest one; `canonical_smiles` then called
   `write_all()` a second, fully redundant time on the already-known winning
-  ranks, on every single call, tied or not. Introduced by `be5dbb1`'s
-  (0.4.26) individualize-refine correctness fix. Reported via an external
-  consumer's `run_reactants`/`apply_retro` performance regression (45-48x
-  slower `canonical_smiles()` in isolation on highly symmetric molecules —
-  plain rings, cages, `CF3`/`tBu`-style substituents — between chematic
-  0.4.25 and 0.4.30). Fixed by returning `(ranks, winning_string)` from
-  `winning_individualized_ranks` so `canonical_smiles` reuses the string
-  instead of recomputing it. Pure refactor: output is byte-identical
-  (verified against the full test suite, including `be5dbb1`'s own
-  golden-string tests and the issue #50 E/Z regression suite). Does **not**
-  fix the larger, still-open cost on genuinely symmetric molecules, which
-  needs automorphism-orbit-aware branch pruning — explicitly deferred as
-  future work. Full bisect, methodology, and before/after numbers in
-  `docs/reaction_transform_perf.md`.
+  ranks, on every single call, tied or not. The redundant call was introduced
+  by `c219ee7` (2026-07-12), two days *after* `be5dbb1`'s (2026-07-10)
+  individualize-refine correctness fix that this redundant work rides on top
+  of — both commits first shipped in 0.4.30, not 0.4.26 (Cargo.toml already
+  read 0.4.29 at both commits; the next release tag after either is
+  `v0.4.30`). `be5dbb1` itself remains correctly attributed as the root cause
+  of the *combinatorial* cost (the expensive-but-currently-necessary
+  branch-and-minimize enumeration) — that part is unfixed here, see below.
+  Reported via an external consumer's `run_reactants`/`apply_retro`
+  performance regression (45-48x slower `canonical_smiles()` in isolation on
+  highly symmetric molecules — plain rings, cages, `CF3`/`tBu`-style
+  substituents — between chematic 0.4.25 and 0.4.30). Fixed by returning
+  `(ranks, winning_string)` from `winning_individualized_ranks` so
+  `canonical_smiles` reuses the string instead of recomputing it. Pure
+  refactor: output is byte-identical (verified against the full test suite,
+  including `be5dbb1`'s own golden-string tests and the issue #50 E/Z
+  regression suite, plus an independent verification pass diffing
+  `canonical_smiles`/`canonical_atom_order` output over a real 5,000-molecule
+  corpus, 0 differences). Measured improvement: real and consistently
+  positive on p95/p99/max; independently re-measured with symmetric
+  instrumentation on both arms at ~13.4% total elapsed (p50 delta not
+  resolvable from run-to-run noise at this sample size — treat the total/p50
+  figures in `docs/reaction_transform_perf.md` as directional, not precise).
+  Does **not** fix the larger, still-open cost on genuinely symmetric
+  molecules, which needs automorphism-orbit-aware branch pruning —
+  explicitly deferred as future work. Full bisect, methodology, and
+  before/after numbers in `docs/reaction_transform_perf.md`.
 
 ### Added — `chematic-rxn`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   has the identical bug and is not fixed here (out of scope for this fix; tracked
   separately).
 
+### Fixed — `chematic-smiles`
+
+- **`canonical_smiles()` wrote its winning individualize-refine branch's
+  string, then wrote it again.** `winning_individualized_ranks` (shared by
+  `canonical_smiles`/`canonical_atom_order`) already had to call
+  `CanonicalWriter::write_all()` on every candidate branch to find the
+  lexicographically smallest one; `canonical_smiles` then called
+  `write_all()` a second, fully redundant time on the already-known winning
+  ranks, on every single call, tied or not. Introduced by `be5dbb1`'s
+  (0.4.26) individualize-refine correctness fix. Reported via an external
+  consumer's `run_reactants`/`apply_retro` performance regression (45-48x
+  slower `canonical_smiles()` in isolation on highly symmetric molecules —
+  plain rings, cages, `CF3`/`tBu`-style substituents — between chematic
+  0.4.25 and 0.4.30). Fixed by returning `(ranks, winning_string)` from
+  `winning_individualized_ranks` so `canonical_smiles` reuses the string
+  instead of recomputing it. Pure refactor: output is byte-identical
+  (verified against the full test suite, including `be5dbb1`'s own
+  golden-string tests and the issue #50 E/Z regression suite). Does **not**
+  fix the larger, still-open cost on genuinely symmetric molecules, which
+  needs automorphism-orbit-aware branch pruning — explicitly deferred as
+  future work. Full bisect, methodology, and before/after numbers in
+  `docs/reaction_transform_perf.md`.
+
+### Added — `chematic-rxn`
+
+- New `perf-instrumentation` Cargo feature (off by default, zero cost when
+  disabled): process-global work counters for `run_reactants`'s hot path
+  (`run_reactants_calls`, `reaction_parse_calls`,
+  `reactant_query_match_calls`, `vf2_match_count`, `match_combination_count`,
+  `build_product_calls`, `product_sets_before_dedup`,
+  `product_molecules_built`, `atoms_copied_to_products`,
+  `bonds_copied_to_products`), added while diagnosing the regression above.
+- New `reaction_transform_perf_report` example: a corpus-weighted
+  `run_reactants` benchmark accepting external template/probe corpora via
+  `RENKIN_TEMPLATES`/`RENKIN_PROBE` env vars, falling back to small
+  hand-authored fixtures in `crates/chematic-rxn/fixtures/`.
+
 _Nothing else yet — everything below `[0.7.0]` has shipped._
 
 ## [0.7.0] — 2026-07-26

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,5 +23,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.7.0
+version: 0.7.1
 date-released: "2026-06-26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 rust-version = "1.85"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -180,10 +180,10 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.7.0
+# chematic v0.7.1
 # Python 3.12.x  |  darwin arm64
 #
-# Descriptor accuracy (benchmark 2026-07-17, v0.7.0 vs RDKit 2026.03.3):
+# Descriptor accuracy (benchmark 2026-07-17, v0.7.1 vs RDKit 2026.03.3):
 #   MW / HBA / HBD / ARC  100%   (4,999-mol ChEMBL subset)
 #   TPSA                  100%   within ±0.1 Å²
 #   LogP (Crippen)        100%*  (max Δ = 1.1×10⁻¹³)
@@ -416,6 +416,10 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +1
 
 ## Recent Development
 
+**v0.7.1** (2026-07-27): **`run_reactants`/`canonical_smiles()` performance fix**
+- `chematic-smiles`: fixed `canonical_smiles()` calling `CanonicalWriter::write_all()` a second, fully redundant time on every call (the winner was already written once while resolving individualize-refine ties, then thrown away and rewritten) — a real regression introduced by the correctness fix in `be5dbb1` (0.4.26), most visible on highly symmetric molecules (plain rings, cages, `CF3`/`tBu`-style substituents: 45-48x slower `canonical_smiles()` in isolation on chematic 0.4.30 vs 0.4.25, reported via an external consumer's `run_reactants`/`apply_retro` regression). Pure refactor — output is byte-identical (verified against all existing tests, including `be5dbb1`'s own golden-string tests and the issue #50 E/Z regression suite). New `chematic-rxn` `perf-instrumentation` feature + `reaction_transform_perf_report` example benchmark added alongside. Full bisect and remaining known gap (genuine automorphism-orbit pruning, not attempted) in `docs/reaction_transform_perf.md`
+- Full details in `CHANGELOG.md`'s `[Unreleased]` section
+
 **v0.7.0** (2026-07-26): **2D wedge/hash + E/Z stereo now perceived automatically from MOL/SDF, verified canonical-SMILES dedup, CIP Rule-5 phosphorus fix, native InChI explicit-H/isotope fix**
 - `chematic-mol`/`chematic-perception`: MOL V2000/V3000/SDF readers now perceive both tetrahedral wedge/hash parity (PR #154) and E/Z double-bond direction (PR #162) automatically on read, CIP-independent, via `read_mol_with_diagnostics`/`read_mol_v3000_with_diagnostics` — typed opt-in diagnostics (`StereoDiagnostic`/`EzDirectionDiagnostic`) never guess on malformed/ambiguous input. Broad-corpus validation (4,999 molecules vs. RDKit 2026.03.3): E/Z — 622 RDKit-resolved double bonds, 0 semantic inversions, 0 false positives. Also fixed a V2000 MDL-code-4 bug, two V3000 `CFG` bugs, and a V2000 writer bug found while building this. PR #162's own corpus reconciliation surfaced a **new, not-yet-fixed** gap: `canonical_smiles()` can drop an already-correctly-`write()`-encoded E/Z marker for some molecules (aromaticity-unaware carrier grouping) — not yet filed as an issue
 - `chematic-inchi`: new verified canonical-SMILES dedup (`dedup` module) — fast canonical-SMILES candidate bucketing reconciled against native-InChI verified identity; fails closed (`VerificationUnavailable`) rather than risk a false merge whenever a specified stereocenter's legacy-CIP ranking is unresolved (closes a real false-`VerifiedDuplicate` found via live 5,000-molecule corpus verification). Follow-up tracked as [#161](https://github.com/kent-tokyo/chematic/issues/161) (an accurate-CIP preflight could recover most of the conservative cases)
@@ -579,7 +583,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v0.7.0)
+├── Cargo.toml                    workspace root (v0.7.1)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)
@@ -632,7 +636,7 @@ If you use chematic in academic or research work, please cite:
   author    = {kent-tokyo},
   title     = {chematic: A pure-Rust cheminformatics toolkit},
   url       = {https://github.com/kent-tokyo/chematic},
-  version   = {0.7.0},
+  version   = {0.7.1},
   year      = {2026},
 }
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -106,10 +106,10 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.7.0
+# chematic v0.7.1
 # Python 3.12.x  |  darwin arm64
 #
-# Descriptor accuracy (benchmark 2026-06, v0.7.0 vs RDKit 2026.03.3):
+# Descriptor accuracy (benchmark 2026-06, v0.7.1 vs RDKit 2026.03.3):
 #   MW / HBA / HBD / ARC  100%   (4,999-mol ChEMBL subset)
 #   TPSA                  98.1%
 #   LogP (Crippen)        ~99%
@@ -280,6 +280,10 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi      
 ---
 
 ## 最近の開発
+
+**v0.7.1**（2026-07-27）: **`run_reactants`/`canonical_smiles()` パフォーマンス修正**
+- `chematic-smiles`: `canonical_smiles()` が毎回 `CanonicalWriter::write_all()` を無駄にもう一度呼んでいたバグを修正（individualize-refineのタイブレーク解決時に勝者は既に一度書き込まれていたが、それを捨てて再度書き直していた）。`be5dbb1`（0.4.26）の正しさ修正で生じた本物の性能回帰で、対称性の高い分子（単純な環、ケージ構造、`CF3`/`tBu`系置換基）で最も顕著（外部利用者の`run_reactants`/`apply_retro`回帰報告経由で発覚、chematic 0.4.30 vs 0.4.25で単体`canonical_smiles()`が45-48倍遅い）。純粋なリファクタリングで出力はバイト単位で同一（`be5dbb1`自身のgolden-stringテスト、issue #50のE/Z回帰スイートを含む既存テスト全てで検証済み）。あわせて`chematic-rxn`に`perf-instrumentation`機能と`reaction_transform_perf_report`ベンチマーク例を追加。詳細な二分探索と既知の残課題（真の自己同型オービット枝刈り、未着手）は`docs/reaction_transform_perf.md`参照
+- 詳細は`CHANGELOG.md`の`[Unreleased]`セクション参照
 
 **v0.7.0**（2026-07-26）: **MOL/SDFから2Dウェッジ/ハッシュ＋E/Z立体化学を自動認識、検証付きcanonical SMILES重複排除、CIP Rule-5リン修正、native InChI明示的水素/同位体修正**
 - `chematic-mol`/`chematic-perception`: MOL V2000/V3000/SDFリーダーが読み込み時にtetrahedralウェッジ/ハッシュparity（PR #154）とE/Z二重結合方向（PR #162）を自動認識するようになった（CIP非依存）。型付きopt-in診断（`StereoDiagnostic`/`EzDirectionDiagnostic`）は不正・曖昧な入力に対して推測しない。広域corpus検証（4,999分子、RDKit 2026.03.3比較）：E/Z — RDKit解決済み622二重結合、semantic inversion 0件、false positive 0件。構築中に見つかったV2000 MDLコード4バグ・V3000 `CFG`バグ2件・V2000 writerバグも修正。PR #162自身のcorpus突合により**新規・未修正のギャップ**を発見: `canonical_smiles()`が一部の分子で正しく`write()`されたE/Zマーカーを失うケースがある（aromaticity非対応のcarrierグルーピングが原因）— まだissue化していない

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.7.0 | Yes | Current release — active support |
+| v0.7.1 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.7.0) receives all security updates.  
+**Active Support**: Latest release (v0.7.1) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -16,12 +16,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.7.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.7.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.7.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.7.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.7.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.7.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.7.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.7.1" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.7.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.7.1" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.7.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.7.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -16,14 +16,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.7.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.7.1" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.7.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.7.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.7.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.7.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.7.0" }
-chematic-cip        = { path = "../chematic-cip",        version = "0.7.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.7.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.7.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.7.1" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.7.1" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.7.1" }
+chematic-cip        = { path = "../chematic-cip",        version = "0.7.1" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.7.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.7.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.7.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.7.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -22,10 +22,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.7.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.7.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.7.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.7.0" }
+chematic-core = { path = "../chematic-core", version = "0.7.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.7.1" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.7.1" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.7.1" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.7.0" }
+chematic-core = { path = "../chematic-core", version = "0.7.1" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.7.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.7.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.7.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.7.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -22,13 +22,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.7.0" }
+chematic-core = { path = "../chematic-core", version = "0.7.1" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.7.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.7.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.7.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.7.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.7.1" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.7.1" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.7.1" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.7.1" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -18,10 +18,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.7.0", path = "../chematic-core" }
-chematic-smiles = { version = "0.7.0", path = "../chematic-smiles" }
-chematic-chem = { version = "0.7.0", path = "../chematic-chem" }
-chematic-rxn = { version = "0.7.0", path = "../chematic-rxn" }
+chematic-core = { version = "0.7.1", path = "../chematic-core" }
+chematic-smiles = { version = "0.7.1", path = "../chematic-smiles" }
+chematic-chem = { version = "0.7.1", path = "../chematic-chem" }
+chematic-rxn = { version = "0.7.1", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.7.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.7.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.7.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.7.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -17,15 +17,15 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.7.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.7.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.7.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.7.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.7.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.7.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.7.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.7.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.7.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.7.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.7.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.7.1", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.7.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.7.1" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.7.1" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.7.1" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.7.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.7.1" }
 
 [dev-dependencies]
 # Real JSON Schema 2020-12 validator, used only in tests to independently

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -16,9 +16,9 @@ documentation = "https://docs.rs/chematic-mol"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.7.0" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.7.0" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.7.0" }
+chematic-core        = { path = "../chematic-core",        version = "0.7.1" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.7.1" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.7.1" }
 serde_json           = "1.0"
 
 [dev-dependencies]

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.7.0" }
+chematic-core = { path = "../chematic-core", version = "0.7.1" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,16 +25,16 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.7.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.7.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.7.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.7.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.7.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.7.0", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.7.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.7.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.7.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.7.0" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.7.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.7.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.7.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.7.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.7.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.7.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.7.1" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.7.1" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.7.1", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.7.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.7.1" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.7.1" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.7.1" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.7.1" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.7.1" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.7.1" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -15,8 +15,19 @@ documentation = "https://docs.rs/chematic-rxn"
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[features]
+# Internal work counters (run_reactants_calls, vf2_match_count, ...) for
+# performance diagnosis -- see src/perf_counters.rs. Off by default so the
+# hot path pays zero cost in normal builds.
+perf-instrumentation = []
+
 [dependencies]
 chematic-core   = { path = "../chematic-core",   version = "0.7.0" }
 chematic-smiles = { path = "../chematic-smiles", version = "0.7.0" }
 chematic-smarts = { path = "../chematic-smarts", version = "0.7.0" }
 rustc-hash = "2"
+
+[dev-dependencies]
+# Path-only (no `version`): mutual dev-dependency, matching the pattern in
+# chematic-smiles/Cargo.toml (avoids a cargo-publish version deadlock).
+chematic-chem = { path = "../chematic-chem" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -22,9 +22,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 perf-instrumentation = []
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.7.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.7.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.7.0" }
+chematic-core   = { path = "../chematic-core",   version = "0.7.1" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.7.1" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.7.1" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-rxn/examples/reaction_transform_perf_report.rs
+++ b/crates/chematic-rxn/examples/reaction_transform_perf_report.rs
@@ -1,0 +1,297 @@
+//! Corpus-weighted `run_reactants` performance report.
+//!
+//! Built while diagnosing the RENKIN-reported `run_reactants`/`apply_retro`
+//! performance regression between chematic 0.4.25 and 0.4.30 (see
+//! `docs/reaction_transform_perf.md`). A single-molecule/single-template
+//! microbenchmark already demonstrably failed to catch that regression (it
+//! is specific to *symmetric* intermediate molecules -- plain rings, cages,
+//! `CF3`/`tBu`-style substituents -- which a handful of drug-like root
+//! targets rarely exercise); this report instead runs a cross-product of
+//! many template rules against many probe molecules, **and** feeds the
+//! fragments produced by round 1 back in as round-2 probe molecules, to put
+//! the same kind of symmetric intermediates a real multi-step retrosynthesis
+//! search encounters into the measured population.
+//!
+//! # External corpora (optional)
+//!
+//! By default this runs against the small, hand-authored, MIT/BSD-clean
+//! witness fixtures committed in `fixtures/` (`witness_templates.smirks`,
+//! `witness_molecules.smi`). Point at a larger, external corpus instead via:
+//!
+//! - `RENKIN_TEMPLATES=/path/to/templates.smi` -- one SMIRKS per line
+//!   (optionally `SMIRKS<TAB>count`, matching RENKIN's own
+//!   `templates_extracted_5000.smi` format; the count column is ignored here).
+//! - `RENKIN_PROBE=/path/to/probe.smi` -- one SMILES per line (optionally
+//!   `SMILES<space>name`).
+//!
+//! Neither this repository nor this file ever contains or ships RENKIN's own
+//! corpus data -- only the paths are read, from wherever the caller points.
+//!
+//! Other env vars: `RXN_PERF_MAX_TEMPLATES` (cap template count),
+//! `RXN_PERF_DEPTH` (how many fragment-feedback rounds, default 2).
+//!
+//! Run for comparability with RENKIN's own methodology (`RAYON_NUM_THREADS=2`
+//! pinned on both arms of a before/after comparison) via:
+//! ```text
+//! RAYON_NUM_THREADS=2 cargo run --release -p chematic-rxn \
+//!     --features perf-instrumentation --example reaction_transform_perf_report
+//! ```
+//! ponytail: this harness is single-threaded (chematic-rxn itself spawns no
+//! threads), so `RAYON_NUM_THREADS` has no effect on it directly -- it is
+//! set purely so the *process environment* matches RENKIN's own measurement
+//! conditions exactly, per the task's comparability requirement. Add rayon
+//! parallelism here if a future user needs this harness to also reproduce
+//! RENKIN's cross-core contention characteristics.
+
+use std::env;
+use std::fs;
+use std::time::{Duration, Instant};
+
+use chematic_chem::standardize::{StandardizeOptions, ZwitterionHandling, standardize};
+use chematic_rxn::run_reactants;
+use chematic_smiles::{canonical_smiles, parse};
+
+const DEFAULT_TEMPLATES: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/fixtures/witness_templates.smirks"
+);
+const DEFAULT_PROBE: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/fixtures/witness_molecules.smi"
+);
+
+struct CallStats {
+    durations: Vec<Duration>,
+    errors_swallowed: u64,
+}
+
+impl CallStats {
+    fn new() -> Self {
+        Self {
+            durations: Vec::new(),
+            errors_swallowed: 0,
+        }
+    }
+
+    fn percentile(&self, p: f64) -> Duration {
+        if self.durations.is_empty() {
+            return Duration::ZERO;
+        }
+        let mut sorted = self.durations.clone();
+        sorted.sort_unstable();
+        let idx = ((sorted.len() - 1) as f64 * p).round() as usize;
+        sorted[idx]
+    }
+
+    fn max(&self) -> Duration {
+        self.durations.iter().copied().max().unwrap_or_default()
+    }
+
+    fn total(&self) -> Duration {
+        self.durations.iter().sum()
+    }
+}
+
+/// Mirror of RENKIN's `apply_retro` -> `split_fragments` pattern: apply one
+/// SMIRKS template to one molecule, then split every product on '.',
+/// re-parse, and standardize each fragment -- the exact call sequence that
+/// (per the bisect in docs/reaction_transform_perf.md) actually carries the
+/// regression, not `run_reactants` in isolation.
+fn apply_retro_like(
+    smirks: &str,
+    mol: &chematic_core::Molecule,
+    opts: &StandardizeOptions,
+    canonical_smiles_calls: &mut u64,
+    standardize_calls: &mut u64,
+    fragments_before_filter: &mut u64,
+    fragments_after_filter: &mut u64,
+) -> (Duration, Vec<String>) {
+    let t0 = Instant::now();
+    let mut fragment_smiles = Vec::new();
+    match run_reactants(smirks, &[mol]) {
+        Ok(product_sets) => {
+            for product_set in product_sets {
+                for product_mol in product_set {
+                    let smi = canonical_smiles(&product_mol);
+                    *canonical_smiles_calls += 1;
+                    for frag in smi.split('.') {
+                        *fragments_before_filter += 1;
+                        if let Ok(m) = parse(frag) {
+                            let std_mol = standardize(&m, opts);
+                            *standardize_calls += 1;
+                            let std_smi = canonical_smiles(&std_mol);
+                            *canonical_smiles_calls += 1;
+                            *fragments_after_filter += 1;
+                            fragment_smiles.push(std_smi);
+                        }
+                    }
+                }
+            }
+        }
+        Err(_) => {
+            // Matches RENKIN's `.unwrap_or_default()` on run_reactants' Result.
+        }
+    }
+    (t0.elapsed(), fragment_smiles)
+}
+
+fn load_lines(path: &str, take_first_field: bool) -> Vec<String> {
+    fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("read '{path}': {e}"))
+        .lines()
+        .filter(|l| !l.starts_with('#') && !l.trim().is_empty())
+        .map(|l| {
+            if take_first_field {
+                l.split(['\t', ' ']).next().unwrap_or(l).to_string()
+            } else {
+                l.to_string()
+            }
+        })
+        .collect()
+}
+
+fn main() {
+    let templates_path = env::var("RENKIN_TEMPLATES").unwrap_or_else(|_| DEFAULT_TEMPLATES.into());
+    let probe_path = env::var("RENKIN_PROBE").unwrap_or_else(|_| DEFAULT_PROBE.into());
+    let max_templates: usize = env::var("RXN_PERF_MAX_TEMPLATES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(usize::MAX);
+    let depth: usize = env::var("RXN_PERF_DEPTH")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(2);
+
+    let mut templates = load_lines(&templates_path, true);
+    templates.truncate(max_templates);
+    let probe_smiles = load_lines(&probe_path, true);
+
+    eprintln!(
+        "templates_path={templates_path} ({} rules) probe_path={probe_path} ({} molecules) depth={depth}",
+        templates.len(),
+        probe_smiles.len()
+    );
+
+    let opts = StandardizeOptions {
+        canonical_tautomer: false,
+        neutralize_charges: false,
+        remove_explicit_h: true,
+        largest_fragment_only: false,
+        zwitterion_handling: ZwitterionHandling::Keep,
+    };
+
+    // Round 0: the probe molecules themselves.
+    let mut current_smiles: Vec<String> = probe_smiles;
+
+    let mut stats = CallStats::new();
+    let mut canonical_smiles_calls: u64 = 0;
+    let mut standardize_calls: u64 = 0;
+    let mut fragments_before_filter: u64 = 0;
+    let mut fragments_after_filter: u64 = 0;
+    let mut product_molecules_seen: u64 = 0;
+
+    chematic_rxn::perf_counters::reset();
+    let wall_t0 = Instant::now();
+
+    for level in 0..depth {
+        let mut next_smiles: Vec<String> = Vec::new();
+        let mols: Vec<_> = current_smiles
+            .iter()
+            .filter_map(|s| parse(s).ok())
+            .collect();
+        eprintln!(
+            "round {level}: {} input molecules ({} parsed)",
+            current_smiles.len(),
+            mols.len()
+        );
+
+        for smirks in &templates {
+            for mol in &mols {
+                let (elapsed, fragments) = apply_retro_like(
+                    smirks,
+                    mol,
+                    &opts,
+                    &mut canonical_smiles_calls,
+                    &mut standardize_calls,
+                    &mut fragments_before_filter,
+                    &mut fragments_after_filter,
+                );
+                stats.durations.push(elapsed);
+                product_molecules_seen += fragments.len() as u64;
+                next_smiles.extend(fragments);
+            }
+        }
+
+        // Dedup + cap: a real search would prune via a visited-set and beam
+        // width; this keeps the next round's population bounded without
+        // biasing which structures survive (sort+dedup is order-independent).
+        next_smiles.sort_unstable();
+        next_smiles.dedup();
+        next_smiles.truncate(200);
+        current_smiles = next_smiles;
+    }
+
+    let wall_elapsed = wall_t0.elapsed();
+    let counters = chematic_rxn::perf_counters::snapshot();
+
+    println!("=== reaction_transform_perf_report ===");
+    println!("total_calls={}", stats.durations.len());
+    println!("wall_elapsed_ms={}", wall_elapsed.as_millis());
+    println!("elapsed_total_ms={}", stats.total().as_millis());
+    println!(
+        "elapsed_per_call_ns={:.1}",
+        stats.total().as_nanos() as f64 / stats.durations.len().max(1) as f64
+    );
+    println!("p50_ns={}", stats.percentile(0.50).as_nanos());
+    println!("p95_ns={}", stats.percentile(0.95).as_nanos());
+    println!("p99_ns={}", stats.percentile(0.99).as_nanos());
+    println!("max_ns={}", stats.max().as_nanos());
+    println!("product_molecules_seen={product_molecules_seen}");
+    println!("canonical_smiles_calls={canonical_smiles_calls}");
+    println!("standardize_calls={standardize_calls}");
+    println!("fragments_before_filter={fragments_before_filter}");
+    println!("fragments_after_filter={fragments_after_filter}");
+    println!(
+        "errors_swallowed_by_unwrap_or_default={}",
+        stats.errors_swallowed
+    );
+    println!(
+        "successful_match_rate={:.4}",
+        product_molecules_seen as f64 / stats.durations.len().max(1) as f64
+    );
+    println!("--- chematic-rxn internal work counters (perf-instrumentation feature) ---");
+    println!("run_reactants_calls={}", counters.run_reactants_calls);
+    println!("reaction_parse_calls={}", counters.reaction_parse_calls);
+    println!(
+        "reactant_query_match_calls={}",
+        counters.reactant_query_match_calls
+    );
+    println!("vf2_match_count={}", counters.vf2_match_count);
+    println!(
+        "match_combination_count={}",
+        counters.match_combination_count
+    );
+    println!("build_product_calls={}", counters.build_product_calls);
+    println!(
+        "product_sets_before_dedup={}",
+        counters.product_sets_before_dedup
+    );
+    println!(
+        "product_molecules_built={}",
+        counters.product_molecules_built
+    );
+    println!(
+        "atoms_copied_to_products={}",
+        counters.atoms_copied_to_products
+    );
+    println!(
+        "bonds_copied_to_products={}",
+        counters.bonds_copied_to_products
+    );
+    if counters.run_reactants_calls == 0 {
+        eprintln!(
+            "note: all internal work counters are zero -- rebuild with \
+             --features perf-instrumentation to populate them."
+        );
+    }
+}

--- a/crates/chematic-rxn/examples/reaction_transform_perf_report.rs
+++ b/crates/chematic-rxn/examples/reaction_transform_perf_report.rs
@@ -62,14 +62,12 @@ const DEFAULT_PROBE: &str = concat!(
 
 struct CallStats {
     durations: Vec<Duration>,
-    errors_swallowed: u64,
 }
 
 impl CallStats {
     fn new() -> Self {
         Self {
             durations: Vec::new(),
-            errors_swallowed: 0,
         }
     }
 
@@ -97,6 +95,13 @@ impl CallStats {
 /// re-parse, and standardize each fragment -- the exact call sequence that
 /// (per the bisect in docs/reaction_transform_perf.md) actually carries the
 /// regression, not `run_reactants` in isolation.
+///
+/// Note: this does *not* reimplement RENKIN's own aromatic-atom-without-a-
+/// ring-closure fragment filter (their `split_fragments`'s BFS-leakage
+/// guard) -- `fragments_parsed_ok` below counts successfully-`parse()`d
+/// fragments, not post-filter survivors, and is named accordingly rather
+/// than promising a filter this harness doesn't apply.
+#[allow(clippy::too_many_arguments)]
 fn apply_retro_like(
     smirks: &str,
     mol: &chematic_core::Molecule,
@@ -104,7 +109,8 @@ fn apply_retro_like(
     canonical_smiles_calls: &mut u64,
     standardize_calls: &mut u64,
     fragments_before_filter: &mut u64,
-    fragments_after_filter: &mut u64,
+    fragments_parsed_ok: &mut u64,
+    errors_swallowed: &mut u64,
 ) -> (Duration, Vec<String>) {
     let t0 = Instant::now();
     let mut fragment_smiles = Vec::new();
@@ -121,7 +127,7 @@ fn apply_retro_like(
                             *standardize_calls += 1;
                             let std_smi = canonical_smiles(&std_mol);
                             *canonical_smiles_calls += 1;
-                            *fragments_after_filter += 1;
+                            *fragments_parsed_ok += 1;
                             fragment_smiles.push(std_smi);
                         }
                     }
@@ -130,6 +136,7 @@ fn apply_retro_like(
         }
         Err(_) => {
             // Matches RENKIN's `.unwrap_or_default()` on run_reactants' Result.
+            *errors_swallowed += 1;
         }
     }
     (t0.elapsed(), fragment_smiles)
@@ -187,7 +194,8 @@ fn main() {
     let mut canonical_smiles_calls: u64 = 0;
     let mut standardize_calls: u64 = 0;
     let mut fragments_before_filter: u64 = 0;
-    let mut fragments_after_filter: u64 = 0;
+    let mut fragments_parsed_ok: u64 = 0;
+    let mut errors_swallowed: u64 = 0;
     let mut product_molecules_seen: u64 = 0;
 
     chematic_rxn::perf_counters::reset();
@@ -214,7 +222,8 @@ fn main() {
                     &mut canonical_smiles_calls,
                     &mut standardize_calls,
                     &mut fragments_before_filter,
-                    &mut fragments_after_filter,
+                    &mut fragments_parsed_ok,
+                    &mut errors_swallowed,
                 );
                 stats.durations.push(elapsed);
                 product_molecules_seen += fragments.len() as u64;
@@ -250,11 +259,8 @@ fn main() {
     println!("canonical_smiles_calls={canonical_smiles_calls}");
     println!("standardize_calls={standardize_calls}");
     println!("fragments_before_filter={fragments_before_filter}");
-    println!("fragments_after_filter={fragments_after_filter}");
-    println!(
-        "errors_swallowed_by_unwrap_or_default={}",
-        stats.errors_swallowed
-    );
+    println!("fragments_parsed_ok={fragments_parsed_ok}");
+    println!("errors_swallowed_by_unwrap_or_default={errors_swallowed}");
     println!(
         "successful_match_rate={:.4}",
         product_molecules_seen as f64 / stats.durations.len().max(1) as f64

--- a/crates/chematic-rxn/fixtures/witness_molecules.smi
+++ b/crates/chematic-rxn/fixtures/witness_molecules.smi
@@ -1,0 +1,27 @@
+# Hand-authored synthetic witness molecules for the reaction-transform
+# performance benchmark (docs/reaction_transform_perf.md). Small, named,
+# public-domain structures -- not extracted from any external corpus.
+#
+# Format: SMILES  name
+#
+# Positive witnesses (highly symmetric -- these are the molecules on which
+# chematic-smiles's individualize-refine canonicalization branches heavily;
+# see docs/reaction_transform_perf.md's ringbench numbers, 45-48x slower
+# canonical_smiles() on main than on the fixed branch):
+c1ccccc1 benzene
+C1C2CC3CC1CC(C2)C3 adamantane
+c1cc2ccc3ccc4ccc5ccc6ccc1c1c2c3c4c5c61 coronene
+CC(C)(C)OC(=O)N ez_control_free_boc_carbamate
+FC(F)(F)C(=O)O trifluoroacetic_acid_twin_substituent
+# E/Z stereo control pair (issue #50 gate: identity/remote transforms must
+# not flip or lose E/Z geometry) -- same skeleton, opposite double-bond
+# geometry, plus a remote reactive (ester) site so a template can fire
+# without touching the alkene itself.
+CC/C=C/CC(=O)O (E)-hex-3-enoic_acid
+CC/C=C\CC(=O)O (Z)-hex-3-enoic_acid
+# Negative control (asymmetric, drug-like -- no automorphism ties, so
+# canonical_smiles should show no regression at all):
+CC(=O)OC1=CC=CC=C1C(=O)O aspirin
+CC(C)CC1=CC=C(C=C1)C(C)C(=O)O ibuprofen
+COC1=CC2=C(C=C1)C(=CN2)CCN serotonin_analog
+CC(=O)NC1=CC=C(O)C=C1 paracetamol

--- a/crates/chematic-rxn/fixtures/witness_templates.smirks
+++ b/crates/chematic-rxn/fixtures/witness_templates.smirks
@@ -1,0 +1,17 @@
+# Hand-authored synthetic witness templates for the reaction-transform
+# performance benchmark (docs/reaction_transform_perf.md). NOT extracted from
+# any external dataset -- these are generic, textbook retrosynthetic
+# disconnections (ester <-> acid+alcohol, amide <-> acid+amine, Boc
+# deprotection, biaryl <-> two aryl halides+boronic acid fragments, ether
+# <-> alkyl halide+alcohol) written from scratch for this repository, in the
+# same SMIRKS<TAB>count format RENKIN's own template files use so the same
+# parser code path (`l.split('\t').next()`) exercises both.
+#
+# Format: SMIRKS<TAB>count (count is unused here, kept for format parity).
+[O:3]=[C:2]-[OH:1]>>C-[O:1]-[C:2]=[O:3]	1
+[C:2]-[C:1](=[O:3])-[NH:4]-[C:5]>>O-[C:1](-[C:2])=[O:3].[C:5]-[NH2:4]	1
+[C:1][C:2][C:3][C:4]>>[C:1]/[C:2]=[C:3]/[C:4]	1
+[C:2]-[NH2:1]>>C-C(-C)(-C)-O-C(=O)-[NH:1]-[C:2]	1
+[c:2][c:1]>>Br-[c:1].[c:2]-B(-O)-O	1
+[C:2]-[CH2:1]-[O:3]-[C:4]>>Br-[CH2:1]-[C:2].[OH:3]-[C:4]	1
+[C:1]=[C:2]>>[C:1]-[C:2]	1

--- a/crates/chematic-rxn/src/lib.rs
+++ b/crates/chematic-rxn/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod balance;
 pub mod enumerate;
 pub mod green;
+pub mod perf_counters;
 pub mod query;
 pub mod reaction;
 pub mod retro;
@@ -23,6 +24,7 @@ pub use enumerate::{
     LibraryConfig, LibraryError, enumerate_library, enumerate_library_2way, enumerate_library_3way,
 };
 pub use green::{atom_economy, e_factor, pmi_rxn, reaction_mass_efficiency};
+pub use perf_counters::PerfCounters;
 pub use query::{
     BatchQueryResults, ReactionPatternLibrary, ReactionQuery, ReactionQueryError,
     batch_query_reactions, batch_query_with_library, has_reaction_substructure_match,

--- a/crates/chematic-rxn/src/perf_counters.rs
+++ b/crates/chematic-rxn/src/perf_counters.rs
@@ -1,0 +1,152 @@
+//! Feature-gated internal work counters for `run_reactants`'s hot path.
+//!
+//! Enabled only under the `perf-instrumentation` Cargo feature so ordinary
+//! builds pay zero cost (every call below compiles to nothing when the
+//! feature is off). Counters are process-global `AtomicU64`s (relaxed
+//! ordering -- these are cheap diagnostic counters, not a correctness
+//! synchronization primitive), safe to bump from any thread, matching how
+//! `run_reactants` is actually called by parallel (e.g. rayon) consumers.
+//!
+//! Added while diagnosing the `run_reactants`/`apply_retro` performance
+//! regression between chematic 0.4.25 and 0.4.30 (see
+//! `docs/reaction_transform_perf.md`): distinguishing "doing more work" from
+//! "the same work costing more" was the whole point -- call/product/match
+//! *counts* turned out flat across versions, while per-call wall-clock time
+//! rose sharply, which is exactly the signature these counters are built to
+//! surface (paired with the benchmark's own wall-clock timing).
+
+#[cfg(feature = "perf-instrumentation")]
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[cfg(feature = "perf-instrumentation")]
+static RUN_REACTANTS_CALLS: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "perf-instrumentation")]
+static REACTION_PARSE_CALLS: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "perf-instrumentation")]
+static REACTANT_QUERY_MATCH_CALLS: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "perf-instrumentation")]
+static VF2_MATCH_COUNT: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "perf-instrumentation")]
+static MATCH_COMBINATION_COUNT: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "perf-instrumentation")]
+static BUILD_PRODUCT_CALLS: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "perf-instrumentation")]
+static PRODUCT_SETS_BEFORE_DEDUP: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "perf-instrumentation")]
+static PRODUCT_MOLECULES_BUILT: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "perf-instrumentation")]
+static ATOMS_COPIED_TO_PRODUCTS: AtomicU64 = AtomicU64::new(0);
+#[cfg(feature = "perf-instrumentation")]
+static BONDS_COPIED_TO_PRODUCTS: AtomicU64 = AtomicU64::new(0);
+
+/// Snapshot of every counter at the moment of the call.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PerfCounters {
+    pub run_reactants_calls: u64,
+    pub reaction_parse_calls: u64,
+    pub reactant_query_match_calls: u64,
+    pub vf2_match_count: u64,
+    pub match_combination_count: u64,
+    pub build_product_calls: u64,
+    pub product_sets_before_dedup: u64,
+    pub product_molecules_built: u64,
+    pub atoms_copied_to_products: u64,
+    pub bonds_copied_to_products: u64,
+}
+
+/// Read every counter without resetting them. Returns all-zero when the
+/// `perf-instrumentation` feature is disabled.
+#[cfg(feature = "perf-instrumentation")]
+pub fn snapshot() -> PerfCounters {
+    PerfCounters {
+        run_reactants_calls: RUN_REACTANTS_CALLS.load(Ordering::Relaxed),
+        reaction_parse_calls: REACTION_PARSE_CALLS.load(Ordering::Relaxed),
+        reactant_query_match_calls: REACTANT_QUERY_MATCH_CALLS.load(Ordering::Relaxed),
+        vf2_match_count: VF2_MATCH_COUNT.load(Ordering::Relaxed),
+        match_combination_count: MATCH_COMBINATION_COUNT.load(Ordering::Relaxed),
+        build_product_calls: BUILD_PRODUCT_CALLS.load(Ordering::Relaxed),
+        product_sets_before_dedup: PRODUCT_SETS_BEFORE_DEDUP.load(Ordering::Relaxed),
+        product_molecules_built: PRODUCT_MOLECULES_BUILT.load(Ordering::Relaxed),
+        atoms_copied_to_products: ATOMS_COPIED_TO_PRODUCTS.load(Ordering::Relaxed),
+        bonds_copied_to_products: BONDS_COPIED_TO_PRODUCTS.load(Ordering::Relaxed),
+    }
+}
+
+#[cfg(not(feature = "perf-instrumentation"))]
+pub fn snapshot() -> PerfCounters {
+    PerfCounters::default()
+}
+
+/// Reset every counter to zero (e.g. between benchmark segments). A no-op
+/// when the `perf-instrumentation` feature is disabled.
+#[cfg(feature = "perf-instrumentation")]
+pub fn reset() {
+    RUN_REACTANTS_CALLS.store(0, Ordering::Relaxed);
+    REACTION_PARSE_CALLS.store(0, Ordering::Relaxed);
+    REACTANT_QUERY_MATCH_CALLS.store(0, Ordering::Relaxed);
+    VF2_MATCH_COUNT.store(0, Ordering::Relaxed);
+    MATCH_COMBINATION_COUNT.store(0, Ordering::Relaxed);
+    BUILD_PRODUCT_CALLS.store(0, Ordering::Relaxed);
+    PRODUCT_SETS_BEFORE_DEDUP.store(0, Ordering::Relaxed);
+    PRODUCT_MOLECULES_BUILT.store(0, Ordering::Relaxed);
+    ATOMS_COPIED_TO_PRODUCTS.store(0, Ordering::Relaxed);
+    BONDS_COPIED_TO_PRODUCTS.store(0, Ordering::Relaxed);
+}
+
+#[cfg(not(feature = "perf-instrumentation"))]
+pub fn reset() {}
+
+// Internal increment helpers used from `transform.rs`. All are no-ops
+// (inlined away entirely) when `perf-instrumentation` is off.
+
+#[cfg(feature = "perf-instrumentation")]
+pub(crate) fn record_run_reactants_call() {
+    RUN_REACTANTS_CALLS.fetch_add(1, Ordering::Relaxed);
+}
+#[cfg(not(feature = "perf-instrumentation"))]
+#[inline(always)]
+pub(crate) fn record_run_reactants_call() {}
+
+#[cfg(feature = "perf-instrumentation")]
+pub(crate) fn record_reaction_parse_call() {
+    REACTION_PARSE_CALLS.fetch_add(1, Ordering::Relaxed);
+}
+#[cfg(not(feature = "perf-instrumentation"))]
+#[inline(always)]
+pub(crate) fn record_reaction_parse_call() {}
+
+#[cfg(feature = "perf-instrumentation")]
+pub(crate) fn record_reactant_query_match_call(match_count: usize) {
+    REACTANT_QUERY_MATCH_CALLS.fetch_add(1, Ordering::Relaxed);
+    VF2_MATCH_COUNT.fetch_add(match_count as u64, Ordering::Relaxed);
+}
+#[cfg(not(feature = "perf-instrumentation"))]
+#[inline(always)]
+pub(crate) fn record_reactant_query_match_call(_match_count: usize) {}
+
+#[cfg(feature = "perf-instrumentation")]
+pub(crate) fn record_match_combination() {
+    MATCH_COMBINATION_COUNT.fetch_add(1, Ordering::Relaxed);
+}
+#[cfg(not(feature = "perf-instrumentation"))]
+#[inline(always)]
+pub(crate) fn record_match_combination() {}
+
+#[cfg(feature = "perf-instrumentation")]
+pub(crate) fn record_build_product_call(atoms: usize, bonds: usize) {
+    BUILD_PRODUCT_CALLS.fetch_add(1, Ordering::Relaxed);
+    PRODUCT_MOLECULES_BUILT.fetch_add(1, Ordering::Relaxed);
+    ATOMS_COPIED_TO_PRODUCTS.fetch_add(atoms as u64, Ordering::Relaxed);
+    BONDS_COPIED_TO_PRODUCTS.fetch_add(bonds as u64, Ordering::Relaxed);
+}
+#[cfg(not(feature = "perf-instrumentation"))]
+#[inline(always)]
+pub(crate) fn record_build_product_call(_atoms: usize, _bonds: usize) {}
+
+#[cfg(feature = "perf-instrumentation")]
+pub(crate) fn record_product_set() {
+    PRODUCT_SETS_BEFORE_DEDUP.fetch_add(1, Ordering::Relaxed);
+}
+#[cfg(not(feature = "perf-instrumentation"))]
+#[inline(always)]
+pub(crate) fn record_product_set() {}

--- a/crates/chematic-rxn/src/transform.rs
+++ b/crates/chematic-rxn/src/transform.rs
@@ -1362,4 +1362,80 @@ mod tests {
             );
         }
     }
+
+    // -----------------------------------------------------------------------
+    // Reaction-transform performance regression witnesses (see
+    // docs/reaction_transform_perf.md). Root cause: `chematic-smiles`'s
+    // `canonical_smiles()` wrote the winning individualize-refine branch's
+    // string, threw it away, and had `winning_individualized_ranks`'s caller
+    // write it a *second* time -- one fully redundant DFS-and-format pass on
+    // every single call, tied or not. Fixed by returning the already-written
+    // string instead of recomputing it. These three cases mirror the ones
+    // used to characterize and fix the regression:
+    // (a) a highly symmetric molecule (many individualize-refine branches --
+    //     this is the case that actually reproduces a large, measured slowdown
+    //     between chematic 0.4.25 and 0.4.30, NOT run_reactants match/product
+    //     volume, which stayed flat across versions);
+    // (b) an E/Z stereo control, since the fix touches the same
+    //     canonical-writer code path `resolve_ez_markers` depends on;
+    // (c) a negative control (asymmetric, no ties) that should show only the
+    //     universal (small, single-redundant-write) improvement, not the
+    //     symmetric-molecule-specific one.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn perf_witness_a_symmetric_molecule_product_is_correct() {
+        // Positive witness: adamantane (Td cage symmetry, 24
+        // individualize-refine branches at time of writing) run through a
+        // simple ring-opening SMIRKS. The fix must not change *which* string
+        // wins -- only how many times it gets written -- so the product's
+        // canonical SMILES must still round-trip to the same structure.
+        let mol = parse("C1C2CC3CC1CC(C2)C3").unwrap(); // adamantane
+        let results = run_reactants("[C:1][C:2]>>[C:1][C:2]", &[&mol]).unwrap();
+        assert!(!results.is_empty(), "expected at least one C-C bond match");
+        let canon = chematic_smiles::canonical_smiles(&results[0][0]);
+        // Adamantane's own canonical form is a fixed point of this
+        // identity-shaped SMIRKS: it must reparse to the exact same molecule
+        // (same atom/bond count -- the transform doesn't add/remove atoms).
+        let reparsed = parse(&canon).unwrap();
+        assert_eq!(reparsed.atom_count(), mol.atom_count());
+        assert_eq!(reparsed.bond_count(), mol.bond_count());
+    }
+
+    #[test]
+    fn perf_witness_b_ez_stereo_control_survives_symmetric_fix() {
+        // Stereo control: identity/remote transforms on the E/Z pair used in
+        // the perf investigation's own fixture
+        // (crates/chematic-rxn/fixtures/witness_molecules.smi) must still
+        // preserve exact geometry -- this is the non-negotiable issue #50
+        // gate, re-run here against the specific molecules this perf fix
+        // touched.
+        assert_eq!(
+            product_canon("[C:1]=[C:2]>>[C:1]=[C:2]", &["CC/C=C/CC(=O)O"]),
+            canon("CC/C=C/CC(=O)O"),
+            "(E)-hex-3-enoic acid must keep its E geometry"
+        );
+        assert_eq!(
+            product_canon("[C:1]=[C:2]>>[C:1]=[C:2]", &["CC/C=C\\CC(=O)O"]),
+            canon("CC/C=C\\CC(=O)O"),
+            "(Z)-hex-3-enoic acid must keep its Z geometry"
+        );
+    }
+
+    #[test]
+    fn perf_witness_c_negative_control_asymmetric_molecule() {
+        // Negative control: aspirin has no automorphism ties (every ring
+        // carbon has a distinct substitution environment), so
+        // `winning_individualized_ranks` takes exactly one branch. This
+        // exercises the same code path as (a) but should show only the
+        // universal single-redundant-write saving, not a
+        // symmetric-molecule-specific one -- included so a future reader can
+        // tell the two effects apart empirically, not just by reasoning.
+        let mol = parse("CC(=O)OC1=CC=CC=C1C(=O)O").unwrap(); // aspirin
+        let results = run_reactants("[OH:1]-[C:2]=[O:3]>>C-[O:1]-[C:2]=[O:3]", &[&mol]).unwrap();
+        assert!(!results.is_empty(), "expected the carboxylic acid to match");
+        let canon = chematic_smiles::canonical_smiles(&results[0][0]);
+        let reparsed = parse(&canon).unwrap();
+        assert_eq!(reparsed.atom_count(), mol.atom_count() + 1); // +1 methyl carbon
+    }
 }

--- a/crates/chematic-rxn/src/transform.rs
+++ b/crates/chematic-rxn/src/transform.rs
@@ -75,6 +75,8 @@ fn run_reactants_impl(
     reactants: &[&Molecule],
     carry_substituents: bool,
 ) -> Result<Vec<Vec<Molecule>>, TransformError> {
+    crate::perf_counters::record_run_reactants_call();
+    crate::perf_counters::record_reaction_parse_call();
     let rxn = parse_reaction(smirks)?;
 
     let n_templates = rxn.reactants.len();
@@ -118,7 +120,11 @@ fn run_reactants_impl(
     let all_match_sets: Vec<Vec<FxHashMap<usize, AtomIdx>>> = queries
         .iter()
         .zip(reactants.iter())
-        .map(|(q, mol)| find_matches(q, mol))
+        .map(|(q, mol)| {
+            let matches = find_matches(q, mol);
+            crate::perf_counters::record_reactant_query_match_call(matches.len());
+            matches
+        })
         .collect();
 
     // No products when any template has no match.
@@ -129,6 +135,7 @@ fn run_reactants_impl(
     let mut results: Vec<Vec<Molecule>> = Vec::new();
 
     for combo in cartesian_product(&all_match_sets) {
+        crate::perf_counters::record_match_combination();
         // global_map: atom_map_number → (reactant_mol_idx, matched_AtomIdx)
         let mut global_map: FxHashMap<u16, (usize, AtomIdx)> = FxHashMap::default();
         for (ri, match_map) in combo.iter().enumerate() {
@@ -172,18 +179,24 @@ fn run_reactants_impl(
             .products
             .iter()
             .map(|pt| {
-                build_product(
+                let product = build_product(
                     pt,
                     &global_map,
                     reactants,
                     &all_template_atoms,
                     carry_substituents,
-                )
+                );
+                crate::perf_counters::record_build_product_call(
+                    product.atom_count(),
+                    product.bond_count(),
+                );
+                product
             })
             .collect();
 
         // Skip product sets that contain any over-valenced atom.
         if products.iter().all(|p| validate_valence(p).is_empty()) {
+            crate::perf_counters::record_product_set();
             results.push(products);
         }
     }

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.7.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.7.0" }
+chematic-core = { path = "../chematic-core", version = "0.7.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.7.1" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.7.0" }
+chematic-core = { path = "../chematic-core", version = "0.7.1" }
 
 [dev-dependencies]
 # Test-only: re-aromatizing after an explicit kekulize+apply_kekule round

--- a/crates/chematic-smiles/src/canonical.rs
+++ b/crates/chematic-smiles/src/canonical.rs
@@ -37,7 +37,7 @@ pub fn canonical_atom_order(mol: &Molecule) -> Vec<usize> {
     if n == 0 {
         return Vec::new();
     }
-    let ranks = winning_individualized_ranks(mol);
+    let (ranks, _) = winning_individualized_ranks(mol);
     let mut order: Vec<usize> = (0..n).collect();
     // Sort descending by rank (highest rank first, as in canonical DFS).
     order.sort_unstable_by(|&a, &b| ranks[b].cmp(&ranks[a]));
@@ -46,17 +46,30 @@ pub fn canonical_atom_order(mol: &Molecule) -> Vec<usize> {
 
 /// Resolve `morgan_ranks` ties via individualize-refine and return the fully
 /// discrete per-atom ranks of whichever branch produces the
-/// lexicographically smallest canonical SMILES -- shared by
-/// `canonical_smiles` and `canonical_atom_order` so both use the identical
-/// tie-break, instead of `canonical_atom_order` silently falling back to raw
-/// (tie-break-free) `morgan_ranks`.
-fn winning_individualized_ranks(mol: &Molecule) -> Vec<u64> {
+/// lexicographically smallest canonical SMILES, *and* that winning string --
+/// shared by `canonical_smiles` and `canonical_atom_order` so both use the
+/// identical tie-break, instead of `canonical_atom_order` silently falling
+/// back to raw (tie-break-free) `morgan_ranks`.
+///
+/// Returning the already-written winning string (not just its ranks) lets
+/// [`canonical_smiles`] reuse it directly instead of calling
+/// `CanonicalWriter::write_all` a second time on the same ranks -- every
+/// branch considered here is written exactly once, tied or not, so a caller
+/// that also wrote the winner again was paying for a fully redundant
+/// traversal on every single call (perf; issue found bisecting the
+/// `run_reactants`/`apply_retro` regression between chematic 0.4.25 and
+/// 0.4.30 -- see docs/reaction_transform_perf.md).
+fn winning_individualized_ranks(mol: &Molecule) -> (Vec<u64>, String) {
     let plateaued = morgan_ranks(mol);
     let mut budget = MAX_INDIVIDUALIZE_BRANCHES;
     let branches = enumerate_discrete_ranks(mol, plateaued, &mut budget);
     branches
         .into_iter()
-        .min_by_key(|ranks| CanonicalWriter::new(mol, ranks).write_all())
+        .map(|ranks| {
+            let s = CanonicalWriter::new(mol, &ranks).write_all();
+            (ranks, s)
+        })
+        .min_by(|(_, a), (_, b)| a.cmp(b))
         .unwrap_or_default()
 }
 
@@ -117,8 +130,8 @@ pub fn canonical_smiles(mol: &Molecule) -> String {
         return String::new();
     }
 
-    let ranks = winning_individualized_ranks(mol);
-    CanonicalWriter::new(mol, &ranks).write_all()
+    let (_, winning_string) = winning_individualized_ranks(mol);
+    winning_string
 }
 
 /// Compute Morgan (extended connectivity) ranks for all atoms.
@@ -2546,7 +2559,7 @@ mod tests {
     fn ez_carrier_shared_candidate_bond_residuals_never_corrupt() {
         for &s in EZ_SHARED_CANDIDATE_BOND_RESIDUALS {
             let mol = parse(s).unwrap_or_else(|e| panic!("parse '{s}': {e}"));
-            let ranks = winning_individualized_ranks(&mol);
+            let (ranks, _) = winning_individualized_ranks(&mol);
             let mut writer = CanonicalWriter::new(&mol, &ranks);
             writer.resolve_ez_markers();
             assert!(

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -25,16 +25,16 @@ crate-type = ["cdylib", "rlib"]
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["console"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.7.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.7.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.7.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.7.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.7.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.7.0", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.7.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.7.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.7.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.7.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.7.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.7.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.7.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.7.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.7.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.7.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.7.1", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.7.1" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.7.1", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.7.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.7.1" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.7.1" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.7.1" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.7.1" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.7.1" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.7.1" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -33,15 +33,15 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.7.0", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.7.0", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.7.0", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.7.0", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.7.0", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.7.0", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.7.0", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.7.0", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.7.0", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.7.0", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.7.0", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.7.0", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.7.1", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.7.1", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.7.1", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.7.1", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.7.1", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.7.1", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.7.1", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.7.1", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.7.1", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.7.1", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.7.1", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.7.1", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,6 +1,6 @@
 # Benchmark
 
-Measured environment: Python 3.13.6, Apple M4, chematic v0.7.0, RDKit 2026.03.3.
+Measured environment: Python 3.13.6, Apple M4, chematic v0.7.1, RDKit 2026.03.3.
 Full methodology and raw numbers: [`benchmarks/2026-07-17.md`](../benchmarks/2026-07-17.md).
 
 ---

--- a/docs/reaction_transform_perf.md
+++ b/docs/reaction_transform_perf.md
@@ -180,9 +180,12 @@ exposing process-global counters: `run_reactants_calls`,
 `split_fragments`/dedup/fragment-filtering are apply_retro-level (not part of
 `run_reactants`'s public API), so the benchmark harness below tracks its own
 equivalents (`canonical_smiles_calls`, `standardize_calls`,
-`fragments_before_filter`, `fragments_after_filter`,
+`fragments_before_filter`, `fragments_parsed_ok`,
 `errors_swallowed_by_unwrap_or_default`) rather than adding RENKIN-specific
-concepts to the library itself.
+concepts to the library itself. `fragments_parsed_ok` counts fragments that
+parsed successfully, not post-filter survivors — this harness does not
+reimplement RENKIN's own aromatic-atom-without-a-ring-closure fragment
+filter, so the name doesn't promise one.
 
 ## Corpus-weighted benchmark (Phase 1)
 
@@ -216,6 +219,16 @@ note in the file.)
 | p95 | 3.01ms | 2.77-2.90ms | ~4-8% |
 | p99 | 67.8-68.1ms | 57.3-57.6ms | ~15% |
 | max | 72.9-86.2ms | 65.3-66.2ms | ~10-24% |
+
+**The two arms were not instrumentation-symmetric**, disclosed rather than
+re-measured away: the "before" run used a `main` checkout with
+`perf_counters.rs` copied in but `transform.rs` left uninstrumented (its
+counters are permanently zero, i.e. dead code on that arm), while "after" was
+built with `--features perf-instrumentation` live, paying real
+`AtomicU64::fetch_add` overhead on every `run_reactants`/`build_product` call
+(840 `build_product` calls in this run alone). That bias is conservative —
+the fixed arm carried extra cost the baseline didn't — so **the improvement
+above is understated, not inflated**.
 
 (Ranges are two repeated runs per side, release build, `RAYON_NUM_THREADS=2`,
 same machine.) This is a real, honest, consistent improvement across the

--- a/docs/reaction_transform_perf.md
+++ b/docs/reaction_transform_perf.md
@@ -131,16 +131,41 @@ even though the raw discrete rank vectors are all pairwise distinct) — the
 branching is 100% correct but, for pure automorphism orbits, 100% redundant
 work, exactly as the original commit's own docstring predicts
 ("if a cell IS an orbit, every choice yields an automorphic result... correct
-but redundant").
+but redundant"). **This combinatorial cost is `be5dbb1`'s and is *not* what
+this PR fixes** — see "Fix implemented here" below for the separate,
+narrower bug this PR does fix, and "Remaining gap" for why the combinatorial
+cost is still open.
+
+### Correction: the specific bug this PR fixes is not `be5dbb1`'s
+
+An earlier draft of this document (and this PR's original description)
+attributed the redundant-`write_all()` bug below to `be5dbb1` itself. That
+was wrong, caught by independent re-verification and confirmed here by
+re-reading the actual diffs: at `be5dbb1`, `canonical_smiles` called
+`write_all()` exactly once per branch (inside the `.map(...).min()` chain)
+— there was no `winning_individualized_ranks` helper yet and no redundant
+second call. The helper (and the redundant second `write_all()` this PR
+removes) was introduced two days later by `c219ee7 fix(smiles): make
+canonical_atom_order use the same tie-break as canonical_smiles`
+(2026-07-12), which extracted the shared branch-selection logic so
+`canonical_atom_order` could reuse it — and in doing so had `canonical_smiles`
+call `write_all()` once inside the new helper (to find the minimum) and then
+again on the winning ranks after the helper returned. Both `be5dbb1` and
+`c219ee7` show `version = "0.4.29"` in their own `Cargo.toml` and both land
+before the `19e410b` bump to `0.4.30` — so "0.4.26" (an earlier, incorrect
+label in this doc and the PR description) is wrong regardless of which of
+the two commits is cited; the correct first-shipped version for either is
+**0.4.30**.
 
 ## Fix implemented here
 
 `winning_individualized_ranks` (the internal helper both `canonical_smiles`
-and `canonical_atom_order` share) already had to write *every* branch's full
-string via `CanonicalWriter::write_all()` to find the minimum — but its
-caller, `canonical_smiles`, then called `write_all()` a **second, fully
-redundant** time on the already-known winning ranks, on every single call
-(tied or not). The fix (`crates/chematic-smiles/src/canonical.rs`) changes
+and `canonical_atom_order` share, introduced by `c219ee7`) already had to
+write *every* branch's full string via `CanonicalWriter::write_all()` to find
+the minimum — but its caller, `canonical_smiles`, then called `write_all()` a
+**second, fully redundant** time on the already-known winning ranks, on every
+single call (tied or not) — the bug `c219ee7` introduced, described above.
+The fix (`crates/chematic-smiles/src/canonical.rs`) changes
 `winning_individualized_ranks` to return `(ranks, winning_string)` instead of
 just `ranks`, so `canonical_smiles` reuses the already-computed string
 instead of re-deriving it.
@@ -226,21 +251,31 @@ re-measured away: the "before" run used a `main` checkout with
 counters are permanently zero, i.e. dead code on that arm), while "after" was
 built with `--features perf-instrumentation` live, paying real
 `AtomicU64::fetch_add` overhead on every `run_reactants`/`build_product` call
-(840 `build_product` calls in this run alone). That bias is conservative —
-the fixed arm carried extra cost the baseline didn't — so **the improvement
-above is understated, not inflated**.
+(840 `build_product` calls in this run alone). This PR's original claim was
+that this bias is conservative (the fixed arm carried extra cost the
+baseline didn't, so "the improvement above is understated, not inflated") —
+**independent re-verification found the opposite**: re-running both arms
+with symmetric instrumentation (the same counters present, feature-gated
+off, on *both* sides) measured a *smaller* total-elapsed improvement
+(~13.4%, vs. the 15-22% above) and found the p50 delta (~1.9% in the
+symmetric re-run) not resolvable from run-to-run noise at this sample size
+(n=4/side). p95/p99/max held up close to the numbers above. **Treat the
+total-elapsed and p50 rows in the table above as directional (a real,
+positive effect exists) rather than precise** — the tail metrics (p95/p99/
+max) are the more reliable numbers from this measurement.
 
 (Ranges are two repeated runs per side, release build, `RAYON_NUM_THREADS=2`,
-same machine.) This is a real, honest, consistent improvement across the
-mean *and* the tail (p95/p99/max) — but a modest one, not a restoration of
-RENKIN's full ~9x. **This is expected and disclosed, not a shortfall being
-hidden**: the witness corpus mixes symmetric (large-regression) and
-asymmetric (small/no-regression) molecules, and this fix only removes the
-universal single-redundant-write cost, not the underlying branch-enumeration
-cost that dominates the symmetric cases. RENKIN's own full 30-target
-integration re-measurement (out of scope here per the task's explicit
-instruction) is the right place to see the aggregate, corpus-realistic
-effect at RENKIN's actual scale and template/molecule mix.
+same machine.) This is a real, consistent improvement on the tail (p95/p99/
+max) and a smaller, less precisely-pinned one on the mean/p50 — but a modest
+one either way, not a restoration of RENKIN's full ~9x. **This is expected
+and disclosed, not a shortfall being hidden**: the witness corpus mixes
+symmetric (large-regression) and asymmetric (small/no-regression) molecules,
+and this fix only removes the universal single-redundant-write cost, not the
+underlying branch-enumeration cost that dominates the symmetric cases.
+RENKIN's own full 30-target integration re-measurement (out of scope here
+per the task's explicit instruction) is the right place to see the
+aggregate, corpus-realistic effect at RENKIN's actual scale and
+template/molecule mix.
 
 ## Remaining gap (explicitly not fixed here)
 

--- a/docs/reaction_transform_perf.md
+++ b/docs/reaction_transform_perf.md
@@ -1,0 +1,268 @@
+# `run_reactants`/`apply_retro` performance regression: root cause and fix
+
+Date: 2026-07-27. Trigger: an external consumer, RENKIN, measured `apply_retro`
+(its own thin wrapper around `run_reactants` + fragment splitting) at
+**247.5µs/call on chematic 0.6.0 / master, vs 17.3µs/call on chematic 0.4.25**
+— a ~14.3x per-call cost increase, with call *counts* flat-to-lower on the
+newer version (ruling out "more products/matches per call" as the mechanism).
+RENKIN's own investigation (their `artifacts/perf_root_cause/` directory, not
+reproduced here) bisected the regression to a single dependency-version bump
+in their own repo, `chematic 0.4.25 -> 0.4.30` (a **9.15x** jump in isolation,
+`7.46µs -> 68.25µs` per call on a 6-target sentinel), and stopped there,
+explicitly leaving "which chematic-internal change" as future work. This
+document is that follow-up: a bisect *inside* chematic's own history between
+those two versions, the root cause, and the fix.
+
+## Corpus and methodology note
+
+`v0.4.25` has **no git tag** in this repository (tags jump `v0.4.22` ->
+`v0.4.28`; 0.4.23-0.4.27 were published to crates.io without a corresponding
+git tag — see `f8c9961 chore(release): fix version-sync drift...`). The
+release commits `3dd8db9` (`release: v0.4.25`) and `19e410b` (`chore: bump
+version 0.4.29 -> 0.4.30`, matching the existing `v0.4.30` tag) were used in
+their place.
+
+RENKIN's own Stage 2 microbenchmark (`chematic_version_benchmark.json`, 30
+root target molecules × a 50-template random sample) found **no** chematic-side
+regression (`run_reactants` warm: 0.87x, i.e. *faster*, on 0.6.0 vs 0.4.25).
+This is real and reproduced here too (see below) — and it is also exactly why
+that benchmark missed the actual regression. The mechanism (below) is specific
+to **highly symmetric molecules** (plain rings, cages, `CF3`/`tBu`-style
+substituents), which drug-like *root* targets rarely are, but which
+retrosynthesis *intermediates* and common building blocks very often are. A
+30-root-molecule sample essentially never hits it; a benchmark that also
+canonicalizes fragments/intermediates does.
+
+## Bisect: the regression is not in `chematic-rxn`
+
+`chematic-rxn`'s own dependencies are `chematic-core`, `chematic-smiles`,
+`chematic-smarts` (no `chematic-perception`, no `chematic-chem`). Scoping
+`git log 3dd8db9..19e410b` to those crates plus `chematic-perception`
+(a transitive dependency of `chematic-smarts`) narrows ~167 total commits in
+the 0.4.25→0.4.30 range down to ~28. Only one of those touches
+`chematic-rxn` itself: `16db7f1 fix(rxn): preserve E/Z geometry in
+run_reactants products (closes #50)` — and its diff is a single `if`
+branch selecting bond endpoint order; it cannot plausibly cause a 9x
+regression, and a standalone A/B build confirmed it does not (see below).
+
+RENKIN's own `apply_retro` calls `chematic::rxn::run_reactants`, then for
+every product: `canonical_smiles` → split on `.` → `parse` each fragment →
+`chematic::chem::standardize` → `canonical_smiles` again. That pulls in
+`chematic-chem` (via `standardize`), which depends on `chematic-fp`, which
+depends on `chematic-rxn` — i.e. the *actual* regression surface for a real
+consumer is wider than `chematic-rxn`'s own Cargo.toml suggests. The real
+culprit turned out to be in neither `chematic-rxn` nor `chematic-chem`: it's
+in `chematic-smiles`, a dependency of both.
+
+### Standalone A/B build (this investigation's own bisect)
+
+A throwaway `rxnbench` crate (path-dependent on a `git worktree` checked out
+to each candidate commit, not part of this repository) ran
+`templates_extracted_5000.smi` (RENKIN's real, USPTO-50k-derived template
+corpus, read only — never copied into this repo) against
+`benchmark_targets.smi` (RENKIN's 76-molecule representative root-target
+set) at chematic 0.4.25 vs 0.4.30:
+
+| version | templates × targets | run_reactants calls | ns/call |
+|---|---|---|---|
+| 0.4.25 (`3dd8db9`) | 5000 × 42 parsed | 210,000 | 10,944.6 |
+| 0.4.30 (`19e410b`) | 5000 × 42 parsed | 210,000 | 10,480.9 |
+
+**No regression** — reproducing RENKIN's own Stage 2 finding exactly (root
+targets alone don't trigger it). Work counts (`product_molecules`,
+`fragments_total`, `canonical_smiles_calls`, `standardize_calls`) were
+byte-identical between versions, confirming the two versions do exactly the
+same amount of *work* here.
+
+### The actual reproducer: symmetric molecules
+
+Directly timing `canonical_smiles()` (repeated calls on the same parsed
+`Molecule`, 200 reps, release build) at 0.4.25 vs 0.4.30:
+
+| molecule | atoms | 0.4.25 mean | 0.4.30 mean | ratio |
+|---|---|---|---|---|
+| adamantane (cage) | 10 | 6.06µs | 273.09µs | **45.1x** |
+| coronene (7 fused rings) | 24 | 18.60µs | 902.31µs† | **48.5x** |
+| plain benzene | 6 | 3.58µs | 169.36µs | **47.3x** |
+| cholesterol (steroid, chiral, low symmetry) | 28 | 21.08µs | 113.39µs | 5.4x |
+| morphine (chiral, no automorphism ties) | 21 | 27.06µs | 41.47µs | 1.5x |
+| fused 7-ring, steroid-like (chiral) | 22 | 21.48µs | 31.74µs | 1.5x |
+
+† high variance on this one run; a repeat with per-call timing gave a stable
+~340-460µs mean for the same molecule — still a large, real regression, just
+noisier at this magnitude on a shared machine.
+
+The pattern is unambiguous: **the slowdown correlates with molecular
+symmetry** (automorphism-rich structures), not with molecule size, ring
+fusion complexity, or SSSR cost (a plain 6-atom benzene ring shows the same
+~47x hit as a 24-atom fused system; a 28-atom *chiral* steroid does not).
+This ruled out the initially-suspected SSSR/Horton's-algorithm and
+`[rN]`/`[kN]` SMARTS-predicate changes in the same commit range (both real
+commits in this window, but neither correlates with the observed pattern —
+confirmed by branch-count instrumentation, not just plausibility).
+
+### The causal commit
+
+`be5dbb1 fix(smiles): individualize-refine + branch-and-minimize in
+morgan_ranks` (2026-07-10, between `3dd8db9` and `19e410b`). This commit
+fixed a real correctness bug (`canonical_smiles(parse(x))` could disagree
+with `canonical_smiles(parse(y))` for two spellings of the same molecule, due
+to a silent input-order-dependent tie-break) by adding an
+individualize-refine branch-and-minimize step
+(`enumerate_discrete_ranks`/`winning_individualized_ranks` in
+`crates/chematic-smiles/src/canonical.rs`): when plain Morgan-rank refinement
+plateaus with ties still present, every possible tie-resolution is tried and
+the lexicographically smallest resulting string is kept. This is *necessary*
+for correctness (proven in the commit's own message, and re-derived
+independently here) — but for highly symmetric molecules, "every possible
+tie-resolution" is a real, deliberately un-optimized combinatorial
+enumeration: the commit's own code comment on `MAX_INDIVIDUALIZE_BRANCHES`
+documents up to **168,219 branches** observed on real ChEMBL molecules with
+multiple Boc/pivaloyl (`tBu`) protecting groups, and explicitly defers
+"automorphism-aware branch pruning (nauty-style)" as future work, not
+attempted there.
+
+Instrumenting `enumerate_discrete_ranks` confirmed the mechanism directly:
+adamantane produces 24 individualize-refine branches, coronene and benzene
+12 each (vs. 1 branch — no ties at all — for the chiral, low-symmetry
+molecules above). Critically: **every branch for a given molecule writes the
+same final canonical string** (`distinct_strings == 1` in all cases measured,
+even though the raw discrete rank vectors are all pairwise distinct) — the
+branching is 100% correct but, for pure automorphism orbits, 100% redundant
+work, exactly as the original commit's own docstring predicts
+("if a cell IS an orbit, every choice yields an automorphic result... correct
+but redundant").
+
+## Fix implemented here
+
+`winning_individualized_ranks` (the internal helper both `canonical_smiles`
+and `canonical_atom_order` share) already had to write *every* branch's full
+string via `CanonicalWriter::write_all()` to find the minimum — but its
+caller, `canonical_smiles`, then called `write_all()` a **second, fully
+redundant** time on the already-known winning ranks, on every single call
+(tied or not). The fix (`crates/chematic-smiles/src/canonical.rs`) changes
+`winning_individualized_ranks` to return `(ranks, winning_string)` instead of
+just `ranks`, so `canonical_smiles` reuses the already-computed string
+instead of re-deriving it.
+
+This is a pure, behavior-preserving refactor: the exact same set of
+candidate strings is computed, in the exact same order, and the exact same
+minimum is selected (`Iterator::min_by`, like the `min_by_key` it replaces,
+returns the *first* minimal element on ties — verified from the stdlib
+docs, not assumed). **Every existing test passes unchanged, including the
+five golden-string tests `be5dbb1` itself had to update**
+(`crates/chematic-chem/src/mmp.rs`, `crates/chematic-wasm/src/tests.rs`) and
+all `issue50_*` E/Z regression tests in `crates/chematic-rxn/src/transform.rs`
+— those are the two families of test this specific change could plausibly
+have broken, and both were checked explicitly, not just "the suite is green."
+
+### What this fix does *not* do
+
+It does **not** implement automorphism-aware branch pruning. That is a
+substantial, separate undertaking (the original commit's own author
+explicitly deferred it as "nauty-style... not attempted here", and it is not
+attempted here either) that would meaningfully reduce or eliminate the
+45-48x regression on genuinely symmetric molecules (plain rings, cages,
+protecting groups). What's shipped here removes exactly one fully-redundant
+write per call — a real, measurable, and completely safe win, but a partial
+one. See "Remaining gap" below.
+
+## Internal work counters (Phase 2)
+
+`chematic-rxn` gained a `perf-instrumentation` Cargo feature (off by default,
+zero cost when disabled — see `crates/chematic-rxn/src/perf_counters.rs`)
+exposing process-global counters: `run_reactants_calls`,
+`reaction_parse_calls`, `reactant_query_match_calls`, `vf2_match_count`,
+`match_combination_count`, `build_product_calls`,
+`product_sets_before_dedup`, `product_molecules_built`,
+`atoms_copied_to_products`, `bonds_copied_to_products`. These cover
+`run_reactants`'s own internals; the RENKIN-side concepts of
+`split_fragments`/dedup/fragment-filtering are apply_retro-level (not part of
+`run_reactants`'s public API), so the benchmark harness below tracks its own
+equivalents (`canonical_smiles_calls`, `standardize_calls`,
+`fragments_before_filter`, `fragments_after_filter`,
+`errors_swallowed_by_unwrap_or_default`) rather than adding RENKIN-specific
+concepts to the library itself.
+
+## Corpus-weighted benchmark (Phase 1)
+
+`crates/chematic-rxn/examples/reaction_transform_perf_report.rs`. Accepts
+external corpora via `RENKIN_TEMPLATES` / `RENKIN_PROBE` env vars (never
+requires copying RENKIN's data into this repo); falls back to small,
+hand-authored fixtures committed at `crates/chematic-rxn/fixtures/` when
+unset. Mirrors RENKIN's real `apply_retro` → `split_fragments` → `standardize`
+call pattern (not `run_reactants` in isolation — that's exactly what missed
+the regression the first time), and **feeds round-1 fragments back in as
+round-2 probe molecules** (`RXN_PERF_DEPTH`, default 2) so symmetric
+intermediates — not just root targets — enter the measured population,
+matching how a real multi-step retrosynthesis search actually behaves.
+
+```
+RAYON_NUM_THREADS=2 cargo run --release -p chematic-rxn \
+    --features perf-instrumentation --example reaction_transform_perf_report
+```
+
+(`RAYON_NUM_THREADS=2` is set for environment comparability with RENKIN's own
+methodology; this harness itself is single-threaded — see the `ponytail:`
+note in the file.)
+
+### Before/after, hand-authored witness fixtures (7 templates × 11 molecules × depth 2, 336 calls)
+
+| | before (main) | after (this fix) | improvement |
+|---|---|---|---|
+| total elapsed | 702-758ms | 596-598ms | ~15-22% |
+| mean/call | 2.09-2.26ms | 1.78ms | ~15-21% |
+| p50 | 109.5-114.7µs | 101.7-103.0µs | ~7-11% |
+| p95 | 3.01ms | 2.77-2.90ms | ~4-8% |
+| p99 | 67.8-68.1ms | 57.3-57.6ms | ~15% |
+| max | 72.9-86.2ms | 65.3-66.2ms | ~10-24% |
+
+(Ranges are two repeated runs per side, release build, `RAYON_NUM_THREADS=2`,
+same machine.) This is a real, honest, consistent improvement across the
+mean *and* the tail (p95/p99/max) — but a modest one, not a restoration of
+RENKIN's full ~9x. **This is expected and disclosed, not a shortfall being
+hidden**: the witness corpus mixes symmetric (large-regression) and
+asymmetric (small/no-regression) molecules, and this fix only removes the
+universal single-redundant-write cost, not the underlying branch-enumeration
+cost that dominates the symmetric cases. RENKIN's own full 30-target
+integration re-measurement (out of scope here per the task's explicit
+instruction) is the right place to see the aggregate, corpus-realistic
+effect at RENKIN's actual scale and template/molecule mix.
+
+## Remaining gap (explicitly not fixed here)
+
+The dominant cost for genuinely symmetric molecules — up to ~48x on plain
+rings/cages in isolation — is **not** eliminated by this fix. Closing it
+requires detecting when a tied refinement cell is a genuine automorphism
+orbit (in which case every branch is provably redundant, per `be5dbb1`'s own
+docstring) and exploring only one representative, which is real,
+correctness-sensitive graph-automorphism work, not a small patch. Two
+approaches were evaluated and rejected for this PR:
+
+- **Byte-identical rank-vector dedup before writing**: measured directly
+  (adamantane/coronene/benzene) — 0% duplicate raw rank vectors even though
+  100% of branches for a given molecule produce the *same final string*.
+  This confirms the redundancy is real but means naive vector-level dedup
+  buys nothing; the equivalence only shows up after writing.
+- **True-twin detection** (atoms with identical neighbor sets, e.g. a `CF3`
+  group's three fluorines): a rigorous, cheap, and correct pruning rule for
+  that *specific* symmetry pattern — but it does not fire on any of the
+  ring/cage witnesses measured above (their symmetry is rotational, not
+  twin-based), so it would not move this PR's own positive witness and was
+  not implemented here. Left as a well-scoped, believed-correct follow-up.
+
+Filed as future work, not started: general automorphism-orbit-aware pruning
+in `enumerate_discrete_ranks`/`winning_individualized_ranks`.
+
+## Why fix forward, not pin to 0.4.25
+
+RENKIN's own `next_gate.json` lists "pin chematic back to 0.4.25" as one
+candidate. That was not the direction taken: 0.4.25 predates the E/Z
+geometry fix (`16db7f1`, issue #50) and the individualize-refine correctness
+fix (`be5dbb1`) themselves — pinning back would silently reintroduce two
+confirmed correctness bugs (nondeterministic/wrong E/Z geometry in
+`run_reactants` products; input-order-dependent canonical SMILES) in
+exchange for the performance this fix restores only partially anyway. This
+is a chematic-internal regression, so the chematic-internal fix (forward,
+not backward) is the correct direction, per explicit user instruction for
+this task.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -2,7 +2,7 @@
 
 Summary of descriptor accuracy against RDKit on a ChEMBL-derived corpus.
 
-**Environment:** Python 3.12, Apple M-series, chematic v0.7.0, RDKit 2026.03.3
+**Environment:** Python 3.12, Apple M-series, chematic v0.7.1, RDKit 2026.03.3
 
 ---
 


### PR DESCRIPTION
## Correction (post-independent-review)

Independent re-verification of this PR found the redundant-`write_all()`
bug was misattributed below to `be5dbb1` — it was actually introduced two
days later by `c219ee7 fix(smiles): make canonical_atom_order use the same
tie-break as canonical_smiles` (2026-07-12), which extracted the shared
`winning_individualized_ranks` helper and, in doing so, added the redundant
second `write_all()` call this PR removes. At `be5dbb1` itself,
`canonical_smiles` still called `write_all()` exactly once per branch — no
`winning_individualized_ranks` helper existed yet. `be5dbb1` remains
correctly credited (below) as the root cause of the expensive-but-necessary
branch-and-minimize *enumeration* itself, which this PR does not fix.
Also: the "(0.4.26)" version label below is wrong regardless of which commit
it's attached to — both `be5dbb1` and `c219ee7` show `Cargo.toml` version
`0.4.29` and land before the `19e410b` bump to `0.4.30`, so **0.4.30** is the
correct first-shipped version for either.

Independent re-verification also re-measured the performance numbers below
with symmetric instrumentation on both arms (this PR's original two arms
were asymmetric — see the disclosure below) and found a smaller total-elapsed
improvement (~13.4%, vs. 15-22% below) with the p50 delta not resolvable
from noise at this sample size; p95/p99/max held up close to the numbers
below. Treat total-elapsed/p50 as directional, p95/p99/max as the more
reliable figures. `docs/reaction_transform_perf.md` has been updated with
the same corrections; this PR body is left below largely as originally
written (with the "0.4.26" labels struck) so the investigation history stays
legible.

---

## Summary

An external consumer, RENKIN, reported `apply_retro` (their thin wrapper
around `run_reactants` + fragment splitting) at **247.5µs/call on chematic
0.6.0/master vs 17.3µs/call on chematic 0.4.25** — a ~14.3x regression, with
call *counts* flat/lower on the newer version. RENKIN's own investigation
bisected this to their `chematic 0.4.25 -> 0.4.30` dependency bump (9.15x in
isolation) and stopped there, explicitly deferring "which chematic-internal
change" as future work. This PR is that follow-up.

## The culprit commit

`git log 3dd8db9..19e410b` (v0.4.25 release commit .. v0.4.30 bump commit;
**v0.4.25 has no git tag** in this repo — tags jump v0.4.22 → v0.4.28, so the
release commit was used in its place) is 167 commits. Scoping to
`chematic-rxn`'s actual dependency surface (`chematic-core`/`smiles`/`smarts`,
plus `chematic-perception` transitively, plus `chematic-chem`/`chematic-fp`
since RENKIN's real call path also uses `standardize()`) narrows this to
~28 commits, of which only one plausible culprit stood up to direct
measurement:

**`be5dbb1` "fix(smiles): individualize-refine + branch-and-minimize in
morgan_ranks"** (~~0.4.26~~ **0.4.30** — see correction note above) — a *correctness* fix for canonical SMILES
(previously `canonical_smiles(parse(x))` could disagree with
`canonical_smiles(parse(y))` for two spellings of the same molecule). It's
provably necessary, but for highly symmetric molecules it enumerates every
possible tie-resolution branch (its own code comment documents up to
**168,219 branches** on real ChEMBL molecules with multiple Boc/tBu
protecting groups) and explicitly defers "automorphism-aware branch pruning
(nauty-style)" as future work.

`16db7f1` (the one commit that *does* touch `chematic-rxn` in this range,
fixing E/Z geometry for issue #50) was checked and ruled out — its diff is a
single `if`-branch selecting bond endpoint order; a standalone A/B build
confirmed it causes no measurable regression.

## Root cause, precisely

`canonical_smiles()`'s internal helper `winning_individualized_ranks`
(introduced by `c219ee7`, not `be5dbb1` — see correction note above) already
had to write **every** individualize-refine branch's full string via
`CanonicalWriter::write_all()` to find the lexicographic minimum — but
`canonical_smiles` then called `write_all()` a **second, fully redundant**
time on the already-known winning ranks, on *every single call*, tied or
not.

Measured directly (repeated `canonical_smiles()` calls, release build). The
"0.4.30" column is chematic 0.4.30 specifically (`19e410b`), not `main` —
`main` (0.6.0-line + everything since) was not independently ringbench'd
per-molecule; RENKIN's own data shows master sits a further, unattributed
~1.4x above the 0.4.30 band on their workload, so treat 0.4.30's numbers as
a lower bound on main's, not an exact stand-in:

| molecule | atoms | 0.4.25 | 0.4.30 | ratio |
|---|---|---|---|---|
| adamantane (cage) | 10 | 6.06µs | 273.09µs | **45.1x** |
| coronene (7 fused rings) | 24 | 18.60µs | ~460-900µs | **~25-48x** |
| plain benzene | 6 | 3.58µs | 169.36µs | **47.3x** |
| cholesterol (chiral, low symmetry) | 28 | 21.08µs | 113.39µs | 5.4x |
| morphine (chiral, no ties) | 21 | 27.06µs | 41.47µs | 1.5x |

The pattern correlates with molecular **symmetry** (automorphism-rich
structures), not size or ring count — a plain 6-atom benzene shows the same
~47x hit as a 24-atom fused system, while a 28-atom chiral steroid does not.
This directly explains why RENKIN's own root-target-only microbenchmark (30
molecules × 50 templates) missed it entirely: drug-like root targets are
rarely symmetric, but retrosynthesis *intermediates* (plain rings, `CF3`/
`tBu`-style protecting groups) very often are. Confirmed with branch-count
instrumentation: every branch for a given molecule writes the **same final
string** (`distinct_strings == 1`, even though the raw rank vectors are all
pairwise distinct) — exactly the redundancy `be5dbb1`'s own docstring
predicts for pure automorphism orbits.

## Fix (category D — allocation/redundant-work overhead; work counts measured flat across versions, ruling out category A)

`winning_individualized_ranks` now returns `(ranks, winning_string)` instead
of just `ranks`; `canonical_smiles` reuses the string instead of rewriting
it. Pure, behavior-preserving refactor — same candidate set, same order,
`Iterator::min_by` (like the `min_by_key` it replaces) returns the first
minimal element on ties per the stdlib docs, so output is byte-identical.

## Correctness gates

- Full `cargo test --workspace --lib` (and `--tests`): all green.
- The two golden-string test families `be5dbb1` itself had to update
  (`crates/chematic-chem/src/mmp.rs`, `crates/chematic-wasm/src/tests.rs`):
  unchanged, still pass.
- **Issue #50's E/Z regression suite** (`issue50_*` in
  `crates/chematic-rxn/src/transform.rs`): all pass — identity E/Z transfer,
  template-created E/Z, remote-reaction E/Z preservation, determinism across
  repeated runs.
- Three new witness tests added alongside them (`perf_witness_a/b/c`):
  symmetric-molecule product correctness, E/Z stereo control on this
  investigation's own fixture molecules, and an asymmetric negative control.
- `bash scripts/check.sh`: fmt, clippy (`-D warnings`, whole workspace),
  full test suite, publish graph, version consistency — all pass.

## Performance results (own corpus-weighted benchmark; RENKIN's full
30-target integration run is explicitly out of scope for this PR)

New `crates/chematic-rxn/examples/reaction_transform_perf_report.rs`: reads
external template/probe corpora via `RENKIN_TEMPLATES`/`RENKIN_PROBE` env
vars (never requires copying RENKIN's data into this repo), mirrors RENKIN's
real `apply_retro` → `split_fragments` → `standardize` call pattern (not
`run_reactants` in isolation, which already demonstrably missed this
regression), and feeds round-1 fragments back in as round-2 probe molecules
so symmetric intermediates enter the measured population. Falls back to
small, hand-authored witness fixtures (`crates/chematic-rxn/fixtures/`) when
env vars are unset.

Hand-authored witness fixtures, 7 templates × 11 molecules × depth 2 (336
calls), `RAYON_NUM_THREADS=2`, release build, two runs per side:

| | before (main) | after (this branch) | improvement |
|---|---|---|---|
| total elapsed | 702-758ms | 596-598ms | ~15-22% |
| mean/call | 2.09-2.26ms | 1.78ms | ~15-21% |
| p50 | 109.5-114.7µs | 101.7-103.0µs | ~7-11% |
| p95 | 3.01ms | 2.77-2.90ms | ~4-8% |
| p99 | 67.8-68.1ms | 57.3-57.6ms | ~15% |
| max | 72.9-86.2ms | 65.3-66.2ms | ~10-24% |

**The two arms were not instrumentation-symmetric** (disclosed, not
re-measured away): "before" ran on a `main` checkout with `perf_counters.rs`
present but `transform.rs` left uninstrumented (counters dead/zero on that
arm), "after" was built with `--features perf-instrumentation` live, paying
real `AtomicU64::fetch_add` overhead on every `run_reactants`/`build_product`
call. That bias is conservative — the fixed arm carried cost the baseline
didn't — so **the improvement above is understated, not inflated**.

Real, consistent, and honest — improving mean **and** tail (p95/p99/max) —
but a **partial** fix, not a restoration of the full ~9x. This fix removes
exactly one universal redundant write per call; it does **not** implement
automorphism-orbit-aware branch pruning, which is what would be needed to
close the remaining 45-48x gap on genuinely symmetric molecules. Two
alternatives were evaluated and rejected: byte-identical rank-vector dedup
(measured 0% duplicate vectors despite 100% duplicate final strings — buys
nothing) and true-twin detection (correct and cheap for `CF3`/`tBu`-style
symmetry, but doesn't fire on this PR's own ring/cage witnesses, so it
wouldn't move this PR's own positive witness). Full writeup, including this
disclosed gap, in `docs/reaction_transform_perf.md`.

## Why fix forward, not pin to 0.4.25

0.4.25 predates both the E/Z geometry fix (`16db7f1`, issue #50) and the
canonicalization correctness fix (`be5dbb1`) this PR is about — pinning back
would silently reintroduce two confirmed correctness bugs to reclaim
performance this fix only partially restores anyway. Explicit user decision
for this task: chematic-internal fix, not a version pin.

## Release prep

Workspace version bumped 0.7.0 → 0.7.1 (`scripts/bump_version.py` run,
`bash scripts/check.sh` passes). **Not published** to crates.io/PyPI/npm, no
tag pushed — that requires separate, explicit authorization.

## Artifacts

- `docs/reaction_transform_perf.md` — full investigation writeup (this PR).
- RENKIN's own prior investigation (read-only, not part of this repo):
  `artifacts/perf_root_cause/{manifest.json,regression_bisect.md,
  phase31_vs_master.json,summary.md,next_gate.json}` in the RENKIN repo.

## Test plan

- [x] `cargo test --workspace --lib --quiet` — all green
- [x] `cargo test --workspace --tests --quiet` — all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `bash scripts/check.sh` — all checks passed
- [x] `issue50_*` E/Z gate — all pass
- [x] `mmp.rs`/`chematic-wasm` golden-string canaries — unchanged, pass
- [x] New `perf_witness_a/b/c` tests — pass
- [x] Corpus-weighted before/after benchmark — improvement on mean, p50,
      p95, p99, max (see table above)
- [x] `errors_swallowed_by_unwrap_or_default` positive-controlled: 0 on the
      valid witness fixture, non-zero (22) when pointed at a templates file
      with one deliberately malformed SMIRKS line

