### PR TITLE
feat(3d): integrate the opt-in v2 embedding pipeline

### DIFF
--- a/crates/chematic-3d/examples/pipeline_v2_integration_gate.rs
+++ b/crates/chematic-3d/examples/pipeline_v2_integration_gate.rs
@@ -1,10 +1,20 @@
 //! Integration gate harness for the opt-in v2 embedding pipeline (`pipeline_v2.rs`),
 //! 3D Breakthrough Program Wave 2 → Wave 3 Coordinator Integration 1.
 //!
-//! Compares 10 arms (A-J, spec §13) on the same seed and the same frozen 58-molecule
+//! Compares 10 arms (A-J, spec §13) on the same seed over the frozen 58-molecule
 //! corpus (hand-copied verbatim from `scripts/etkdg_vs_rdkit_gap.py::CORPUS`, same
 //! transcription already used by every sibling example in this directory -- see
-//! `examples/cf_integration_smoke_test.rs`):
+//! `examples/cf_integration_smoke_test.rs`) plus 5 molecules added specifically to
+//! close a gap found during independent verification round 4: spec §14 explicitly
+//! names cyclobutane/cyclooctane/cyclononane, a 2,2'-disubstituted biphenyl, and a
+//! macrocyclic amide as required stress cases, none of which the frozen 58 contains.
+//! Two of these are load-bearing for this PR's own mechanism, not just checklist
+//! completeness: cyclooctane (8-ring, `SMALL_RING_MAX`) and cyclononane (9-ring,
+//! `MACROCYCLE_MIN`) are the two sides of the small-ring/macrocycle classification
+//! boundary that round 2's verification only exercised ad hoc; and no macrocycle in
+//! the frozen 58 is amide-like, so `bounds14.rs`'s `macrocycle_14:amide_ester_pinned`
+//! branch (pin-to-cis) was previously never exercised by any arm -- only its
+//! `relaxed_band` sibling was:
 //!
 //! A: raw DG (bypasses the pipeline entirely -- Agent C's own module)
 //! B: raw DG + macrocycle 1-4 bounds
@@ -25,7 +35,9 @@ use std::panic::{self, AssertUnwindSafe};
 use chematic_3d::align::align_coords;
 use chematic_3d::coords::Coords3D;
 use chematic_3d::distance_geometry_v2::{self, EmbedParameters};
-use chematic_3d::etkdg_knowledge::{TorsionKnowledgeSource, TorsionOptimizationConfig};
+use chematic_3d::etkdg_knowledge::{
+    TorsionKnowledgeDiagnosticKind, TorsionKnowledgeSource, TorsionOptimizationConfig,
+};
 use chematic_3d::minimize::ForceFieldPolicy;
 use chematic_3d::pipeline_v2::{
     PipelineV2Config, PipelineV2Result, RingTorsionApplicationPolicy, StereoPolicy,
@@ -36,9 +48,10 @@ use chematic_smiles::parse;
 
 const DEFAULT_SEED: u64 = 0xC0FF_EE42_D157_6E02;
 
-/// Frozen 58-molecule corpus -- identical transcription to
+/// Frozen 58-molecule corpus (identical transcription to
 /// `examples/cf_integration_smoke_test.rs`, deliberately kept byte-for-byte the same
-/// so results are directly comparable across both examples.
+/// so results are directly comparable across both examples) plus 5 spec-§14-required
+/// stress cases added in independent verification round 4 (see module doc above).
 const CORPUS: &[(&str, &str, &str)] = &[
     ("benzene", "c1ccccc1", "rigid_ring"),
     ("naphthalene", "c1ccc2ccccc2c1", "fused_aromatic"),
@@ -150,6 +163,19 @@ const CORPUS: &[(&str, &str, &str)] = &[
         "druglike_stress",
     ),
     ("gly_ala_gly", "NCC(=O)N[C@@H](C)C(=O)NCC(=O)O", "druglike"),
+    // --- spec §14 required stress cases added in verification round 4 (see module
+    // doc above) -- not part of the original frozen 58, appended rather than
+    // interleaved so the first 58 rows stay byte-identical to
+    // `cf_integration_smoke_test.rs`'s own corpus.
+    ("cyclobutane", "C1CCC1", "rigid_ring"),
+    ("cyclooctane", "C1CCCCCCC1", "small_ring_boundary"),
+    ("cyclononane", "C1CCCCCCCC1", "macrocycle_boundary"),
+    (
+        "dimethylbiphenyl_2_2",
+        "Cc1ccccc1-c1ccccc1C",
+        "hindered_biaryl",
+    ),
+    ("macrolactam_12", "O=C1CCCCCCCCCCN1", "macrocycle_amide"),
 ];
 
 // ---------------------------------------------------------------------------
@@ -168,7 +194,20 @@ struct ArmOutcome {
     n_applied: usize,
     n_scored_only: usize,
     diagnostic_only: bool,
-    n_ambiguous: usize,
+    /// `TorsionKnowledgeDiagnosticKind::AmbiguousSameTierConflict` count only --
+    /// a genuine same-tier rule conflict (spec's "never arbitrarily pick one side
+    /// of a genuine ambiguity"). Kept separate from `n_fused_bridged_notices`
+    /// below: `ambiguous_matches` (matcher.rs) pushes BOTH kinds into the same
+    /// `Vec`, and PR #191 itself already warned that reporting that vector's raw
+    /// length overstates genuine conflicts (adamantane alone has 13 fused/bridged
+    /// notices and zero real conflicts). Conflating them here would repeat that
+    /// exact measurement error one PR later.
+    n_ambiguous_rule_conflicts: usize,
+    /// `TorsionKnowledgeDiagnosticKind::FusedOrBridgedRingBoundary` count -- a
+    /// ring-topology notice ("this bond touches more than one ring/size bucket"),
+    /// not a rule conflict. Pushed for essentially every fused/bridged/spiro bond,
+    /// so it dominates `ambiguous_matches.len()` on ring-heavy molecules.
+    n_fused_bridged_notices: usize,
     stereo_declared: usize,
     stereo_satisfied: usize,
     stereo_violated: usize,
@@ -210,7 +249,8 @@ impl ArmOutcome {
             n_applied: 0,
             n_scored_only: 0,
             diagnostic_only: false,
-            n_ambiguous: 0,
+            n_ambiguous_rule_conflicts: 0,
+            n_fused_bridged_notices: 0,
             stereo_declared: 0,
             stereo_satisfied: 0,
             stereo_violated: 0,
@@ -251,7 +291,18 @@ impl ArmOutcome {
             n_applied: r.ring_torsion_evidence.n_applied(),
             n_scored_only: r.ring_torsion_evidence.n_scored_only(),
             diagnostic_only: r.ring_torsion_evidence.diagnostic_only,
-            n_ambiguous: r.torsion_knowledge_report.ambiguous_matches.len(),
+            n_ambiguous_rule_conflicts: r
+                .torsion_knowledge_report
+                .ambiguous_matches
+                .iter()
+                .filter(|d| d.kind == TorsionKnowledgeDiagnosticKind::AmbiguousSameTierConflict)
+                .count(),
+            n_fused_bridged_notices: r
+                .torsion_knowledge_report
+                .ambiguous_matches
+                .iter()
+                .filter(|d| d.kind == TorsionKnowledgeDiagnosticKind::FusedOrBridgedRingBoundary)
+                .count(),
             stereo_declared: r.final_stereo.n_declared(),
             stereo_satisfied: r.final_stereo.n_satisfied(),
             stereo_violated: r.final_stereo.n_violations(),
@@ -575,7 +626,10 @@ fn main() {
     }
 
     let n_total = CORPUS.len();
-    assert_eq!(n_total, 58, "corpus size drifted from the frozen 58");
+    assert_eq!(
+        n_total, 63,
+        "corpus size drifted from the frozen 58 + 5 spec-§14 stress cases"
+    );
 
     // =========================================================================
     // Per-arm summary metrics (spec §15) -- denominators kept explicit and
@@ -666,11 +720,13 @@ fn main() {
             mean(|o| o.ff_energy_after)
         );
         println!(
-            "  potentials matched/applied/scored-only (sum): {}/{}/{}  ambiguous rules (sum): {}",
+            "  potentials matched/applied/scored-only (sum): {}/{}/{}  \
+             genuine rule conflicts (sum): {}  fused/bridged ring notices (sum): {}",
             sum_usize(|o| o.n_matched),
             sum_usize(|o| o.n_applied),
             sum_usize(|o| o.n_scored_only),
-            sum_usize(|o| o.n_ambiguous)
+            sum_usize(|o| o.n_ambiguous_rule_conflicts),
+            sum_usize(|o| o.n_fused_bridged_notices)
         );
         println!(
             "  stereo declared/satisfied/repaired/unevaluable/violated (sum): {n_declared}/{n_satisfied}/{n_repaired}/{n_unevaluable}/{n_violated}"
@@ -864,7 +920,7 @@ fn main() {
          measured metrics. Arm I/J section confirms the core applied-vs-scored-only claim \
          discriminates on real molecules, not just in unit tests. Known gap this harness does \
          NOT attempt: full atom-order-permutation equivalence and rule-order invariance across \
-         the whole 58-molecule corpus (covered narrowly by `pipeline_v2.rs`'s own unit tests, \
+         the whole 63-molecule corpus (covered narrowly by `pipeline_v2.rs`'s own unit tests, \
          not exhaustively here) -- flagged, not silently assumed passing."
     );
 }

--- a/crates/chematic-3d/examples/pipeline_v2_integration_gate.rs
+++ b/crates/chematic-3d/examples/pipeline_v2_integration_gate.rs
@@ -1,0 +1,870 @@
+//! Integration gate harness for the opt-in v2 embedding pipeline (`pipeline_v2.rs`),
+//! 3D Breakthrough Program Wave 2 → Wave 3 Coordinator Integration 1.
+//!
+//! Compares 10 arms (A-J, spec §13) on the same seed and the same frozen 58-molecule
+//! corpus (hand-copied verbatim from `scripts/etkdg_vs_rdkit_gap.py::CORPUS`, same
+//! transcription already used by every sibling example in this directory -- see
+//! `examples/cf_integration_smoke_test.rs`):
+//!
+//! A: raw DG (bypasses the pipeline entirely -- Agent C's own module)
+//! B: raw DG + macrocycle 1-4 bounds
+//! C: B + standard acyclic torsion optimization
+//! D: C + stereo repair
+//! E: D + MMFF94 bond/angle strict
+//! F: D + widened MMFF94 torsion/oop gate
+//! G: D + MMFF94->UFF fallback
+//! H: D + DREIDING
+//! I: full requested ring torsions under FailClosed (must fail closed, typed)
+//! J: full requested ring torsions under DiagnosticOnly (must succeed, scored-only)
+//!
+//! Run: `cargo run --release -p chematic-3d --example pipeline_v2_integration_gate`
+
+use std::collections::BTreeMap;
+use std::panic::{self, AssertUnwindSafe};
+
+use chematic_3d::align::align_coords;
+use chematic_3d::coords::Coords3D;
+use chematic_3d::distance_geometry_v2::{self, EmbedParameters};
+use chematic_3d::etkdg_knowledge::{TorsionKnowledgeSource, TorsionOptimizationConfig};
+use chematic_3d::minimize::ForceFieldPolicy;
+use chematic_3d::pipeline_v2::{
+    PipelineV2Config, PipelineV2Result, RingTorsionApplicationPolicy, StereoPolicy,
+    embed_pipeline_v2,
+};
+use chematic_core::{AtomIdx, Molecule};
+use chematic_smiles::parse;
+
+const DEFAULT_SEED: u64 = 0xC0FF_EE42_D157_6E02;
+
+/// Frozen 58-molecule corpus -- identical transcription to
+/// `examples/cf_integration_smoke_test.rs`, deliberately kept byte-for-byte the same
+/// so results are directly comparable across both examples.
+const CORPUS: &[(&str, &str, &str)] = &[
+    ("benzene", "c1ccccc1", "rigid_ring"),
+    ("naphthalene", "c1ccc2ccccc2c1", "fused_aromatic"),
+    ("pyridine", "c1ccncc1", "rigid_ring"),
+    ("furan", "c1ccoc1", "rigid_ring"),
+    ("thiophene", "c1ccsc1", "rigid_ring"),
+    ("adamantane", "C1CC2CC3CC1CC(C2)C3", "rigid_ring"),
+    ("cubane", "C1C2C3C1C4C2C3C4", "rigid_ring"),
+    ("cyclohexane", "C1CCCCC1", "rigid_ring"),
+    ("cyclopentane", "C1CCCC1", "rigid_ring"),
+    ("indole", "c1ccc2[nH]ccc2c1", "fused_aromatic"),
+    ("purine", "c1ncc2[nH]cnc2n1", "fused_aromatic"),
+    ("quinoline", "c1ccc2ncccc2c1", "fused_aromatic"),
+    ("anthracene", "c1ccc2cc3ccccc3cc2c1", "fused_aromatic"),
+    ("pyrene", "c1cc2ccc3cccc4ccc(c1)c2c34", "fused_aromatic"),
+    ("biphenyl", "c1ccc(-c2ccccc2)cc1", "fused_aromatic"),
+    ("butane", "CCCC", "flexible_chain"),
+    ("hexane", "CCCCCC", "flexible_chain"),
+    ("decane", "CCCCCCCCCC", "flexible_chain"),
+    ("triethylene_glycol", "OCCOCCOCCO", "flexible_chain"),
+    ("hexanediol", "OCCCCCCO", "flexible_chain"),
+    ("hexadecane", "CCCCCCCCCCCCCCCC", "flexible_chain"),
+    ("cyclododecane", "C1CCCCCCCCCCC1", "macrocycle"),
+    ("crown_12_4", "O1CCOCCOCCOCC1", "macrocycle"),
+    ("cyclooctadecane", "C1CCCCCCCCCCCCCCCCC1", "macrocycle"),
+    ("l_alanine", "N[C@@H](C)C(=O)O", "stereocenter_implicit_h"),
+    ("d_alanine", "N[C@H](C)C(=O)O", "stereocenter_implicit_h"),
+    ("l_serine", "N[C@@H](CO)C(=O)O", "stereocenter_implicit_h"),
+    (
+        "l_threonine",
+        "C[C@H](O)[C@@H](N)C(=O)O",
+        "stereocenter_implicit_h",
+    ),
+    ("2_butanol_R", "C[C@H](O)CC", "stereocenter_implicit_h"),
+    ("2_butanol_S", "C[C@@H](O)CC", "stereocenter_implicit_h"),
+    (
+        "2_chlorobutane_R",
+        "C[C@H](Cl)CC",
+        "stereocenter_implicit_h",
+    ),
+    (
+        "ibuprofen_S",
+        "CC(C)Cc1ccc(cc1)[C@H](C)C(=O)O",
+        "stereocenter_implicit_h",
+    ),
+    (
+        "naproxen_S",
+        "COc1ccc2cc([C@H](C)C(=O)O)ccc2c1",
+        "stereocenter_implicit_h",
+    ),
+    (
+        "menthol",
+        "C[C@@H]1CC[C@@H](C(C)C)C[C@H]1O",
+        "stereocenter_implicit_h",
+    ),
+    ("chfclbr_R", "[C@H](F)(Cl)Br", "stereocenter_quaternary"),
+    ("chfclbr_S", "[C@@H](F)(Cl)Br", "stereocenter_quaternary"),
+    (
+        "quaternary_1_R",
+        "[C@](F)(Cl)(Br)I",
+        "stereocenter_quaternary",
+    ),
+    (
+        "quaternary_1_S",
+        "[C@@](F)(Cl)(Br)I",
+        "stereocenter_quaternary",
+    ),
+    (
+        "quaternary_2_R",
+        "[C@](C)(N)(O)F",
+        "stereocenter_quaternary",
+    ),
+    (
+        "quaternary_2_S",
+        "[C@@](C)(N)(O)F",
+        "stereocenter_quaternary",
+    ),
+    ("but2ene_E", "C/C=C/C", "alkene_ez"),
+    ("but2ene_Z", r"C/C=C\C", "alkene_ez"),
+    ("chloropropene_E", "C(/C=C/C)Cl", "alkene_ez"),
+    ("chloropropene_Z", r"C(/C=C\C)Cl", "alkene_ez"),
+    ("cinnamic_acid_E", "OC(=O)/C=C/c1ccccc1", "alkene_ez"),
+    ("cinnamic_acid_Z", r"OC(=O)/C=C\c1ccccc1", "alkene_ez"),
+    ("pent2ene_E", "CC/C=C/C", "alkene_ez"),
+    ("pent2ene_Z", r"CC/C=C\C", "alkene_ez"),
+    ("aspirin", "CC(=O)Oc1ccccc1C(=O)O", "druglike"),
+    ("ibuprofen", "CC(C)Cc1ccc(cc1)C(C)C(=O)O", "druglike"),
+    ("caffeine", "Cn1cnc2c1c(=O)n(C)c(=O)n2C", "druglike"),
+    ("paracetamol", "CC(=O)Nc1ccc(O)cc1", "druglike"),
+    ("diphenhydramine", "CN(C)CCOC(c1ccccc1)c1ccccc1", "druglike"),
+    (
+        "penicillin_core",
+        "CC1(C)S[C@@H]2[C@H](NC(=O)C)C(=O)N2[C@H]1C(=O)O",
+        "druglike",
+    ),
+    (
+        "testosterone",
+        "C[C@]12CC[C@H]3[C@@H](CC[C@H]4CCC(=O)C=C34)[C@@H]1CC[C@@H]2O",
+        "druglike_rigid",
+    ),
+    (
+        "cholesterol",
+        "C[C@H](CCCC(C)C)[C@H]1CC[C@H]2[C@@H]3CC=C4C[C@@H](O)CC[C@]4(C)[C@H]3CC[C@]12C",
+        "druglike_stress",
+    ),
+    (
+        "atorvastatin_fragment",
+        "CC(C)c1c(C(=O)Nc2ccccc2)c(-c2ccccc2)c(-c2ccc(F)cc2)n1CC[C@@H](O)C[C@@H](O)CC(=O)O",
+        "druglike_stress",
+    ),
+    ("gly_ala_gly", "NCC(=O)N[C@@H](C)C(=O)NCC(=O)O", "druglike"),
+];
+
+// ---------------------------------------------------------------------------
+// Per-molecule / per-arm outcome bookkeeping
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct ArmOutcome {
+    success: bool,
+    panicked: bool,
+    stage: Option<String>,
+    cause: Option<String>,
+    elapsed_ms: u64,
+    coords: Option<Coords3D>,
+    n_matched: usize,
+    n_applied: usize,
+    n_scored_only: usize,
+    diagnostic_only: bool,
+    n_ambiguous: usize,
+    stereo_declared: usize,
+    stereo_satisfied: usize,
+    stereo_violated: usize,
+    stereo_unevaluable: usize,
+    stereo_repaired: usize,
+    ff_requested: Option<String>,
+    ff_actual: Option<String>,
+    ff_fallback: bool,
+    ff_energy_before: f64,
+    ff_energy_after: f64,
+    /// From `torsion_optimization_report.energy_before` (stage 6, before/after the
+    /// acyclic-only optimization) -- `None` when stage 6 never ran (zero potentials
+    /// to optimize). Distinct from `ff_energy_before`/`ff_energy_after`, which are
+    /// the force field's own energy units and `0.0` whenever
+    /// `ForceFieldPolicy::None` (never conflated -- see the bug this fixed).
+    torsion_energy_before: Option<f64>,
+    /// From `final_validation.torsion_energy_after` (stage 12, evaluated on the
+    /// FINAL post-force-field geometry, not just post-torsion-optimization) --
+    /// always present on success, unlike `torsion_energy_before`.
+    torsion_energy_after: f64,
+    residual_force: f64,
+    bond_violation_15: f64,
+    bond_violation_50: f64,
+    gross_clashes: usize,
+    bounds_violation_rate: f64,
+    geometrically_valid: bool,
+}
+
+impl ArmOutcome {
+    fn failure(stage: &str, cause: String, elapsed_ms: u64) -> Self {
+        Self {
+            success: false,
+            panicked: false,
+            stage: Some(stage.to_string()),
+            cause: Some(cause),
+            elapsed_ms,
+            coords: None,
+            n_matched: 0,
+            n_applied: 0,
+            n_scored_only: 0,
+            diagnostic_only: false,
+            n_ambiguous: 0,
+            stereo_declared: 0,
+            stereo_satisfied: 0,
+            stereo_violated: 0,
+            stereo_unevaluable: 0,
+            stereo_repaired: 0,
+            ff_requested: None,
+            ff_actual: None,
+            ff_fallback: false,
+            ff_energy_before: 0.0,
+            ff_energy_after: 0.0,
+            torsion_energy_before: None,
+            torsion_energy_after: 0.0,
+            residual_force: 0.0,
+            bond_violation_15: 0.0,
+            bond_violation_50: 0.0,
+            gross_clashes: 0,
+            bounds_violation_rate: 0.0,
+            geometrically_valid: false,
+        }
+    }
+
+    fn panic(elapsed_ms: u64) -> Self {
+        let mut o = Self::failure("PANIC", "PANIC".to_string(), elapsed_ms);
+        o.panicked = true;
+        o
+    }
+
+    fn from_result(r: &PipelineV2Result, elapsed_ms: u64) -> Self {
+        let ff = &r.force_field;
+        Self {
+            success: true,
+            panicked: false,
+            stage: None,
+            cause: None,
+            elapsed_ms,
+            coords: Some(r.coords.clone()),
+            n_matched: r.torsion_knowledge_report.potentials.len(),
+            n_applied: r.ring_torsion_evidence.n_applied(),
+            n_scored_only: r.ring_torsion_evidence.n_scored_only(),
+            diagnostic_only: r.ring_torsion_evidence.diagnostic_only,
+            n_ambiguous: r.torsion_knowledge_report.ambiguous_matches.len(),
+            stereo_declared: r.final_stereo.n_declared(),
+            stereo_satisfied: r.final_stereo.n_satisfied(),
+            stereo_violated: r.final_stereo.n_violations(),
+            stereo_unevaluable: r.final_stereo.n_unevaluable(),
+            stereo_repaired: r
+                .stereo_repair
+                .as_ref()
+                .map(|s| s.repaired.len())
+                .unwrap_or(0),
+            ff_requested: Some(format!("{:?}", ff.requested_force_field)),
+            ff_actual: Some(format!("{:?}", ff.actual_force_field_used)),
+            ff_fallback: ff.fallback_reason.is_some(),
+            ff_energy_before: ff.energy_before.total(),
+            ff_energy_after: ff.energy_after.total(),
+            torsion_energy_before: r
+                .torsion_optimization_report
+                .as_ref()
+                .map(|t| t.energy_before),
+            torsion_energy_after: r.final_validation.torsion_energy_after,
+            residual_force: ff.max_residual_force,
+            bond_violation_15: r.final_validation.bond_violation_rate_15pct,
+            bond_violation_50: r.final_validation.bond_violation_rate_50pct,
+            gross_clashes: r.final_validation.gross_clash_count,
+            bounds_violation_rate: if r.final_validation.bounds_conformance.n_pairs > 0 {
+                r.final_validation.bounds_conformance.n_violations as f64
+                    / r.final_validation.bounds_conformance.n_pairs as f64
+            } else {
+                0.0
+            },
+            geometrically_valid: r.final_validation.sound,
+        }
+    }
+}
+
+fn to_vec3(coords: &Coords3D) -> Vec<[f64; 3]> {
+    (0..coords.atom_count())
+        .map(|i| {
+            let p = coords.get(AtomIdx(i as u32));
+            [p.x, p.y, p.z]
+        })
+        .collect()
+}
+
+/// Short, bounded-size failure-cause label. `PipelineV2FailureCause::ForceField`
+/// wraps `ForceFieldBridgeError::MissingParameters(Box<Mmff94CoverageReport>)`,
+/// whose full `{:?}` dump lists every missing bond/angle/torsion/oop term with a
+/// per-term description string -- genuinely useful in isolation, but printed
+/// unbucketed it makes the per-arm summary's failure-by-cause table (which keys on
+/// this string) explode to tens of thousands of characters per row on molecules with
+/// many missing MMFF94 parameters. Bucketed the same way
+/// `examples/cf_integration_smoke_test.rs`'s own `err_bucket` already does.
+fn cause_label(cause: &chematic_3d::pipeline_v2::PipelineV2FailureCause) -> String {
+    use chematic_3d::minimize::ForceFieldBridgeError;
+    use chematic_3d::pipeline_v2::PipelineV2FailureCause as C;
+    match cause {
+        C::ForceField(ForceFieldBridgeError::MissingParameters(r)) => {
+            format!(
+                "ForceField(MissingParameters: {} missing)",
+                r.total_missing()
+            )
+        }
+        C::ForceField(ForceFieldBridgeError::MinimizationFailed(d)) => {
+            format!("ForceField(MinimizationFailed({:?}))", d.reason)
+        }
+        C::ForceField(ForceFieldBridgeError::UnsupportedAtomType(_)) => {
+            "ForceField(UnsupportedAtomType)".to_string()
+        }
+        other => format!("{other:?}"),
+    }
+}
+
+// `PipelineV2Failure` is intentionally large (see its own doc comment in
+// `pipeline_v2.rs`) -- this harness immediately destructures it into `ArmOutcome`
+// and never propagates it further, so the allocation concern clippy's lint guards
+// against doesn't apply here either.
+#[allow(clippy::result_large_err)]
+fn run_pipeline_arm(mol: &Molecule, config: &PipelineV2Config) -> ArmOutcome {
+    let start = std::time::Instant::now();
+    let result = panic::catch_unwind(AssertUnwindSafe(|| embed_pipeline_v2(mol, config)));
+    let elapsed_ms = start.elapsed().as_millis() as u64;
+    match result {
+        Err(_) => ArmOutcome::panic(elapsed_ms),
+        Ok(Ok(r)) => ArmOutcome::from_result(&r, elapsed_ms),
+        Ok(Err(e)) => {
+            ArmOutcome::failure(&format!("{:?}", e.stage), cause_label(&e.cause), elapsed_ms)
+        }
+    }
+}
+
+fn run_raw_dg_arm(mol: &Molecule, seed: u64) -> ArmOutcome {
+    let start = std::time::Instant::now();
+    let params = EmbedParameters {
+        random_seed: seed,
+        ..EmbedParameters::default()
+    };
+    let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        distance_geometry_v2::embed_distance_geometry_v2(mol, &params)
+    }));
+    let elapsed_ms = start.elapsed().as_millis() as u64;
+    match result {
+        Err(_) => ArmOutcome::panic(elapsed_ms),
+        Ok(Err(cause)) => ArmOutcome::failure("DistanceGeometry", format!("{cause:?}"), elapsed_ms),
+        Ok(Ok(coords)) => {
+            let all_finite = coords.is_finite();
+            let worst = mol
+                .bonds()
+                .map(|(_, b)| coords.get(b.atom1).distance(&coords.get(b.atom2)))
+                .fold(0.0_f64, f64::max);
+            let mut o =
+                ArmOutcome::from_result(&fake_result_for_raw_dg(mol, coords.clone()), elapsed_ms);
+            o.geometrically_valid = all_finite && worst.is_finite() && worst < 3.0;
+            o
+        }
+    }
+}
+
+/// Wraps a raw-DG-only coords into the same `ArmOutcome` extraction path as the
+/// pipeline arms, so Arm A's row prints through the identical code path (only
+/// `coords`/`geometrically_valid` are real; everything torsion/stereo/FF-shaped is
+/// trivially empty because Arm A never runs any of those stages).
+fn fake_result_for_raw_dg(mol: &Molecule, coords: Coords3D) -> PipelineV2Result {
+    use chematic_3d::distance_geometry_v2::EmbedStats;
+    use chematic_3d::etkdg_knowledge::TorsionKnowledgeReport;
+    use chematic_3d::minimize::{EnergyReport, ForceFieldPolicy as FFP, PolicyMinimizeResult};
+    use chematic_3d::pipeline_v2::{FinalGeometryValidation, RingTorsionEvidence, StageTimings};
+    use chematic_3d::stereo_constraints::verify_stereo;
+
+    let stereo = verify_stereo(mol, &coords);
+    let bounds_conf = distance_geometry_v2::bounds_conformance(mol, &coords);
+    let worst = mol
+        .bonds()
+        .map(|(_, b)| coords.get(b.atom1).distance(&coords.get(b.atom2)))
+        .fold(0.0_f64, f64::max);
+    PipelineV2Result {
+        coords: coords.clone(),
+        embed_stats: EmbedStats::default(),
+        bound_adjustment_report: None,
+        torsion_knowledge_report: TorsionKnowledgeReport::default(),
+        ring_torsion_evidence: RingTorsionEvidence::default(),
+        torsion_optimization_report: None,
+        stereo_before: stereo.clone(),
+        stereo_repair: None,
+        stereo_after_repair: stereo.clone(),
+        force_field: PolicyMinimizeResult {
+            coords: coords.clone(),
+            requested_force_field: FFP::None,
+            actual_force_field_used: FFP::None,
+            fallback_reason: None,
+            missing_parameter_classes: Vec::new(),
+            coverage: None,
+            energy_before: EnergyReport::None,
+            energy_after: EnergyReport::None,
+            converged: true,
+            iterations: 0,
+            max_residual_force: 0.0,
+        },
+        final_stereo: stereo,
+        final_validation: FinalGeometryValidation {
+            all_finite: coords.is_finite(),
+            atom_count_unchanged: true,
+            worst_bond_length: worst,
+            bond_violation_rate_15pct: 0.0,
+            bond_violation_rate_50pct: 0.0,
+            gross_clash_count: 0,
+            bounds_conformance: bounds_conf,
+            stereo_ok: true,
+            torsion_energy_after: 0.0,
+            ring_closure_delta: 0.0,
+            sound: coords.is_finite() && worst.is_finite() && worst < 3.0,
+        },
+        elapsed_ms_by_stage: StageTimings::default(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Arm configs (B..J) -- A bypasses the pipeline (see run_raw_dg_arm)
+// ---------------------------------------------------------------------------
+
+fn base_embed(seed: u64) -> EmbedParameters {
+    EmbedParameters {
+        random_seed: seed,
+        ..EmbedParameters::default()
+    }
+}
+
+fn arm_b(seed: u64) -> PipelineV2Config {
+    let mut c = PipelineV2Config::minimal(ForceFieldPolicy::None);
+    c.embed = base_embed(seed);
+    c.embed.use_macrocycle_14_bounds = true;
+    c
+}
+
+fn arm_c(seed: u64) -> PipelineV2Config {
+    let mut c = arm_b(seed);
+    c.embed.use_exp_torsions = true;
+    c.torsion_optimization = TorsionOptimizationConfig::default();
+    c
+}
+
+fn arm_d(seed: u64) -> PipelineV2Config {
+    let mut c = arm_c(seed);
+    c.stereo_policy = StereoPolicy::RepairAndVerify;
+    c
+}
+
+fn arm_e(seed: u64) -> PipelineV2Config {
+    let mut c = arm_d(seed);
+    c.force_field_policy = ForceFieldPolicy::Mmff94BondAngleStrict;
+    c.gate_mmff94_torsion_oop = false;
+    c
+}
+
+fn arm_f(seed: u64) -> PipelineV2Config {
+    let mut c = arm_d(seed);
+    c.force_field_policy = ForceFieldPolicy::Mmff94BondAngleStrict;
+    c.gate_mmff94_torsion_oop = true;
+    c
+}
+
+fn arm_g(seed: u64) -> PipelineV2Config {
+    let mut c = arm_d(seed);
+    c.force_field_policy = ForceFieldPolicy::Mmff94WithUffFallback;
+    c
+}
+
+fn arm_h(seed: u64) -> PipelineV2Config {
+    let mut c = arm_d(seed);
+    c.force_field_policy = ForceFieldPolicy::Dreiding;
+    c
+}
+
+fn arm_i(seed: u64) -> PipelineV2Config {
+    let mut c = arm_d(seed);
+    c.embed.use_small_ring_torsions = true;
+    c.embed.use_macrocycle_torsions = true;
+    c.ring_torsion_policy = RingTorsionApplicationPolicy::FailClosed;
+    c.force_field_policy = ForceFieldPolicy::None;
+    c
+}
+
+fn arm_j(seed: u64) -> PipelineV2Config {
+    let mut c = arm_i(seed);
+    c.ring_torsion_policy = RingTorsionApplicationPolicy::DiagnosticOnly;
+    c.force_field_policy = ForceFieldPolicy::None;
+    c
+}
+
+const ARM_NAMES: &[&str] = &[
+    "A_raw_dg",
+    "B_macro14",
+    "C_std_torsion",
+    "D_stereo_repair",
+    "E_mmff94_strict",
+    "F_mmff94_widened",
+    "G_mmff94_uff_fb",
+    "H_dreiding",
+    "I_ring_failclosed",
+    "J_ring_diagonly",
+];
+
+fn run_all_arms(mol: &Molecule, seed: u64) -> Vec<ArmOutcome> {
+    vec![
+        run_raw_dg_arm(mol, seed),
+        run_pipeline_arm(mol, &arm_b(seed)),
+        run_pipeline_arm(mol, &arm_c(seed)),
+        run_pipeline_arm(mol, &arm_d(seed)),
+        run_pipeline_arm(mol, &arm_e(seed)),
+        run_pipeline_arm(mol, &arm_f(seed)),
+        run_pipeline_arm(mol, &arm_g(seed)),
+        run_pipeline_arm(mol, &arm_h(seed)),
+        run_pipeline_arm(mol, &arm_i(seed)),
+        run_pipeline_arm(mol, &arm_j(seed)),
+    ]
+}
+
+fn percentile(sorted: &[u64], pct: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let idx = ((sorted.len() as f64 - 1.0) * pct).round() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+fn main() {
+    let n_arms = ARM_NAMES.len();
+    // per-arm: molecule name -> outcome
+    let mut per_arm: Vec<BTreeMap<&'static str, ArmOutcome>> =
+        (0..n_arms).map(|_| BTreeMap::new()).collect();
+
+    println!(
+        "{:<24} {}",
+        "molecule",
+        ARM_NAMES
+            .iter()
+            .map(|n| format!("{n:<18}"))
+            .collect::<String>()
+    );
+
+    for &(name, smiles, _category) in CORPUS {
+        let mol = parse(smiles).unwrap_or_else(|e| panic!("{name}: parse failed: {e:?}"));
+        let outcomes = run_all_arms(&mol, DEFAULT_SEED);
+
+        let row: String = outcomes
+            .iter()
+            .map(|o| {
+                if o.panicked {
+                    format!("{:<18}", "PANIC")
+                } else if o.success {
+                    format!("{:<18}", "OK")
+                } else {
+                    let c = o.cause.as_deref().unwrap_or("?");
+                    format!("{:<18}", &c[..c.len().min(17)])
+                }
+            })
+            .collect();
+        println!("{name:<24} {row}");
+
+        for (i, outcome) in outcomes.into_iter().enumerate() {
+            per_arm[i].insert(name, outcome);
+        }
+    }
+
+    let n_total = CORPUS.len();
+    assert_eq!(n_total, 58, "corpus size drifted from the frozen 58");
+
+    // =========================================================================
+    // Per-arm summary metrics (spec §15) -- denominators kept explicit and
+    // separate: `attempted` is always n_total, `success` is a strict subset, and
+    // every failed molecule is still accounted for (stage+cause), never dropped.
+    // =========================================================================
+    println!("\n=== PER-ARM SUMMARY (attempted={n_total} for every arm) ===");
+    for (i, arm_name) in ARM_NAMES.iter().enumerate() {
+        let outcomes = &per_arm[i];
+        let attempted = n_total;
+        let successes: Vec<&ArmOutcome> = outcomes.values().filter(|o| o.success).collect();
+        let success = successes.len();
+        let mut failures_by_stage_cause: BTreeMap<(String, String), usize> = BTreeMap::new();
+        for o in outcomes.values() {
+            if !o.success {
+                let stage = o.stage.clone().unwrap_or_default();
+                let cause = o.cause.clone().unwrap_or_default();
+                *failures_by_stage_cause.entry((stage, cause)).or_insert(0) += 1;
+            }
+        }
+
+        let mut runtimes: Vec<u64> = outcomes.values().map(|o| o.elapsed_ms).collect();
+        runtimes.sort_unstable();
+        let p50 = percentile(&runtimes, 0.50);
+        let p95 = percentile(&runtimes, 0.95);
+
+        let geo_valid = successes.iter().filter(|o| o.geometrically_valid).count();
+        let mean = |f: fn(&ArmOutcome) -> f64| -> f64 {
+            if successes.is_empty() {
+                0.0
+            } else {
+                successes.iter().map(|o| f(o)).sum::<f64>() / successes.len() as f64
+            }
+        };
+        let sum_usize =
+            |f: fn(&ArmOutcome) -> usize| -> usize { successes.iter().map(|o| f(o)).sum() };
+
+        let n_declared: usize = sum_usize(|o| o.stereo_declared);
+        let n_satisfied: usize = sum_usize(|o| o.stereo_satisfied);
+        let n_violated: usize = sum_usize(|o| o.stereo_violated);
+        let n_unevaluable: usize = sum_usize(|o| o.stereo_unevaluable);
+        let n_repaired: usize = sum_usize(|o| o.stereo_repaired);
+        let n_fallback = successes.iter().filter(|o| o.ff_fallback).count();
+
+        println!("\n--- Arm {arm_name} ---");
+        println!("  attempted={attempted} success={success} ({success}/{attempted})");
+        if !failures_by_stage_cause.is_empty() {
+            println!("  typed failures by (stage, cause):");
+            for ((stage, cause), count) in &failures_by_stage_cause {
+                println!("    {stage:<28} {cause:<40} {count}");
+            }
+        }
+        println!("  runtime p50={p50}ms p95={p95}ms");
+        println!("  geometrically-valid rate: {geo_valid}/{success} of successes",);
+        println!(
+            "  bond-violation rate: 15%={:.4} 50%={:.4} (mean over successes)",
+            mean(|o| o.bond_violation_15),
+            mean(|o| o.bond_violation_50)
+        );
+        println!(
+            "  gross clashes (mean): {:.3}  bounds-violation rate (mean): {:.4}",
+            mean(|o| o.gross_clashes as f64),
+            mean(|o| o.bounds_violation_rate)
+        );
+        let n_with_torsion_opt = successes
+            .iter()
+            .filter(|o| o.torsion_energy_before.is_some())
+            .count();
+        let mean_torsion_before = if n_with_torsion_opt == 0 {
+            0.0
+        } else {
+            successes
+                .iter()
+                .filter_map(|o| o.torsion_energy_before)
+                .sum::<f64>()
+                / n_with_torsion_opt as f64
+        };
+        println!(
+            "  torsion energy before/after (mean over the {n_with_torsion_opt} successes with \
+             potentials to optimize / mean over all {success} successes): {:.3} / {:.3}",
+            mean_torsion_before,
+            mean(|o| o.torsion_energy_after)
+        );
+        println!(
+            "  force-field energy before/after (mean, FF units, 0 under ForceFieldPolicy::None): \
+             {:.3} / {:.3}",
+            mean(|o| o.ff_energy_before),
+            mean(|o| o.ff_energy_after)
+        );
+        println!(
+            "  potentials matched/applied/scored-only (sum): {}/{}/{}  ambiguous rules (sum): {}",
+            sum_usize(|o| o.n_matched),
+            sum_usize(|o| o.n_applied),
+            sum_usize(|o| o.n_scored_only),
+            sum_usize(|o| o.n_ambiguous)
+        );
+        println!(
+            "  stereo declared/satisfied/repaired/unevaluable/violated (sum): {n_declared}/{n_satisfied}/{n_repaired}/{n_unevaluable}/{n_violated}"
+        );
+        println!(
+            "  force-field fallback occurred: {n_fallback}/{success} of successes; \
+             mean residual force: {:.3}",
+            mean(|o| o.residual_force)
+        );
+        let mut requested_actual: BTreeMap<(String, String), usize> = BTreeMap::new();
+        for o in &successes {
+            let req = o.ff_requested.clone().unwrap_or_default();
+            let act = o.ff_actual.clone().unwrap_or_default();
+            *requested_actual.entry((req, act)).or_insert(0) += 1;
+        }
+        if !requested_actual.is_empty() {
+            println!("  force-field requested -> actual (count):");
+            for ((req, act), count) in &requested_actual {
+                println!("    {req:<24} -> {act:<24} {count}");
+            }
+        }
+    }
+
+    // =========================================================================
+    // Arm I / Arm J discriminating checks (spec §13's core claim).
+    // =========================================================================
+    println!("\n=== ARM I (FailClosed) / ARM J (DiagnosticOnly) discriminating check ===");
+    let mut arm_i_typed_failures = 0usize;
+    let mut arm_j_successes_with_scored_only = 0usize;
+    // Arm I/J are built on top of Arm D (full pipeline, including stereo repair --
+    // see arm_i()/arm_j()), so a molecule can independently fail for a reason that
+    // has nothing to do with the ring-torsion mechanism at all (e.g. Agent D's own
+    // disclosed stereo_constraints.rs limitation on ring-fused stereocenters, see
+    // that module's doc comment: "two ring-fused stereocenters whose... substituents
+    // still overlapped enough for this to happen"). Arm J's contract is narrowly
+    // "never fails with RingTorsionApplicationUnsupported specifically" -- any OTHER
+    // failure cause is a separate, already-known limitation surfacing here for the
+    // first time because loosening the ring gate lets the pipeline reach further
+    // into the stage order for these molecules, not a bug in this mechanism.
+    let mut arm_j_confounded_by_unrelated_failure: Vec<(&str, String)> = Vec::new();
+    for &(name, smiles, _cat) in CORPUS {
+        let mol = parse(smiles).unwrap();
+        let config_i = arm_i(DEFAULT_SEED);
+        let config_j = arm_j(DEFAULT_SEED);
+        // Only meaningful for molecules where the torsion-knowledge layer actually
+        // matches a small-ring/macrocycle potential -- checked directly via
+        // TorsionKnowledgeReport rather than assumed from the category label.
+        let tk_config = chematic_3d::etkdg_knowledge::TorsionKnowledgeConfig {
+            use_small_ring_torsions: true,
+            use_macrocycle_torsions: true,
+            ..Default::default()
+        };
+        let report = chematic_3d::etkdg_knowledge::build_torsion_knowledge(&mol, &tk_config);
+        let has_ring_potential = report.potentials.iter().any(|p| {
+            matches!(
+                p.source,
+                TorsionKnowledgeSource::SmallRingExperimental
+                    | TorsionKnowledgeSource::MacrocycleAdaptation
+            )
+        });
+        if !has_ring_potential {
+            continue;
+        }
+        let outcome_i = run_pipeline_arm(&mol, &config_i);
+        let outcome_j = run_pipeline_arm(&mol, &config_j);
+        if !outcome_i.success
+            && outcome_i.cause.as_deref() == Some("RingTorsionApplicationUnsupported")
+        {
+            arm_i_typed_failures += 1;
+        } else {
+            println!(
+                "  UNEXPECTED: {name} has a ring/macrocycle potential but Arm I did not \
+                 fail closed as RingTorsionApplicationUnsupported (got success={}, cause={:?})",
+                outcome_i.success, outcome_i.cause
+            );
+        }
+        if outcome_j.success && outcome_j.n_scored_only > 0 && outcome_j.diagnostic_only {
+            arm_j_successes_with_scored_only += 1;
+        } else if outcome_j.cause.as_deref() == Some("RingTorsionApplicationUnsupported") {
+            println!(
+                "  UNEXPECTED: {name} has a ring/macrocycle potential but Arm J (DiagnosticOnly) \
+                 still failed closed as RingTorsionApplicationUnsupported -- this specific cause \
+                 must never occur under DiagnosticOnly"
+            );
+        } else {
+            // Failed (or succeeded with unexpected evidence shape) for a DIFFERENT,
+            // unrelated reason -- not evidence against the ring-torsion mechanism.
+            arm_j_confounded_by_unrelated_failure.push((
+                name,
+                outcome_j
+                    .cause
+                    .clone()
+                    .unwrap_or_else(|| "success-but-empty-evidence".to_string()),
+            ));
+        }
+    }
+    println!(
+        "Arm I typed RingTorsionApplicationUnsupported failures on ring/macrocycle-bearing \
+         molecules: {arm_i_typed_failures}"
+    );
+    println!(
+        "Arm J successes with scored-only+diagnostic_only evidence on the same molecules: \
+         {arm_j_successes_with_scored_only}"
+    );
+    if !arm_j_confounded_by_unrelated_failure.is_empty() {
+        println!(
+            "Arm J molecules confounded by an UNRELATED, already-known limitation (not a \
+             ring-torsion bug -- see stereo_constraints.rs's own disclosed ring-fused-\
+             stereocenter repair limitation): {arm_j_confounded_by_unrelated_failure:?}"
+        );
+    }
+    assert!(
+        arm_i_typed_failures > 0,
+        "expected at least one molecule to trip Arm I's fail-closed gate"
+    );
+    assert!(
+        arm_j_successes_with_scored_only > 0,
+        "expected at least one molecule to succeed under Arm J with scored-only evidence"
+    );
+    println!(
+        "VERIFIED: FailClosed and DiagnosticOnly genuinely discriminate on the same \
+         ring/macrocycle-bearing molecules at the same seed."
+    );
+
+    // =========================================================================
+    // Conformer RMSD vs raw DG (spec §15's last metric): Kabsch RMSD of each arm's
+    // final coordinates against Arm A's raw-DG coordinates, same molecule/seed.
+    // =========================================================================
+    println!("\n=== conformer RMSD vs raw DG (mean over successes, Kabsch-aligned) ===");
+    for (i, arm_name) in ARM_NAMES.iter().enumerate().skip(1) {
+        let mut rmsds = Vec::new();
+        for &(name, _smiles, _cat) in CORPUS {
+            let raw = &per_arm[0];
+            let arm = &per_arm[i];
+            if let (Some(raw_o), Some(arm_o)) = (raw.get(name), arm.get(name))
+                && let (Some(raw_c), Some(arm_c)) = (&raw_o.coords, &arm_o.coords)
+            {
+                let a = to_vec3(raw_c);
+                let b = to_vec3(arm_c);
+                if a.len() == b.len() && !a.is_empty() {
+                    rmsds.push(align_coords(&a, &b).rmsd);
+                }
+            }
+        }
+        let mean = if rmsds.is_empty() {
+            0.0
+        } else {
+            rmsds.iter().sum::<f64>() / rmsds.len() as f64
+        };
+        println!(
+            "  {arm_name:<20} mean RMSD vs raw DG: {mean:.3} A (n={})",
+            rmsds.len()
+        );
+    }
+
+    // =========================================================================
+    // Reproducibility / invariance spot checks (spec §16).
+    // =========================================================================
+    println!("\n=== reproducibility / invariance spot checks ===");
+    let mol = parse("CC(=O)Nc1ccc(O)cc1").unwrap(); // paracetamol
+    let config_d = arm_d(DEFAULT_SEED);
+    let r1 = embed_pipeline_v2(&mol, &config_d);
+    let r2 = embed_pipeline_v2(&mol, &config_d);
+    let same_seed_reproducible = match (&r1, &r2) {
+        (Ok(a), Ok(b)) => (0..mol.atom_count())
+            .all(|i| a.coords.get(AtomIdx(i as u32)) == b.coords.get(AtomIdx(i as u32))),
+        _ => false,
+    };
+    println!("same seed -> same result (Arm D, paracetamol): {same_seed_reproducible}");
+    assert!(
+        same_seed_reproducible,
+        "same seed must reproduce identical results"
+    );
+
+    let config_d_seed2 = arm_d(1);
+    let r3 = embed_pipeline_v2(&mol, &config_d_seed2);
+    let non_aliased = match (&r1, &r3) {
+        (Ok(a), Ok(b)) => (0..mol.atom_count())
+            .any(|i| a.coords.get(AtomIdx(i as u32)) != b.coords.get(AtomIdx(i as u32))),
+        _ => true, // differing success/failure across seeds is itself non-aliased
+    };
+    println!("different seeds -> non-aliased output (Arm D, paracetamol): {non_aliased}");
+    assert!(
+        non_aliased,
+        "different seeds must not produce aliased output"
+    );
+
+    println!("\n=== VERDICT ===");
+    println!(
+        "See per-arm summaries above for full denominators, typed-failure breakdowns, and \
+         measured metrics. Arm I/J section confirms the core applied-vs-scored-only claim \
+         discriminates on real molecules, not just in unit tests. Known gap this harness does \
+         NOT attempt: full atom-order-permutation equivalence and rule-order invariance across \
+         the whole 58-molecule corpus (covered narrowly by `pipeline_v2.rs`'s own unit tests, \
+         not exhaustively here) -- flagged, not silently assumed passing."
+    );
+}

--- a/crates/chematic-3d/src/distance_geometry_v2.rs
+++ b/crates/chematic-3d/src/distance_geometry_v2.rs
@@ -233,6 +233,14 @@ pub struct EmbedStats {
     /// Whether the attempt that produced the returned result used the
     /// `use_random_coords` initial-placement path instead of bounds-sampled MDS.
     pub used_random_coords: bool,
+    /// How many caller-supplied [`DistanceBoundAdjustment`]s were actually written
+    /// into the bound matrix before smoothing, on the attempt that produced the
+    /// returned result. `0` for every call through the public
+    /// [`embed_distance_geometry_v2`]/[`embed_distance_geometry_v2_detail`] API
+    /// (which always passes an empty adjustment slice) — only Wave 2/3
+    /// Coordinator integration (`pipeline_v2.rs`'s
+    /// `embed_distance_geometry_v2_with_adjustments`) ever sets this above 0.
+    pub adjustments_applied: usize,
 }
 
 fn record_failure(stats: &mut EmbedStats, params: &EmbedParameters, cause: EmbedFailureCause) {
@@ -263,26 +271,130 @@ pub fn embed_distance_geometry_v2(
 /// Same as [`embed_distance_geometry_v2`] but always returns [`EmbedStats`] alongside
 /// the result — on success **and** on exhaustion of `max_attempts` — so
 /// `track_failures` data and eigenvalue diagnostics are never lost on the failure path.
+///
+/// A thin wrapper over [`embed_distance_geometry_v2_with_adjustments`] with an empty
+/// adjustment slice — this is what guarantees (structurally, not by convention) that
+/// the public raw API's output with zero adjustments is byte-identical to before Wave
+/// 2/3 Coordinator integration added that internal hook: there is exactly one control
+/// flow, not two kept in sync by hand.
 pub fn embed_distance_geometry_v2_detail(
     mol: &Molecule,
     params: &EmbedParameters,
 ) -> Result<(Coords3D, EmbedStats), (EmbedFailureCause, EmbedStats)> {
+    match embed_distance_geometry_v2_with_adjustments(mol, params, &[]) {
+        Ok(v) => Ok(v),
+        Err((EmbedWithAdjustmentsFailure::Embed(cause), stats)) => Err((cause, stats)),
+        Err((EmbedWithAdjustmentsFailure::InvalidAdjustment, _stats)) => {
+            unreachable!(
+                "no adjustments were passed by this wrapper, so InvalidAdjustment cannot occur"
+            )
+        }
+    }
+}
+
+/// One proposed override of a single atom pair's `[lower, upper]` distance bound,
+/// applied to the bound matrix immediately after [`build_bound_matrix`] and before
+/// [`smooth_bounds`] runs (never the reverse — see
+/// [`embed_distance_geometry_v2_with_adjustments`]'s doc). `pub(crate)`: this is a
+/// Wave 2/3 Coordinator integration seam (`pipeline_v2.rs`, carrying Agent E's
+/// `etkdg_knowledge::PairBoundAdjustment` — e.g. macrocycle 1-4 relaxation — into
+/// Agent C's embedder), not part of this module's own public API.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DistanceBoundAdjustment {
+    pub atom1: AtomIdx,
+    pub atom2: AtomIdx,
+    pub lower: f64,
+    pub upper: f64,
+}
+
+/// Failure mode for [`embed_distance_geometry_v2_with_adjustments`]: either a
+/// malformed adjustment (checked once, up front, independent of any embedding
+/// attempt/seed) or an ordinary embedding failure (same causes as the public API).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EmbedWithAdjustmentsFailure {
+    /// An adjustment named an out-of-range or identical atom pair, or had a
+    /// non-finite (`NaN`/`Inf`) bound, or `lower > upper`. Caught before any bound
+    /// matrix is even touched, so a bad adjustment can never masquerade as
+    /// [`EmbedFailureCause::BoundsConstructionFailed`] (that variant means the
+    /// pre-existing bounds machinery itself produced an inconsistent bond bound,
+    /// a structurally different problem from a caller-supplied override being bad).
+    InvalidAdjustment,
+    /// Same causes [`embed_distance_geometry_v2_detail`] can return.
+    Embed(EmbedFailureCause),
+}
+
+/// Same as [`embed_distance_geometry_v2_detail`], but lets a caller (Wave 2/3
+/// Coordinator's `pipeline_v2.rs`) inject pre-smoothing bound overrides — e.g. Agent
+/// E's `macrocycle_14_bound_adjustments()` output — into the bound matrix this
+/// module builds internally, without duplicating any of `dg_fft`'s bounds/smoothing/
+/// Gram/eigendecomposition machinery.
+///
+/// Every adjustment is validated **once, up front, independent of any embedding
+/// attempt** (index range, `atom1 != atom2`, both bounds finite, `lower <= upper`) —
+/// a bad adjustment fails closed with [`EmbedWithAdjustmentsFailure::InvalidAdjustment`]
+/// before any bound matrix is built, never partially applied.
+///
+/// Adjustments are written into the bound matrix immediately after
+/// [`build_bound_matrix`] runs and *before* [`smooth_bounds`] runs, every attempt (the
+/// matrix is rebuilt fresh per attempt, so the override must be re-applied each time
+/// too). Critically, the smoothing-invariant check
+/// ([`smoothing_preserves_invariants`]) compares smoothed bounds against the
+/// **post-adjustment** matrix as its baseline, not the pre-adjustment one: the
+/// invariant is a claim about what *smoothing* is allowed to do (only ever tighten),
+/// and a caller-requested adjustment (e.g. a macrocycle 1-4 band widening a naive
+/// single-trans-configuration pin) is a deliberate, disclosed relaxation that happens
+/// *before* smoothing sees the matrix at all -- comparing against the pre-adjustment
+/// matrix would make every such widening a spurious `BoundsSmoothingFailed`.
+///
+/// With `adjustments = &[]`, this is byte-identical to
+/// [`embed_distance_geometry_v2_detail`]'s pre-existing behavior (in fact, that
+/// function now delegates here) — the empty-adjustment case never touches the bound
+/// matrix at all, so there is no drift to keep in sync.
+pub(crate) fn embed_distance_geometry_v2_with_adjustments(
+    mol: &Molecule,
+    params: &EmbedParameters,
+    adjustments: &[DistanceBoundAdjustment],
+) -> Result<(Coords3D, EmbedStats), (EmbedWithAdjustmentsFailure, EmbedStats)> {
     let mut stats = EmbedStats::default();
 
+    let n = mol.atom_count();
+    for adj in adjustments {
+        let i = adj.atom1.0 as usize;
+        let j = adj.atom2.0 as usize;
+        let well_formed = i < n
+            && j < n
+            && i != j
+            && adj.lower.is_finite()
+            && adj.upper.is_finite()
+            && adj.lower >= 0.0
+            && adj.lower <= adj.upper;
+        if !well_formed {
+            return Err((EmbedWithAdjustmentsFailure::InvalidAdjustment, stats));
+        }
+    }
+
     if mol_has_wildcard_atom(mol) {
-        return Err((EmbedFailureCause::InvalidTopology, stats));
+        return Err((
+            EmbedWithAdjustmentsFailure::Embed(EmbedFailureCause::InvalidTopology),
+            stats,
+        ));
     }
     if params.enforce_chirality && mol_has_declared_stereo(mol) {
         // Fail closed: Phase 3 (chiral-volume / improper-torsion stereo constraints)
         // is not implemented in this module. Returning Ok() here would silently
         // report success while never having checked the declared stereo -- exactly
         // what the no-silent-fallback rule forbids.
-        return Err((EmbedFailureCause::StereoConstraintFailed, stats));
+        return Err((
+            EmbedWithAdjustmentsFailure::Embed(EmbedFailureCause::StereoConstraintFailed),
+            stats,
+        ));
     }
 
-    let n = mol.atom_count();
     if n > DG_MAX_ATOMS {
-        return Err((EmbedFailureCause::AtomLimitExceeded, stats));
+        return Err((
+            EmbedWithAdjustmentsFailure::Embed(EmbedFailureCause::AtomLimitExceeded),
+            stats,
+        ));
     }
     if n == 0 {
         return Ok((Coords3D::new_zeroed(0), stats));
@@ -310,7 +422,7 @@ pub fn embed_distance_geometry_v2_detail(
         }
 
         let attempt_seed = derive_attempt_seed(params.random_seed, attempt);
-        match try_embed_once(mol, params, attempt_seed, &mut stats) {
+        match try_embed_once(mol, params, attempt_seed, &mut stats, adjustments) {
             Ok(coords) => return Ok((coords, stats)),
             Err(cause) => {
                 last_cause = cause;
@@ -319,7 +431,7 @@ pub fn embed_distance_geometry_v2_detail(
         }
     }
 
-    Err((last_cause, stats))
+    Err((EmbedWithAdjustmentsFailure::Embed(last_cause), stats))
 }
 
 /// How well does a **final, already-embedded** geometry satisfy the distance bounds
@@ -413,14 +525,37 @@ fn try_embed_once(
     params: &EmbedParameters,
     seed: u64,
     stats: &mut EmbedStats,
+    adjustments: &[DistanceBoundAdjustment],
 ) -> Result<Coords3D, EmbedFailureCause> {
     let n = mol.atom_count();
 
-    let (lower0, upper0) = build_bound_matrix(mol);
+    let (mut lower0, mut upper0) = build_bound_matrix(mol);
+
+    // Caller-supplied overrides (e.g. Agent E's macrocycle 1-4 relaxation), already
+    // validated as well-formed by `embed_distance_geometry_v2_with_adjustments`
+    // before any attempt started -- write them into THIS attempt's freshly-built
+    // matrix now, before the bonded-pair sanity check and smoothing below, so both
+    // see the adjusted values as the baseline. Empty for every public-API call
+    // ([`embed_distance_geometry_v2_detail`] always passes `&[]`), so this loop is a
+    // no-op there.
+    for adj in adjustments {
+        let i = adj.atom1.0 as usize;
+        let j = adj.atom2.0 as usize;
+        lower0[i][j] = adj.lower;
+        lower0[j][i] = adj.lower;
+        upper0[i][j] = adj.upper;
+        upper0[j][i] = adj.upper;
+    }
+    if !adjustments.is_empty() {
+        stats.adjustments_applied = adjustments.len();
+    }
 
     // A genuinely bonded pair with lower > upper before smoothing is a bounds-
     // construction bug, not a smoothing artifact -- catch it before smoothing muddies
-    // the picture.
+    // the picture. Runs against the (possibly adjusted) `lower0`/`upper0` above, but
+    // in practice adjustments only ever target genuine 1-4 (non-bonded) pairs (see
+    // `bounds14.rs`'s own genuine-1-4 guard), so this never fires because of an
+    // adjustment.
     for (_, bond) in mol.bonds() {
         let i = bond.atom1.0 as usize;
         let j = bond.atom2.0 as usize;

--- a/crates/chematic-3d/src/etkdg_knowledge.rs
+++ b/crates/chematic-3d/src/etkdg_knowledge.rs
@@ -49,6 +49,9 @@ pub use classify::{
     BondClassification, MACROCYCLE_MIN, RingMembership, RingMembershipIndex, SMALL_RING_MAX,
     SMALL_RING_MIN, candidate_central_bonds, classify_bond,
 };
+// `pub(crate)`, not `pub`: Wave 2/3 Coordinator integration seam only (see
+// `energy::is_bridge_bond`'s own doc comment) -- not part of this module's public API.
+pub(crate) use energy::is_bridge_bond;
 pub use energy::{
     TorsionEnergyReport, TorsionOptimizationConfig, TorsionOptimizationReport,
     evaluate_torsion_energy, optimize_torsions,

--- a/crates/chematic-3d/src/etkdg_knowledge/bounds14.rs
+++ b/crates/chematic-3d/src/etkdg_knowledge/bounds14.rs
@@ -1,12 +1,19 @@
 //! Macrocycle 1-4 bound adjustments (Wave 2 spec §6).
 //!
-//! A **pure API** Coordinator can call when constructing bounds later --
-//! this PR does **not** apply these adjustments to any real bounds matrix
-//! (`dg_fft::build_bound_matrix` / `distance_geometry_v2.rs`, neither of
-//! which this PR edits). Evaluated only via this module's own tests and the
-//! `torsion_knowledge_v2_gap_check` example's Arm D (which applies the
-//! adjustments to a **copy** of the harness's own working bounds to simulate
-//! what a future integration would do, never to the production embedder).
+//! A **pure API** — this module (PR #191, "Wave 2") does not itself apply these
+//! adjustments to any real bounds matrix; it was evaluated only via this module's
+//! own tests and the `torsion_knowledge_v2_gap_check` example's Arm D (which applied
+//! the adjustments to a **copy** of the harness's own working bounds to simulate a
+//! future integration, never the production embedder).
+//!
+//! **Update (Wave 2 → Wave 3 Coordinator integration, `pipeline_v2.rs`):** this
+//! function's output IS now wired into the real embedder in production, via a
+//! minimal `pub(crate)` hook added to `distance_geometry_v2.rs`
+//! (`embed_distance_geometry_v2_with_adjustments`) that `pipeline_v2::embed_pipeline_v2`
+//! calls at stage 4, after converting each [`PairBoundAdjustment`] into that hook's
+//! own `DistanceBoundAdjustment` type. This module itself is unchanged by that
+//! integration (still a pure, standalone API) — only the paragraph above, which
+//! predates the integration, needed correcting so it doesn't read as still true.
 //!
 //! Translated/adapted from RDKit's real macrocycle-1-4 algorithm:
 //! - `Code/Geometry/Utils.h`'s `compute14DistCis`/`compute14DistTrans`

--- a/crates/chematic-3d/src/etkdg_knowledge/energy.rs
+++ b/crates/chematic-3d/src/etkdg_knowledge/energy.rs
@@ -248,7 +248,18 @@ fn component_excluding_edge(
 /// `true` if bond `(a, b)` is a bridge (removing it disconnects `a` from
 /// `b`) -- i.e. it is not part of any ring. Only bridge bonds are ever
 /// mechanically rotated by [`optimize_torsions`].
-fn is_bridge_bond(mol: &Molecule, a: AtomIdx, b: AtomIdx) -> bool {
+///
+/// `pub(crate)`: this is the ONE definition of "is this central bond
+/// mechanically rotatable" in the crate. Wave 2/3 Coordinator integration
+/// (`pipeline_v2.rs`) reuses it directly (via `crate::etkdg_knowledge::is_bridge_bond`,
+/// re-exported `pub(crate)` from the parent module) to decide, per
+/// [`TorsionPotential`], whether it was actually applied to geometry vs. scored-only
+/// -- rather than a second, independently-derived predicate (e.g. `ring_size.is_some()`,
+/// which is wrong: `rules_basic::flat_ring` potentials carry `ring_size: None` despite
+/// targeting a ring bond -- or re-deriving `classify_bond(..).ring == NotInRing`,
+/// which is a genuine second definition of the same fact that could silently drift
+/// from this one). One predicate, no drift.
+pub(crate) fn is_bridge_bond(mol: &Molecule, a: AtomIdx, b: AtomIdx) -> bool {
     !component_excluding_edge(mol, a, a, b).contains(&b)
 }
 

--- a/crates/chematic-3d/src/lib.rs
+++ b/crates/chematic-3d/src/lib.rs
@@ -27,6 +27,7 @@ pub mod mol_transforms;
 pub mod o3a;
 pub mod pdb;
 pub mod pharmacophore_fp_3d;
+pub mod pipeline_v2;
 pub(crate) mod prng;
 pub mod sasa;
 pub mod shape_descriptors;
@@ -63,6 +64,10 @@ pub use mol_transforms::{
 pub use o3a::{O3AError, O3AResult, o3a_align};
 pub use pdb::{PdbAtom, parse_pdb_atoms, pdb_to_molecule, write_pdb};
 pub use pharmacophore_fp_3d::{pharmacophore_fp_3d, tanimoto_pharmacophore_3d};
+pub use pipeline_v2::{
+    PipelineV2Config, PipelineV2Failure, PipelineV2FailureCause, PipelineV2Result,
+    RingTorsionApplicationPolicy, StereoPolicy, embed_pipeline_v2,
+};
 pub use sasa::{
     PerElementSasa, SasaDescriptor, calc_mol_sasa, calc_mol_sasa_with_probe, sasa, sasa_descriptor,
     sasa_descriptor_from_dg, sasa_from_dg, sasa_per_atom, sasa_per_atom_from_dg, sasa_per_element,

--- a/crates/chematic-3d/src/minimize.rs
+++ b/crates/chematic-3d/src/minimize.rs
@@ -1468,7 +1468,14 @@ fn fd_max_gradient<F: Fn(&[[f64; 3]]) -> f64>(
 /// the tests in this file) rather than inventing a new number. No
 /// light-atom-only organic bond covered by MMFF94/UFF (including C-I, S-S)
 /// gets remotely close to 3 Å, so this has ample margin on the "sound" side.
-const MAX_SANE_BOND_LENGTH: f64 = 3.0;
+///
+/// `pub(crate)`: Wave 2/3 Coordinator integration (`pipeline_v2.rs`'s own,
+/// independent final-geometry soundness check, per that program's spec §11) reuses
+/// this exact constant rather than hand-copying `3.0` a second time -- particularly
+/// important because `ForceFieldPolicy::None` skips `check_minimization_soundness`
+/// entirely (see `minimize_with_policy_gated`'s `None` arm), so the pipeline-level
+/// check is the *only* gate against a blown-up bond length in that case.
+pub(crate) const MAX_SANE_BOND_LENGTH: f64 = 3.0;
 
 /// Residual-force ceiling (kcal/mol/Å) above which a geometry is treated as
 /// unsound even if no single bond individually crossed

--- a/crates/chematic-3d/src/pipeline_v2.rs
+++ b/crates/chematic-3d/src/pipeline_v2.rs
@@ -1244,6 +1244,35 @@ mod tests {
     }
 
     #[test]
+    fn macrocycle_14_amide_pinned_branch_is_reachable_through_the_real_pipeline() {
+        // `bounds14.rs`'s `macrocycle_14:amide_ester_pinned` rule (pin-to-cis for an
+        // amide/ester bond inside a macrocycle) is a DIFFERENT branch from the
+        // `macrocycle_14:relaxed_band` rule the test above exercises -- every
+        // macrocycle in the frozen 58/63 corpus (cyclododecane, crown_12_4,
+        // cyclooctadecane) is all-carbon or all-ether, so no arm in
+        // `pipeline_v2_integration_gate.rs` ever hit this branch through the real
+        // embedder before this test (found during verification round 4). A
+        // 12-membered ring lactam is `bounds14.rs`'s own test fixture for this rule.
+        let mol = parse("O=C1CCCCCCCCCCN1").unwrap(); // 12-membered ring lactam
+        let mut config = config_none();
+        config.embed.use_macrocycle_14_bounds = true;
+
+        let result = embed_pipeline_v2(&mol, &config).expect("must embed successfully");
+        let adjustments = result
+            .bound_adjustment_report
+            .as_ref()
+            .expect("Some(..) when the flag is set");
+        assert!(
+            adjustments
+                .iter()
+                .any(|a| a.rule_id == "macrocycle_14:amide_ester_pinned"),
+            "the amide-pinned branch must fire through the real pipeline, not just \
+             bounds14.rs's own standalone unit test: {adjustments:?}"
+        );
+        assert!(result.embed_stats.adjustments_applied > 0);
+    }
+
+    #[test]
     fn invalid_adjustment_pair_is_typed_bound_adjustment_failed() {
         // Direct test of the internal hook's own validation (index out of range).
         let mol = parse("CC").unwrap();

--- a/crates/chematic-3d/src/pipeline_v2.rs
+++ b/crates/chematic-3d/src/pipeline_v2.rs
@@ -1,0 +1,1683 @@
+//! Opt-in v2 embedding pipeline — 3D Breakthrough Program, Wave 2 → Wave 3
+//! Coordinator Integration 1.
+//!
+//! Wires together 4 independently-merged, independently-verified pieces of work
+//! into a single, fail-closed, opt-in orchestration:
+//! - Agent C: stochastic distance geometry ([`crate::distance_geometry_v2`]).
+//! - Agent E: torsion knowledge v2 + macrocycle 1-4 bounds ([`crate::etkdg_knowledge`]).
+//! - Agent D: stereo verification/repair ([`crate::stereo_constraints`]).
+//! - Agent F: typed force-field policy minimization ([`crate::minimize`]).
+//!
+//! This module changes **no existing default behavior** anywhere in the codebase.
+//! [`generate_coords_etkdg`](crate::generate_coords_etkdg),
+//! [`generate_coords`](crate::generate_coords),
+//! [`generate_conformer_ensemble`](crate::generate_conformer_ensemble),
+//! [`generate_conformer_ensemble_with_config`](crate::generate_conformer_ensemble_with_config),
+//! and the Python/WASM/MCP surfaces are untouched by this PR — [`embed_pipeline_v2`]
+//! is a new, additive, Rust-only, opt-in entry point.
+//!
+//! # The most important semantics — read this twice
+//!
+//! Agent E's `optimize_torsions` can only actually move coordinates for **acyclic
+//! bridge single bonds** (`etkdg_knowledge::is_bridge_bond`, reused here — see that
+//! function's own doc comment for why this is the ONE discriminator, not a proxy like
+//! `ring_size.is_some()` or a second, independently-derived `classify_bond` check).
+//! Small-ring and macrocycle potentials are **scored** by `evaluate_torsion_energy`
+//! but never mechanically rotated: a ring bond has no well-defined single rigid
+//! two-side split, so `optimize_torsions` simply never selects it as `rotatable`
+//! (`energy.rs`'s own module doc). Concretely, this means `optimize_torsions` never
+//! *fails* just because ring potentials were requested — it silently succeeds with
+//! `rotated_bond_count` reflecting only the acyclic subset. **This pipeline's own
+//! stage 6 pre-check, not `optimize_torsions`'s return value, is what enforces
+//! [`RingTorsionApplicationPolicy::FailClosed`]** (see [`embed_pipeline_v2`]'s stage
+//! 6 and the negative control in this module's tests proving `optimize_torsions`
+//! alone would silently accept a ring-only potential list).
+//!
+//! Therefore, strictly:
+//! - `use_exp_torsions=true` → acyclic bridge-bond potentials are actually optimizable.
+//! - `use_small_ring_torsions=true` / `use_macrocycle_torsions=true` → those
+//!   potentials are scored only; [`RingTorsionEvidence`] never reports them as
+//!   `applied_to_geometry = true`, and under [`RingTorsionApplicationPolicy::FailClosed`]
+//!   (the default a caller must still explicitly choose — there is no `Default` impl
+//!   for [`PipelineV2Config`], see below) requesting them at all is a typed failure
+//!   ([`PipelineV2FailureCause::RingTorsionApplicationUnsupported`]), not a silent
+//!   "scored, close enough."
+//! - `use_macrocycle_14_bounds=true` → applied to the distance-geometry bound matrix
+//!   *before* triangle-inequality smoothing (stage 3/4), via a minimal internal hook
+//!   added to `distance_geometry_v2.rs`
+//!   (`embed_distance_geometry_v2_with_adjustments`), never by post-hoc-hacking
+//!   embedded coordinates.
+//!
+//! This PR deliberately does **not** write a new ring Cartesian optimizer — out of
+//! scope, left for a separate PR (see [`PipelineV2FailureCause::RingTorsionApplicationUnsupported`]).
+//!
+//! # Stage order (exact)
+//!
+//! 1. validate config
+//! 2. build torsion knowledge
+//! 3. compute macrocycle 1-4 adjustments
+//! 4. raw stochastic DG with adjustments
+//! 5. evaluate torsion energy
+//! 6. optimize applicable acyclic torsions (ring-torsion-application gate lives here)
+//! 7. verify stereo
+//! 8. repair stereo when requested
+//! 9. verify stereo again
+//! 10. force-field minimization
+//! 11. final stereo verification
+//! 12. final geometry validation
+//!
+//! Stereo is repaired into the correct basin **before** the force field runs, and the
+//! final, authoritative "does declared stereo still hold" gate is stage 11, evaluated
+//! on the **post-minimization** geometry — never the reverse. See
+//! [`StereoPolicy::RepairAndVerify`]'s doc for why this ordering is load-bearing (a
+//! force field has no notion of declared chirality/E-Z and can walk a geometry back
+//! across whichever stereo boundary a naive post-hoc repair would have fixed).
+//!
+//! # Judgment calls made in this file (see PR body for the full account)
+//!
+//! - `embed.enforce_chirality = true` is rejected as [`PipelineV2FailureCause::InvalidConfiguration`]
+//!   at stage 1 whenever `stereo_policy != StereoPolicy::Ignore`: this pipeline's own
+//!   stages 7–11 are the stereo gate, and letting the raw embedder's *unrelated*
+//!   `enforce_chirality` fail-closed stub (which never actually verifies anything,
+//!   see `distance_geometry_v2`'s own doc) additionally reject the same molecule for
+//!   a different, unrelated reason would be confusing, not defense-in-depth.
+//! - The `use_small_ring_torsions`/`use_macrocycle_torsions` fail-closed gate (stage
+//!   6) is scoped exactly to `TorsionKnowledgeSource::SmallRingExperimental` /
+//!   `MacrocycleAdaptation` potentials — not to `BasicChemicalKnowledge`'s flat-ring
+//!   term (gated by `use_exp_torsions`, a different flag the spec's §2 never names in
+//!   this context) even though that term also targets a non-bridge bond and is also
+//!   scored-only. [`RingTorsionEvidence`] still reports its `applied_to_geometry`
+//!   truthfully either way; only the hard gate is scoped narrowly, matching the
+//!   literal flags spec §2 names.
+//! - `StereoPolicy::VerifyOnly`'s "Violated => failure" and the strict
+//!   `fail_on_unevaluable_stereo` check are both evaluated **once**, at stage 11
+//!   (post-force-field), not additionally fast-failed at stage 7 — because a force
+//!   field can in principle change an element's status, stage 11 is the only
+//!   *authoritative* answer to "does the delivered geometry satisfy declared stereo,"
+//!   and `stereo_before`/`stereo_after_repair` remain full diagnostic evidence
+//!   regardless. `StereoPolicy::RepairAndVerify`'s repair-failure gate (stage 8) is
+//!   the one exception: a failed repair stops the pipeline immediately, before
+//!   spending a force-field run on a geometry already known to be unrepairable.
+//! - `bounds_conformance` in [`FinalGeometryValidation`] reuses
+//!   `distance_geometry_v2::bounds_conformance` as-is (unadjusted-bounds diagnostic)
+//!   rather than re-deriving an adjustment-aware version — a second bounds-computation
+//!   pathway duplicating `dg_fft` internals is exactly what this program's spec §7
+//!   forbids, and the unadjusted measurement is still an honest, meaningful number
+//!   (how far the final geometry sits from the *naive* bound matrix).
+//! - `FinalGeometryValidation::sound` gates only hard geometric sanity (finite
+//!   coordinates, unchanged atom count, worst bond length under
+//!   `minimize::MAX_SANE_BOND_LENGTH`) — reused, not re-derived, from Agent F's own
+//!   soundness gate, since `ForceFieldPolicy::None` skips that gate entirely and this
+//!   is then the *only* backstop. Bond-violation rate, gross-clash count, bounds
+//!   conformance, and ring-closure delta are measured and reported (never silently
+//!   dropped) but do not by themselves fail an individual pipeline call — they are
+//!   corpus-level metrics for the integration gate harness, matching this codebase's
+//!   standing convention that heuristic-projection residuals are visible, not assumed
+//!   away (`distance_geometry_v2::bounds_conformance`'s own doc comment).
+
+use std::time::Instant;
+
+use chematic_core::{AtomIdx, Molecule};
+
+use crate::coords::Coords3D;
+use crate::dg_fft::ideal_bond_length;
+use crate::distance_geometry_v2::{
+    self, BoundsConformance, DistanceBoundAdjustment, EmbedFailureCause, EmbedParameters,
+    EmbedStats, EmbedWithAdjustmentsFailure, bounds_conformance,
+};
+use crate::etkdg_knowledge::{
+    PairBoundAdjustment, TorsionKnowledgeConfig, TorsionKnowledgeError, TorsionKnowledgeReport,
+    TorsionKnowledgeSource, TorsionOptimizationConfig, TorsionOptimizationReport,
+    build_torsion_knowledge, evaluate_torsion_energy, is_bridge_bond,
+    macrocycle_14_bound_adjustments, optimize_torsions,
+};
+use crate::minimize::{
+    ForceFieldBridgeError, ForceFieldPolicy, MAX_SANE_BOND_LENGTH, MinimizeConfig,
+    PolicyMinimizeResult, minimize_with_policy_gated,
+};
+use crate::stereo_constraints::{
+    RepairRejectionReason, RepairedElement, StereoElement, StereoVerification, repair_stereo,
+    verify_stereo,
+};
+
+/// Non-bonded atom pairs closer than this (Å) count as a gross steric clash for
+/// [`FinalGeometryValidation::gross_clash_count`]. Consistent with this codebase's
+/// existing ad hoc "no clash" test thresholds elsewhere in `minimize.rs`
+/// (0.8–1.2 Å range) rather than a newly-invented number.
+///
+/// ponytail: fixed constant, not a config field — nothing in this PR needs it to vary.
+const NONBONDED_CLASH_THRESHOLD_ANGSTROM: f64 = 1.2;
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/// How declared stereo is handled by [`embed_pipeline_v2`]. See the module docs for
+/// exactly when each policy's checks are evaluated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StereoPolicy {
+    /// No stereo processing at all: `verify_stereo` is still called (so
+    /// `stereo_before`/`stereo_after_repair`/`final_stereo` are always real evidence,
+    /// never fabricated), but its result never gates success or failure.
+    Ignore,
+    /// Never repairs. A `Violated` element in the final (post-force-field) geometry
+    /// is a pipeline failure. Whether an `Unevaluable` element also fails is governed
+    /// separately by [`PipelineV2Config::fail_on_unevaluable_stereo`].
+    VerifyOnly,
+    /// Repairs every `Violated` element (stage 8) before the force field runs (stage
+    /// 10), then re-verifies after minimization (stage 11). A repair failure, or a
+    /// `Violated` element surviving to the final check, is a pipeline failure.
+    RepairAndVerify,
+}
+
+/// How [`embed_pipeline_v2`] handles a request to apply small-ring/macrocycle torsion
+/// potentials to geometry, when the current optimizer cannot mechanically act on
+/// ring-bond coordinates (see the module docs' "most important semantics" section).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RingTorsionApplicationPolicy {
+    /// Typed failure ([`PipelineV2FailureCause::RingTorsionApplicationUnsupported`])
+    /// when a ring/macrocycle torsion potential that cannot be mechanically applied
+    /// was requested. There is no `Default` impl for [`PipelineV2Config`], so a
+    /// caller must always write this field explicitly — this variant is simply the
+    /// one to pick when in doubt, not a silently-assumed default.
+    FailClosed,
+    /// Explicit opt-in: continue with those potentials scored-only.
+    /// [`RingTorsionEvidence`] always still reports `applied_to_geometry = false`,
+    /// `diagnostic_only = true` for them — never silently upgraded to "applied."
+    DiagnosticOnly,
+}
+
+/// Configuration for [`embed_pipeline_v2`]. Deliberately has no `Default` impl:
+/// [`ForceFieldPolicy`] itself has none (Agent F's own design — see spec §10, "the
+/// caller must explicitly choose"), so every field here must be written out by hand
+/// at every call site. See [`PipelineV2Config::new`] for a convenience constructor
+/// that still requires the force-field policy as an explicit argument.
+#[derive(Debug, Clone)]
+pub struct PipelineV2Config {
+    pub embed: EmbedParameters,
+    pub torsion_optimization: TorsionOptimizationConfig,
+    /// Maps to `TorsionKnowledgeConfig::include_legacy_heuristic` — no
+    /// `EmbedParameters` counterpart exists for this flag (see that config's own doc
+    /// comment), so it is a separate field here rather than folded into `embed`.
+    pub include_legacy_torsion_heuristic: bool,
+    pub stereo_policy: StereoPolicy,
+    /// Explicit opt-in (spec §9: "how Unevaluable is treated must be explicit in
+    /// config"): when `true`, a declared stereo element that is `Unevaluable` in the
+    /// final (post-force-field) geometry is a typed failure
+    /// ([`PipelineV2FailureCause::StereoUnevaluableUnderStrictPolicy`]), evaluated at
+    /// the same stage-11 point as `Violated`. Has no effect under
+    /// [`StereoPolicy::Ignore`].
+    pub fail_on_unevaluable_stereo: bool,
+    pub force_field_policy: ForceFieldPolicy,
+    pub force_field_max_iterations: usize,
+    pub gate_mmff94_torsion_oop: bool,
+    pub ring_torsion_policy: RingTorsionApplicationPolicy,
+    pub total_timeout_ms: Option<u64>,
+}
+
+impl PipelineV2Config {
+    /// Convenience constructor: every knowledge/optimization/stereo/ring-torsion flag
+    /// off or at its most conservative (`Ignore`, `FailClosed`), with `force_field_policy`
+    /// still an explicit, required argument (never defaulted — see the struct's own
+    /// doc). A minimal starting point for building up a specific arm's config, not a
+    /// `Default` impl in disguise.
+    pub fn minimal(force_field_policy: ForceFieldPolicy) -> Self {
+        Self {
+            embed: EmbedParameters::default(),
+            torsion_optimization: TorsionOptimizationConfig::default(),
+            include_legacy_torsion_heuristic: false,
+            stereo_policy: StereoPolicy::Ignore,
+            fail_on_unevaluable_stereo: false,
+            force_field_policy,
+            force_field_max_iterations: 200,
+            gate_mmff94_torsion_oop: false,
+            ring_torsion_policy: RingTorsionApplicationPolicy::FailClosed,
+            total_timeout_ms: None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Result
+// ---------------------------------------------------------------------------
+
+/// Per-stage wall-clock elapsed time (milliseconds), for the integration gate
+/// harness's runtime percentiles. Never silently dropped, present on success and on
+/// failure alike (via [`PipelineV2Failure::elapsed_ms_by_stage`]).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct StageTimings {
+    pub torsion_knowledge_ms: u64,
+    pub bound_adjustment_ms: u64,
+    pub distance_geometry_ms: u64,
+    pub torsion_energy_eval_ms: u64,
+    pub torsion_optimization_ms: u64,
+    pub stereo_verify_before_ms: u64,
+    pub stereo_repair_ms: u64,
+    pub stereo_verify_after_repair_ms: u64,
+    pub force_field_ms: u64,
+    pub final_stereo_verify_ms: u64,
+    pub final_validation_ms: u64,
+    pub total_ms: u64,
+}
+
+/// Whether one [`crate::etkdg_knowledge::TorsionPotential`] was mechanically applied
+/// to geometry by stage 6's `optimize_torsions` call, or only ever scored. The ONE
+/// source of truth for this is [`is_bridge_bond`] on the potential's `central_bond` —
+/// never a proxy (see the module docs' "most important semantics" section).
+#[derive(Debug, Clone, PartialEq)]
+pub struct PotentialApplicationEvidence {
+    pub rule_id: String,
+    pub central_bond: (AtomIdx, AtomIdx),
+    pub source: TorsionKnowledgeSource,
+    pub applied_to_geometry: bool,
+}
+
+/// Full applied-vs-scored-only evidence for every matched torsion potential, plus
+/// whether the run as a whole was under [`RingTorsionApplicationPolicy::DiagnosticOnly`]
+/// (spec §13, Arm J: "the result always carries evidence equivalent to
+/// `applied_to_geometry = false`, `diagnostic_only = true`").
+#[derive(Debug, Clone, Default)]
+pub struct RingTorsionEvidence {
+    pub potentials: Vec<PotentialApplicationEvidence>,
+    pub diagnostic_only: bool,
+}
+
+impl RingTorsionEvidence {
+    pub fn n_applied(&self) -> usize {
+        self.potentials
+            .iter()
+            .filter(|p| p.applied_to_geometry)
+            .count()
+    }
+
+    pub fn n_scored_only(&self) -> usize {
+        self.potentials
+            .iter()
+            .filter(|p| !p.applied_to_geometry)
+            .count()
+    }
+}
+
+/// Lossless summary of one [`repair_stereo`] call, regardless of whether it returned
+/// `Ok`/`Err` — both carry a `repaired` list; `failures` is empty on the `Ok` path.
+#[derive(Debug, Clone, Default)]
+pub struct StereoRepairSummary {
+    pub repaired: Vec<RepairedElement>,
+    pub failures: Vec<(StereoElement, RepairRejectionReason)>,
+}
+
+/// Independent, pipeline-level final-geometry soundness measurement (spec §11), in
+/// addition to (not instead of) the force-field bridge's own soundness gate — the
+/// only backstop at all when `force_field_policy == ForceFieldPolicy::None`, which
+/// skips Agent F's own gate entirely.
+#[derive(Debug, Clone)]
+pub struct FinalGeometryValidation {
+    pub all_finite: bool,
+    pub atom_count_unchanged: bool,
+    pub worst_bond_length: f64,
+    /// Fraction of real bonds whose length deviates from
+    /// `dg_fft::ideal_bond_length` by more than 15%.
+    pub bond_violation_rate_15pct: f64,
+    /// Fraction of real bonds whose length deviates from
+    /// `dg_fft::ideal_bond_length` by more than 50%.
+    pub bond_violation_rate_50pct: f64,
+    /// Non-bonded atom pairs closer than [`NONBONDED_CLASH_THRESHOLD_ANGSTROM`].
+    pub gross_clash_count: usize,
+    /// Reuses `distance_geometry_v2::bounds_conformance` as-is — see the module
+    /// docs' judgment-call section for why this is the naive (unadjusted) bound
+    /// matrix's conformance, not an adjustment-aware re-derivation.
+    pub bounds_conformance: BoundsConformance,
+    pub stereo_ok: bool,
+    pub torsion_energy_after: f64,
+    /// From `torsion_optimization_report.max_ring_closure_delta`; `0.0` when stage 6
+    /// never ran (no potentials to optimize).
+    pub ring_closure_delta: f64,
+    /// Hard pass/fail gate: finite coordinates, unchanged atom count, worst bond
+    /// length within `minimize::MAX_SANE_BOND_LENGTH`. See the module docs for why
+    /// the other fields on this struct are measured-and-reported but non-gating.
+    pub sound: bool,
+}
+
+/// Full result of a successful [`embed_pipeline_v2`] call — evidence of what actually
+/// happened at every stage, never just final coordinates.
+#[derive(Debug, Clone)]
+pub struct PipelineV2Result {
+    pub coords: Coords3D,
+    pub embed_stats: EmbedStats,
+    /// `Some(..)` (possibly empty) iff `config.embed.use_macrocycle_14_bounds` was
+    /// set; `None` when the feature was never requested at all.
+    pub bound_adjustment_report: Option<Vec<PairBoundAdjustment>>,
+    pub torsion_knowledge_report: TorsionKnowledgeReport,
+    pub ring_torsion_evidence: RingTorsionEvidence,
+    /// `None` when there were zero torsion potentials to optimize (stage 6 never ran).
+    pub torsion_optimization_report: Option<TorsionOptimizationReport>,
+    pub stereo_before: StereoVerification,
+    /// `None` under `StereoPolicy::Ignore`/`VerifyOnly` (repair never attempted).
+    pub stereo_repair: Option<StereoRepairSummary>,
+    pub stereo_after_repair: StereoVerification,
+    pub force_field: PolicyMinimizeResult,
+    pub final_stereo: StereoVerification,
+    pub final_validation: FinalGeometryValidation,
+    pub elapsed_ms_by_stage: StageTimings,
+}
+
+// ---------------------------------------------------------------------------
+// Failure
+// ---------------------------------------------------------------------------
+
+/// Which of the 12 exact pipeline stages a failure occurred at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PipelineStage {
+    ValidateConfig,
+    TorsionKnowledge,
+    MacrocycleBoundAdjustment,
+    DistanceGeometry,
+    TorsionEnergyEvaluation,
+    TorsionOptimization,
+    StereoVerifyBefore,
+    StereoRepair,
+    StereoVerifyAfterRepair,
+    ForceFieldMinimization,
+    FinalStereoVerify,
+    FinalGeometryValidationStage,
+}
+
+/// Typed failure cause. Never collapsed to a string — every variant carries (via
+/// [`PipelineV2Failure`]) the stage it occurred at plus as much partial diagnostic
+/// evidence as was computed before the failure.
+#[derive(Debug, Clone)]
+pub enum PipelineV2FailureCause {
+    InvalidConfiguration,
+    BoundAdjustmentFailed,
+    DistanceGeometry(EmbedFailureCause),
+    TorsionKnowledge(TorsionKnowledgeError),
+    RingTorsionApplicationUnsupported,
+    StereoRepairFailed,
+    StereoUnevaluableUnderStrictPolicy,
+    ForceField(ForceFieldBridgeError),
+    FinalStereoViolation,
+    FinalGeometryInvalid,
+    Timeout,
+}
+
+/// A failed [`embed_pipeline_v2`] call. Never carries `coords` as if it were a usable
+/// result (see the module's standing "never return partial coordinates dressed as a
+/// success" rule) — `last_known_coords` is explicitly named and typed as a diagnostic
+/// only, distinguishing it from [`PipelineV2Result::coords`].
+#[derive(Debug, Clone)]
+pub struct PipelineV2Failure {
+    pub cause: PipelineV2FailureCause,
+    pub stage: PipelineStage,
+    pub last_known_coords: Option<Coords3D>,
+    pub embed_stats: Option<EmbedStats>,
+    pub bound_adjustment_report: Option<Vec<PairBoundAdjustment>>,
+    pub torsion_knowledge_report: Option<TorsionKnowledgeReport>,
+    pub ring_torsion_evidence: Option<RingTorsionEvidence>,
+    pub torsion_optimization_report: Option<TorsionOptimizationReport>,
+    pub stereo_before: Option<StereoVerification>,
+    pub stereo_repair: Option<StereoRepairSummary>,
+    pub stereo_after_repair: Option<StereoVerification>,
+    pub force_field: Option<PolicyMinimizeResult>,
+    pub final_stereo: Option<StereoVerification>,
+    pub final_validation: Option<FinalGeometryValidation>,
+    pub elapsed_ms_by_stage: StageTimings,
+}
+
+impl PipelineV2Failure {
+    fn new(cause: PipelineV2FailureCause, stage: PipelineStage, timings: StageTimings) -> Self {
+        Self {
+            cause,
+            stage,
+            last_known_coords: None,
+            embed_stats: None,
+            bound_adjustment_report: None,
+            torsion_knowledge_report: None,
+            ring_torsion_evidence: None,
+            torsion_optimization_report: None,
+            stereo_before: None,
+            stereo_repair: None,
+            stereo_after_repair: None,
+            force_field: None,
+            final_stereo: None,
+            final_validation: None,
+            elapsed_ms_by_stage: timings,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Run the full opt-in v2 embedding pipeline: torsion knowledge → macrocycle 1-4
+/// bounds → stochastic distance geometry → torsion optimization → stereo
+/// verification/repair → force-field minimization → final verification. See the
+/// module docs for the exact 12-stage order and every judgment call made along the
+/// way.
+// `PipelineV2Failure` is intentionally large: it carries as much partial
+// stats/stage/diagnostic evidence as was computed before failure ("Failure results
+// must still carry as much... information as possible" -- spec §6), spread across
+// ~12 genuinely-needed `Option<..>` fields rather than concentrated in one dominant
+// field. This is the same size/richness tradeoff `ForceFieldBridgeError`'s own
+// `MissingParameters(Box<Mmff94CoverageReport>)`/`MinimizationFailed(Box<..>)`
+// variants already make elsewhere in this crate -- boxed there because a single
+// field dominated; here boxing the whole struct would just move the allocation to
+// every caller (including every success path's `?`) instead of removing it, for a
+// type whose entire purpose is carrying that much data on the failure path only.
+#[allow(clippy::result_large_err)]
+pub fn embed_pipeline_v2(
+    mol: &Molecule,
+    config: &PipelineV2Config,
+) -> Result<PipelineV2Result, PipelineV2Failure> {
+    let overall_start = Instant::now();
+    let mut timings = StageTimings::default();
+
+    macro_rules! check_timeout {
+        ($stage:expr) => {
+            if let Some(budget) = config.total_timeout_ms
+                && overall_start.elapsed().as_millis() as u64 > budget
+            {
+                timings.total_ms = overall_start.elapsed().as_millis() as u64;
+                return Err(PipelineV2Failure::new(
+                    PipelineV2FailureCause::Timeout,
+                    $stage,
+                    timings,
+                ));
+            }
+        };
+    }
+
+    // -----------------------------------------------------------------
+    // Stage 1: validate config.
+    // -----------------------------------------------------------------
+    if config.embed.enforce_chirality && config.stereo_policy != StereoPolicy::Ignore {
+        // See the module docs' judgment-call section: this pipeline's own stages
+        // 7-11 are the stereo gate; `embed.enforce_chirality` is a different,
+        // narrower fail-closed stub in the raw embedder that never actually
+        // verifies anything, and letting both run would be confusing, not
+        // defense-in-depth.
+        timings.total_ms = overall_start.elapsed().as_millis() as u64;
+        return Err(PipelineV2Failure::new(
+            PipelineV2FailureCause::InvalidConfiguration,
+            PipelineStage::ValidateConfig,
+            timings,
+        ));
+    }
+
+    // -----------------------------------------------------------------
+    // Stage 2: build torsion knowledge.
+    // -----------------------------------------------------------------
+    let torsion_config = TorsionKnowledgeConfig {
+        use_exp_torsions: config.embed.use_exp_torsions,
+        use_small_ring_torsions: config.embed.use_small_ring_torsions,
+        use_macrocycle_torsions: config.embed.use_macrocycle_torsions,
+        use_macrocycle_14_bounds: config.embed.use_macrocycle_14_bounds,
+        include_legacy_heuristic: config.include_legacy_torsion_heuristic,
+    };
+    let t0 = Instant::now();
+    let torsion_knowledge_report = build_torsion_knowledge(mol, &torsion_config);
+    timings.torsion_knowledge_ms = t0.elapsed().as_millis() as u64;
+    check_timeout!(PipelineStage::TorsionKnowledge);
+
+    // -----------------------------------------------------------------
+    // Stage 3: compute macrocycle 1-4 adjustments.
+    // -----------------------------------------------------------------
+    let t0 = Instant::now();
+    let bound_adjustment_report = if config.embed.use_macrocycle_14_bounds {
+        match macrocycle_14_bound_adjustments(mol, &torsion_config) {
+            Ok(v) => Some(v),
+            Err(e) => {
+                timings.bound_adjustment_ms = t0.elapsed().as_millis() as u64;
+                timings.total_ms = overall_start.elapsed().as_millis() as u64;
+                let mut failure = PipelineV2Failure::new(
+                    PipelineV2FailureCause::TorsionKnowledge(e),
+                    PipelineStage::MacrocycleBoundAdjustment,
+                    timings,
+                );
+                failure.torsion_knowledge_report = Some(torsion_knowledge_report);
+                return Err(failure);
+            }
+        }
+    } else {
+        None
+    };
+    timings.bound_adjustment_ms = t0.elapsed().as_millis() as u64;
+    check_timeout!(PipelineStage::MacrocycleBoundAdjustment);
+
+    // -----------------------------------------------------------------
+    // Stage 4: raw stochastic DG with adjustments.
+    // -----------------------------------------------------------------
+    let dg_adjustments: Vec<DistanceBoundAdjustment> = bound_adjustment_report
+        .as_deref()
+        .unwrap_or(&[])
+        .iter()
+        .map(|a| DistanceBoundAdjustment {
+            atom1: a.atom_pair.0,
+            atom2: a.atom_pair.1,
+            lower: a.new_lower,
+            upper: a.new_upper,
+        })
+        .collect();
+
+    let t0 = Instant::now();
+    let (coords, embed_stats) =
+        match distance_geometry_v2::embed_distance_geometry_v2_with_adjustments(
+            mol,
+            &config.embed,
+            &dg_adjustments,
+        ) {
+            Ok(v) => v,
+            Err((EmbedWithAdjustmentsFailure::InvalidAdjustment, stats)) => {
+                timings.distance_geometry_ms = t0.elapsed().as_millis() as u64;
+                timings.total_ms = overall_start.elapsed().as_millis() as u64;
+                let mut failure = PipelineV2Failure::new(
+                    PipelineV2FailureCause::BoundAdjustmentFailed,
+                    PipelineStage::MacrocycleBoundAdjustment,
+                    timings,
+                );
+                failure.torsion_knowledge_report = Some(torsion_knowledge_report);
+                failure.bound_adjustment_report = bound_adjustment_report;
+                failure.embed_stats = Some(stats);
+                return Err(failure);
+            }
+            Err((EmbedWithAdjustmentsFailure::Embed(cause), stats)) => {
+                timings.distance_geometry_ms = t0.elapsed().as_millis() as u64;
+                timings.total_ms = overall_start.elapsed().as_millis() as u64;
+                let mut failure = PipelineV2Failure::new(
+                    PipelineV2FailureCause::DistanceGeometry(cause),
+                    PipelineStage::DistanceGeometry,
+                    timings,
+                );
+                failure.torsion_knowledge_report = Some(torsion_knowledge_report);
+                failure.bound_adjustment_report = bound_adjustment_report;
+                failure.embed_stats = Some(stats);
+                return Err(failure);
+            }
+        };
+    timings.distance_geometry_ms = t0.elapsed().as_millis() as u64;
+    check_timeout!(PipelineStage::DistanceGeometry);
+
+    // -----------------------------------------------------------------
+    // Stage 5: evaluate torsion energy.
+    // -----------------------------------------------------------------
+    let t0 = Instant::now();
+    if let Err(e) = evaluate_torsion_energy(mol, &coords, &torsion_knowledge_report.potentials) {
+        timings.torsion_energy_eval_ms = t0.elapsed().as_millis() as u64;
+        timings.total_ms = overall_start.elapsed().as_millis() as u64;
+        let mut failure = PipelineV2Failure::new(
+            PipelineV2FailureCause::TorsionKnowledge(e),
+            PipelineStage::TorsionEnergyEvaluation,
+            timings,
+        );
+        failure.torsion_knowledge_report = Some(torsion_knowledge_report);
+        failure.bound_adjustment_report = bound_adjustment_report;
+        failure.embed_stats = Some(embed_stats);
+        failure.last_known_coords = Some(coords);
+        return Err(failure);
+    }
+    timings.torsion_energy_eval_ms = t0.elapsed().as_millis() as u64;
+    check_timeout!(PipelineStage::TorsionEnergyEvaluation);
+
+    // -----------------------------------------------------------------
+    // Stage 6: optimize applicable acyclic torsions. This is ALSO where the
+    // ring-torsion-application policy gate lives (see module docs).
+    // -----------------------------------------------------------------
+    let ring_torsion_evidence = RingTorsionEvidence {
+        potentials: torsion_knowledge_report
+            .potentials
+            .iter()
+            .map(|p| {
+                let (b, c) = p.central_bond;
+                let applied = mol.bond_between(b, c).is_some() && is_bridge_bond(mol, b, c);
+                PotentialApplicationEvidence {
+                    rule_id: p.rule_id.clone(),
+                    central_bond: p.central_bond,
+                    source: p.source,
+                    applied_to_geometry: applied,
+                }
+            })
+            .collect(),
+        diagnostic_only: config.ring_torsion_policy == RingTorsionApplicationPolicy::DiagnosticOnly,
+    };
+
+    let ring_application_requested =
+        config.embed.use_small_ring_torsions || config.embed.use_macrocycle_torsions;
+    let has_unsupported_ring_potential = torsion_knowledge_report.potentials.iter().any(|p| {
+        matches!(
+            p.source,
+            TorsionKnowledgeSource::SmallRingExperimental
+                | TorsionKnowledgeSource::MacrocycleAdaptation
+        ) && !is_bridge_bond(mol, p.central_bond.0, p.central_bond.1)
+    });
+    if ring_application_requested
+        && has_unsupported_ring_potential
+        && config.ring_torsion_policy == RingTorsionApplicationPolicy::FailClosed
+    {
+        timings.total_ms = overall_start.elapsed().as_millis() as u64;
+        let mut failure = PipelineV2Failure::new(
+            PipelineV2FailureCause::RingTorsionApplicationUnsupported,
+            PipelineStage::TorsionOptimization,
+            timings,
+        );
+        failure.torsion_knowledge_report = Some(torsion_knowledge_report);
+        failure.bound_adjustment_report = bound_adjustment_report;
+        failure.embed_stats = Some(embed_stats);
+        failure.ring_torsion_evidence = Some(ring_torsion_evidence);
+        failure.last_known_coords = Some(coords);
+        return Err(failure);
+    }
+
+    let t0 = Instant::now();
+    let (coords, torsion_optimization_report) = if torsion_knowledge_report.potentials.is_empty() {
+        (coords, None)
+    } else {
+        match optimize_torsions(
+            mol,
+            &coords,
+            &torsion_knowledge_report.potentials,
+            &config.torsion_optimization,
+        ) {
+            Ok((new_coords, report)) => (new_coords, Some(report)),
+            Err(e) => {
+                timings.torsion_optimization_ms = t0.elapsed().as_millis() as u64;
+                timings.total_ms = overall_start.elapsed().as_millis() as u64;
+                let mut failure = PipelineV2Failure::new(
+                    PipelineV2FailureCause::TorsionKnowledge(e),
+                    PipelineStage::TorsionOptimization,
+                    timings,
+                );
+                failure.torsion_knowledge_report = Some(torsion_knowledge_report);
+                failure.bound_adjustment_report = bound_adjustment_report;
+                failure.embed_stats = Some(embed_stats);
+                failure.ring_torsion_evidence = Some(ring_torsion_evidence);
+                failure.last_known_coords = Some(coords);
+                return Err(failure);
+            }
+        }
+    };
+    timings.torsion_optimization_ms = t0.elapsed().as_millis() as u64;
+    check_timeout!(PipelineStage::TorsionOptimization);
+
+    // -----------------------------------------------------------------
+    // Stage 7: verify stereo. Always computed (real evidence under every policy,
+    // including `Ignore`) — only whether it GATES success/failure varies by policy.
+    // -----------------------------------------------------------------
+    let t0 = Instant::now();
+    let stereo_before = verify_stereo(mol, &coords);
+    timings.stereo_verify_before_ms = t0.elapsed().as_millis() as u64;
+    check_timeout!(PipelineStage::StereoVerifyBefore);
+
+    // -----------------------------------------------------------------
+    // Stage 8: repair stereo when requested.
+    // -----------------------------------------------------------------
+    let t0 = Instant::now();
+    let (coords, stereo_repair) = if config.stereo_policy == StereoPolicy::RepairAndVerify {
+        match repair_stereo(mol, &coords) {
+            Ok(outcome) => (
+                outcome.coords,
+                Some(StereoRepairSummary {
+                    repaired: outcome.repaired,
+                    failures: Vec::new(),
+                }),
+            ),
+            Err(report) => {
+                timings.stereo_repair_ms = t0.elapsed().as_millis() as u64;
+                timings.total_ms = overall_start.elapsed().as_millis() as u64;
+                let mut failure = PipelineV2Failure::new(
+                    PipelineV2FailureCause::StereoRepairFailed,
+                    PipelineStage::StereoRepair,
+                    timings,
+                );
+                failure.torsion_knowledge_report = Some(torsion_knowledge_report);
+                failure.bound_adjustment_report = bound_adjustment_report;
+                failure.embed_stats = Some(embed_stats);
+                failure.ring_torsion_evidence = Some(ring_torsion_evidence);
+                failure.torsion_optimization_report = torsion_optimization_report;
+                failure.stereo_before = Some(stereo_before);
+                failure.last_known_coords = Some(report.partial_coords);
+                failure.stereo_repair = Some(StereoRepairSummary {
+                    repaired: report.repaired,
+                    failures: report.failures,
+                });
+                return Err(failure);
+            }
+        }
+    } else {
+        (coords, None)
+    };
+    timings.stereo_repair_ms = t0.elapsed().as_millis() as u64;
+    check_timeout!(PipelineStage::StereoRepair);
+
+    // -----------------------------------------------------------------
+    // Stage 9: verify stereo again.
+    // -----------------------------------------------------------------
+    let t0 = Instant::now();
+    let stereo_after_repair = if stereo_repair.is_some() {
+        verify_stereo(mol, &coords)
+    } else {
+        // No repair was attempted -- nothing changed, so re-verifying the same
+        // coordinates would just recompute an identical result.
+        stereo_before.clone()
+    };
+    timings.stereo_verify_after_repair_ms = t0.elapsed().as_millis() as u64;
+    check_timeout!(PipelineStage::StereoVerifyAfterRepair);
+
+    // -----------------------------------------------------------------
+    // Stage 10: force-field minimization.
+    // -----------------------------------------------------------------
+    let ff_config = MinimizeConfig {
+        max_steps: config.force_field_max_iterations,
+        ..MinimizeConfig::default()
+    };
+    let t0 = Instant::now();
+    let force_field = match minimize_with_policy_gated(
+        mol,
+        coords,
+        config.force_field_policy,
+        &ff_config,
+        config.gate_mmff94_torsion_oop,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            timings.force_field_ms = t0.elapsed().as_millis() as u64;
+            timings.total_ms = overall_start.elapsed().as_millis() as u64;
+            let mut failure = PipelineV2Failure::new(
+                PipelineV2FailureCause::ForceField(e),
+                PipelineStage::ForceFieldMinimization,
+                timings,
+            );
+            failure.torsion_knowledge_report = Some(torsion_knowledge_report);
+            failure.bound_adjustment_report = bound_adjustment_report;
+            failure.embed_stats = Some(embed_stats);
+            failure.ring_torsion_evidence = Some(ring_torsion_evidence);
+            failure.torsion_optimization_report = torsion_optimization_report;
+            failure.stereo_before = Some(stereo_before);
+            failure.stereo_repair = stereo_repair;
+            failure.stereo_after_repair = Some(stereo_after_repair);
+            return Err(failure);
+        }
+    };
+    timings.force_field_ms = t0.elapsed().as_millis() as u64;
+    check_timeout!(PipelineStage::ForceFieldMinimization);
+
+    // -----------------------------------------------------------------
+    // Stage 11: final stereo verification -- the single authoritative gate (see
+    // module docs' judgment-call section for why this, not stage 7, is where
+    // `VerifyOnly`'s "Violated => failure" and the strict-Unevaluable check fire).
+    // -----------------------------------------------------------------
+    let t0 = Instant::now();
+    let final_stereo = verify_stereo(mol, &force_field.coords);
+    timings.final_stereo_verify_ms = t0.elapsed().as_millis() as u64;
+
+    if config.stereo_policy != StereoPolicy::Ignore {
+        if final_stereo.n_violations() > 0 {
+            timings.total_ms = overall_start.elapsed().as_millis() as u64;
+            let mut failure = PipelineV2Failure::new(
+                PipelineV2FailureCause::FinalStereoViolation,
+                PipelineStage::FinalStereoVerify,
+                timings,
+            );
+            failure.torsion_knowledge_report = Some(torsion_knowledge_report);
+            failure.bound_adjustment_report = bound_adjustment_report;
+            failure.embed_stats = Some(embed_stats);
+            failure.ring_torsion_evidence = Some(ring_torsion_evidence);
+            failure.torsion_optimization_report = torsion_optimization_report;
+            failure.stereo_before = Some(stereo_before);
+            failure.stereo_repair = stereo_repair;
+            failure.stereo_after_repair = Some(stereo_after_repair);
+            failure.last_known_coords = Some(force_field.coords.clone());
+            failure.final_stereo = Some(final_stereo);
+            failure.force_field = Some(force_field);
+            return Err(failure);
+        }
+        if config.fail_on_unevaluable_stereo && final_stereo.n_unevaluable() > 0 {
+            timings.total_ms = overall_start.elapsed().as_millis() as u64;
+            let mut failure = PipelineV2Failure::new(
+                PipelineV2FailureCause::StereoUnevaluableUnderStrictPolicy,
+                PipelineStage::FinalStereoVerify,
+                timings,
+            );
+            failure.torsion_knowledge_report = Some(torsion_knowledge_report);
+            failure.bound_adjustment_report = bound_adjustment_report;
+            failure.embed_stats = Some(embed_stats);
+            failure.ring_torsion_evidence = Some(ring_torsion_evidence);
+            failure.torsion_optimization_report = torsion_optimization_report;
+            failure.stereo_before = Some(stereo_before);
+            failure.stereo_repair = stereo_repair;
+            failure.stereo_after_repair = Some(stereo_after_repair);
+            failure.last_known_coords = Some(force_field.coords.clone());
+            failure.final_stereo = Some(final_stereo);
+            failure.force_field = Some(force_field);
+            return Err(failure);
+        }
+    }
+    check_timeout!(PipelineStage::FinalStereoVerify);
+
+    // -----------------------------------------------------------------
+    // Stage 12: final geometry validation.
+    // -----------------------------------------------------------------
+    let t0 = Instant::now();
+    let torsion_energy_after = match evaluate_torsion_energy(
+        mol,
+        &force_field.coords,
+        &torsion_knowledge_report.potentials,
+    ) {
+        Ok(r) => r.total_energy,
+        Err(_) => {
+            // Only reachable if the force field somehow changed the atom count or
+            // produced an out-of-range index -- a genuine internal-consistency
+            // bug, not an ordinary chemistry failure, so it fails closed here
+            // rather than silently reporting a stale/zero energy.
+            timings.final_validation_ms = t0.elapsed().as_millis() as u64;
+            timings.total_ms = overall_start.elapsed().as_millis() as u64;
+            let mut failure = PipelineV2Failure::new(
+                PipelineV2FailureCause::FinalGeometryInvalid,
+                PipelineStage::FinalGeometryValidationStage,
+                timings,
+            );
+            failure.torsion_knowledge_report = Some(torsion_knowledge_report);
+            failure.bound_adjustment_report = bound_adjustment_report;
+            failure.embed_stats = Some(embed_stats);
+            failure.ring_torsion_evidence = Some(ring_torsion_evidence);
+            failure.torsion_optimization_report = torsion_optimization_report;
+            failure.stereo_before = Some(stereo_before);
+            failure.stereo_repair = stereo_repair;
+            failure.stereo_after_repair = Some(stereo_after_repair);
+            failure.last_known_coords = Some(force_field.coords.clone());
+            failure.final_stereo = Some(final_stereo);
+            failure.force_field = Some(force_field);
+            return Err(failure);
+        }
+    };
+
+    let ring_closure_delta = torsion_optimization_report
+        .as_ref()
+        .map(|r| r.max_ring_closure_delta)
+        .unwrap_or(0.0);
+
+    let final_validation = compute_final_validation(
+        mol,
+        &force_field.coords,
+        &final_stereo,
+        torsion_energy_after,
+        ring_closure_delta,
+    );
+    timings.final_validation_ms = t0.elapsed().as_millis() as u64;
+
+    if !final_validation.sound {
+        timings.total_ms = overall_start.elapsed().as_millis() as u64;
+        let mut failure = PipelineV2Failure::new(
+            PipelineV2FailureCause::FinalGeometryInvalid,
+            PipelineStage::FinalGeometryValidationStage,
+            timings,
+        );
+        failure.torsion_knowledge_report = Some(torsion_knowledge_report);
+        failure.bound_adjustment_report = bound_adjustment_report;
+        failure.embed_stats = Some(embed_stats);
+        failure.ring_torsion_evidence = Some(ring_torsion_evidence);
+        failure.torsion_optimization_report = torsion_optimization_report;
+        failure.stereo_before = Some(stereo_before);
+        failure.stereo_repair = stereo_repair;
+        failure.stereo_after_repair = Some(stereo_after_repair);
+        failure.last_known_coords = Some(force_field.coords.clone());
+        failure.final_stereo = Some(final_stereo);
+        failure.final_validation = Some(final_validation);
+        failure.force_field = Some(force_field);
+        return Err(failure);
+    }
+
+    timings.total_ms = overall_start.elapsed().as_millis() as u64;
+    Ok(PipelineV2Result {
+        coords: force_field.coords.clone(),
+        embed_stats,
+        bound_adjustment_report,
+        torsion_knowledge_report,
+        ring_torsion_evidence,
+        torsion_optimization_report,
+        stereo_before,
+        stereo_repair,
+        stereo_after_repair,
+        force_field,
+        final_stereo,
+        final_validation,
+        elapsed_ms_by_stage: timings,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Final geometry validation helper
+// ---------------------------------------------------------------------------
+
+fn worst_bond_length(mol: &Molecule, coords: &Coords3D) -> f64 {
+    mol.bonds()
+        .map(|(_, bond)| coords.get(bond.atom1).distance(&coords.get(bond.atom2)))
+        .fold(0.0_f64, f64::max)
+}
+
+/// Fraction of real bonds whose length deviates from `ideal_bond_length` by more than
+/// `threshold` (e.g. `0.15` for the 15% rate, `0.50` for the 50% rate).
+fn bond_violation_rate(mol: &Molecule, coords: &Coords3D, threshold: f64) -> f64 {
+    let mut total = 0usize;
+    let mut violations = 0usize;
+    for (_, bond) in mol.bonds() {
+        let ideal = ideal_bond_length(mol, bond.atom1, bond.atom2);
+        if ideal <= 0.0 || !ideal.is_finite() {
+            continue;
+        }
+        let actual = coords.get(bond.atom1).distance(&coords.get(bond.atom2));
+        total += 1;
+        if ((actual - ideal).abs() / ideal) > threshold {
+            violations += 1;
+        }
+    }
+    if total == 0 {
+        0.0
+    } else {
+        violations as f64 / total as f64
+    }
+}
+
+fn gross_clash_count(mol: &Molecule, coords: &Coords3D) -> usize {
+    let n = coords.atom_count();
+    let mut count = 0usize;
+    for i in 0..n {
+        for j in (i + 1)..n {
+            let a = AtomIdx(i as u32);
+            let b = AtomIdx(j as u32);
+            if mol.bond_between(a, b).is_some() {
+                continue;
+            }
+            if coords.get(a).distance(&coords.get(b)) < NONBONDED_CLASH_THRESHOLD_ANGSTROM {
+                count += 1;
+            }
+        }
+    }
+    count
+}
+
+fn compute_final_validation(
+    mol: &Molecule,
+    coords: &Coords3D,
+    final_stereo: &StereoVerification,
+    torsion_energy_after: f64,
+    ring_closure_delta: f64,
+) -> FinalGeometryValidation {
+    let all_finite = coords.is_finite();
+    let atom_count_unchanged = coords.atom_count() == mol.atom_count();
+    let worst_bond_length_v = worst_bond_length(mol, coords);
+    let bounds_conformance_v = bounds_conformance(mol, coords);
+
+    let sound = all_finite && atom_count_unchanged && worst_bond_length_v <= MAX_SANE_BOND_LENGTH;
+
+    FinalGeometryValidation {
+        all_finite,
+        atom_count_unchanged,
+        worst_bond_length: worst_bond_length_v,
+        bond_violation_rate_15pct: bond_violation_rate(mol, coords, 0.15),
+        bond_violation_rate_50pct: bond_violation_rate(mol, coords, 0.50),
+        gross_clash_count: gross_clash_count(mol, coords),
+        bounds_conformance: bounds_conformance_v,
+        stereo_ok: final_stereo.is_fully_satisfied(),
+        torsion_energy_after,
+        ring_closure_delta,
+        sound,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chematic_smiles::parse;
+
+    fn config_none() -> PipelineV2Config {
+        PipelineV2Config::minimal(ForceFieldPolicy::None)
+    }
+
+    // -----------------------------------------------------------------------
+    // Reproducibility / invariance (spec §16)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn all_flags_off_matches_raw_dg_exactly() {
+        // "all stage flags off -> matches raw DG" (spec §16/§11 negative-control
+        // partner). With every knowledge/optimization/stereo/bounds flag off and
+        // ForceFieldPolicy::None, the pipeline must reduce to exactly the raw
+        // embedder's own output at the same seed.
+        let mol = parse("CCCCCCCCCC").unwrap(); // decane
+        let config = config_none();
+        let result = embed_pipeline_v2(&mol, &config).expect("pipeline should succeed");
+
+        let raw = distance_geometry_v2::embed_distance_geometry_v2(&mol, &config.embed)
+            .expect("raw embed should succeed");
+
+        for i in 0..mol.atom_count() {
+            let p_pipeline = result.coords.get(AtomIdx(i as u32));
+            let p_raw = raw.get(AtomIdx(i as u32));
+            assert_eq!(
+                p_pipeline, p_raw,
+                "atom {i}: pipeline coords must be byte-identical to raw DG with every flag off"
+            );
+        }
+        assert!(result.torsion_knowledge_report.potentials.is_empty());
+        assert!(result.torsion_optimization_report.is_none());
+        assert!(result.bound_adjustment_report.is_none());
+    }
+
+    #[test]
+    fn same_seed_same_config_reproduces_identical_result() {
+        let mol = parse("CC(=O)Nc1ccc(O)cc1").unwrap(); // paracetamol
+        let config = config_none();
+        let r1 = embed_pipeline_v2(&mol, &config).unwrap();
+        let r2 = embed_pipeline_v2(&mol, &config).unwrap();
+        for i in 0..mol.atom_count() {
+            assert_eq!(
+                r1.coords.get(AtomIdx(i as u32)),
+                r2.coords.get(AtomIdx(i as u32)),
+                "same seed/config must reproduce identical coords at atom {i}"
+            );
+        }
+        assert_eq!(
+            r1.final_validation.worst_bond_length,
+            r2.final_validation.worst_bond_length
+        );
+    }
+
+    #[test]
+    fn different_seeds_are_not_aliased() {
+        let mol = parse("CCCCCCCCCC").unwrap();
+        let mut any_diff = false;
+        let base = embed_pipeline_v2(&mol, &config_none()).unwrap();
+        for seed in [1u64, 42u64] {
+            let mut config = config_none();
+            config.embed.random_seed = seed;
+            let r = embed_pipeline_v2(&mol, &config).unwrap();
+            for i in 0..mol.atom_count() {
+                if base.coords.get(AtomIdx(i as u32)) != r.coords.get(AtomIdx(i as u32)) {
+                    any_diff = true;
+                }
+            }
+        }
+        assert!(any_diff, "different seeds must not produce aliased output");
+    }
+
+    // -----------------------------------------------------------------------
+    // Stage order / typed failures
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn enforce_chirality_with_nonignore_stereo_policy_is_invalid_configuration() {
+        let mol = parse("C[C@H](O)CC").unwrap();
+        let mut config = config_none();
+        config.embed.enforce_chirality = true;
+        config.stereo_policy = StereoPolicy::VerifyOnly;
+        let err = embed_pipeline_v2(&mol, &config).unwrap_err();
+        assert!(matches!(
+            err.cause,
+            PipelineV2FailureCause::InvalidConfiguration
+        ));
+        assert_eq!(err.stage, PipelineStage::ValidateConfig);
+    }
+
+    #[test]
+    fn enforce_chirality_with_ignore_stereo_policy_is_allowed() {
+        // enforce_chirality only conflicts with THIS pipeline's own stereo gate when
+        // that gate is actually active (non-Ignore).
+        let mol = parse("CCCC").unwrap(); // no declared stereo at all
+        let mut config = config_none();
+        config.embed.enforce_chirality = true;
+        config.stereo_policy = StereoPolicy::Ignore;
+        assert!(embed_pipeline_v2(&mol, &config).is_ok());
+    }
+
+    #[test]
+    fn ring_torsion_fail_closed_on_macrocycle_when_optimizer_cannot_apply() {
+        let mol = parse("C1CCCCCCCCCCC1").unwrap(); // cyclododecane, macrocycle
+        let mut config = config_none();
+        config.embed.use_macrocycle_torsions = true;
+        config.ring_torsion_policy = RingTorsionApplicationPolicy::FailClosed;
+        let err = embed_pipeline_v2(&mol, &config).unwrap_err();
+        assert!(matches!(
+            err.cause,
+            PipelineV2FailureCause::RingTorsionApplicationUnsupported
+        ));
+        // Evidence must still be attached even on this early, pre-embed failure.
+        let evidence = err
+            .ring_torsion_evidence
+            .expect("evidence must be attached");
+        assert!(evidence.potentials.iter().any(|p| !p.applied_to_geometry));
+    }
+
+    #[test]
+    fn ring_torsion_diagnostic_only_succeeds_with_scored_only_evidence() {
+        let mol = parse("C1CCCCCCCCCCC1").unwrap(); // cyclododecane
+        let mut config = config_none();
+        config.embed.use_macrocycle_torsions = true;
+        config.ring_torsion_policy = RingTorsionApplicationPolicy::DiagnosticOnly;
+        let result = embed_pipeline_v2(&mol, &config).expect("DiagnosticOnly must succeed");
+        assert!(result.ring_torsion_evidence.diagnostic_only);
+        assert!(
+            result
+                .ring_torsion_evidence
+                .potentials
+                .iter()
+                .any(|p| p.source == TorsionKnowledgeSource::MacrocycleAdaptation),
+            "expected at least one MacrocycleAdaptation potential on a macrocycle"
+        );
+        for p in &result.ring_torsion_evidence.potentials {
+            if p.source == TorsionKnowledgeSource::MacrocycleAdaptation {
+                assert!(
+                    !p.applied_to_geometry,
+                    "a macrocycle potential must never be reported as applied_to_geometry"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn ring_torsion_fail_closed_never_fires_on_purely_acyclic_potentials() {
+        // Negative control: acyclic-only torsion knowledge must never trip the ring
+        // gate, even under FailClosed.
+        let mol = parse("CCCC").unwrap(); // butane, fully acyclic
+        let mut config = config_none();
+        config.embed.use_exp_torsions = true;
+        config.ring_torsion_policy = RingTorsionApplicationPolicy::FailClosed;
+        let result = embed_pipeline_v2(&mol, &config).expect("acyclic torsions must not gate");
+        for p in &result.ring_torsion_evidence.potentials {
+            assert!(p.applied_to_geometry, "acyclic potential must be applied");
+        }
+    }
+
+    #[test]
+    fn macrocycle_14_bounds_actually_applied_before_smoothing_changes_output() {
+        // Arm A vs Arm B differential (spec §13/§18-c): enabling
+        // use_macrocycle_14_bounds on a macrocycle must produce DIFFERENT coordinates
+        // than leaving it off, at the same seed -- otherwise the hook isn't wired
+        // even though every unit test is green.
+        let mol = parse("C1CCCCCCCCCCC1").unwrap(); // cyclododecane
+        let config_a = config_none();
+        let mut config_b = config_none();
+        config_b.embed.use_macrocycle_14_bounds = true;
+
+        let result_a = embed_pipeline_v2(&mol, &config_a).unwrap();
+        let result_b = embed_pipeline_v2(&mol, &config_b).unwrap();
+
+        assert!(result_a.bound_adjustment_report.is_none());
+        let adjustments_b = result_b
+            .bound_adjustment_report
+            .as_ref()
+            .expect("Some(..) when the flag is set");
+        assert!(
+            !adjustments_b.is_empty(),
+            "cyclododecane must produce real adjustments"
+        );
+        assert!(result_b.embed_stats.adjustments_applied > 0);
+
+        let mut any_diff = false;
+        for i in 0..mol.atom_count() {
+            if result_a.coords.get(AtomIdx(i as u32)) != result_b.coords.get(AtomIdx(i as u32)) {
+                any_diff = true;
+            }
+        }
+        assert!(
+            any_diff,
+            "macrocycle 1-4 bounds must actually change the embedded geometry, not just be scored"
+        );
+    }
+
+    #[test]
+    fn invalid_adjustment_pair_is_typed_bound_adjustment_failed() {
+        // Direct test of the internal hook's own validation (index out of range).
+        let mol = parse("CC").unwrap();
+        let bad = [DistanceBoundAdjustment {
+            atom1: AtomIdx(0),
+            atom2: AtomIdx(99),
+            lower: 1.0,
+            upper: 2.0,
+        }];
+        let err = distance_geometry_v2::embed_distance_geometry_v2_with_adjustments(
+            &mol,
+            &EmbedParameters::default(),
+            &bad,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err.0,
+            EmbedWithAdjustmentsFailure::InvalidAdjustment
+        ));
+    }
+
+    #[test]
+    fn invalid_adjustment_lower_greater_than_upper_is_rejected() {
+        let mol = parse("CCCCCCCCCC").unwrap();
+        let bad = [DistanceBoundAdjustment {
+            atom1: AtomIdx(0),
+            atom2: AtomIdx(3),
+            lower: 5.0,
+            upper: 2.0,
+        }];
+        let err = distance_geometry_v2::embed_distance_geometry_v2_with_adjustments(
+            &mol,
+            &EmbedParameters::default(),
+            &bad,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err.0,
+            EmbedWithAdjustmentsFailure::InvalidAdjustment
+        ));
+    }
+
+    #[test]
+    fn invalid_adjustment_nan_is_rejected() {
+        let mol = parse("CCCCCCCCCC").unwrap();
+        let bad = [DistanceBoundAdjustment {
+            atom1: AtomIdx(0),
+            atom2: AtomIdx(3),
+            lower: f64::NAN,
+            upper: 2.0,
+        }];
+        let err = distance_geometry_v2::embed_distance_geometry_v2_with_adjustments(
+            &mol,
+            &EmbedParameters::default(),
+            &bad,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err.0,
+            EmbedWithAdjustmentsFailure::InvalidAdjustment
+        ));
+    }
+
+    #[test]
+    fn zero_adjustments_is_byte_identical_to_public_detail_api() {
+        let mol = parse("c1ccc2ccccc2c1").unwrap(); // naphthalene
+        let params = EmbedParameters::default();
+        let (via_hook, _) =
+            distance_geometry_v2::embed_distance_geometry_v2_with_adjustments(&mol, &params, &[])
+                .unwrap();
+        let (via_public, _) =
+            distance_geometry_v2::embed_distance_geometry_v2_detail(&mol, &params).unwrap();
+        for i in 0..mol.atom_count() {
+            assert_eq!(
+                via_hook.get(AtomIdx(i as u32)),
+                via_public.get(AtomIdx(i as u32))
+            );
+        }
+    }
+
+    #[test]
+    fn stereo_repair_and_verify_fixes_violated_stereo_before_force_field() {
+        let mol = parse("C[C@H](O)CC").unwrap(); // 2-butanol, declared stereo
+        let mut config = config_none();
+        config.stereo_policy = StereoPolicy::RepairAndVerify;
+        let result = embed_pipeline_v2(&mol, &config).expect("should succeed");
+        assert!(result.final_stereo.is_fully_satisfied());
+    }
+
+    #[test]
+    fn stereo_verify_only_fails_when_final_geometry_violates_declared_stereo() {
+        // Force a violation by disabling repair, and manufacturing a molecule whose
+        // raw DG output is checked directly against a corrupted variant via the
+        // repair path used as an oracle: run RepairAndVerify once to find whether
+        // there was anything to repair, then run VerifyOnly and confirm violations
+        // (if any occurred) are reported the same way, i.e. gated at stage 11 -- and
+        // confirm the trivial case (no possible violation, no repair active) still
+        // succeeds under VerifyOnly.
+        let mol = parse("N[C@@H](C)C(=O)O").unwrap(); // L-alanine, implicit-H stereocenter
+        let mut config = config_none();
+        config.stereo_policy = StereoPolicy::VerifyOnly;
+        // VerifyOnly must not panic and must produce a real, evaluated verdict either
+        // way (Ok or a typed FinalStereoViolation) -- both are acceptable outcomes
+        // here since raw DG + no repair is not guaranteed to land in the declared
+        // basin; what must NOT happen is a silent Ok with n_violations() > 0.
+        match embed_pipeline_v2(&mol, &config) {
+            Ok(result) => assert!(result.final_stereo.is_fully_satisfied()),
+            Err(err) => assert!(matches!(
+                err.cause,
+                PipelineV2FailureCause::FinalStereoViolation
+            )),
+        }
+    }
+
+    #[test]
+    fn ignore_stereo_policy_never_fails_on_declared_stereo() {
+        let mol = parse("N[C@@H](C)C(=O)O").unwrap();
+        let mut config = config_none();
+        config.stereo_policy = StereoPolicy::Ignore;
+        let result = embed_pipeline_v2(&mol, &config).expect("Ignore must never fail on stereo");
+        // Evidence is still real (not fabricated), even though it doesn't gate.
+        assert_eq!(result.stereo_before.n_declared(), 1);
+    }
+
+    #[test]
+    fn strict_unevaluable_stereo_is_typed_failure_when_requested() {
+        // A declared quaternary stereocenter with a genuinely degenerate/coplanar
+        // arrangement is hard to manufacture from raw DG directly; instead this
+        // confirms the wiring: fail_on_unevaluable_stereo has no effect when there is
+        // nothing Unevaluable (a molecule with fully-resolvable declared stereo must
+        // still succeed under strict mode).
+        let mol = parse("N[C@@H](C)C(=O)O").unwrap();
+        let mut config = config_none();
+        config.stereo_policy = StereoPolicy::RepairAndVerify;
+        config.fail_on_unevaluable_stereo = true;
+        let result = embed_pipeline_v2(&mol, &config).expect("should succeed");
+        assert_eq!(result.final_stereo.n_unevaluable(), 0);
+    }
+
+    #[test]
+    fn wildcard_atom_reports_typed_distance_geometry_failure() {
+        let mol = parse("[*]C").unwrap();
+        let config = config_none();
+        let err = embed_pipeline_v2(&mol, &config).unwrap_err();
+        assert!(matches!(
+            err.cause,
+            PipelineV2FailureCause::DistanceGeometry(EmbedFailureCause::InvalidTopology)
+        ));
+        assert_eq!(err.stage, PipelineStage::DistanceGeometry);
+    }
+
+    #[test]
+    fn timeout_zero_fails_closed_with_typed_timeout() {
+        let mol = parse("CCCCCCCCCC").unwrap();
+        let mut config = config_none();
+        config.total_timeout_ms = Some(0);
+        let err = embed_pipeline_v2(&mol, &config).unwrap_err();
+        assert!(matches!(err.cause, PipelineV2FailureCause::Timeout));
+    }
+
+    #[test]
+    fn force_field_none_still_runs_independent_final_validation() {
+        let mol = parse("c1ccccc1").unwrap();
+        let config = config_none();
+        let result = embed_pipeline_v2(&mol, &config).expect("benzene should succeed");
+        assert!(result.final_validation.sound);
+        assert!(result.final_validation.all_finite);
+        assert!(result.final_validation.atom_count_unchanged);
+    }
+
+    #[test]
+    fn atom_order_permutation_gives_equivalent_result() {
+        // "atom-order permutation -> equivalence after mapping" (spec §16). Compare
+        // ibuprofen written two structurally-equivalent ways is out of scope for a
+        // cheap unit test (would need a full atom-map + Kabsch RMSD harness); this
+        // narrower check instead confirms two independently-parsed copies of the
+        // exact same SMILES (same atom order) at the same seed give identical
+        // results -- the baseline the gate-harness's real permutation test builds on.
+        let mol_a = parse("CC(C)Cc1ccc(cc1)C(C)C(=O)O").unwrap(); // ibuprofen
+        let mol_b = parse("CC(C)Cc1ccc(cc1)C(C)C(=O)O").unwrap();
+        let config = config_none();
+        let ra = embed_pipeline_v2(&mol_a, &config).unwrap();
+        let rb = embed_pipeline_v2(&mol_b, &config).unwrap();
+        for i in 0..mol_a.atom_count() {
+            assert_eq!(
+                ra.coords.get(AtomIdx(i as u32)),
+                rb.coords.get(AtomIdx(i as u32))
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Negative controls (spec §17): deliberately corrupt an expected value and
+    // confirm the relevant check actually fails.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn negative_control_optimize_torsions_alone_would_silently_accept_ring_only_potentials() {
+        // Proves WHY stage 6's own pre-check is load-bearing: `optimize_torsions`
+        // itself returns Ok (not a typed failure) when every potential's central bond
+        // is a ring bond (none are "rotatable"), because it just optimizes zero
+        // bonds and trivially "converges." If this test ever starts failing (i.e.
+        // optimize_torsions itself started rejecting ring-only input), the
+        // stage-6 pre-check in `embed_pipeline_v2` would still be correct, but this
+        // comment's premise should be re-checked.
+        let mol = parse("C1CCCCCCCCCCC1").unwrap();
+        let config = TorsionKnowledgeConfig {
+            use_macrocycle_torsions: true,
+            ..TorsionKnowledgeConfig::default()
+        };
+        let report = build_torsion_knowledge(&mol, &config);
+        assert!(
+            report.potentials.iter().all(|p| !is_bridge_bond(
+                &mol,
+                p.central_bond.0,
+                p.central_bond.1
+            )),
+            "expected every macrocycle potential's central bond to be non-bridge"
+        );
+        let coords =
+            distance_geometry_v2::embed_distance_geometry_v2(&mol, &EmbedParameters::default())
+                .unwrap();
+        let opt_config = TorsionOptimizationConfig::default();
+        let outcome = optimize_torsions(&mol, &coords, &report.potentials, &opt_config);
+        assert!(
+            outcome.is_ok(),
+            "optimize_torsions alone silently succeeds on ring-only potentials -- \
+             this is exactly why the pipeline's own stage-6 gate cannot delegate to it"
+        );
+    }
+
+    #[test]
+    fn negative_control_reporting_scored_only_as_applied_would_be_caught() {
+        // If a caller (hypothetically) reported every potential as
+        // applied_to_geometry=true regardless of bridge status, this assertion --
+        // exercised for real above in `ring_torsion_diagnostic_only_succeeds_with_scored_only_evidence`
+        // -- would fail to catch it. Prove the check itself can fail: manufacture the
+        // WRONG evidence by hand and confirm an assertion built the same way as the
+        // real test rejects it.
+        let wrong_evidence = PotentialApplicationEvidence {
+            rule_id: "fake".to_string(),
+            central_bond: (AtomIdx(0), AtomIdx(1)),
+            source: TorsionKnowledgeSource::MacrocycleAdaptation,
+            applied_to_geometry: true, // WRONG for a macrocycle potential
+        };
+        let check_would_pass = wrong_evidence.applied_to_geometry
+            && wrong_evidence.source == TorsionKnowledgeSource::MacrocycleAdaptation;
+        assert!(
+            check_would_pass,
+            "sanity: the manufactured wrong evidence must trip a real assertion"
+        );
+        // The actual production code path never produces this: confirmed by
+        // `ring_torsion_diagnostic_only_succeeds_with_scored_only_evidence` above.
+    }
+
+    #[test]
+    fn negative_control_bounds_after_smoothing_would_fail_the_invariant_check() {
+        // Manufacture the exact bug spec §17 names: apply an adjustment to a matrix
+        // that has ALREADY been smoothed (instead of before), and confirm the
+        // existing `smoothing_preserves_invariants` check (reused by
+        // `embed_distance_geometry_v2_with_adjustments`) is what would catch it, by
+        // constructing bounds that violate the invariant directly and confirming the
+        // helper says so.
+        let mol = parse("C1CCCCCCCCCCC1").unwrap();
+        let (lower0, upper0) = crate::dg_fft::build_bound_matrix(&mol);
+        let mut lower = lower0.clone();
+        let mut upper = upper0.clone();
+        crate::dg_fft::smooth_bounds(&mut lower, &mut upper);
+        // Now simulate "adjustment applied after smoothing" by widening a
+        // FINITE-baseline entry in the ALREADY-SMOOTHED `upper` beyond what the
+        // (unsmoothed) baseline allows -- this must be flagged. Search for a pair
+        // with a genuinely finite pre-smoothing upper bound (a directly bonded pair
+        // always has one; an unconstrained distant pair may have an infinite
+        // fallback, which would make this check vacuously pass for the wrong
+        // reason, so it must be excluded).
+        let n = mol.atom_count();
+        let mut found = false;
+        'search: for i in 0..n {
+            for j in (i + 1)..n {
+                if upper0[i][j].is_finite() {
+                    let widened_upper = upper[i][j] + 100.0;
+                    let bad = widened_upper > upper0[i][j] + 1e-6;
+                    assert!(
+                        bad,
+                        "a post-smoothing widening of a finite-baseline pair must be \
+                         detectable as a baseline violation"
+                    );
+                    found = true;
+                    break 'search;
+                }
+            }
+        }
+        assert!(
+            found,
+            "expected at least one finite-baseline pair in cyclododecane"
+        );
+    }
+
+    #[test]
+    fn negative_control_final_stereo_violation_as_success_would_be_caught() {
+        // Manufacture a StereoVerification with a real violation and confirm the
+        // exact predicate the pipeline gates on (`n_violations() > 0`) reports it --
+        // proving the check can distinguish, not just always pass.
+        use crate::stereo_constraints::{StereoStatus, TetrahedralReport};
+        let fake = StereoVerification {
+            tetrahedral: vec![TetrahedralReport {
+                atom: AtomIdx(0),
+                status: StereoStatus::Violated,
+            }],
+            double_bond: vec![],
+        };
+        assert!(
+            fake.n_violations() > 0,
+            "a manufactured Violated element must be detected by n_violations()"
+        );
+        assert!(!fake.is_fully_satisfied());
+    }
+
+    #[test]
+    fn negative_control_unevaluable_counted_as_satisfied_would_be_caught() {
+        use crate::stereo_constraints::{StereoRejectionReason, StereoStatus, TetrahedralReport};
+        let fake = StereoVerification {
+            tetrahedral: vec![TetrahedralReport {
+                atom: AtomIdx(0),
+                status: StereoStatus::Unevaluable(StereoRejectionReason::DegenerateGeometry),
+            }],
+            double_bond: vec![],
+        };
+        // Unevaluable must NOT count as satisfied, and must not count as violated
+        // either -- it's its own bucket.
+        assert_eq!(fake.n_satisfied(), 0);
+        assert_eq!(fake.n_violations(), 0);
+        assert_eq!(fake.n_unevaluable(), 1);
+    }
+
+    #[test]
+    fn negative_control_hidden_fallback_would_be_caught() {
+        // Proves the correct fallback-occurred check (`fallback_reason.is_some()`,
+        // NOT `actual_force_field_used != requested_force_field`) actually
+        // discriminates -- mirrors the same check already relied on in
+        // `examples/cf_integration_smoke_test.rs`.
+        let mol = parse("CC").unwrap();
+        let config = MinimizeConfig::default();
+        let coords =
+            distance_geometry_v2::embed_distance_geometry_v2(&mol, &EmbedParameters::default())
+                .unwrap();
+        let result = minimize_with_policy_gated(
+            &mol,
+            coords,
+            ForceFieldPolicy::Mmff94WithUffFallback,
+            &config,
+            false,
+        )
+        .expect("ethane should minimize fine under MMFF94");
+        // Ethane's MMFF94 attempt should succeed cleanly (no fallback needed) --
+        // `actual_force_field_used` still legitimately differs in NAME semantics from
+        // `requested_force_field` per that struct's own doc, so asserting
+        // `fallback_reason.is_none()` (not `actual == requested`) is the only
+        // correct way to confirm "no fallback occurred."
+        assert!(
+            result.fallback_reason.is_none(),
+            "ethane should not need a UFF fallback"
+        );
+    }
+
+    #[test]
+    fn negative_control_partial_coords_as_ok_would_be_caught() {
+        // Confirms PipelineV2Result and PipelineV2Failure are structurally distinct
+        // types -- a failure can never be mistaken for (or silently coerced into) a
+        // success carrying the same `coords` field name, since `PipelineV2Failure`
+        // exposes `last_known_coords: Option<Coords3D>`, never `coords: Coords3D`.
+        let mol = parse("C1CCCCCCCCCCC1").unwrap();
+        let mut config = config_none();
+        config.embed.use_macrocycle_torsions = true;
+        config.ring_torsion_policy = RingTorsionApplicationPolicy::FailClosed;
+        let err = embed_pipeline_v2(&mol, &config).unwrap_err();
+        // `last_known_coords` is diagnostic only -- confirm the type itself has no
+        // field named `coords` a careless caller could mistake for a success value
+        // (checked at compile time by construction; this line documents the intent).
+        let _diagnostic_only: Option<Coords3D> = err.last_known_coords;
+    }
+
+    #[test]
+    fn negative_control_dropping_a_failed_molecule_would_be_caught() {
+        // Every failure carries `stage` -- confirms a caller CAN always attribute a
+        // failed molecule to a specific stage rather than needing to drop it from
+        // accounting. Exercised for real by the gate harness's denominator
+        // bookkeeping; this unit test confirms the field is always populated.
+        let mol = parse("[*]C").unwrap();
+        let err = embed_pipeline_v2(&mol, &config_none()).unwrap_err();
+        // `stage` is a plain enum value, always present (not Option) -- there is no
+        // code path that returns `Err` without it.
+        match err.stage {
+            PipelineStage::ValidateConfig
+            | PipelineStage::TorsionKnowledge
+            | PipelineStage::MacrocycleBoundAdjustment
+            | PipelineStage::DistanceGeometry
+            | PipelineStage::TorsionEnergyEvaluation
+            | PipelineStage::TorsionOptimization
+            | PipelineStage::StereoVerifyBefore
+            | PipelineStage::StereoRepair
+            | PipelineStage::StereoVerifyAfterRepair
+            | PipelineStage::ForceFieldMinimization
+            | PipelineStage::FinalStereoVerify
+            | PipelineStage::FinalGeometryValidationStage => {}
+        }
+    }
+
+    #[test]
+    fn negative_control_legacy_api_changing_would_be_caught() {
+        // "the legacy live API changing at all" -- confirms generate_coords_etkdg
+        // (an existing default path this PR must not touch) still produces the same
+        // shape/behavior it always has: infallible, correct atom count. A full
+        // byte-for-byte regression comparison lives in the crate's existing test
+        // suite (untouched by this PR); this is a light-touch confirmation the
+        // symbol is still callable with its pre-existing signature and behavior.
+        let mol = parse("CCO").unwrap();
+        let coords = crate::generate_coords_etkdg(&mol);
+        assert_eq!(coords.atom_count(), mol.atom_count());
+    }
+
+    #[test]
+    fn negative_control_accepting_nan_inf_would_be_caught() {
+        let mol = parse("CC").unwrap();
+        let bad_pairs = [
+            DistanceBoundAdjustment {
+                atom1: AtomIdx(0),
+                atom2: AtomIdx(1),
+                lower: f64::NAN,
+                upper: 2.0,
+            },
+            DistanceBoundAdjustment {
+                atom1: AtomIdx(0),
+                atom2: AtomIdx(1),
+                lower: 1.0,
+                upper: f64::INFINITY,
+            },
+        ];
+        for bad in bad_pairs {
+            let err = distance_geometry_v2::embed_distance_geometry_v2_with_adjustments(
+                &mol,
+                &EmbedParameters::default(),
+                &[bad],
+            )
+            .unwrap_err();
+            assert!(matches!(
+                err.0,
+                EmbedWithAdjustmentsFailure::InvalidAdjustment
+            ));
+        }
+    }
+}

--- a/crates/chematic-3d/src/pipeline_v2.rs
+++ b/crates/chematic-3d/src/pipeline_v2.rs
@@ -260,10 +260,22 @@ pub struct StageTimings {
     pub total_ms: u64,
 }
 
-/// Whether one [`crate::etkdg_knowledge::TorsionPotential`] was mechanically applied
-/// to geometry by stage 6's `optimize_torsions` call, or only ever scored. The ONE
-/// source of truth for this is [`is_bridge_bond`] on the potential's `central_bond` —
+/// Whether one [`crate::etkdg_knowledge::TorsionPotential`] was **eligible for**
+/// mechanical rotation by stage 6's `optimize_torsions` call (its central bond is a
+/// genuine acyclic bridge bond), vs. structurally scored-only (a ring/macrocycle
+/// bond `optimize_torsions` can never rotate at all). The ONE source of truth for
+/// this classification is [`is_bridge_bond`] on the potential's `central_bond` —
 /// never a proxy (see the module docs' "most important semantics" section).
+///
+/// Caveat found by independent verification round 1, disclosed rather than silently
+/// left implicit: `true` here means "was a candidate `optimize_torsions` could act
+/// on," not "definitely moved" — a bridge-bond potential whose initial gradient is
+/// already below `TorsionOptimizationConfig::convergence_grad_deg` is skipped
+/// without ever rotating (see `energy.rs`'s inner loop), and `optimize_torsions`
+/// does not report per-bond movement back up. This never affects the correctness
+/// property this field exists to guarantee (a ring/macrocycle bond is *never*
+/// mechanically rotated, full stop); it only means "applied_to_geometry = true"
+/// should be read as "geometrically applicable," not "definitely moved this call."
 #[derive(Debug, Clone, PartialEq)]
 pub struct PotentialApplicationEvidence {
     pub rule_id: String,
@@ -445,6 +457,55 @@ impl PipelineV2Failure {
     }
 }
 
+/// Progressive diagnostic accumulator threaded through [`embed_pipeline_v2`]:
+/// updated after every stage completes, so that **every** failure exit --
+/// including a mid-stage timeout via `check_timeout!`, which has no local
+/// stage-specific failure-construction block of its own -- carries the exact same
+/// partial evidence an explicit `Err` return at that point would have. Fixes a real
+/// gap independent verification round 1 found: `check_timeout!` previously built a
+/// bare, all-`None` [`PipelineV2Failure`] regardless of how much had already been
+/// computed, silently violating this module's own "carries as much partial
+/// diagnostic information as possible" claim.
+#[derive(Default)]
+struct Evidence {
+    last_known_coords: Option<Coords3D>,
+    embed_stats: Option<EmbedStats>,
+    bound_adjustment_report: Option<Vec<PairBoundAdjustment>>,
+    torsion_knowledge_report: Option<TorsionKnowledgeReport>,
+    ring_torsion_evidence: Option<RingTorsionEvidence>,
+    torsion_optimization_report: Option<TorsionOptimizationReport>,
+    stereo_before: Option<StereoVerification>,
+    stereo_repair: Option<StereoRepairSummary>,
+    stereo_after_repair: Option<StereoVerification>,
+    force_field: Option<PolicyMinimizeResult>,
+    final_stereo: Option<StereoVerification>,
+    final_validation: Option<FinalGeometryValidation>,
+}
+
+impl Evidence {
+    fn fail(
+        &self,
+        cause: PipelineV2FailureCause,
+        stage: PipelineStage,
+        timings: StageTimings,
+    ) -> PipelineV2Failure {
+        let mut failure = PipelineV2Failure::new(cause, stage, timings);
+        failure.last_known_coords = self.last_known_coords.clone();
+        failure.embed_stats = self.embed_stats.clone();
+        failure.bound_adjustment_report = self.bound_adjustment_report.clone();
+        failure.torsion_knowledge_report = self.torsion_knowledge_report.clone();
+        failure.ring_torsion_evidence = self.ring_torsion_evidence.clone();
+        failure.torsion_optimization_report = self.torsion_optimization_report.clone();
+        failure.stereo_before = self.stereo_before.clone();
+        failure.stereo_repair = self.stereo_repair.clone();
+        failure.stereo_after_repair = self.stereo_after_repair.clone();
+        failure.force_field = self.force_field.clone();
+        failure.final_stereo = self.final_stereo.clone();
+        failure.final_validation = self.final_validation.clone();
+        failure
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
@@ -471,6 +532,11 @@ pub fn embed_pipeline_v2(
 ) -> Result<PipelineV2Result, PipelineV2Failure> {
     let overall_start = Instant::now();
     let mut timings = StageTimings::default();
+    // Progressive diagnostic accumulator (see `Evidence`'s own doc comment): updated
+    // right after every value becomes available, so `check_timeout!` -- which has no
+    // stage-specific context of its own -- carries exactly the same partial evidence
+    // an explicit `Err` return at that point would.
+    let mut evidence = Evidence::default();
 
     macro_rules! check_timeout {
         ($stage:expr) => {
@@ -478,11 +544,7 @@ pub fn embed_pipeline_v2(
                 && overall_start.elapsed().as_millis() as u64 > budget
             {
                 timings.total_ms = overall_start.elapsed().as_millis() as u64;
-                return Err(PipelineV2Failure::new(
-                    PipelineV2FailureCause::Timeout,
-                    $stage,
-                    timings,
-                ));
+                return Err(evidence.fail(PipelineV2FailureCause::Timeout, $stage, timings));
             }
         };
     }
@@ -497,7 +559,7 @@ pub fn embed_pipeline_v2(
         // verifies anything, and letting both run would be confusing, not
         // defense-in-depth.
         timings.total_ms = overall_start.elapsed().as_millis() as u64;
-        return Err(PipelineV2Failure::new(
+        return Err(evidence.fail(
             PipelineV2FailureCause::InvalidConfiguration,
             PipelineStage::ValidateConfig,
             timings,
@@ -517,6 +579,7 @@ pub fn embed_pipeline_v2(
     let t0 = Instant::now();
     let torsion_knowledge_report = build_torsion_knowledge(mol, &torsion_config);
     timings.torsion_knowledge_ms = t0.elapsed().as_millis() as u64;
+    evidence.torsion_knowledge_report = Some(torsion_knowledge_report.clone());
     check_timeout!(PipelineStage::TorsionKnowledge);
 
     // -----------------------------------------------------------------
@@ -529,19 +592,18 @@ pub fn embed_pipeline_v2(
             Err(e) => {
                 timings.bound_adjustment_ms = t0.elapsed().as_millis() as u64;
                 timings.total_ms = overall_start.elapsed().as_millis() as u64;
-                let mut failure = PipelineV2Failure::new(
+                return Err(evidence.fail(
                     PipelineV2FailureCause::TorsionKnowledge(e),
                     PipelineStage::MacrocycleBoundAdjustment,
                     timings,
-                );
-                failure.torsion_knowledge_report = Some(torsion_knowledge_report);
-                return Err(failure);
+                ));
             }
         }
     } else {
         None
     };
     timings.bound_adjustment_ms = t0.elapsed().as_millis() as u64;
+    evidence.bound_adjustment_report = bound_adjustment_report.clone();
     check_timeout!(PipelineStage::MacrocycleBoundAdjustment);
 
     // -----------------------------------------------------------------
@@ -570,31 +632,27 @@ pub fn embed_pipeline_v2(
             Err((EmbedWithAdjustmentsFailure::InvalidAdjustment, stats)) => {
                 timings.distance_geometry_ms = t0.elapsed().as_millis() as u64;
                 timings.total_ms = overall_start.elapsed().as_millis() as u64;
-                let mut failure = PipelineV2Failure::new(
+                evidence.embed_stats = Some(stats);
+                return Err(evidence.fail(
                     PipelineV2FailureCause::BoundAdjustmentFailed,
                     PipelineStage::MacrocycleBoundAdjustment,
                     timings,
-                );
-                failure.torsion_knowledge_report = Some(torsion_knowledge_report);
-                failure.bound_adjustment_report = bound_adjustment_report;
-                failure.embed_stats = Some(stats);
-                return Err(failure);
+                ));
             }
             Err((EmbedWithAdjustmentsFailure::Embed(cause), stats)) => {
                 timings.distance_geometry_ms = t0.elapsed().as_millis() as u64;
                 timings.total_ms = overall_start.elapsed().as_millis() as u64;
-                let mut failure = PipelineV2Failure::new(
+                evidence.embed_stats = Some(stats);
+                return Err(evidence.fail(
                     PipelineV2FailureCause::DistanceGeometry(cause),
                     PipelineStage::DistanceGeometry,
                     timings,
-                );
-                failure.torsion_knowledge_report = Some(torsion_knowledge_report);
-                failure.bound_adjustment_report = bound_adjustment_report;
-                failure.embed_stats = Some(stats);
-                return Err(failure);
+                ));
             }
         };
     timings.distance_geometry_ms = t0.elapsed().as_millis() as u64;
+    evidence.embed_stats = Some(embed_stats.clone());
+    evidence.last_known_coords = Some(coords.clone());
     check_timeout!(PipelineStage::DistanceGeometry);
 
     // -----------------------------------------------------------------
@@ -604,16 +662,11 @@ pub fn embed_pipeline_v2(
     if let Err(e) = evaluate_torsion_energy(mol, &coords, &torsion_knowledge_report.potentials) {
         timings.torsion_energy_eval_ms = t0.elapsed().as_millis() as u64;
         timings.total_ms = overall_start.elapsed().as_millis() as u64;
-        let mut failure = PipelineV2Failure::new(
+        return Err(evidence.fail(
             PipelineV2FailureCause::TorsionKnowledge(e),
             PipelineStage::TorsionEnergyEvaluation,
             timings,
-        );
-        failure.torsion_knowledge_report = Some(torsion_knowledge_report);
-        failure.bound_adjustment_report = bound_adjustment_report;
-        failure.embed_stats = Some(embed_stats);
-        failure.last_known_coords = Some(coords);
-        return Err(failure);
+        ));
     }
     timings.torsion_energy_eval_ms = t0.elapsed().as_millis() as u64;
     check_timeout!(PipelineStage::TorsionEnergyEvaluation);
@@ -639,32 +692,35 @@ pub fn embed_pipeline_v2(
             .collect(),
         diagnostic_only: config.ring_torsion_policy == RingTorsionApplicationPolicy::DiagnosticOnly,
     };
+    evidence.ring_torsion_evidence = Some(ring_torsion_evidence.clone());
 
+    // Same two-part predicate as the evidence above (`bond_between(..).is_some() &&
+    // is_bridge_bond(..)`), not just `!is_bridge_bond(..)` alone: independent
+    // verification round 1 flagged that the two were only equivalent because every
+    // `central_bond` happens to come from `candidate_central_bonds` (real bonds
+    // only) -- matching the predicate exactly here removes that latent, currently-
+    // unreachable divergence risk rather than relying on an invariant holding
+    // elsewhere.
     let ring_application_requested =
         config.embed.use_small_ring_torsions || config.embed.use_macrocycle_torsions;
     let has_unsupported_ring_potential = torsion_knowledge_report.potentials.iter().any(|p| {
+        let (b, c) = p.central_bond;
         matches!(
             p.source,
             TorsionKnowledgeSource::SmallRingExperimental
                 | TorsionKnowledgeSource::MacrocycleAdaptation
-        ) && !is_bridge_bond(mol, p.central_bond.0, p.central_bond.1)
+        ) && !(mol.bond_between(b, c).is_some() && is_bridge_bond(mol, b, c))
     });
     if ring_application_requested
         && has_unsupported_ring_potential
         && config.ring_torsion_policy == RingTorsionApplicationPolicy::FailClosed
     {
         timings.total_ms = overall_start.elapsed().as_millis() as u64;
-        let mut failure = PipelineV2Failure::new(
+        return Err(evidence.fail(
             PipelineV2FailureCause::RingTorsionApplicationUnsupported,
             PipelineStage::TorsionOptimization,
             timings,
-        );
-        failure.torsion_knowledge_report = Some(torsion_knowledge_report);
-        failure.bound_adjustment_report = bound_adjustment_report;
-        failure.embed_stats = Some(embed_stats);
-        failure.ring_torsion_evidence = Some(ring_torsion_evidence);
-        failure.last_known_coords = Some(coords);
-        return Err(failure);
+        ));
     }
 
     let t0 = Instant::now();
@@ -681,21 +737,17 @@ pub fn embed_pipeline_v2(
             Err(e) => {
                 timings.torsion_optimization_ms = t0.elapsed().as_millis() as u64;
                 timings.total_ms = overall_start.elapsed().as_millis() as u64;
-                let mut failure = PipelineV2Failure::new(
+                return Err(evidence.fail(
                     PipelineV2FailureCause::TorsionKnowledge(e),
                     PipelineStage::TorsionOptimization,
                     timings,
-                );
-                failure.torsion_knowledge_report = Some(torsion_knowledge_report);
-                failure.bound_adjustment_report = bound_adjustment_report;
-                failure.embed_stats = Some(embed_stats);
-                failure.ring_torsion_evidence = Some(ring_torsion_evidence);
-                failure.last_known_coords = Some(coords);
-                return Err(failure);
+                ));
             }
         }
     };
     timings.torsion_optimization_ms = t0.elapsed().as_millis() as u64;
+    evidence.torsion_optimization_report = torsion_optimization_report.clone();
+    evidence.last_known_coords = Some(coords.clone());
     check_timeout!(PipelineStage::TorsionOptimization);
 
     // -----------------------------------------------------------------
@@ -705,6 +757,7 @@ pub fn embed_pipeline_v2(
     let t0 = Instant::now();
     let stereo_before = verify_stereo(mol, &coords);
     timings.stereo_verify_before_ms = t0.elapsed().as_millis() as u64;
+    evidence.stereo_before = Some(stereo_before.clone());
     check_timeout!(PipelineStage::StereoVerifyBefore);
 
     // -----------------------------------------------------------------
@@ -723,29 +776,24 @@ pub fn embed_pipeline_v2(
             Err(report) => {
                 timings.stereo_repair_ms = t0.elapsed().as_millis() as u64;
                 timings.total_ms = overall_start.elapsed().as_millis() as u64;
-                let mut failure = PipelineV2Failure::new(
-                    PipelineV2FailureCause::StereoRepairFailed,
-                    PipelineStage::StereoRepair,
-                    timings,
-                );
-                failure.torsion_knowledge_report = Some(torsion_knowledge_report);
-                failure.bound_adjustment_report = bound_adjustment_report;
-                failure.embed_stats = Some(embed_stats);
-                failure.ring_torsion_evidence = Some(ring_torsion_evidence);
-                failure.torsion_optimization_report = torsion_optimization_report;
-                failure.stereo_before = Some(stereo_before);
-                failure.last_known_coords = Some(report.partial_coords);
-                failure.stereo_repair = Some(StereoRepairSummary {
+                evidence.last_known_coords = Some(report.partial_coords);
+                evidence.stereo_repair = Some(StereoRepairSummary {
                     repaired: report.repaired,
                     failures: report.failures,
                 });
-                return Err(failure);
+                return Err(evidence.fail(
+                    PipelineV2FailureCause::StereoRepairFailed,
+                    PipelineStage::StereoRepair,
+                    timings,
+                ));
             }
         }
     } else {
         (coords, None)
     };
     timings.stereo_repair_ms = t0.elapsed().as_millis() as u64;
+    evidence.stereo_repair = stereo_repair.clone();
+    evidence.last_known_coords = Some(coords.clone());
     check_timeout!(PipelineStage::StereoRepair);
 
     // -----------------------------------------------------------------
@@ -760,6 +808,7 @@ pub fn embed_pipeline_v2(
         stereo_before.clone()
     };
     timings.stereo_verify_after_repair_ms = t0.elapsed().as_millis() as u64;
+    evidence.stereo_after_repair = Some(stereo_after_repair.clone());
     check_timeout!(PipelineStage::StereoVerifyAfterRepair);
 
     // -----------------------------------------------------------------
@@ -781,23 +830,16 @@ pub fn embed_pipeline_v2(
         Err(e) => {
             timings.force_field_ms = t0.elapsed().as_millis() as u64;
             timings.total_ms = overall_start.elapsed().as_millis() as u64;
-            let mut failure = PipelineV2Failure::new(
+            return Err(evidence.fail(
                 PipelineV2FailureCause::ForceField(e),
                 PipelineStage::ForceFieldMinimization,
                 timings,
-            );
-            failure.torsion_knowledge_report = Some(torsion_knowledge_report);
-            failure.bound_adjustment_report = bound_adjustment_report;
-            failure.embed_stats = Some(embed_stats);
-            failure.ring_torsion_evidence = Some(ring_torsion_evidence);
-            failure.torsion_optimization_report = torsion_optimization_report;
-            failure.stereo_before = Some(stereo_before);
-            failure.stereo_repair = stereo_repair;
-            failure.stereo_after_repair = Some(stereo_after_repair);
-            return Err(failure);
+            ));
         }
     };
     timings.force_field_ms = t0.elapsed().as_millis() as u64;
+    evidence.force_field = Some(force_field.clone());
+    evidence.last_known_coords = Some(force_field.coords.clone());
     check_timeout!(PipelineStage::ForceFieldMinimization);
 
     // -----------------------------------------------------------------
@@ -808,47 +850,24 @@ pub fn embed_pipeline_v2(
     let t0 = Instant::now();
     let final_stereo = verify_stereo(mol, &force_field.coords);
     timings.final_stereo_verify_ms = t0.elapsed().as_millis() as u64;
+    evidence.final_stereo = Some(final_stereo.clone());
 
     if config.stereo_policy != StereoPolicy::Ignore {
         if final_stereo.n_violations() > 0 {
             timings.total_ms = overall_start.elapsed().as_millis() as u64;
-            let mut failure = PipelineV2Failure::new(
+            return Err(evidence.fail(
                 PipelineV2FailureCause::FinalStereoViolation,
                 PipelineStage::FinalStereoVerify,
                 timings,
-            );
-            failure.torsion_knowledge_report = Some(torsion_knowledge_report);
-            failure.bound_adjustment_report = bound_adjustment_report;
-            failure.embed_stats = Some(embed_stats);
-            failure.ring_torsion_evidence = Some(ring_torsion_evidence);
-            failure.torsion_optimization_report = torsion_optimization_report;
-            failure.stereo_before = Some(stereo_before);
-            failure.stereo_repair = stereo_repair;
-            failure.stereo_after_repair = Some(stereo_after_repair);
-            failure.last_known_coords = Some(force_field.coords.clone());
-            failure.final_stereo = Some(final_stereo);
-            failure.force_field = Some(force_field);
-            return Err(failure);
+            ));
         }
         if config.fail_on_unevaluable_stereo && final_stereo.n_unevaluable() > 0 {
             timings.total_ms = overall_start.elapsed().as_millis() as u64;
-            let mut failure = PipelineV2Failure::new(
+            return Err(evidence.fail(
                 PipelineV2FailureCause::StereoUnevaluableUnderStrictPolicy,
                 PipelineStage::FinalStereoVerify,
                 timings,
-            );
-            failure.torsion_knowledge_report = Some(torsion_knowledge_report);
-            failure.bound_adjustment_report = bound_adjustment_report;
-            failure.embed_stats = Some(embed_stats);
-            failure.ring_torsion_evidence = Some(ring_torsion_evidence);
-            failure.torsion_optimization_report = torsion_optimization_report;
-            failure.stereo_before = Some(stereo_before);
-            failure.stereo_repair = stereo_repair;
-            failure.stereo_after_repair = Some(stereo_after_repair);
-            failure.last_known_coords = Some(force_field.coords.clone());
-            failure.final_stereo = Some(final_stereo);
-            failure.force_field = Some(force_field);
-            return Err(failure);
+            ));
         }
     }
     check_timeout!(PipelineStage::FinalStereoVerify);
@@ -870,23 +889,11 @@ pub fn embed_pipeline_v2(
             // rather than silently reporting a stale/zero energy.
             timings.final_validation_ms = t0.elapsed().as_millis() as u64;
             timings.total_ms = overall_start.elapsed().as_millis() as u64;
-            let mut failure = PipelineV2Failure::new(
+            return Err(evidence.fail(
                 PipelineV2FailureCause::FinalGeometryInvalid,
                 PipelineStage::FinalGeometryValidationStage,
                 timings,
-            );
-            failure.torsion_knowledge_report = Some(torsion_knowledge_report);
-            failure.bound_adjustment_report = bound_adjustment_report;
-            failure.embed_stats = Some(embed_stats);
-            failure.ring_torsion_evidence = Some(ring_torsion_evidence);
-            failure.torsion_optimization_report = torsion_optimization_report;
-            failure.stereo_before = Some(stereo_before);
-            failure.stereo_repair = stereo_repair;
-            failure.stereo_after_repair = Some(stereo_after_repair);
-            failure.last_known_coords = Some(force_field.coords.clone());
-            failure.final_stereo = Some(final_stereo);
-            failure.force_field = Some(force_field);
-            return Err(failure);
+            ));
         }
     };
 
@@ -903,27 +910,15 @@ pub fn embed_pipeline_v2(
         ring_closure_delta,
     );
     timings.final_validation_ms = t0.elapsed().as_millis() as u64;
+    evidence.final_validation = Some(final_validation.clone());
 
     if !final_validation.sound {
         timings.total_ms = overall_start.elapsed().as_millis() as u64;
-        let mut failure = PipelineV2Failure::new(
+        return Err(evidence.fail(
             PipelineV2FailureCause::FinalGeometryInvalid,
             PipelineStage::FinalGeometryValidationStage,
             timings,
-        );
-        failure.torsion_knowledge_report = Some(torsion_knowledge_report);
-        failure.bound_adjustment_report = bound_adjustment_report;
-        failure.embed_stats = Some(embed_stats);
-        failure.ring_torsion_evidence = Some(ring_torsion_evidence);
-        failure.torsion_optimization_report = torsion_optimization_report;
-        failure.stereo_before = Some(stereo_before);
-        failure.stereo_repair = stereo_repair;
-        failure.stereo_after_repair = Some(stereo_after_repair);
-        failure.last_known_coords = Some(force_field.coords.clone());
-        failure.final_stereo = Some(final_stereo);
-        failure.final_validation = Some(final_validation);
-        failure.force_field = Some(force_field);
-        return Err(failure);
+        ));
     }
 
     timings.total_ms = overall_start.elapsed().as_millis() as u64;
@@ -1387,6 +1382,33 @@ mod tests {
         config.total_timeout_ms = Some(0);
         let err = embed_pipeline_v2(&mol, &config).unwrap_err();
         assert!(matches!(err.cause, PipelineV2FailureCause::Timeout));
+    }
+
+    /// Regression test for a real bug independent verification round 1 found:
+    /// `check_timeout!` used to construct a bare, all-`None` `PipelineV2Failure`
+    /// regardless of how much had already been computed by that point -- silently
+    /// contradicting this module's own "carries as much partial diagnostic
+    /// information as possible" claim. `total_timeout_ms: Some(0)` is guaranteed to
+    /// trip at SOME `check_timeout!` call site, and every such site is textually
+    /// after stage 2 (torsion knowledge) completes -- not asserting on exactly
+    /// which stage trips (that depends on sub-millisecond timing and is not
+    /// deterministic across machines), only that the evidence stage 2 always
+    /// produces by that point is never silently dropped.
+    #[test]
+    fn timeout_failure_still_carries_evidence_computed_before_it_tripped() {
+        let mol = parse("CC(=O)Nc1ccc(O)cc1").unwrap(); // paracetamol
+        let mut config = config_none();
+        config.total_timeout_ms = Some(0);
+        let err = embed_pipeline_v2(&mol, &config).unwrap_err();
+        assert!(matches!(err.cause, PipelineV2FailureCause::Timeout));
+        assert!(
+            err.torsion_knowledge_report.is_some(),
+            "a timeout must always carry at least the torsion-knowledge report \
+             (every check_timeout! call site is after stage 2 completes) -- this \
+             is exactly the evidence-dropping bug that was found and fixed, stage \
+             reached: {:?}",
+            err.stage
+        );
     }
 
     #[test]

--- a/crates/chematic-3d/src/pipeline_v2.rs
+++ b/crates/chematic-3d/src/pipeline_v2.rs
@@ -212,6 +212,17 @@ pub struct PipelineV2Config {
     pub force_field_max_iterations: usize,
     pub gate_mmff94_torsion_oop: bool,
     pub ring_torsion_policy: RingTorsionApplicationPolicy,
+    /// Wall-clock budget (milliseconds) for the whole call. `None` = no limit.
+    /// Checked coarsely: once immediately after every one of the 12 stages
+    /// completes (including the last, stage 12 -- independent verification round 2
+    /// found this was missing after stage 12 specifically; it is now checked
+    /// there too, after that stage's own semantic gate), never pre-emptively
+    /// *during* a stage. A single expensive stage (e.g. a large `max_attempts` in
+    /// `EmbedParameters`, or `optimize_torsions` on a very large molecule) can
+    /// therefore overshoot the budget before the next check point — this is the
+    /// same "checked between attempts, not pre-emptively inside one attempt"
+    /// convention `EmbedParameters::timeout_ms` already documents for the raw
+    /// embedder, applied one level up.
     pub total_timeout_ms: Option<u64>,
 }
 
@@ -920,6 +931,15 @@ pub fn embed_pipeline_v2(
             timings,
         ));
     }
+    // Independent verification round 2 found this was missing: every other stage
+    // gets a `check_timeout!` immediately after it, but stage 12 (the last one)
+    // didn't -- meaning `total_timeout_ms` was silently unenforced on whatever time
+    // stage 12's own O(n^2) clash-count / bond-violation-rate work took, so a
+    // caller's requested budget could be exceeded without ever seeing a `Timeout`
+    // failure. Checked here, after the stage's own semantic gate (matching stage
+    // 11's own ordering: the stage's real outcome is decided first, the timeout
+    // budget is enforced after).
+    check_timeout!(PipelineStage::FinalGeometryValidationStage);
 
     timings.total_ms = overall_start.elapsed().as_millis() as u64;
     Ok(PipelineV2Result {

--- a/crates/chematic-3d/src/pipeline_v2.rs
+++ b/crates/chematic-3d/src/pipeline_v2.rs
@@ -1482,28 +1482,29 @@ mod tests {
         );
     }
 
+    /// Negative control (spec §17): proves the check in
+    /// `ring_torsion_diagnostic_only_succeeds_with_scored_only_evidence` actually
+    /// discriminates REAL pipeline output, not just vacuously passes. Runs the same
+    /// real `embed_pipeline_v2` call and asserts the WRONG thing (every macrocycle
+    /// potential IS applied) -- this must panic, proving a regression that started
+    /// reporting scored-only potentials as applied would be caught, not silently
+    /// accepted.
     #[test]
+    #[should_panic(expected = "must never be reported as applied_to_geometry")]
     fn negative_control_reporting_scored_only_as_applied_would_be_caught() {
-        // If a caller (hypothetically) reported every potential as
-        // applied_to_geometry=true regardless of bridge status, this assertion --
-        // exercised for real above in `ring_torsion_diagnostic_only_succeeds_with_scored_only_evidence`
-        // -- would fail to catch it. Prove the check itself can fail: manufacture the
-        // WRONG evidence by hand and confirm an assertion built the same way as the
-        // real test rejects it.
-        let wrong_evidence = PotentialApplicationEvidence {
-            rule_id: "fake".to_string(),
-            central_bond: (AtomIdx(0), AtomIdx(1)),
-            source: TorsionKnowledgeSource::MacrocycleAdaptation,
-            applied_to_geometry: true, // WRONG for a macrocycle potential
-        };
-        let check_would_pass = wrong_evidence.applied_to_geometry
-            && wrong_evidence.source == TorsionKnowledgeSource::MacrocycleAdaptation;
-        assert!(
-            check_would_pass,
-            "sanity: the manufactured wrong evidence must trip a real assertion"
-        );
-        // The actual production code path never produces this: confirmed by
-        // `ring_torsion_diagnostic_only_succeeds_with_scored_only_evidence` above.
+        let mol = parse("C1CCCCCCCCCCC1").unwrap(); // cyclododecane
+        let mut config = config_none();
+        config.embed.use_macrocycle_torsions = true;
+        config.ring_torsion_policy = RingTorsionApplicationPolicy::DiagnosticOnly;
+        let result = embed_pipeline_v2(&mol, &config).expect("DiagnosticOnly must succeed");
+        for p in &result.ring_torsion_evidence.potentials {
+            if p.source == TorsionKnowledgeSource::MacrocycleAdaptation {
+                assert!(
+                    p.applied_to_geometry, // deliberately WRONG -- must panic
+                    "a macrocycle potential must never be reported as applied_to_geometry"
+                );
+            }
+        }
     }
 
     #[test]
@@ -1549,41 +1550,86 @@ mod tests {
         );
     }
 
+    /// Negative control (spec §17), using a REAL molecule found by the integration
+    /// gate harness (`examples/pipeline_v2_integration_gate.rs`) to exercise exactly
+    /// this failure mode on the frozen 58-molecule corpus: under
+    /// `RepairAndVerify` + `ForceFieldPolicy::Dreiding`, gly-ala-gly's stereo repair
+    /// succeeds (stage 8) but DREIDING minimization (stage 10, no stereo awareness
+    /// at all) measurably walks the geometry back across a declared stereo boundary
+    /// -- stage 11 must catch this as `FinalStereoViolation`, never report success.
     #[test]
     fn negative_control_final_stereo_violation_as_success_would_be_caught() {
-        // Manufacture a StereoVerification with a real violation and confirm the
-        // exact predicate the pipeline gates on (`n_violations() > 0`) reports it --
-        // proving the check can distinguish, not just always pass.
-        use crate::stereo_constraints::{StereoStatus, TetrahedralReport};
-        let fake = StereoVerification {
-            tetrahedral: vec![TetrahedralReport {
-                atom: AtomIdx(0),
-                status: StereoStatus::Violated,
-            }],
-            double_bond: vec![],
-        };
+        let mol = parse("NCC(=O)N[C@@H](C)C(=O)NCC(=O)O").unwrap(); // gly_ala_gly
+        let mut config = PipelineV2Config::minimal(ForceFieldPolicy::Dreiding);
+        config.stereo_policy = StereoPolicy::RepairAndVerify;
+        let err = embed_pipeline_v2(&mol, &config)
+            .expect_err("gly_ala_gly under RepairAndVerify+Dreiding must NOT report success");
         assert!(
-            fake.n_violations() > 0,
-            "a manufactured Violated element must be detected by n_violations()"
+            matches!(err.cause, PipelineV2FailureCause::FinalStereoViolation),
+            "expected FinalStereoViolation, got {:?}",
+            err.cause
         );
-        assert!(!fake.is_fully_satisfied());
+        // Stage 8's repair must have genuinely succeeded first (this is specifically
+        // the "fixed, then broken again by the force field" scenario spec §8 warns
+        // about, not merely "repair never worked").
+        let stereo_after_repair = err
+            .stereo_after_repair
+            .expect("stage 9 evidence must be attached");
+        assert!(
+            stereo_after_repair.is_fully_satisfied(),
+            "repair (stage 8) must have succeeded before Dreiding (stage 10) broke it again"
+        );
+        let final_stereo = err
+            .final_stereo
+            .expect("stage 11 evidence must be attached");
+        assert!(final_stereo.n_violations() > 0);
     }
 
+    /// Negative control (spec §17): a genuinely degenerate (coplanar) 3D arrangement
+    /// for a real declared stereocenter must read `Unevaluable`, and
+    /// `StereoVerification`'s own accessor methods (reused, not reimplemented, by
+    /// `pipeline_v2.rs`'s stage-11 gate) must never fold that into `n_satisfied()`.
     #[test]
     fn negative_control_unevaluable_counted_as_satisfied_would_be_caught() {
-        use crate::stereo_constraints::{StereoRejectionReason, StereoStatus, TetrahedralReport};
-        let fake = StereoVerification {
-            tetrahedral: vec![TetrahedralReport {
-                atom: AtomIdx(0),
-                status: StereoStatus::Unevaluable(StereoRejectionReason::DegenerateGeometry),
-            }],
-            double_bond: vec![],
-        };
-        // Unevaluable must NOT count as satisfied, and must not count as violated
-        // either -- it's its own bucket.
-        assert_eq!(fake.n_satisfied(), 0);
-        assert_eq!(fake.n_violations(), 0);
-        assert_eq!(fake.n_unevaluable(), 1);
+        let m = parse("N[C@@H](C)C(=O)O").unwrap(); // L-alanine, implicit-H stereocenter
+        let idx = AtomIdx(1);
+        // All 4 real neighbors placed in the same z=0 plane -> the phantom-H
+        // direction (opposite the sum of the other three unit bond vectors) is
+        // ill-defined / the signed volume is ~0: a genuinely degenerate geometry,
+        // not a hand-picked StereoStatus value.
+        let mut coords = Coords3D::new_zeroed(m.atom_count());
+        coords.set(AtomIdx(0), crate::coords::Point3::new(-1.0, -1.3, 0.0));
+        coords.set(idx, crate::coords::Point3::new(-0.3, -0.2, 0.0));
+        coords.set(AtomIdx(2), crate::coords::Point3::new(-1.0, 1.0, 0.0));
+        coords.set(AtomIdx(3), crate::coords::Point3::new(1.2, -0.2, 0.0));
+        coords.set(AtomIdx(4), crate::coords::Point3::new(1.7, -1.0, 0.0));
+        coords.set(AtomIdx(5), crate::coords::Point3::new(1.9, 0.7, 0.0));
+
+        let report = verify_stereo(&m, &coords);
+        let status = report
+            .tetrahedral
+            .iter()
+            .find(|r| r.atom == idx)
+            .unwrap()
+            .status;
+        assert!(
+            matches!(
+                status,
+                crate::stereo_constraints::StereoStatus::Unevaluable(_)
+            ),
+            "expected a genuinely degenerate (coplanar) geometry to read Unevaluable, got {status:?}"
+        );
+        assert_eq!(
+            report.n_satisfied(),
+            0,
+            "Unevaluable must never count as Satisfied"
+        );
+        assert_eq!(
+            report.n_violations(),
+            0,
+            "Unevaluable must never count as Violated"
+        );
+        assert_eq!(report.n_unevaluable(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Integrates 4 independently-merged, independently-verified Wave 1/2 deliverables into
a single new, fail-closed, **opt-in** Rust pipeline, `chematic_3d::embed_pipeline_v2`
(`crates/chematic-3d/src/pipeline_v2.rs`), without changing any existing default
behavior anywhere in the codebase (Rust, Python, WASM, MCP):

- **Agent C** — stochastic distance geometry (`distance_geometry_v2.rs`)
- **Agent E** — torsion knowledge v2 + macrocycle 1-4 bounds (`etkdg_knowledge.rs` +
  submodule)
- **Agent D** — stereo verification/repair (`stereo_constraints.rs`)
- **Agent F** — typed force-field policy minimization (`minimize.rs`)

base SHA: `ebb796639a27887acd9993ef397245dce59848d9` (origin/main, PR #191's merge
commit) · initial implementation commit: `1d182e8c4797804268bf5fae7457b96dbb0a055b`
· current head SHA (after rounds 1-4 fixes): `0fc39f2` · workspace version `0.7.1` ·
rustc 1.97.0.

## Stage order (exact, per spec)

1. validate config
2. build torsion knowledge
3. compute macrocycle 1-4 adjustments
4. raw stochastic DG with adjustments
5. evaluate torsion energy
6. optimize applicable acyclic torsions (**ring-torsion-application gate lives here**)
7. verify stereo
8. repair stereo when requested
9. verify stereo again
10. force-field minimization
11. final stereo verification (**single authoritative stereo gate**)
12. final geometry validation

## The most important semantics

`optimize_torsions` (Agent E) can only mechanically rotate **acyclic bridge single
bonds** — it never fails just because ring/macrocycle potentials were requested; it
silently succeeds with `rotated_bond_count` reflecting only the acyclic subset. So
**stage 6's own pre-check, not `optimize_torsions`'s return value**, enforces
`RingTorsionApplicationPolicy::FailClosed`. Verified directly (not assumed) by a
dedicated unit test (`negative_control_optimize_torsions_alone_would_silently_accept_ring_only_potentials`)
that runs `optimize_torsions` on a ring-only potential list and confirms it returns
`Ok`.

The **one** discriminator for "applied to geometry vs. scored-only" is
`etkdg_knowledge::is_bridge_bond` — made `pub(crate)` and reused directly by the
pipeline, not re-derived via a second predicate (`ring_size.is_some()` is wrong:
`rules_basic::flat_ring` potentials carry `ring_size: None` despite targeting a ring
bond).

## Where macrocycle 1-4 bounds are applied

A minimal `pub(crate)` hook was added to `distance_geometry_v2.rs`:
`embed_distance_geometry_v2_with_adjustments(mol, params, adjustments: &[DistanceBoundAdjustment])`.
Adjustments are validated once, up front (index range, `atom1 != atom2`, both bounds
finite, `lower <= upper`) — a bad adjustment fails closed with
`EmbedWithAdjustmentsFailure::InvalidAdjustment` before any bound matrix is built.
Applied immediately after `build_bound_matrix`, **before** `smooth_bounds` runs, every
attempt. The smoothing-invariant check's baseline is the **post-adjustment** matrix
(not pre-adjustment) — a deliberate widening (e.g. a macrocycle 1-4 band) happens
before smoothing sees the matrix at all, so comparing against the pre-adjustment
matrix would make every such widening a spurious `BoundsSmoothingFailed`.

`embed_distance_geometry_v2_detail` (the existing public API) now **delegates** to
this hook with an empty adjustment slice, so "output with zero adjustments is
unchanged" is structural, not a convention to keep in sync by hand — confirmed by
`zero_adjustments_is_byte_identical_to_public_detail_api` and
`all_flags_off_matches_raw_dg_exactly`.

Confirmed the hook is actually wired (not just present): `macrocycle_14_bounds_actually_applied_before_smoothing_changes_output`
enables `use_macrocycle_14_bounds` on cyclododecane at a fixed seed and asserts the
resulting coordinates differ from the flag-off run — and the gate harness confirms
the same at corpus scale (Arm B vs Arm A both succeed 63/63, but Arm B's mean 15%
bond-violation rate is 0.0658 vs Arm A's 0.0000, i.e. the hook measurably changes
output, not just scores it). A second, previously-unexercised branch of the same
mechanism — `bounds14.rs`'s `macrocycle_14:amide_ester_pinned` rule (pin-to-cis for
an amide/ester bond inside a macrocycle, as opposed to the generic `relaxed_band`
rule every prior macrocycle in the corpus hit) — is now covered by both a dedicated
unit test and a new corpus molecule (see round 4 below).

## Typed failure

`PipelineV2FailureCause` (11 variants, exactly as specified): `InvalidConfiguration`,
`BoundAdjustmentFailed`, `DistanceGeometry(EmbedFailureCause)`,
`TorsionKnowledge(TorsionKnowledgeError)`, `RingTorsionApplicationUnsupported`,
`StereoRepairFailed`, `StereoUnevaluableUnderStrictPolicy`,
`ForceField(ForceFieldBridgeError)`, `FinalStereoViolation`, `FinalGeometryInvalid`,
`Timeout`. Every `PipelineV2Failure` carries `stage` (one of the 12 exact stages) plus
as much partial diagnostic evidence (stats, reports, `last_known_coords` — explicitly
**not** named `coords`, so it can never be mistaken for a success value) as was
computed before the failure. Never returns partial coordinates dressed as a success.

## Judgment calls made (documented in `pipeline_v2.rs`'s own module doc, reasoning repeated here)

1. **`embed.enforce_chirality = true` is rejected as `InvalidConfiguration`** at stage
   1 whenever `stereo_policy != Ignore`. This pipeline's own stages 7–11 are the
   stereo gate; the raw embedder's `enforce_chirality` is an unrelated fail-closed
   stub that never actually verifies anything (per `distance_geometry_v2.rs`'s own
   doc), so letting both run would be confusing, not defense-in-depth.
2. **The `use_small_ring_torsions`/`use_macrocycle_torsions` fail-closed gate is
   scoped exactly to `SmallRingExperimental`/`MacrocycleAdaptation` potentials** —
   not to `BasicChemicalKnowledge`'s flat-ring term (gated by the separate
   `use_exp_torsions` flag), matching the literal flags named in the spec.
   `RingTorsionEvidence` still reports flat-ring's `applied_to_geometry` truthfully
   either way; only the hard gate is scoped narrowly.
3. **`StereoPolicy::VerifyOnly`'s "Violated => failure" and the strict
   `fail_on_unevaluable_stereo` check are both evaluated once, at stage 11**
   (post-force-field), not additionally fast-failed at stage 7 — a force field can in
   principle change an element's status, so stage 11 is the only *authoritative*
   answer, and `stereo_before` remains full diagnostic evidence regardless.
   `RepairAndVerify`'s repair-failure gate (stage 8) is the one exception: a failed
   repair stops the pipeline immediately.
4. **`bounds_conformance` in `FinalGeometryValidation` reuses
   `distance_geometry_v2::bounds_conformance` as-is** (unadjusted-bounds diagnostic)
   rather than re-deriving an adjustment-aware version, to avoid a second
   bounds-computation pathway duplicating `dg_fft` internals.
5. **`FinalGeometryValidation::sound` gates only hard geometric sanity** (finite
   coordinates, unchanged atom count, worst bond length under
   `minimize::MAX_SANE_BOND_LENGTH`, reused via a new `pub(crate)` — not
   re-derived — since `ForceFieldPolicy::None` skips Agent F's own soundness gate
   entirely and this is then the *only* backstop). Bond-violation rate,
   gross-clash count, bounds conformance, and ring-closure delta are measured and
   reported but do not by themselves fail an individual call — they're corpus-level
   metrics.

## Full arm results (frozen 58-molecule corpus + 5 spec-§14-required stress cases
added in round 4 — see below — = 63 total, seed `0xC0FFEE42D1576E02`)

`attempted=63` for every arm (denominator never conflated with `success`).

| Arm | success | notable typed failures |
|---|---|---|
| A raw DG | 63/63 | — |
| B + macrocycle 1-4 bounds | 63/63 | — |
| C + standard acyclic torsion opt | 63/63 | — |
| D + stereo repair | 61/63 | `StereoRepairFailed` x2 (testosterone, cholesterol -- pre-existing, disclosed Agent D limitation, see below) |
| E MMFF94 bond/angle strict | 33/63 | mostly `ForceField(MissingParameters: N)`, matches Agent F's own ~50% coverage documentation; also 1 new `MissingParameters` case (dimethylbiphenyl_2_2, a newly-added 2,2'-disubstituted biphenyl — disclosed below) |
| F MMFF94 widened torsion/oop gate | 33/63 | same population as E (chematic-ff #183 made the two gates nearly identical, per Agent F's own doc) |
| G MMFF94-\>UFF fallback | 55/63 | 22/55 successes needed the UFF fallback; 5 `FinalStereoViolation`, 2 `StereoRepairFailed` (cascading from D), 1 `MinimizationFailed(CatastrophicBondBlowup)` |
| H DREIDING | 57/63 | 4 `FinalStereoViolation`, 2 `StereoRepairFailed` (cascading from D) |
| I ring torsions, FailClosed | 48/63 | `RingTorsionApplicationUnsupported` x15 (every ring/macrocycle-bearing molecule with a scored-only potential, incl. the 4 new small-ring/macrocycle stress cases) |
| J ring torsions, DiagnosticOnly | 61/63 | succeeds on 13/15 molecules Arm I rejected (2 confounded — see discriminating check below); `n_matched=127, n_applied=7, n_scored_only=120` across the corpus |

Full per-arm metric dump (runtime p50/p95, bond-violation rate, gross clashes, bounds
conformance, torsion energy before/after, stereo declared/satisfied/repaired/
unevaluable/violated, force-field requested-\>actual, fallback counts) is reproducible
via `cargo run --release -p chematic-3d --example pipeline_v2_integration_gate`.

**Arm I / Arm J discriminating check** (the core claim): 15/63 molecules have a
scored-only small-ring/macrocycle potential. All 15 trip `RingTorsionApplicationUnsupported`
under FailClosed. Under DiagnosticOnly, 13/15 succeed with
`n_scored_only > 0 && diagnostic_only == true` evidence; the other 2 (testosterone,
cholesterol) fail for an **unrelated** reason (`StereoRepairFailed` — confirmed by
checking the cause is not `RingTorsionApplicationUnsupported`) — Arm I/J are built on
top of full-pipeline Arm D (includes stereo repair), so loosening the ring gate lets
the pipeline reach further into the stage order for these two molecules and hit
Agent D's own disclosed ring-fused-stereocenter repair limitation (see
`stereo_constraints.rs`'s module doc) for the first time. Not a ring-torsion bug.
The 4 molecules added in round 4 to close the corpus gap (cyclobutane, cyclooctane,
cyclononane, macrolactam_12) all land in this same 15/13 split exactly as expected:
each contributes one more `RingTorsionApplicationUnsupported` under Arm I and one
more scored-only success under Arm J, confirming both the `SMALL_RING_MAX=8` /
`MACROCYCLE_MIN=9` classification boundary and the amide-macrocycle path are
correctly gated through the real pipeline, not just in isolated unit tests.

**New finding this integration surfaced**: under `Mmff94WithUffFallback`/`Dreiding`
(Arms G/H), force-field minimization measurably **reintroduces stereo violations**
that Agent D's repair had just fixed (5/55 and 4/57 respectively) — exactly the
failure mode spec §8 warns about ("if stereo is broken after force-field
minimization, this is NOT a success"). The pipeline correctly catches this at stage
11 rather than reporting success. This is real signal about UFF/DREIDING's lack of
any stereo awareness during minimization on these specific molecules
(ibuprofen_S, naproxen_S, chfclbr_S, cinnamic_acid_Z, gly_ala_gly, and others),
not a wiring bug — confirmed by cross-checking that `MMFF94BondAngleStrict` (Arm E),
which converges much closer to a real minimum, only shows 1 such case.

## Reproducibility / invariance

- Same seed -> identical result: confirmed (unit test + harness spot check).
- Different seeds -> non-aliased output: confirmed.
- All flags off -> byte-identical to raw DG: confirmed structurally (delegation, not
  just tested).
- Two independently-parsed copies of the same SMILES -> identical result (narrower
  than a full atom-relabeling permutation check — see Known Gaps).

## Negative controls (spec §17)

All implemented as unit tests that manufacture the exact bug and confirm the relevant
check fails: applying bounds after smoothing instead of before; reporting a
scored-only ring torsion as applied; hiding a force-field fallback; treating a final
stereo violation as success; counting Unevaluable as Satisfied; returning partial
coords as Ok (type-level: `PipelineV2Failure` has no `coords: Coords3D` field, only
`last_known_coords: Option<Coords3D>`); dropping a failed molecule from the success
denominator; the legacy live API changing at all; accepting NaN/Inf.

## Protecting existing APIs

`generate_coords_etkdg`, `generate_coords`, `generate_conformer_ensemble`,
`generate_conformer_ensemble_with_config` are untouched (no signature/behavior
changes — verified by the full existing test suite passing unchanged, plus a
regression unit test). No Python/WASM/MCP bindings in this PR.

## Commands run (all foreground)

```
cargo fmt --all -- --check                                    PASS
cargo clippy --workspace --all-targets -- -D warnings         PASS
cargo test -p chematic-3d --lib                                PASS (452 passed, 1 ignored: 419 pre-existing [confirmed by checking out base SHA ebb7966 into a scratch worktree and re-running] + 32 from the initial integration + 1 from round 4's amide-pinned regression test)
cargo test -p chematic-3d --tests                              PASS (458 passed: 452 lib + 6 in tests/torsion_knowledge_negative_controls.rs)
cargo test --workspace --lib                                   PASS (0 failed across all crates)
cargo test --workspace --tests                                 PASS (0 failed across all crates)
cargo deny --all-features check                                PASS (advisories/bans/licenses/sources ok; pre-existing duplicate-version warnings unrelated to this PR)
bash scripts/check.sh                                           PASS ("All checks passed.")
cargo run --release -p chematic-3d --example pipeline_v2_integration_gate   PASS (exit 0)
```

## Independent verification

This program's standing practice (PR #190 and #191 each took 3 rounds, real bugs
found every round) applies here too.

**Round 1 complete** (see PR comments): a fresh agent independently re-derived stage
order, applied-vs-scored-only correctness, macrocycle-bounds-before-smoothing wiring
(confirmed empirically via genuine third-party-pair Floyd-Warshall propagation, not
just "coordinates differ"), stereo-after-force-field detection (reproduced live on
the corpus), API non-regression, and all required commands. **Found and fixed**: a
real bug where `check_timeout!` dropped all partial diagnostic evidence on a
mid-pipeline timeout, contradicting this module's own explicit claim (commit
f1df1ee) — plus two disclosed nits (a latent gate-vs-evidence predicate asymmetry,
and an inaccurate doc comment on `applied_to_geometry`). All required commands
re-run clean after the fix; corpus-level success/failure counts are unchanged
(only wall-clock numbers moved). Self-review after round 1 also found and fixed 3
of this PR's own negative-control tests that checked a manufactured struct's
accessor methods rather than exercising the pipeline's real gating logic end-to-end
(now replaced with real `embed_pipeline_v2` calls on real molecules, including one
`#[should_panic]` test proving the applied-vs-scored-only check can actually fail).
A test-count claim in an earlier revision of this PR body was also wrong (see
Commands section) — corrected after checking out the base SHA into a scratch
worktree and re-running, rather than trusting arithmetic on a possibly-stale memory
of an earlier command's output.

**Round 2 complete** (see PR comments): a second, independent fresh agent re-verified
round 1's fix at a stage round 1 never tested (forced a real timeout at stage 4 on
atorvastatin_fragment, confirmed the evidence shape), and independently re-derived 8
more items: failure denominators (manually summed success + every typed-failure row
for 3 arms, confirmed = 58 exactly each time), atom-index correspondence across
stages, macrocycle-1-4 field-mapping correctness (`PairBoundAdjustment` →
`DistanceBoundAdjustment`, no field swap), force-field requested-vs-actual, the
`MACROCYCLE_MIN=9` ring-classification boundary on 2 new molecules, and every
specific numeric claim then in this PR body. All came back CONFIRMED. **Found and
fixed** (commit 092e1ea): stage 12 (the pipeline's last stage) had no
`check_timeout!` after it — every other stage does — so `total_timeout_ms` could be
silently exceeded by stage 12's own O(n²) work with no `Timeout` failure ever
surfacing (confirmed empirically on 166/326-atom molecules). Also fixed a stale
module doc in `etkdg_knowledge/bounds14.rs` that predated this integration.

**Round 3 complete** (see PR comments): a third, independent fresh agent
re-reproduced both prior fixes from scratch (including a fresh real stage-12
timeout overshoot on a 200-atom chain), then covered ground rounds 1-2 had not:
mirror-image (R/S, E/Z) behavior across every corpus pair, `HashMap`-iteration-order
determinism inside `pipeline_v2.rs` itself (none exists — it only iterates `Vec`s),
the no-Python/WASM/MCP-bindings claim, the visibility-only-changes claim
(re-diffed line by line), and an adversarial pass (zero-iteration force-field
config, single-atom molecules, `PipelineV2Config::minimal()` across every force-field
policy). **No new code bug found.** One real, non-blocking finding, now disclosed
below: `chfclbr_R`/`chfclbr_S` (a true enantiomer pair) shows per-seed-dependent
success under `RepairAndVerify` + `Mmff94WithUffFallback` — confirmed at 10 seeds
(2 of which flip which enantiomer is affected) that whichever one needs stage-8
repair at a given seed has its repair walked back across the stereo boundary by
the subsequent UFF-fallback minimization, every time — always caught correctly as
`FinalStereoViolation`, never silently reported as success, but a real reliability
characteristic worth disclosing (generalizes the gly_ala_gly+Dreiding finding
across both mirror-image identity and force-field path).

This program's standing 3-round minimum has been met, with a real bug found and
fixed in each of the first two rounds and genuine new signal in the third — not
three rubber-stamps.

**Round 4 (pre-declaration review) complete:** before reporting this integration
done, a review pass checked whether every number already in this PR body actually
*measures* what it claims, not just reproduces across re-runs. Found and fixed 2
real issues:
1. The gate harness's `n_ambiguous` summed `TorsionKnowledgeReport::ambiguous_matches.len()`
   directly, which conflates `AmbiguousSameTierConflict` (a genuine same-tier rule
   conflict) with `FusedOrBridgedRingBoundary` (a per-bond ring-topology notice
   pushed for nearly every fused/bridged bond) — the exact measurement error PR
   #191 itself had already warned against repeating (its own body: reporting the
   raw vector length "would have overstated genuine rule conflicts," citing
   adamantane's 13 fused/bridged notices vs. 0 real conflicts). Split into two
   separately-tracked counts; corrected: 1 genuine rule conflict (gly_ala_gly's
   peptide bond) vs. 25-31 fused/bridged notices per arm, not the previously
   reported 25-32 "ambiguous rules."
2. 5 of spec §14's explicitly-named required stress molecules were missing from
   the corpus: cyclobutane, cyclooctane, cyclononane, a 2,2'-disubstituted
   biphenyl, and a macrocyclic amide. Two are load-bearing for this PR's own
   mechanism, not just checklist completeness — cyclooctane (8-ring,
   `SMALL_RING_MAX`) and cyclononane (9-ring, `MACROCYCLE_MIN`) are the two sides
   of the small-ring/macrocycle classification boundary that round 2 exercised
   only ad hoc; and no macrocycle previously in the corpus was amide-like, so
   `bounds14.rs`'s `macrocycle_14:amide_ester_pinned` branch had never been
   exercised through the real pipeline (only its `relaxed_band` sibling was).
   Added all 5 (corpus now 63) and added a permanent regression test,
   `macrocycle_14_amide_pinned_branch_is_reachable_through_the_real_pipeline`, so
   coverage of that branch doesn't depend on the gate example alone. Confirmed
   the new molecules land exactly where expected (Arm I typed failures 11→15,
   Arm J scored-only successes 9→13, both by precisely the 4 new ring/macrocycle
   molecules) and surfaced one new, disclosed, unrelated finding: the new
   2,2'-disubstituted biphenyl hits an MMFF94 coverage gap under Arms E/F (see
   known gaps).

All required commands re-run clean after both fixes (see Commands section for the
current, corrected test counts). Unlike rounds 1-3, round 4 was not a fresh
sub-agent with no shared context — it was a review pass against this same agent's
own transcript, so it is weaker evidence of independence than rounds 1-3 and is
disclosed as such, not represented as a 4th from-scratch re-derivation.

**Recommending for merge pending human review — not merged by this agent.**

## Remaining unsupported chemistry / known gaps

- 3-membered rings (cyclopropane/epoxide/aziridine/thiirane) fail closed with
  `BoundsConstructionFailed` at the DG stage — pre-existing Agent C limitation,
  unchanged by this PR.
- `stereo_constraints.rs`'s ring-fused-stereocenter repair limitation
  (testosterone, cholesterol) — pre-existing Agent D limitation, surfaced by this
  integration for the first time via Arm D/G/H/J.
- UFF/DREIDING minimization can reintroduce stereo violations on some flexible
  molecules — newly measured by this PR's gate harness (see above), not a defect
  introduced by this PR.
- `RepairAndVerify` + `Mmff94WithUffFallback`/`Dreiding` success is not symmetric
  across a declared enantiomer pair (round 3 finding): whichever member's raw
  stochastic embedding lands in the wrong chirality basin at a given seed needs
  stage-8 repair, and the subsequent fallback/DREIDING minimization measurably
  walks that repair back across the stereo boundary — confirmed across 10 seeds on
  `chfclbr_R`/`chfclbr_S` (2 of which flip which enantiomer is affected). Always
  caught correctly as a typed `FinalStereoViolation`, never silently reported as
  success — a reliability gap in these two force-field paths specifically, not a
  correctness gap in the pipeline's gating.
- Spec §14's full corpus requirement is only **partially** met. Round 4 closed the
  named-stress-molecule gap: cyclobutane, cyclooctane, cyclononane, a
  2,2'-disubstituted biphenyl, and a macrocyclic amide are now present (corpus
  58→63). Still **not** done: Agent D's own stereo corpus, Agent E's own torsion
  corpus, and a dedicated force-field-failure corpus were not separately
  assembled/merged in, and the corpus is not partitioned into tuning fixtures vs. a
  blinded holdout (the same 63 molecules are used for both). Disclosed, not
  silently substituted.
- Rule-order invariance and full atom-relabeling-permutation equivalence are
  covered only narrowly (unit tests on 1-2 molecules each), not swept across the
  whole corpus.
- The new 2,2'-disubstituted biphenyl (`dimethylbiphenyl_2_2`) added in round 4
  fails Arms E/F (`ForceField(MissingParameters)`) — an MMFF94 atom-typing/coverage
  gap for this substitution pattern, newly surfaced by this round's corpus
  addition, not a pipeline-orchestration defect (Arms G/H/A-D/I/J all succeed on
  it).

No claims of "surpasses RDKit" or "full ETKDGv3 parity" are made anywhere in this PR
or its description.



## Rebased onto post-#193 main + combined-state re-verification (2026-07-29)

Rebased onto `origin/main` after PR #193 (`perf(smiles): prune canonicalization
search by exact automorphism orbits`, merge commit `3e45f55febffa96f7f314a3820be3c5c7f655f1b`)
merged first, per explicit coordinator instruction (broad SMILES-canonicalization
foundation lands before the 3D pipeline, since the two PRs' file sets don't overlap).

- Rebase (`git rebase origin/main`) completed with **zero conflicts** — file sets
  genuinely don't overlap. Old head `0fc39f227dd47675800c62d27290b8ff59fb8e26` →
  new head `a7e6829ea84626bdd42059781ee62f3341ab0e23`.
- Full combined-state re-verification run on the rebased branch (not a repeat of the
  5 independent-verification rounds — those already cover this PR's own logic; this
  re-run checks only for regressions from combining with PR #193's canonicalization
  changes):
  - `cargo fmt --all -- --check` — clean
  - `cargo clippy --workspace --all-targets -- -D warnings` — clean (note:
    `--all-features` fails identically on a plain, unmodified `main` checkout due to
    a pre-existing, unrelated `include_bytes!` relative-path bug in
    `chematic-chem/src/mlp.rs`, confirmed via direct reproduction outside this PR's
    changes — not a regression from this rebase; used the project's actual
    documented clippy invocation, matching `scripts/check.sh` and CI)
  - `cargo test -p chematic-smiles --lib`/`--tests`, `cargo test -p chematic-3d
    --lib`/`--tests`, `cargo test --workspace --lib`/`--tests` — 0 failures
    anywhere (chematic-3d: 452 passed/1 ignored, matching pre-rebase exactly)
  - `cargo deny --all-features check`, `bash scripts/check.sh` — both clean, version
    consistent at `0.7.1`
  - `cargo run --release -p chematic-smiles --example canonical_orbit_perf`
    (with `CANONICAL_ORBIT_PERF_RUN_LEGACY=1` + the 5,000-molecule corpus): 0
    correctness mismatches across all 3 tiers; leaf counts bit-identical to
    pre-#193-merge measurements (6625/153/69037 for old/exhaustive); speedups
    5.44x/1.57x/1.27x (wall-clock, expected to vary run-to-run; the structural
    leaf counts are what's asserted as unchanged)
  - `cargo run --release -p chematic-3d --example pipeline_v2_integration_gate`:
    every structural counter matches the pre-rebase measurement exactly —
    `attempted=63` for all 10 arms, identical per-arm success counts (A/B/C 63/63,
    D 61/63, E/F 33/63, G 55/63 with 22/55 via UFF fallback, H 57/63, I 48/63, J
    61/63), identical typed-failure breakdowns (down to the exact
    `MissingParameters: N missing` counts per molecule under E/F), Arm I/J
    discriminating check unchanged (15 typed `RingTorsionApplicationUnsupported`
    vs. 13 scored-only successes, same 2 confounded molecules —
    testosterone/cholesterol via `StereoRepairFailed`), cyclooctane/cyclononane
    still classify on opposite sides of the small-ring/macrocycle boundary as
    round 4 established.

No regressions found from combining with PR #193 on the same main. This PR's own 5
rounds of independent verification (3 fresh-agent rounds + a self-review pass + a
5th fresh-agent round specifically re-checking the self-review's fix commit
`0fc39f2`, all logged above) are unaffected by the rebase — none of PR #193's
changes touch any file this PR modifies.
