### PR TITLE
perf(smiles): prune canonicalization search by exact automorphism orbits

### DIFF
--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -18,6 +18,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 chematic-core = { path = "../chematic-core", version = "0.7.1" }
 
+[features]
+# Feature-gated internal work counters for the orbit-pruning canonical
+# search (`src/canonical_search.rs`). Off by default -- every counter bump
+# compiles to nothing without this feature, matching the existing
+# `chematic-rxn`/`perf-instrumentation` pattern (`docs/reaction_transform_perf.md`).
+canonical-search-instrumentation = []
+
 [dev-dependencies]
 # Test-only: re-aromatizing after an explicit kekulize+apply_kekule round
 # trip needs perception-level Huckel logic to get back to a fairly

--- a/crates/chematic-smiles/examples/canonical_orbit_perf.rs
+++ b/crates/chematic-smiles/examples/canonical_orbit_perf.rs
@@ -1,0 +1,587 @@
+//! Automorphism-orbit-pruning performance report for `canonical_smiles`.
+//!
+//! Built while implementing `fix/canonical-automorphism-pruning` (see
+//! `docs/canonical_automorphism_pruning.md` and `docs/reaction_transform_perf.md`).
+//! Compares the current orbit-pruned engine (`canonical_smiles`) against the
+//! exact pre-pruning exhaustive search
+//! (`chematic_smiles::canonical::legacy_canonical_smiles_for_benchmark`,
+//! `#[doc(hidden)]`, same code as before this PR, kept only for this
+//! comparison) across three tiers:
+//!
+//! - **Tier A (high symmetry)**: plain rings, cages, PAHs, `CF3`/`tBu`,
+//!   multiple independent Boc/pivaloyl groups, repeated disconnected
+//!   components. Performance gate: >= 80% leaf-count reduction on
+//!   benzene/adamantane/coronene; >= 2x geometric-mean speedup overall; 0
+//!   search-budget exhaustions on the multi-Boc/pivaloyl fixtures.
+//! - **Tier B (low symmetry)**: chiral drug-like/heteroatom-rich molecules.
+//!   Gate: <= 5% geometric-mean regression (most take exactly 1 branch under
+//!   both engines, so this should be near-zero by construction).
+//! - **Tier C (external corpus, optional)**: one SMILES per line via
+//!   `CANONICAL_ORBIT_PERF_CORPUS=/path/to/file.smi`. Never required to be
+//!   present in this repository -- point it at, e.g., `~/Downloads/SMILES.csv`
+//!   (the project's 5,000-molecule benchmark corpus, see `scripts/bench5k.py`)
+//!   or any other externally supplied file. Correctness differential (old
+//!   string == new string) is a hard gate across every tier.
+//!
+//! Run:
+//! ```text
+//! cargo run --release -p chematic-smiles --example canonical_orbit_perf
+//! cargo run --release -p chematic-smiles --features canonical-search-instrumentation \
+//!     --example canonical_orbit_perf
+//! CANONICAL_ORBIT_PERF_CORPUS=~/Downloads/SMILES.csv \
+//!     cargo run --release -p chematic-smiles --example canonical_orbit_perf
+//! ```
+
+use std::env;
+use std::fs;
+use std::time::{Duration, Instant};
+
+use chematic_smiles::canonical::{
+    legacy_branch_count_for_benchmark, legacy_canonical_smiles_for_benchmark,
+};
+use chematic_smiles::{
+    CanonicalSearchStats, canonical_smiles, parse, reset_search_stats, search_stats_snapshot,
+};
+
+struct Stats {
+    durations: Vec<Duration>,
+}
+
+impl Stats {
+    fn new() -> Self {
+        Self {
+            durations: Vec::new(),
+        }
+    }
+
+    fn percentile(&self, p: f64) -> Duration {
+        if self.durations.is_empty() {
+            return Duration::ZERO;
+        }
+        let mut sorted = self.durations.clone();
+        sorted.sort_unstable();
+        let idx = ((sorted.len() - 1) as f64 * p).round() as usize;
+        sorted[idx]
+    }
+
+    fn max(&self) -> Duration {
+        self.durations
+            .iter()
+            .copied()
+            .max()
+            .unwrap_or(Duration::ZERO)
+    }
+
+    fn total(&self) -> Duration {
+        self.durations.iter().sum()
+    }
+
+    /// Geometric mean, in nanoseconds. Zero-duration entries are floored to
+    /// 1ns so a free-running clock's occasional true-zero sample doesn't
+    /// poison the product with a zero.
+    fn geomean_ns(&self) -> f64 {
+        if self.durations.is_empty() {
+            return 0.0;
+        }
+        let log_sum: f64 = self
+            .durations
+            .iter()
+            .map(|d| (d.as_nanos().max(1) as f64).ln())
+            .sum();
+        (log_sum / self.durations.len() as f64).exp()
+    }
+}
+
+fn fmt_dur(d: Duration) -> String {
+    if d.as_micros() < 1000 {
+        format!("{}us", d.as_micros())
+    } else {
+        format!("{:.2}ms", d.as_secs_f64() * 1000.0)
+    }
+}
+
+/// Tier A: high-symmetry fixtures. Cubane is built programmatically (cube
+/// graph Q3, 8 atoms/12 bonds, |Aut|=48) rather than reusing this repo's
+/// pre-existing "cubane" SMILES fixture used elsewhere
+/// (`C12C3C4C1C1C2C3C41`, an 11-bond graph -- NOT a valid cube graph), per
+/// this task's explicit instruction not to reuse that mislabeled fixture.
+fn tier_a_high_symmetry() -> Vec<(&'static str, String)> {
+    let mut v: Vec<(&'static str, String)> = vec![
+        ("benzene", "c1ccccc1".to_string()),
+        ("cyclohexane", "C1CCCCC1".to_string()),
+        ("neopentane", "CC(C)(C)C".to_string()),
+        ("tert-butanol", "CC(C)(C)O".to_string()),
+        ("trifluoromethylbenzene", "FC(F)(F)c1ccccc1".to_string()),
+        ("adamantane", "C1C2CC3CC1CC(C2)C3".to_string()),
+        ("naphthalene", "c1ccc2ccccc2c1".to_string()),
+        ("biphenyl", "c1ccc(-c2ccccc2)cc1".to_string()),
+        (
+            "multi-Boc intermediate",
+            "CC(C)(C)OC(=O)NCC(CCNC(=O)OC(C)(C)C)CNC(=O)OC(C)(C)C".to_string(),
+        ),
+        (
+            "multi-pivaloyl intermediate",
+            "CC(C)(C)C(=O)NCC(CCNC(=O)C(C)(C)C)CNC(=O)C(C)(C)C".to_string(),
+        ),
+        (
+            "repeated disconnected components",
+            "CC(C)(C)C.CC(C)(C)C.CC(C)(C)C".to_string(),
+        ),
+    ];
+    v.push(("cubane", cubane_smiles()));
+    v.push(("coronene", coronene_smiles()));
+    v
+}
+
+/// Build a correct cube graph (Q3): two 4-cycles `0-1-2-3-0` and
+/// `4-5-6-7-4`, joined by the 4 "vertical" edges `0-4, 1-5, 2-6, 3-7`. Every
+/// vertex has degree 3, 8 atoms, 12 bonds -- the real cubane skeleton
+/// (`|Aut(Q3)| = 48`), unlike this repo's pre-existing, differently-shaped
+/// "cubane" SMILES fixture used elsewhere (11 bonds).
+fn cubane_smiles() -> String {
+    use chematic_core::{BondOrder, Element, MoleculeBuilder};
+    let mut b = MoleculeBuilder::new();
+    let atoms: Vec<_> = (0..8)
+        .map(|_| b.add_atom(chematic_core::Atom::organic(Element::C)))
+        .collect();
+    let edges: [(usize, usize); 12] = [
+        (0, 1),
+        (1, 2),
+        (2, 3),
+        (3, 0),
+        (4, 5),
+        (5, 6),
+        (6, 7),
+        (7, 4),
+        (0, 4),
+        (1, 5),
+        (2, 6),
+        (3, 7),
+    ];
+    for (i, j) in edges {
+        b.add_bond(atoms[i], atoms[j], BondOrder::Single).unwrap();
+    }
+    let mol = b.build();
+    assert_eq!(mol.atom_count(), 8);
+    assert_eq!(mol.bond_count(), 12);
+    for i in 0..8 {
+        assert_eq!(
+            mol.degree(chematic_core::AtomIdx(i as u32)),
+            3,
+            "cube graph must be 3-regular"
+        );
+    }
+    canonical_smiles(&mol)
+}
+
+/// Build a verified, correctly-sized coronene skeleton (C24H12, 24 atoms,
+/// 30 bonds, 7 fused aromatic hexagons) geometrically: a flower of 7 unit
+/// hexagons (1 center + 6 pointy-top neighbors) in axial hex coordinates,
+/// corners deduped by rounded pixel coordinate, edges taken from each
+/// hexagon's own 6-cycle (also deduped where two hexagons share an edge).
+///
+/// This project's own pre-existing `coronene` test fixture elsewhere in
+/// this repo (`c1ccc2ccc3ccc4ccc5ccc6ccccc6c5c4c3c2c1`, used by the
+/// previously-`#[ignore]`d `coronene_canonical_known_bug` test) was found
+/// during this task to parse to **26** atoms, not the 24 a real coronene
+/// (C24H12) has -- the same class of mislabeled-fixture problem this task
+/// was warned about for "cubane" elsewhere in this repo. That pre-existing
+/// fixture's test coverage is still valid (it is a real, if differently
+/// sized, highly symmetric fused-ring molecule, and the idempotence fix it
+/// exercises is real -- see `docs/canonical_automorphism_pruning.md`), but
+/// this function builds an independently *verified* correctly-sized
+/// coronene from first principles (geometric construction, not a
+/// hand-typed/memorized SMILES string) for this task's own performance
+/// gate, which specifically names "coronene" as a required fixture.
+fn coronene_smiles() -> String {
+    use chematic_core::{Atom, AtomIdx, BondIdx, BondOrder, Element, MoleculeBuilder};
+    use std::collections::{HashMap, HashSet};
+
+    let axial_centers: [(i64, i64); 7] =
+        [(0, 0), (1, 0), (1, -1), (0, -1), (-1, 0), (-1, 1), (0, 1)];
+    let size = 1.0_f64;
+    let key = |x: f64, y: f64| -> (i64, i64) {
+        ((x * 1000.0).round() as i64, (y * 1000.0).round() as i64)
+    };
+
+    let mut corner_of: HashMap<(i64, i64), AtomIdx> = HashMap::new();
+    let mut builder = MoleculeBuilder::new();
+    let mut seen_edges: HashSet<(i64, i64, i64, i64)> = HashSet::new();
+
+    for &(q, r) in &axial_centers {
+        let cx = size * (3f64.sqrt() * q as f64 + 3f64.sqrt() / 2.0 * r as f64);
+        let cy = size * (1.5 * r as f64);
+        let mut ring_atoms = Vec::with_capacity(6);
+        for i in 0..6 {
+            let angle = (std::f64::consts::PI / 180.0) * (60.0 * i as f64 - 30.0);
+            let x = cx + size * angle.cos();
+            let y = cy + size * angle.sin();
+            let k = key(x, y);
+            let atom = *corner_of
+                .entry(k)
+                .or_insert_with(|| builder.add_atom(Atom::organic(Element::C)));
+            ring_atoms.push((k, atom));
+        }
+        for i in 0..6 {
+            let (ka, a) = ring_atoms[i];
+            let (kb, b) = ring_atoms[(i + 1) % 6];
+            let ek = if ka <= kb {
+                (ka.0, ka.1, kb.0, kb.1)
+            } else {
+                (kb.0, kb.1, ka.0, ka.1)
+            };
+            if seen_edges.insert(ek) {
+                builder.add_bond(a, b, BondOrder::Single).unwrap();
+            }
+        }
+    }
+    let skeleton = builder.build();
+    assert_eq!(
+        skeleton.atom_count(),
+        24,
+        "coronene must have 24 carbons (C24H12)"
+    );
+    assert_eq!(
+        skeleton.bond_count(),
+        30,
+        "coronene skeleton must have 30 bonds"
+    );
+
+    // Find a Kekule structure (perfect matching: every atom incident to
+    // exactly one double bond) via trivial backtracking.
+    fn find_matching(mol: &chematic_core::Molecule) -> Vec<BondIdx> {
+        let n = mol.atom_count();
+        let mut matched = vec![false; n];
+        let mut chosen = Vec::new();
+        fn go(
+            mol: &chematic_core::Molecule,
+            matched: &mut [bool],
+            chosen: &mut Vec<BondIdx>,
+        ) -> bool {
+            let n = matched.len();
+            let Some(u) = (0..n).find(|&i| !matched[i]) else {
+                return true;
+            };
+            let candidates: Vec<(AtomIdx, BondIdx)> = mol
+                .neighbors(AtomIdx(u as u32))
+                .filter(|(nb, _)| !matched[nb.0 as usize])
+                .collect();
+            for (nb, bidx) in candidates {
+                matched[u] = true;
+                matched[nb.0 as usize] = true;
+                chosen.push(bidx);
+                if go(mol, matched, chosen) {
+                    return true;
+                }
+                chosen.pop();
+                matched[u] = false;
+                matched[nb.0 as usize] = false;
+            }
+            false
+        }
+        assert!(
+            go(mol, &mut matched, &mut chosen),
+            "coronene skeleton has no Kekule structure"
+        );
+        chosen
+    }
+    let matching: HashSet<BondIdx> = find_matching(&skeleton).into_iter().collect();
+
+    let mut kek_builder = MoleculeBuilder::new();
+    for (_, atom) in skeleton.atoms() {
+        kek_builder.add_atom(atom.clone());
+    }
+    for (bidx, bond) in skeleton.bonds() {
+        let order = if matching.contains(&bidx) {
+            BondOrder::Double
+        } else {
+            BondOrder::Single
+        };
+        kek_builder.add_bond(bond.atom1, bond.atom2, order).unwrap();
+    }
+    let kekule_mol = kek_builder.build();
+
+    let aromatic_mol = chematic_perception::apply_aromaticity(&kekule_mol);
+    let rings = chematic_perception::count_aromatic_rings(&aromatic_mol);
+    assert_eq!(rings, 7, "coronene must have 7 aromatic rings");
+    canonical_smiles(&aromatic_mol)
+}
+
+/// Tier B: low-symmetry negative-control fixtures (chiral drug-like,
+/// heteroatom-rich). These should need exactly 1 individualize-refine
+/// branch under both engines, so orbit pruning has ~nothing to prune -- the
+/// gate here is that pruning must not *regress* this common case.
+fn tier_b_low_symmetry() -> Vec<(&'static str, String)> {
+    vec![
+        (
+            "cholesterol-like steroid",
+            "CC(C)CCC[C@@H](C)[C@H]1CC[C@H]2[C@@H]3CC=C4C[C@@H](O)CC[C@]4(C)[C@H]3CC[C@]12C"
+                .to_string(),
+        ),
+        (
+            "morphine-like polycyclic alkaloid",
+            "CN1CC[C@]23c4c5ccc(O)c4O[C@H]2C(=O)CC[C@H]3[C@H]1C5".to_string(),
+        ),
+        ("ibuprofen", "CC(C)Cc1ccc(cc1)C(C)C(=O)O".to_string()),
+        ("L-alanine", "N[C@@H](C)C(=O)O".to_string()),
+        (
+            "heteroatom-rich asymmetric",
+            "O=C(NCc1cccnc1)NC[C@H]1CCC[C@H](OCc2cc(C(F)(F)F)cc(C(F)(F)F)c2)[C@@H]1c1ccccc1"
+                .to_string(),
+        ),
+        ("caffeine", "Cn1cnc2c1c(=O)n(c(=O)n2C)C".to_string()),
+    ]
+}
+
+fn tier_c_external_corpus() -> Option<Vec<(String, String)>> {
+    let path = env::var("CANONICAL_ORBIT_PERF_CORPUS").ok()?;
+    let contents =
+        fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
+    Some(
+        contents
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .enumerate()
+            .map(|(i, l)| {
+                (
+                    format!("corpus#{i}"),
+                    l.split_whitespace().next().unwrap_or(l).to_string(),
+                )
+            })
+            .collect(),
+    )
+}
+
+struct TierReport {
+    name: &'static str,
+    old_stats: Stats,
+    new_stats: Stats,
+    mismatches: Vec<String>,
+    parse_failures: usize,
+    empty_outputs: usize,
+    n: usize,
+    /// Cumulative orbit-search instrumentation across every fixture in this
+    /// tier (all-zero when `canonical-search-instrumentation` is disabled --
+    /// see `canonical_search::stats`).
+    search: CanonicalSearchStats,
+    /// Sum of `legacy_branch_count_for_benchmark` across every fixture --
+    /// the old engine's exhaustive leaf count, independent of the
+    /// instrumentation feature (always available).
+    old_branch_count: usize,
+}
+
+fn add_stats(a: &CanonicalSearchStats, b: &CanonicalSearchStats) -> CanonicalSearchStats {
+    CanonicalSearchStats {
+        nodes_visited: a.nodes_visited + b.nodes_visited,
+        leaves_written: a.leaves_written + b.leaves_written,
+        orbit_tests: a.orbit_tests + b.orbit_tests,
+        orbit_unions: a.orbit_unions + b.orbit_unions,
+        children_pruned: a.children_pruned + b.children_pruned,
+        max_depth: a.max_depth.max(b.max_depth),
+        largest_target_cell: a.largest_target_cell.max(b.largest_target_cell),
+        budget_exhaustions: a.budget_exhaustions + b.budget_exhaustions,
+    }
+}
+
+fn run_tier(name: &'static str, fixtures: &[(String, String)], run_legacy: bool) -> TierReport {
+    let mut old_stats = Stats::new();
+    let mut new_stats = Stats::new();
+    let mut mismatches = Vec::new();
+    let mut parse_failures = 0;
+    let mut empty_outputs = 0;
+    let mut search = CanonicalSearchStats::default();
+    let mut old_branch_count = 0usize;
+
+    for (label, smi) in fixtures {
+        let mol = match parse(smi) {
+            Ok(m) => m,
+            Err(_) => {
+                parse_failures += 1;
+                continue;
+            }
+        };
+
+        reset_search_stats();
+        let t0 = Instant::now();
+        let new_out = canonical_smiles(&mol);
+        new_stats.durations.push(t0.elapsed());
+        let per_fixture = search_stats_snapshot();
+        search = add_stats(&search, &per_fixture);
+
+        if env::var("CANONICAL_ORBIT_PERF_VERBOSE").is_ok() {
+            let old_leaves = if run_legacy {
+                legacy_branch_count_for_benchmark(&mol)
+            } else {
+                0
+            };
+            println!(
+                "    [{label}] old_leaves={old_leaves} new_leaves={} nodes={} orbit_tests={} \
+                 children_pruned={}",
+                per_fixture.leaves_written,
+                per_fixture.nodes_visited,
+                per_fixture.orbit_tests,
+                per_fixture.children_pruned
+            );
+        }
+
+        if new_out.is_empty() {
+            empty_outputs += 1;
+        }
+
+        if run_legacy {
+            let t1 = Instant::now();
+            let old_out = legacy_canonical_smiles_for_benchmark(&mol);
+            old_stats.durations.push(t1.elapsed());
+            old_branch_count += legacy_branch_count_for_benchmark(&mol);
+
+            if old_out != new_out {
+                mismatches.push(format!("{label} ({smi}): old='{old_out}' new='{new_out}'"));
+            }
+        }
+    }
+
+    TierReport {
+        name,
+        old_stats,
+        search,
+        old_branch_count,
+        new_stats,
+        mismatches,
+        parse_failures,
+        empty_outputs,
+        n: fixtures.len(),
+    }
+}
+
+fn print_report(r: &TierReport) {
+    println!("\n=== {} ({} fixtures) ===", r.name, r.n);
+    println!("  parse failures: {}", r.parse_failures);
+    println!("  empty outputs:  {}", r.empty_outputs);
+    println!(
+        "  correctness mismatches (old vs new): {}",
+        r.mismatches.len()
+    );
+    for m in &r.mismatches {
+        println!("    MISMATCH: {m}");
+    }
+    if !r.old_stats.durations.is_empty() {
+        println!(
+            "  old: p50={} p95={} max={} total={} geomean={:.0}ns",
+            fmt_dur(r.old_stats.percentile(0.50)),
+            fmt_dur(r.old_stats.percentile(0.95)),
+            fmt_dur(r.old_stats.max()),
+            fmt_dur(r.old_stats.total()),
+            r.old_stats.geomean_ns()
+        );
+    }
+    println!(
+        "  new: p50={} p95={} max={} total={} geomean={:.0}ns",
+        fmt_dur(r.new_stats.percentile(0.50)),
+        fmt_dur(r.new_stats.percentile(0.95)),
+        fmt_dur(r.new_stats.max()),
+        fmt_dur(r.new_stats.total()),
+        r.new_stats.geomean_ns()
+    );
+    if !r.old_stats.durations.is_empty() {
+        let speedup = r.old_stats.geomean_ns() / r.new_stats.geomean_ns().max(1.0);
+        println!("  geometric-mean speedup (old/new): {speedup:.2}x");
+    }
+    if r.old_branch_count > 0 {
+        println!(
+            "  leaf count: old (exhaustive) = {}, new (orbit-pruned, requires \
+             --features canonical-search-instrumentation for a nonzero value) = {}",
+            r.old_branch_count, r.search.leaves_written
+        );
+        if r.search.leaves_written > 0 {
+            let reduction = 100.0 * (r.old_branch_count as f64 - r.search.leaves_written as f64)
+                / r.old_branch_count as f64;
+            println!("    leaf-count reduction (old -> new): {reduction:.1}%");
+        }
+    }
+    println!(
+        "  orbit search (new engine, cumulative; all-zero unless built with \
+         --features canonical-search-instrumentation):"
+    );
+    println!(
+        "    nodes_visited={} leaves_written={} orbit_tests={} orbit_unions={} \
+         children_pruned={} max_depth={} largest_target_cell={} budget_exhaustions={}",
+        r.search.nodes_visited,
+        r.search.leaves_written,
+        r.search.orbit_tests,
+        r.search.orbit_unions,
+        r.search.children_pruned,
+        r.search.max_depth,
+        r.search.largest_target_cell,
+        r.search.budget_exhaustions
+    );
+}
+
+fn main() {
+    println!("Canonical SMILES automorphism-orbit-pruning performance report");
+    println!("(see docs/canonical_automorphism_pruning.md)");
+
+    let tier_a: Vec<(String, String)> = tier_a_high_symmetry()
+        .into_iter()
+        .map(|(n, s)| (n.to_string(), s))
+        .collect();
+    let tier_b: Vec<(String, String)> = tier_b_low_symmetry()
+        .into_iter()
+        .map(|(n, s)| (n.to_string(), s))
+        .collect();
+
+    let report_a = run_tier("Tier A: high symmetry", &tier_a, true);
+    print_report(&report_a);
+
+    let report_b = run_tier("Tier B: low symmetry (negative control)", &tier_b, true);
+    print_report(&report_b);
+
+    if let Some(corpus) = tier_c_external_corpus() {
+        println!(
+            "\nTier C external corpus: {} molecules loaded",
+            corpus.len()
+        );
+        // Old engine is intentionally SKIPPED on a large external corpus by
+        // default (it is exhaustive/unbounded-cap and can be extremely slow
+        // on genuinely large symmetric molecules); set
+        // CANONICAL_ORBIT_PERF_RUN_LEGACY=1 to force the full old-vs-new
+        // differential anyway.
+        let run_legacy = env::var("CANONICAL_ORBIT_PERF_RUN_LEGACY").is_ok();
+        let report_c = run_tier("Tier C: external corpus", &corpus, run_legacy);
+        print_report(&report_c);
+        assert_eq!(
+            report_c.mismatches.len(),
+            0,
+            "external corpus produced {} old-vs-new canonical string differences",
+            report_c.mismatches.len()
+        );
+        assert_eq!(
+            report_c.empty_outputs, 0,
+            "external corpus produced empty canonical output(s)"
+        );
+    } else {
+        println!(
+            "\nTier C external corpus: not configured (set CANONICAL_ORBIT_PERF_CORPUS=/path/to/file.smi)"
+        );
+    }
+
+    assert_eq!(
+        report_a.mismatches.len(),
+        0,
+        "Tier A produced old-vs-new mismatches"
+    );
+    assert_eq!(
+        report_b.mismatches.len(),
+        0,
+        "Tier B produced old-vs-new mismatches"
+    );
+    assert_eq!(
+        report_a.empty_outputs, 0,
+        "Tier A produced empty canonical output(s)"
+    );
+    assert_eq!(
+        report_b.empty_outputs, 0,
+        "Tier B produced empty canonical output(s)"
+    );
+
+    println!("\nAll correctness gates passed.");
+}

--- a/crates/chematic-smiles/examples/canonical_orbit_perf.rs
+++ b/crates/chematic-smiles/examples/canonical_orbit_perf.rs
@@ -20,15 +20,28 @@
 //!   `CANONICAL_ORBIT_PERF_CORPUS=/path/to/file.smi`. Never required to be
 //!   present in this repository -- point it at, e.g., `~/Downloads/SMILES.csv`
 //!   (the project's 5,000-molecule benchmark corpus, see `scripts/bench5k.py`)
-//!   or any other externally supplied file. Correctness differential (old
-//!   string == new string) is a hard gate across every tier.
+//!   or any other externally supplied file.
+//!
+//! Correctness differential (old string == new string) is a hard gate on
+//! Tiers A and B unconditionally. On Tier C it additionally requires
+//! `CANONICAL_ORBIT_PERF_RUN_LEGACY=1` (see below) -- **without it, the old
+//! engine never runs on the corpus and the differential is SKIPPED, not
+//! passed**; the report and exit status say so explicitly rather than
+//! silently asserting 0 mismatches against zero comparisons (a real gap an
+//! independent Round-3 performance-claim audit found in this file, PR #193).
 //!
 //! Run:
 //! ```text
 //! cargo run --release -p chematic-smiles --example canonical_orbit_perf
 //! cargo run --release -p chematic-smiles --features canonical-search-instrumentation \
 //!     --example canonical_orbit_perf
+//! # Timing/leaf-count only on Tier C, correctness differential SKIPPED there:
 //! CANONICAL_ORBIT_PERF_CORPUS=~/Downloads/SMILES.csv \
+//!     cargo run --release -p chematic-smiles --example canonical_orbit_perf
+//! # Full old-vs-new correctness differential on Tier C too (slower: runs the
+//! # exhaustive legacy engine on every corpus molecule):
+//! CANONICAL_ORBIT_PERF_CORPUS=~/Downloads/SMILES.csv \
+//! CANONICAL_ORBIT_PERF_RUN_LEGACY=1 \
 //!     cargo run --release -p chematic-smiles --example canonical_orbit_perf
 //! ```
 
@@ -360,6 +373,12 @@ struct TierReport {
     parse_failures: usize,
     empty_outputs: usize,
     n: usize,
+    /// Whether the old-vs-new correctness differential actually ran for this
+    /// tier (`run_legacy` as passed to `run_tier`). When `false`,
+    /// `mismatches` is trivially empty because it was never populated --
+    /// callers must not read `mismatches.is_empty()` as "0 verified
+    /// mismatches" in that case. See the module doc comment.
+    differential_ran: bool,
     /// Cumulative orbit-search instrumentation across every fixture in this
     /// tier (all-zero when `canonical-search-instrumentation` is disabled --
     /// see `canonical_search::stats`).
@@ -392,7 +411,7 @@ fn run_tier(name: &'static str, fixtures: &[(String, String)], run_legacy: bool)
     let mut search = CanonicalSearchStats::default();
     let mut old_branch_count = 0usize;
 
-    for (label, smi) in fixtures {
+    for (i, (label, smi)) in fixtures.iter().enumerate() {
         let mol = match parse(smi) {
             Ok(m) => m,
             Err(_) => {
@@ -401,42 +420,95 @@ fn run_tier(name: &'static str, fixtures: &[(String, String)], run_legacy: bool)
             }
         };
 
-        reset_search_stats();
-        let t0 = Instant::now();
-        let new_out = canonical_smiles(&mol);
-        new_stats.durations.push(t0.elapsed());
-        let per_fixture = search_stats_snapshot();
-        search = add_stats(&search, &per_fixture);
+        // Alternate which engine's timer starts first, by fixture index.
+        // An independent Round-3 performance-claim audit found (via a
+        // throwaway microbench, since deleted) that whichever arm runs
+        // first in this loop measures ~10-15% slower regardless of which
+        // engine it is -- a harness artifact, not a real per-call effect.
+        // Always timing new-then-old (the previous behavior) biased every
+        // per-call comparison in the same direction; alternating cancels it
+        // out in aggregate instead of just disclosing it.
+        let new_first = i % 2 == 0;
 
-        if env::var("CANONICAL_ORBIT_PERF_VERBOSE").is_ok() {
-            let old_leaves = if run_legacy {
-                legacy_branch_count_for_benchmark(&mol)
+        let (new_out, old_out_opt);
+        if new_first {
+            reset_search_stats();
+            let t0 = Instant::now();
+            let out = canonical_smiles(&mol);
+            new_stats.durations.push(t0.elapsed());
+            let per_fixture = search_stats_snapshot();
+            search = add_stats(&search, &per_fixture);
+            new_out = out;
+
+            old_out_opt = if run_legacy {
+                let t1 = Instant::now();
+                let out = legacy_canonical_smiles_for_benchmark(&mol);
+                old_stats.durations.push(t1.elapsed());
+                old_branch_count += legacy_branch_count_for_benchmark(&mol);
+                Some(out)
             } else {
-                0
+                None
             };
-            println!(
-                "    [{label}] old_leaves={old_leaves} new_leaves={} nodes={} orbit_tests={} \
-                 children_pruned={}",
-                per_fixture.leaves_written,
-                per_fixture.nodes_visited,
-                per_fixture.orbit_tests,
-                per_fixture.children_pruned
-            );
+
+            if env::var("CANONICAL_ORBIT_PERF_VERBOSE").is_ok() {
+                let old_leaves = if run_legacy {
+                    legacy_branch_count_for_benchmark(&mol)
+                } else {
+                    0
+                };
+                println!(
+                    "    [{label}] old_leaves={old_leaves} new_leaves={} nodes={} orbit_tests={} \
+                     children_pruned={}",
+                    per_fixture.leaves_written,
+                    per_fixture.nodes_visited,
+                    per_fixture.orbit_tests,
+                    per_fixture.children_pruned
+                );
+            }
+        } else {
+            old_out_opt = if run_legacy {
+                let t1 = Instant::now();
+                let out = legacy_canonical_smiles_for_benchmark(&mol);
+                old_stats.durations.push(t1.elapsed());
+                old_branch_count += legacy_branch_count_for_benchmark(&mol);
+                Some(out)
+            } else {
+                None
+            };
+
+            reset_search_stats();
+            let t0 = Instant::now();
+            let out = canonical_smiles(&mol);
+            new_stats.durations.push(t0.elapsed());
+            let per_fixture = search_stats_snapshot();
+            search = add_stats(&search, &per_fixture);
+            new_out = out;
+
+            if env::var("CANONICAL_ORBIT_PERF_VERBOSE").is_ok() {
+                let old_leaves = if run_legacy {
+                    legacy_branch_count_for_benchmark(&mol)
+                } else {
+                    0
+                };
+                println!(
+                    "    [{label}] old_leaves={old_leaves} new_leaves={} nodes={} orbit_tests={} \
+                     children_pruned={}",
+                    per_fixture.leaves_written,
+                    per_fixture.nodes_visited,
+                    per_fixture.orbit_tests,
+                    per_fixture.children_pruned
+                );
+            }
         }
 
         if new_out.is_empty() {
             empty_outputs += 1;
         }
 
-        if run_legacy {
-            let t1 = Instant::now();
-            let old_out = legacy_canonical_smiles_for_benchmark(&mol);
-            old_stats.durations.push(t1.elapsed());
-            old_branch_count += legacy_branch_count_for_benchmark(&mol);
-
-            if old_out != new_out {
-                mismatches.push(format!("{label} ({smi}): old='{old_out}' new='{new_out}'"));
-            }
+        if let Some(old_out) = old_out_opt
+            && old_out != new_out
+        {
+            mismatches.push(format!("{label} ({smi}): old='{old_out}' new='{new_out}'"));
         }
     }
 
@@ -450,6 +522,7 @@ fn run_tier(name: &'static str, fixtures: &[(String, String)], run_legacy: bool)
         parse_failures,
         empty_outputs,
         n: fixtures.len(),
+        differential_ran: run_legacy,
     }
 }
 
@@ -457,12 +530,19 @@ fn print_report(r: &TierReport) {
     println!("\n=== {} ({} fixtures) ===", r.name, r.n);
     println!("  parse failures: {}", r.parse_failures);
     println!("  empty outputs:  {}", r.empty_outputs);
-    println!(
-        "  correctness mismatches (old vs new): {}",
-        r.mismatches.len()
-    );
-    for m in &r.mismatches {
-        println!("    MISMATCH: {m}");
+    if r.differential_ran {
+        println!(
+            "  correctness mismatches (old vs new): {}",
+            r.mismatches.len()
+        );
+        for m in &r.mismatches {
+            println!("    MISMATCH: {m}");
+        }
+    } else {
+        println!(
+            "  correctness differential: SKIPPED (old engine not run for this tier -- \
+             set CANONICAL_ORBIT_PERF_RUN_LEGACY=1 to actually check old-vs-new agreement)"
+        );
     }
     if !r.old_stats.durations.is_empty() {
         println!(
@@ -535,6 +615,11 @@ fn main() {
     let report_b = run_tier("Tier B: low symmetry (negative control)", &tier_b, true);
     print_report(&report_b);
 
+    // `None` = no corpus configured; `Some(true)` = Tier C's differential
+    // actually ran; `Some(false)` = corpus loaded but the differential was
+    // skipped (see below) -- drives the final summary line's wording.
+    let mut tier_c_differential_ran: Option<bool> = None;
+
     if let Some(corpus) = tier_c_external_corpus() {
         println!(
             "\nTier C external corpus: {} molecules loaded",
@@ -546,14 +631,23 @@ fn main() {
         // CANONICAL_ORBIT_PERF_RUN_LEGACY=1 to force the full old-vs-new
         // differential anyway.
         let run_legacy = env::var("CANONICAL_ORBIT_PERF_RUN_LEGACY").is_ok();
+        tier_c_differential_ran = Some(run_legacy);
         let report_c = run_tier("Tier C: external corpus", &corpus, run_legacy);
         print_report(&report_c);
-        assert_eq!(
-            report_c.mismatches.len(),
-            0,
-            "external corpus produced {} old-vs-new canonical string differences",
-            report_c.mismatches.len()
-        );
+        if run_legacy {
+            assert_eq!(
+                report_c.mismatches.len(),
+                0,
+                "external corpus produced {} old-vs-new canonical string differences",
+                report_c.mismatches.len()
+            );
+        } else {
+            println!(
+                "\nTier C correctness differential: SKIPPED (CANONICAL_ORBIT_PERF_RUN_LEGACY not \
+                 set) -- this run is leaf-count/timing-only, NOT a verified 0-mismatch claim. \
+                 Re-run with CANONICAL_ORBIT_PERF_RUN_LEGACY=1 to actually check."
+            );
+        }
         assert_eq!(
             report_c.empty_outputs, 0,
             "external corpus produced empty canonical output(s)"
@@ -583,5 +677,11 @@ fn main() {
         "Tier B produced empty canonical output(s)"
     );
 
-    println!("\nAll correctness gates passed.");
+    match tier_c_differential_ran {
+        Some(false) => println!(
+            "\nAll correctness gates passed for Tier A/B. Tier C's differential was SKIPPED \
+             (see above) -- not a verified 0-mismatch claim for Tier C."
+        ),
+        _ => println!("\nAll correctness gates passed."),
+    }
 }

--- a/crates/chematic-smiles/src/canonical.rs
+++ b/crates/chematic-smiles/src/canonical.rs
@@ -154,6 +154,37 @@ pub(crate) fn canonical_smiles_exhaustive_oracle(mol: &Molecule) -> String {
         .unwrap_or_default()
 }
 
+/// Same ground truth as [`canonical_smiles_exhaustive_oracle`], but also
+/// returns the winning rank vector -- found necessary during independent
+/// Round-1 correctness review (PR #193): the existing oracle checks only
+/// ever compared the winning canonical *string*, never the *rank vector*
+/// `canonical_search::winning_individualized_ranks_with_limits` also
+/// returns and the public `canonical_atom_order` API consumes. Two branches
+/// within one automorphism orbit can legitimately share a minimal string
+/// via different rank vectors, so string equality alone does not prove
+/// rank-vector equality. Compare the orbit-pruned engine's rank vector
+/// against *this* (the unbounded exhaustive oracle's), not against
+/// `legacy_winning_individualized_ranks`'s -- the legacy engine's own
+/// winning leaf can legitimately differ too (same reason, independently
+/// flagged by Round 2), so oracle-vs-oracle is the correct ground truth.
+#[cfg(test)]
+pub(crate) fn canonical_smiles_exhaustive_oracle_with_ranks(mol: &Molecule) -> (Vec<u64>, String) {
+    if mol.atom_count() == 0 {
+        return (Vec::new(), String::new());
+    }
+    let plateaued = morgan_ranks(mol);
+    let mut budget = usize::MAX;
+    let branches = enumerate_discrete_ranks(mol, plateaued, &mut budget);
+    branches
+        .into_iter()
+        .map(|ranks| {
+            let s = CanonicalWriter::new(mol, &ranks).write_all();
+            (ranks, s)
+        })
+        .min_by(|(_, a), (_, b)| a.cmp(b))
+        .unwrap_or_default()
+}
+
 /// Return `true` if atoms `a` and `b` are topologically equivalent (symmetric).
 ///
 /// Two atoms are considered equivalent when they have the same Morgan rank —

--- a/crates/chematic-smiles/src/canonical.rs
+++ b/crates/chematic-smiles/src/canonical.rs
@@ -59,7 +59,35 @@ pub fn canonical_atom_order(mol: &Molecule) -> Vec<usize> {
 /// traversal on every single call (perf; issue found bisecting the
 /// `run_reactants`/`apply_retro` regression between chematic 0.4.25 and
 /// 0.4.30 -- see docs/reaction_transform_perf.md).
+///
+/// As of this PR, the actual search is `canonical_search::
+/// winning_individualized_ranks_with_limits` (automorphism-orbit-pruned,
+/// streaming, called here with `CanonicalizationLimits::unbounded()`),
+/// which is provably equivalent to (a strict subset of the same candidate
+/// (ranks, string) pairs considered by) the legacy exhaustive enumeration
+/// below -- see `docs/canonical_automorphism_pruning.md`. The legacy
+/// exhaustive path (`legacy_winning_individualized_ranks`) is kept as a
+/// last-resort fallback for the astronomically-rare case of an internal bug
+/// in the new engine (`CanonicalizationError::InvalidInternalMapping`): it
+/// degrades to "slow but correct" rather than panicking or returning wrong
+/// output. `CanonicalizationError::SearchBudgetExceeded` cannot occur here
+/// since `unbounded()` never checks either budget.
 fn winning_individualized_ranks(mol: &Molecule) -> (Vec<u64>, String) {
+    match crate::canonical_search::winning_individualized_ranks_with_limits(
+        mol,
+        &crate::canonical_search::CanonicalizationLimits::unbounded(),
+    ) {
+        Ok(result) => result,
+        Err(_) => legacy_winning_individualized_ranks(mol),
+    }
+}
+
+/// The original (pre-orbit-pruning) individualize-refine search: exhaustive,
+/// capped at `MAX_INDIVIDUALIZE_BRANCHES`. Kept as (a) the fallback of last
+/// resort for `winning_individualized_ranks` and (b) test-only exhaustive
+/// oracle support (`canonical_smiles_exhaustive_oracle`, `usize::MAX`
+/// budget). No longer the default hot path.
+fn legacy_winning_individualized_ranks(mol: &Molecule) -> (Vec<u64>, String) {
     let plateaued = morgan_ranks(mol);
     let mut budget = MAX_INDIVIDUALIZE_BRANCHES;
     let branches = enumerate_discrete_ranks(mol, plateaued, &mut budget);
@@ -70,6 +98,59 @@ fn winning_individualized_ranks(mol: &Molecule) -> (Vec<u64>, String) {
             (ranks, s)
         })
         .min_by(|(_, a), (_, b)| a.cmp(b))
+        .unwrap_or_default()
+}
+
+/// Benchmark-only: the pre-orbit-pruning exhaustive search (same code as
+/// [`legacy_winning_individualized_ranks`], capped at
+/// `MAX_INDIVIDUALIZE_BRANCHES` exactly like before this PR), exposed so
+/// `examples/canonical_orbit_perf.rs` can measure a genuine before/after
+/// comparison against the exact prior algorithm from within the same crate
+/// version, instead of requiring a separate git-worktree checkout. Not part
+/// of the stable public API (`#[doc(hidden)]`); never call this from
+/// production code -- use [`canonical_smiles`].
+#[doc(hidden)]
+pub fn legacy_canonical_smiles_for_benchmark(mol: &Molecule) -> String {
+    if mol.atom_count() == 0 {
+        return String::new();
+    }
+    legacy_winning_individualized_ranks(mol).1
+}
+
+/// Benchmark-only: the number of individualize-refine branches (leaves) the
+/// pre-orbit-pruning exhaustive search would explore for `mol`, capped at
+/// `MAX_INDIVIDUALIZE_BRANCHES` exactly like before this PR. Paired with
+/// [`legacy_canonical_smiles_for_benchmark`] so `examples/
+/// canonical_orbit_perf.rs` can report a precise leaf-count reduction
+/// (old branch count vs the new engine's `leaves_written` instrumentation
+/// counter), not just wall-clock timing. `#[doc(hidden)]`, benchmark-only.
+#[doc(hidden)]
+pub fn legacy_branch_count_for_benchmark(mol: &Molecule) -> usize {
+    if mol.atom_count() == 0 {
+        return 0;
+    }
+    let plateaued = morgan_ranks(mol);
+    let mut budget = MAX_INDIVIDUALIZE_BRANCHES;
+    enumerate_discrete_ranks(mol, plateaued, &mut budget).len()
+}
+
+/// Test-only, unbounded, orbit-pruning-free exhaustive individualize-refine
+/// oracle (section 12): the legacy enumeration with an effectively
+/// unlimited budget, used to cross-check the orbit-pruned engine's output.
+/// Never called "the" canonicalization implementation -- this is a
+/// deliberately slow ground truth for tests only.
+#[cfg(test)]
+pub(crate) fn canonical_smiles_exhaustive_oracle(mol: &Molecule) -> String {
+    if mol.atom_count() == 0 {
+        return String::new();
+    }
+    let plateaued = morgan_ranks(mol);
+    let mut budget = usize::MAX;
+    let branches = enumerate_discrete_ranks(mol, plateaued, &mut budget);
+    branches
+        .into_iter()
+        .map(|ranks| CanonicalWriter::new(mol, &ranks).write_all())
+        .min()
         .unwrap_or_default()
 }
 
@@ -160,7 +241,7 @@ pub fn morgan_ranks(mol: &Molecule) -> Vec<u64> {
 /// classes stops increasing. Used both for the plain (tie-preserving) ranks
 /// in [`morgan_ranks`] and, with a perturbed starting coloring, as the
 /// "refine" half of individualize-refine in `enumerate_discrete_ranks`.
-fn refine_ranks(mol: &Molecule, mut ranks: Vec<u64>) -> Vec<u64> {
+pub(crate) fn refine_ranks(mol: &Molecule, mut ranks: Vec<u64>) -> Vec<u64> {
     let n = ranks.len();
     let max_iter = n + 2;
     for _ in 0..max_iter {
@@ -225,12 +306,29 @@ fn refine_ranks(mol: &Molecule, mut ranks: Vec<u64>) -> Vec<u64> {
 /// real fix is the orbit-aware pruning mentioned above.
 const MAX_INDIVIDUALIZE_BRANCHES: usize = 10_000;
 
+/// Group atom indices by their current (gap-free ordinal) rank value.
+/// `by_rank[r]` lists, in ascending atom-index order, every atom whose rank
+/// equals `r`. Shared by the legacy exhaustive `enumerate_discrete_ranks`
+/// and the orbit-pruned `canonical_search::search_canonical`, so both agree
+/// on cell membership and (within a cell) traversal order.
+pub(crate) fn group_by_rank(ranks: &[u64]) -> Vec<Vec<usize>> {
+    let mut by_rank: Vec<Vec<usize>> = Vec::new();
+    for (i, &r) in ranks.iter().enumerate() {
+        let r = r as usize;
+        if by_rank.len() <= r {
+            by_rank.resize(r + 1, Vec::new());
+        }
+        by_rank[r].push(i);
+    }
+    by_rank
+}
+
 /// Individualize atom `atom_idx` within its current rank class: insert a new
 /// rank strictly between its class and the next-higher class, so a
 /// subsequent refinement pass can propagate the distinction through the rest
 /// of the graph. `ranks` must be gap-free ordinals (as produced by
 /// `refine_ranks`/`normalize_ranks`).
-fn individualize(ranks: &[u64], atom_idx: usize) -> Vec<u64> {
+pub(crate) fn individualize(ranks: &[u64], atom_idx: usize) -> Vec<u64> {
     let v = ranks[atom_idx];
     ranks
         .iter()
@@ -264,14 +362,7 @@ fn individualize(ranks: &[u64], atom_idx: usize) -> Vec<u64> {
 /// non-singleton class to branch on next) is itself order-independent:
 /// always the lowest-ranked non-singleton cell.
 fn enumerate_discrete_ranks(mol: &Molecule, ranks: Vec<u64>, budget: &mut usize) -> Vec<Vec<u64>> {
-    let mut by_rank: Vec<Vec<usize>> = Vec::new();
-    for (i, &r) in ranks.iter().enumerate() {
-        let r = r as usize;
-        if by_rank.len() <= r {
-            by_rank.resize(r + 1, Vec::new());
-        }
-        by_rank[r].push(i);
-    }
+    let by_rank = group_by_rank(&ranks);
 
     // `by_rank` is indexed by ordinal rank value, so the first multi-member
     // entry found is the lowest-ranked non-singleton cell.
@@ -364,7 +455,7 @@ fn normalize_ranks(ranks: &[u64]) -> Vec<u64> {
     result
 }
 
-struct CanonicalWriter<'a> {
+pub(crate) struct CanonicalWriter<'a> {
     mol: &'a Molecule,
     ranks: &'a [u64],
     written: Vec<bool>,
@@ -406,7 +497,7 @@ struct CanonicalWriter<'a> {
 }
 
 impl<'a> CanonicalWriter<'a> {
-    fn new(mol: &'a Molecule, ranks: &'a [u64]) -> Self {
+    pub(crate) fn new(mol: &'a Molecule, ranks: &'a [u64]) -> Self {
         let n = mol.atom_count();
         Self {
             mol,
@@ -774,7 +865,7 @@ impl<'a> CanonicalWriter<'a> {
         }
     }
 
-    fn write_all(mut self) -> String {
+    pub(crate) fn write_all(mut self) -> String {
         // Phase -1: pick, for every tri-/tetra-substituted stereo alkene
         // end, which substituent bond canonically carries the `/`/`\`
         // marker (topology + rank only — independent of write order, and of
@@ -1229,6 +1320,65 @@ fn permutation_is_odd(original: &[u32], canonical: &[u32]) -> bool {
 mod tests {
     use super::*;
     use crate::parser::parse;
+
+    /// Positive control (section 3/19): directly verify -- by calling the
+    /// legacy exhaustive enumeration itself, not by trusting a doc comment
+    /// -- that budget exhaustion in the *old* design silently returns a
+    /// partial/wrong result rather than failing closed. With `budget = 0`,
+    /// `enumerate_discrete_ranks`'s very first non-singleton cell hits the
+    /// `*budget == 0 { break; }` guard on its first loop iteration and
+    /// returns an empty `Vec`; the caller's `.min_by(..).unwrap_or_default()`
+    /// then silently produces `("", vec![])` -- an EMPTY canonical SMILES,
+    /// not an error. This is exactly the anti-pattern the new
+    /// `canonical_smiles_with_limits`/`CanonicalizationError::
+    /// SearchBudgetExceeded` API (in `canonical_search.rs`) exists to
+    /// retire for callers who opt into a bounded search.
+    #[test]
+    fn old_design_zero_budget_silently_returns_empty_string_not_an_error() {
+        let mol = parse("c1ccccc1").unwrap(); // benzene: 1 non-singleton cell of all 6 atoms
+        let plateaued = morgan_ranks(&mol);
+        let mut budget = 0usize;
+        let branches = enumerate_discrete_ranks(&mol, plateaued, &mut budget);
+        assert!(
+            branches.is_empty(),
+            "zero budget should yield zero explored branches from the old design"
+        );
+
+        // Reproduce exactly what `legacy_winning_individualized_ranks` (and,
+        // before this PR, `winning_individualized_ranks`) does with that
+        // empty branch list.
+        let (ranks, s) = branches
+            .into_iter()
+            .map(|r: Vec<u64>| {
+                let s = CanonicalWriter::new(&mol, &r).write_all();
+                (r, s)
+            })
+            .min_by(|(_, a), (_, b)| a.cmp(b))
+            .unwrap_or_default();
+        assert_eq!(
+            s, "",
+            "old design: zero budget silently yields an EMPTY canonical string"
+        );
+        assert!(ranks.is_empty());
+
+        // Confirm the NEW engine does NOT reproduce this failure mode: the
+        // same molecule under an equivalently tiny bounded search fails
+        // closed (a typed error), never an empty string.
+        let bounded = crate::canonical_search::canonical_smiles_with_limits(
+            &mol,
+            &crate::canonical_search::CanonicalizationLimits {
+                max_search_nodes: Some(0),
+                max_automorphism_tests: None,
+            },
+        );
+        assert!(
+            matches!(
+                bounded,
+                Err(crate::canonical_search::CanonicalizationError::SearchBudgetExceeded { .. })
+            ),
+            "new engine must fail closed, got {bounded:?}"
+        );
+    }
 
     /// Build a copy of `mol` with atoms reordered by `perm` (perm[new_idx] = old_idx).
     /// Bonds are remapped to the new indices; stereo/direction metadata is

--- a/crates/chematic-smiles/src/canonical_automorphism.rs
+++ b/crates/chematic-smiles/src/canonical_automorphism.rs
@@ -1,0 +1,789 @@
+//! Exact colored-graph automorphism checking.
+//!
+//! `has_colored_automorphism_mapping` decides, via a real bijection search
+//! (never a substructure/subgraph match, never a hash-based shortcut),
+//! whether an automorphism of the current search node's colored graph
+//! exists mapping `from` to `to`. Molecules handled by this crate are small
+//! (even cage/cubane/coronene fixtures are well under 100 atoms), so a
+//! pairwise exact backtracking search is used, per the task's own guidance
+//! to prefer correctness over unproven speedups.
+//!
+//! Absolute invariant: a `false` result may cost performance (a missed
+//! prune); a `true` result must always be a genuine automorphism. Every
+//! candidate mapping is re-verified in full (`verify_full_bijection`) after
+//! backtracking finds a complete assignment, independent of the incremental
+//! `feasible` pruning used during search.
+
+use chematic_core::AtomIdx;
+
+use crate::canonical_partition::{CanonicalColoredGraph, Partition};
+
+/// Does a color-preserving, edge-color-preserving bijection of the whole
+/// graph exist that maps `from` to `to` and keeps every already-singleton
+/// (individualized) cell fixed?
+///
+/// `coloring` must already reflect the current search node's individualized
+/// and refined state (see `canonical_search::search_canonical`). Atoms in a
+/// singleton cell can only ever map to themselves, since the candidate
+/// search below is restricted to same-cell atoms and a singleton's only
+/// same-cell candidate is itself. That is exactly what "keep
+/// already-individualized singletons fixed" means in practice.
+pub(crate) fn has_colored_automorphism_mapping(
+    graph: &CanonicalColoredGraph,
+    coloring: &Partition,
+    from: AtomIdx,
+    to: AtomIdx,
+) -> bool {
+    if from == to {
+        return true;
+    }
+    if graph.vertex_color(from) != graph.vertex_color(to) {
+        return false;
+    }
+    if coloring.cell_of[from.0 as usize] != coloring.cell_of[to.0 as usize] {
+        return false;
+    }
+
+    let n = graph.n();
+    let mut image: Vec<Option<u32>> = vec![None; n];
+    let mut used: Vec<bool> = vec![false; n];
+    image[from.0 as usize] = Some(to.0);
+    used[to.0 as usize] = true;
+
+    if !extend_mapping(graph, coloring, &mut image, &mut used) {
+        return false;
+    }
+
+    verify_full_bijection(graph, &image)
+}
+
+fn extend_mapping(
+    graph: &CanonicalColoredGraph,
+    coloring: &Partition,
+    image: &mut [Option<u32>],
+    used: &mut [bool],
+) -> bool {
+    let n = image.len();
+    let Some(u) = (0..n).find(|&i| image[i].is_none()) else {
+        return true;
+    };
+    let cell = coloring.cell_of[u];
+    let u_color = graph.vertex_color(AtomIdx(u as u32));
+    // Filter candidates by BOTH partition cell (respects the current search
+    // node's individualization state -- e.g. keeps already-individualized
+    // singletons fixed) AND raw vertex color directly. In production,
+    // `coloring` always comes from `initial_partition` (which bakes vertex
+    // color into the composite cell key), so the two filters agree and this
+    // is redundant defense-in-depth. But this function must not silently
+    // rely on that caller invariant: without the explicit color check here,
+    // a coarser partition (e.g. a single-cell "ignore individualization"
+    // partition, as used by several of this module's own unit tests) could
+    // let the search commit to a color-mismatched candidate, which
+    // `verify_full_bijection` would then reject -- and since this function
+    // does not backtrack past a `verify_full_bijection` failure, that could
+    // spuriously report `false` for a genuinely automorphic pair reachable
+    // via a different candidate. Checking color directly here removes that
+    // dependency entirely.
+    let candidates: Vec<u32> = (0..n as u32)
+        .filter(|&v| {
+            !used[v as usize]
+                && coloring.cell_of[v as usize] == cell
+                && graph.vertex_color(AtomIdx(v)) == u_color
+        })
+        .collect();
+
+    for v in candidates {
+        if !feasible(graph, image, u as u32, v) {
+            continue;
+        }
+        image[u] = Some(v);
+        used[v as usize] = true;
+        if extend_mapping(graph, coloring, image, used) {
+            return true;
+        }
+        image[u] = None;
+        used[v as usize] = false;
+    }
+    false
+}
+
+/// Incremental feasibility check for tentatively mapping `u -> v`: every
+/// edge from `u` to an already-assigned neighbor must correspond to an
+/// edge of the same color from `v` to that neighbor's image (and,
+/// symmetrically, every edge from `v` to an already-assigned vertex's image
+/// must correspond to an edge from `u` to that vertex) -- both directions,
+/// so a missing/extra edge relative to any already-committed part of the
+/// mapping is caught immediately rather than only at final verification.
+fn feasible(graph: &CanonicalColoredGraph, image: &[Option<u32>], u: u32, v: u32) -> bool {
+    let ua = AtomIdx(u);
+    let va = AtomIdx(v);
+
+    for (nb, bidx) in graph.neighbors(ua) {
+        if let Some(mapped) = image[nb.0 as usize] {
+            let want = graph.edge_color(ua, bidx);
+            let has = graph
+                .mol()
+                .bond_between(va, AtomIdx(mapped))
+                .map(|(bidx2, _)| graph.edge_color(va, bidx2));
+            if has != Some(want) {
+                return false;
+            }
+        }
+    }
+
+    for (nb, bidx) in graph.neighbors(va) {
+        if let Some(preimage) = (0..image.len() as u32).find(|&i| image[i as usize] == Some(nb.0)) {
+            let want = graph.edge_color(va, bidx);
+            let has = graph
+                .mol()
+                .bond_between(ua, AtomIdx(preimage))
+                .map(|(bidx2, _)| graph.edge_color(ua, bidx2));
+            if has != Some(want) {
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
+/// Full, from-scratch re-verification of a complete candidate mapping:
+/// bijectivity, vertex-color preservation, and edge existence + edge-color
+/// preservation checked from every vertex's own perspective (so both
+/// directions of every edge are independently checked). Never accepts a
+/// partial or subgraph match -- every vertex of the graph must be mapped.
+fn verify_full_bijection(graph: &CanonicalColoredGraph, image: &[Option<u32>]) -> bool {
+    let n = image.len();
+    let mut seen = vec![false; n];
+    for (i, &mapped) in image.iter().enumerate() {
+        let Some(v) = mapped else {
+            return false;
+        };
+        if seen[v as usize] {
+            return false; // not injective
+        }
+        seen[v as usize] = true;
+        if graph.vertex_color(AtomIdx(i as u32)) != graph.vertex_color(AtomIdx(v)) {
+            return false;
+        }
+    }
+    if seen.iter().any(|&s| !s) {
+        return false; // not surjective
+    }
+
+    for i in 0..n {
+        let img_i = image[i].expect("fully assigned");
+        if graph.mol().degree(AtomIdx(i as u32)) != graph.mol().degree(AtomIdx(img_i)) {
+            return false;
+        }
+        for (nb, bidx) in graph.neighbors(AtomIdx(i as u32)) {
+            let img_nb = image[nb.0 as usize].expect("fully assigned");
+            let want = graph.edge_color(AtomIdx(i as u32), bidx);
+            match graph.mol().bond_between(AtomIdx(img_i), AtomIdx(img_nb)) {
+                Some((bidx2, _)) if graph.edge_color(AtomIdx(img_i), bidx2) == want => {}
+                _ => return false,
+            }
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::parse;
+    use chematic_core::{Chirality, Molecule, MoleculeBuilder};
+
+    fn trivial_partition(graph: &CanonicalColoredGraph) -> Partition {
+        // A partition with every atom in the same single cell (used by
+        // tests that want the automorphism checker to consider the whole
+        // vertex color / edge structure alone, not any current-search-node
+        // individualization state).
+        Partition {
+            cell_of: vec![0; graph.n()],
+        }
+    }
+
+    // --- Positive controls -------------------------------------------------
+
+    #[test]
+    fn benzene_ring_rotation_is_automorphic() {
+        let mol = parse("c1ccccc1").unwrap();
+        let graph = CanonicalColoredGraph::new(&mol);
+        let part = trivial_partition(&graph);
+        for i in 1..6 {
+            assert!(
+                has_colored_automorphism_mapping(&graph, &part, AtomIdx(0), AtomIdx(i)),
+                "benzene atom 0 and atom {i} must be automorphic"
+            );
+        }
+    }
+
+    #[test]
+    fn cf3_fluorines_are_automorphic() {
+        // FC(F)(F)C -- the three fluorines of a CF3 group are a true-twin
+        // orbit (identical neighbor set), the exact shape RENKIN's
+        // regression corpus hits repeatedly (docs/reaction_transform_perf.md).
+        let mol = parse("FC(F)(F)C").unwrap();
+        let graph = CanonicalColoredGraph::new(&mol);
+        let part = trivial_partition(&graph);
+        assert!(has_colored_automorphism_mapping(
+            &graph,
+            &part,
+            AtomIdx(0),
+            AtomIdx(2)
+        ));
+        assert!(has_colored_automorphism_mapping(
+            &graph,
+            &part,
+            AtomIdx(0),
+            AtomIdx(3)
+        ));
+    }
+
+    // --- Negative controls (section 19: must be provably breakable) --------
+
+    #[test]
+    fn different_element_never_automorphic() {
+        let mol = parse("FC(Cl)(Br)C").unwrap();
+        let graph = CanonicalColoredGraph::new(&mol);
+        let part = trivial_partition(&graph);
+        assert!(!has_colored_automorphism_mapping(
+            &graph,
+            &part,
+            AtomIdx(0),
+            AtomIdx(2)
+        ));
+    }
+
+    #[test]
+    fn isotope_difference_never_automorphic() {
+        // Two otherwise-identical fluorines, one isotope-labeled.
+        let mol = parse("[19F]C(F)(F)C").unwrap();
+        let graph = CanonicalColoredGraph::new(&mol);
+        let part = trivial_partition(&graph);
+        assert!(!has_colored_automorphism_mapping(
+            &graph,
+            &part,
+            AtomIdx(0),
+            AtomIdx(2)
+        ));
+    }
+
+    #[test]
+    fn charge_difference_never_automorphic() {
+        let mut b = MoleculeBuilder::new();
+        // Two terminal N atoms off a central C, one charged +1 (as NH3+),
+        // one neutral -- otherwise same degree/element.
+        let c = b.add_atom(chematic_core::Atom::organic(chematic_core::Element::C));
+        let mut n1 = chematic_core::Atom::organic(chematic_core::Element::N);
+        n1.charge = 1;
+        let n1i = b.add_atom(n1);
+        let n2 = b.add_atom(chematic_core::Atom::organic(chematic_core::Element::N));
+        b.add_bond(c, n1i, chematic_core::BondOrder::Single)
+            .unwrap();
+        b.add_bond(c, n2, chematic_core::BondOrder::Single).unwrap();
+        let mol: Molecule = b.build();
+        let graph = CanonicalColoredGraph::new(&mol);
+        let part = trivial_partition(&graph);
+        assert!(!has_colored_automorphism_mapping(&graph, &part, n1i, n2));
+    }
+
+    #[test]
+    fn stereo_difference_never_automorphic() {
+        // A tetrahedral stereocenter is always stereo_unique -- never
+        // automorphic with anything, even a chemically-identical-looking
+        // atom, per this PR's conservative stereo-handling judgment call.
+        let mol = parse("C[C@H](N)O").unwrap();
+        let graph = CanonicalColoredGraph::new(&mol);
+        let part = trivial_partition(&graph);
+        // Atom 1 is the stereocenter; no other atom shares its color.
+        for other in [0u32, 2, 3] {
+            assert!(!has_colored_automorphism_mapping(
+                &graph,
+                &part,
+                AtomIdx(1),
+                AtomIdx(other)
+            ));
+        }
+        assert_eq!(mol.atom(AtomIdx(1)).chirality, Chirality::CounterClockwise);
+    }
+
+    #[test]
+    fn partial_mapping_never_accepted() {
+        // Manually construct an `image` that is deliberately incomplete
+        // (only maps 0 -> 1) and confirm verify_full_bijection rejects it.
+        let mol = parse("c1ccccc1").unwrap();
+        let graph = CanonicalColoredGraph::new(&mol);
+        let mut image = vec![None; graph.n()];
+        image[0] = Some(1);
+        assert!(!verify_full_bijection(&graph, &image));
+    }
+
+    #[test]
+    fn non_bijective_mapping_never_accepted() {
+        // Two source atoms mapped to the SAME target atom.
+        let mol = parse("c1ccccc1").unwrap();
+        let graph = CanonicalColoredGraph::new(&mol);
+        let mut image: Vec<Option<u32>> = (0..graph.n() as u32).map(Some).collect();
+        image[1] = Some(0); // 0 -> 0 and 1 -> 0: not injective
+        assert!(!verify_full_bijection(&graph, &image));
+    }
+
+    #[test]
+    fn different_cell_never_automorphic_even_if_color_matches() {
+        // Force a partition that pins atom 0 into its own singleton cell
+        // (simulating "already individualized") -- atom 0 must then never
+        // be considered automorphic with any other same-colored atom, even
+        // though a trivial (single-cell) partition would allow it.
+        let mol = parse("c1ccccc1").unwrap();
+        let graph = CanonicalColoredGraph::new(&mol);
+        let mut cell_of = vec![1u32; graph.n()];
+        cell_of[0] = 0; // atom 0 alone in cell 0, everyone else in cell 1
+        let part = Partition { cell_of };
+        assert!(!has_colored_automorphism_mapping(
+            &graph,
+            &part,
+            AtomIdx(0),
+            AtomIdx(1)
+        ));
+    }
+
+    // --- Exhaustive small-graph checks (section 13) -------------------------
+
+    /// Build an unlabeled (all-same-color) cycle graph C_n as a Molecule
+    /// (single bonds only -- color content is irrelevant to this check, only
+    /// topology is exercised).
+    fn cycle_molecule(n: usize) -> Molecule {
+        let mut b = MoleculeBuilder::new();
+        let atoms: Vec<_> = (0..n)
+            .map(|_| b.add_atom(chematic_core::Atom::organic(chematic_core::Element::C)))
+            .collect();
+        for i in 0..n {
+            b.add_bond(
+                atoms[i],
+                atoms[(i + 1) % n],
+                chematic_core::BondOrder::Single,
+            )
+            .unwrap();
+        }
+        b.build()
+    }
+
+    #[test]
+    fn cycles_up_to_8_are_fully_vertex_transitive() {
+        for n in 3..=8 {
+            let mol = cycle_molecule(n);
+            let graph = CanonicalColoredGraph::new(&mol);
+            let part = trivial_partition(&graph);
+            for i in 0..n as u32 {
+                for j in 0..n as u32 {
+                    assert!(
+                        has_colored_automorphism_mapping(&graph, &part, AtomIdx(i), AtomIdx(j)),
+                        "C{n}: {i} and {j} must be automorphic (rotation)"
+                    );
+                }
+            }
+        }
+    }
+
+    fn complete_graph(n: usize) -> Molecule {
+        let mut b = MoleculeBuilder::new();
+        let atoms: Vec<_> = (0..n)
+            .map(|_| b.add_atom(chematic_core::Atom::organic(chematic_core::Element::C)))
+            .collect();
+        for i in 0..n {
+            for j in (i + 1)..n {
+                b.add_bond(atoms[i], atoms[j], chematic_core::BondOrder::Single)
+                    .unwrap();
+            }
+        }
+        b.build()
+    }
+
+    #[test]
+    fn complete_graphs_up_to_6_are_fully_vertex_transitive() {
+        for n in 2..=6 {
+            let mol = complete_graph(n);
+            let graph = CanonicalColoredGraph::new(&mol);
+            let part = trivial_partition(&graph);
+            for i in 0..n as u32 {
+                for j in 0..n as u32 {
+                    assert!(has_colored_automorphism_mapping(
+                        &graph,
+                        &part,
+                        AtomIdx(i),
+                        AtomIdx(j)
+                    ));
+                }
+            }
+        }
+    }
+
+    fn complete_bipartite(a: usize, b: usize) -> Molecule {
+        let mut bld = MoleculeBuilder::new();
+        let left: Vec<_> = (0..a)
+            .map(|_| bld.add_atom(chematic_core::Atom::organic(chematic_core::Element::C)))
+            .collect();
+        let right: Vec<_> = (0..b)
+            .map(|_| bld.add_atom(chematic_core::Atom::organic(chematic_core::Element::N)))
+            .collect();
+        for &l in &left {
+            for &r in &right {
+                bld.add_bond(l, r, chematic_core::BondOrder::Single)
+                    .unwrap();
+            }
+        }
+        bld.build()
+    }
+
+    #[test]
+    fn complete_bipartite_respects_the_two_sides() {
+        let mol = complete_bipartite(3, 4);
+        let graph = CanonicalColoredGraph::new(&mol);
+        let part = trivial_partition(&graph);
+        // Any two atoms on the same (differently-colored, C vs N) side are automorphic...
+        assert!(has_colored_automorphism_mapping(
+            &graph,
+            &part,
+            AtomIdx(0),
+            AtomIdx(1)
+        ));
+        assert!(has_colored_automorphism_mapping(
+            &graph,
+            &part,
+            AtomIdx(3),
+            AtomIdx(4)
+        ));
+        // ...but never across sides (different element => different color).
+        assert!(!has_colored_automorphism_mapping(
+            &graph,
+            &part,
+            AtomIdx(0),
+            AtomIdx(3)
+        ));
+    }
+
+    /// The section-13 positive-control witness: a graph where 1-WL /
+    /// Morgan-style refinement puts two vertices in the same cell, but they
+    /// are in *different* automorphism orbits -- i.e. a graph that is
+    /// regular (so plain degree/neighbor-hash refinement never splits it)
+    /// but NOT vertex-transitive.
+    ///
+    /// The disjoint union of a triangle (C3) and a square (C4) is exactly
+    /// this: every vertex is degree 2 with degree-2 neighbors, so 1-WL /
+    /// Morgan-rank refinement (which only ever looks at local neighbor
+    /// colors, never global path length or component identity) can never
+    /// split the two components apart -- this is the textbook fact that
+    /// 1-WL cannot distinguish regular graphs of different girth/size. A
+    /// naive Morgan-rank-only pruning scheme would therefore treat all 7
+    /// vertices as one orbit and wrongly merge e.g. a triangle vertex with a
+    /// square vertex. But no automorphism can map a component of order 3 to
+    /// a component of order 4 (an automorphism must map connected
+    /// components to connected components of the same order); the true
+    /// orbit structure is `{0,1,2}` (triangle) and `{3,4,5,6}` (square).
+    ///
+    /// (An earlier draft of this test used two disjoint *triangles*
+    /// instead -- that premise was actually wrong: `Aut(C3 |_| C3)` DOES
+    /// include a whole-component swap, since the two components are
+    /// isomorphic, so it IS transitive on all 6 vertices. C3 |_| C4 has no
+    /// such swap since the components differ in size, which is exactly why
+    /// it works as a same-WL-cell/different-orbit witness and two
+    /// isomorphic components do not.)
+    #[test]
+    fn triangle_and_square_same_wl_cell_different_orbits() {
+        let mut b = MoleculeBuilder::new();
+        let atoms: Vec<_> = (0..7)
+            .map(|_| b.add_atom(chematic_core::Atom::organic(chematic_core::Element::C)))
+            .collect();
+        // Triangle: 0-1-2-0. Square: 3-4-5-6-3.
+        for &(i, j) in &[(0, 1), (1, 2), (2, 0), (3, 4), (4, 5), (5, 6), (6, 3)] {
+            b.add_bond(atoms[i], atoms[j], chematic_core::BondOrder::Single)
+                .unwrap();
+        }
+        let mol = b.build();
+
+        // Verify the WL/Morgan-rank premise empirically (don't assert what
+        // we want -- read it off the actual implementation): all 7 atoms
+        // must tie under plain Morgan refinement.
+        let ranks = crate::canonical::morgan_ranks(&mol);
+        assert_eq!(
+            ranks.iter().collect::<std::collections::HashSet<_>>().len(),
+            1,
+            "triangle and square must tie under plain Morgan refinement (both 2-regular)"
+        );
+
+        let graph = CanonicalColoredGraph::new(&mol);
+        let part = trivial_partition(&graph);
+
+        // Within-component: automorphic.
+        assert!(has_colored_automorphism_mapping(
+            &graph,
+            &part,
+            AtomIdx(0),
+            AtomIdx(1)
+        ));
+        assert!(has_colored_automorphism_mapping(
+            &graph,
+            &part,
+            AtomIdx(3),
+            AtomIdx(5)
+        ));
+        // Across components: NOT automorphic, despite the same WL cell --
+        // this is exactly what a rank-hash-only pruning scheme would get
+        // wrong (it would wrongly prune away the square's individualization
+        // entirely, believing it redundant with the triangle's).
+        for i in 0..3u32 {
+            for j in 3..7u32 {
+                assert!(
+                    !has_colored_automorphism_mapping(&graph, &part, AtomIdx(i), AtomIdx(j)),
+                    "atom {i} (triangle) and atom {j} (square) must NOT be automorphic"
+                );
+            }
+        }
+    }
+
+    // --- Exhaustive/randomized small-graph checks against a brute-force ----
+    // --- ground truth (section 13) -----------------------------------------
+
+    /// Ground truth: is there ANY permutation of `0..n` that fixes color
+    /// classes, maps `a -> b`, and preserves edge presence + edge color?
+    /// O(n!) -- only used in tests, only for tiny `n`.
+    fn brute_force_automorphic(
+        n: usize,
+        edges: &std::collections::HashMap<(usize, usize), u8>,
+        colors: &[u32],
+        a: usize,
+        b: usize,
+    ) -> bool {
+        if colors[a] != colors[b] {
+            return false;
+        }
+        let mut perm: Vec<usize> = (0..n).collect();
+
+        fn edge_color(
+            edges: &std::collections::HashMap<(usize, usize), u8>,
+            x: usize,
+            y: usize,
+        ) -> Option<u8> {
+            let k = if x <= y { (x, y) } else { (y, x) };
+            edges.get(&k).copied()
+        }
+
+        fn permutations<F: FnMut(&[usize]) -> bool>(
+            perm: &mut Vec<usize>,
+            k: usize,
+            f: &mut F,
+        ) -> bool {
+            if k == perm.len() {
+                return f(perm);
+            }
+            for i in k..perm.len() {
+                perm.swap(k, i);
+                if permutations(perm, k + 1, f) {
+                    perm.swap(k, i);
+                    return true;
+                }
+                perm.swap(k, i);
+            }
+            false
+        }
+
+        permutations(&mut perm, 0, &mut |p: &[usize]| {
+            if p[a] != b {
+                return false;
+            }
+            for i in 0..n {
+                if colors[i] != colors[p[i]] {
+                    return false;
+                }
+            }
+            for x in 0..n {
+                for y in (x + 1)..n {
+                    if edge_color(edges, x, y) != edge_color(edges, p[x], p[y]) {
+                        return false;
+                    }
+                }
+            }
+            true
+        })
+    }
+
+    /// Build a `Molecule` from an explicit edge set (keyed by (min,max) pair
+    /// -> an edge-color tag 0/1, mapped to Single/Double) and a per-atom
+    /// color tag (mapped to a small distinct-element palette), for exact
+    /// cross-checking against `brute_force_automorphic`.
+    fn build_colored_graph(
+        n: usize,
+        edges: &std::collections::HashMap<(usize, usize), u8>,
+        colors: &[u32],
+    ) -> Molecule {
+        let palette = [
+            chematic_core::Element::C,
+            chematic_core::Element::N,
+            chematic_core::Element::O,
+            chematic_core::Element::F,
+        ];
+        let mut b = MoleculeBuilder::new();
+        let atoms: Vec<_> = (0..n)
+            .map(|i| {
+                b.add_atom(chematic_core::Atom::organic(
+                    palette[colors[i] as usize % palette.len()],
+                ))
+            })
+            .collect();
+        for x in 0..n {
+            for y in (x + 1)..n {
+                if let Some(&ec) = edges.get(&(x, y)) {
+                    let order = if ec == 0 {
+                        chematic_core::BondOrder::Single
+                    } else {
+                        chematic_core::BondOrder::Double
+                    };
+                    b.add_bond(atoms[x], atoms[y], order).unwrap();
+                }
+            }
+        }
+        b.build()
+    }
+
+    /// Exhaustive: every simple (uncolored, unweighted) graph on `n <= 5`
+    /// vertices (all `2^C(n,2)` edge subsets), every vertex pair, cross-
+    /// checked against brute-force ground truth. `n=6` would need
+    /// `2^15 * 15` permutation-searches (each up to `6!`), too slow for a
+    /// unit test at debug-build speed -- covered instead by the structured
+    /// n<=8 cases above (cycles/complete/bipartite) plus the randomized
+    /// n<=8 fuzz test below, per this task's "wherever feasible" guidance.
+    #[test]
+    fn exhaustive_simple_graphs_n_le_5_match_brute_force() {
+        for n in 1..=5usize {
+            let pairs: Vec<(usize, usize)> = (0..n)
+                .flat_map(|x| ((x + 1)..n).map(move |y| (x, y)))
+                .collect();
+            let m = pairs.len();
+            for mask in 0u32..(1u32 << m) {
+                let mut edges = std::collections::HashMap::new();
+                for (i, &(x, y)) in pairs.iter().enumerate() {
+                    if mask & (1 << i) != 0 {
+                        edges.insert((x, y), 0u8);
+                    }
+                }
+                let colors = vec![0u32; n]; // uncolored: all same color class
+                let mol = build_colored_graph(n, &edges, &colors);
+                let graph = CanonicalColoredGraph::new(&mol);
+                let part = trivial_partition(&graph);
+                for a in 0..n {
+                    for bb in 0..n {
+                        let expected = brute_force_automorphic(n, &edges, &colors, a, bb);
+                        let got = has_colored_automorphism_mapping(
+                            &graph,
+                            &part,
+                            AtomIdx(a as u32),
+                            AtomIdx(bb as u32),
+                        );
+                        assert_eq!(
+                            got, expected,
+                            "n={n} mask={mask:b} a={a} b={bb}: got {got}, brute force says {expected}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Tiny deterministic xorshift PRNG -- avoids adding a `rand`
+    /// dependency (and the `Cargo.lock` churn that would bring) for what a
+    /// few lines of arithmetic can do just as well for a seeded fuzz test.
+    struct Xorshift64(u64);
+    impl Xorshift64 {
+        fn next_u64(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            self.0 = x;
+            x
+        }
+        fn next_range(&mut self, bound: usize) -> usize {
+            (self.next_u64() % bound as u64) as usize
+        }
+    }
+
+    /// Randomized: colored graphs AND edge-colored graphs, `n` in `6..=8`,
+    /// disconnected graphs included (edge density low enough that some
+    /// generated graphs are disconnected), cross-checked against brute
+    /// force. Seeded PRNG for reproducibility.
+    #[test]
+    fn random_colored_edge_colored_graphs_n_6_to_8_match_brute_force() {
+        let mut rng = Xorshift64(0x9E3779B97F4A7C15);
+        for n in 6..=8usize {
+            for _trial in 0..40 {
+                let pairs: Vec<(usize, usize)> = (0..n)
+                    .flat_map(|x| ((x + 1)..n).map(move |y| (x, y)))
+                    .collect();
+                let mut edges = std::collections::HashMap::new();
+                for &(x, y) in &pairs {
+                    if rng.next_range(10) < 4 {
+                        // ~40% edge density -- some trials will be disconnected.
+                        let ec = (rng.next_range(2)) as u8; // edge color 0 or 1 (Single/Double)
+                        edges.insert((x, y), ec);
+                    }
+                }
+                let num_colors = 1 + rng.next_range(3); // 1..=3 vertex color classes
+                let colors: Vec<u32> = (0..n).map(|_| rng.next_range(num_colors) as u32).collect();
+
+                let mol = build_colored_graph(n, &edges, &colors);
+                let graph = CanonicalColoredGraph::new(&mol);
+                let part = trivial_partition(&graph);
+                for a in 0..n {
+                    for bb in 0..n {
+                        let expected = brute_force_automorphic(n, &edges, &colors, a, bb);
+                        let got = has_colored_automorphism_mapping(
+                            &graph,
+                            &part,
+                            AtomIdx(a as u32),
+                            AtomIdx(bb as u32),
+                        );
+                        assert_eq!(
+                            got, expected,
+                            "n={n} trial={_trial} edges={edges:?} colors={colors:?} a={a} b={bb}: \
+                             got {got}, brute force says {expected}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Explicitly-disconnected graphs (two separate components of unequal
+    /// size, mirroring the triangle+square witness above but with random
+    /// internal edges) -- brute-force cross-check.
+    #[test]
+    fn disconnected_graphs_match_brute_force() {
+        // Component A: 3 vertices, a path 0-1-2. Component B: 4 vertices, a
+        // path 3-4-5-6. No automorphism should ever cross components (of
+        // different order), matching the earlier structural witness test.
+        let mut edges = std::collections::HashMap::new();
+        edges.insert((0, 1), 0u8);
+        edges.insert((1, 2), 0u8);
+        edges.insert((3, 4), 0u8);
+        edges.insert((4, 5), 0u8);
+        edges.insert((5, 6), 0u8);
+        let colors = vec![0u32; 7];
+        let mol = build_colored_graph(7, &edges, &colors);
+        let graph = CanonicalColoredGraph::new(&mol);
+        let part = trivial_partition(&graph);
+        for a in 0..7 {
+            for b in 0..7 {
+                let expected = brute_force_automorphic(7, &edges, &colors, a, b);
+                let got = has_colored_automorphism_mapping(
+                    &graph,
+                    &part,
+                    AtomIdx(a as u32),
+                    AtomIdx(b as u32),
+                );
+                assert_eq!(got, expected, "a={a} b={b}");
+            }
+        }
+    }
+}

--- a/crates/chematic-smiles/src/canonical_partition.rs
+++ b/crates/chematic-smiles/src/canonical_partition.rs
@@ -22,6 +22,19 @@
 //!    `HashMap`/`sort`/`dedup` already resolve collisions via real `Eq`/`Ord`
 //!    comparison -- this is standard hash-table behavior, not the forbidden
 //!    "hash collision as proof of equivalence" pattern.
+//!
+//!    This is true of `exact_refine`'s *own* iterations. Its *starting
+//!    point* (`initial_partition`'s `ranks` component) is a different story:
+//!    `ranks` comes from `crate::canonical`'s pre-existing, unchanged
+//!    `individualize`/`refine_ranks`, and the latter's `normalize_ranks`
+//!    step does group by raw FNV-1a hash-value equality. See
+//!    `canonical_search::exact_orbit_representatives`'s doc comment for the
+//!    full account of what that means for this module's callers (in short:
+//!    a hypothetical hash collision there is a pre-existing, crate-wide,
+//!    practically-unreachable risk already relied on by
+//!    `equivalent_atom_classes`/`are_atoms_equivalent`, not one this PR
+//!    introduces -- but this PR does change its potential consequence from
+//!    "redundant exploration" to "a silently skipped branch").
 
 use std::collections::HashSet;
 

--- a/crates/chematic-smiles/src/canonical_partition.rs
+++ b/crates/chematic-smiles/src/canonical_partition.rs
@@ -1,0 +1,381 @@
+//! Exact colored-graph coloring + partition refinement for the
+//! automorphism-orbit-aware canonical search (`canonical_search.rs`).
+//!
+//! This module is a *parallel* structure to `canonical.rs`'s existing
+//! `morgan_ranks`/`refine_ranks` (the hash-based Morgan refinement whose
+//! public meaning this PR does not change -- see `docs/
+//! canonical_automorphism_pruning.md`). It is consulted only to decide
+//! which individualize-refine branches are *provably* redundant; the rank
+//! vectors actually handed to `CanonicalWriter` always come from the
+//! original `individualize` + `refine_ranks` pipeline, unperturbed.
+//!
+//! Two things distinguish this from `refine_ranks`:
+//! 1. The vertex/edge coloring audits every attribute `CanonicalWriter`
+//!    (and the plain, non-canonical writer) actually distinguish in their
+//!    output -- not just the coarser set `initial_invariant` uses for
+//!    Morgan-rank search-order heuristics. See the design doc for the full
+//!    writer-visible-attribute audit.
+//! 2. Refinement here NEVER merges two cells on hash collision alone: cell
+//!    membership is decided by full signature *equality* (`Eq`/`Ord`
+//!    comparison of the whole signature struct). A `u64`/hash may still be
+//!    used internally by a `HashMap`/sort for fast lookup, but Rust's
+//!    `HashMap`/`sort`/`dedup` already resolve collisions via real `Eq`/`Ord`
+//!    comparison -- this is standard hash-table behavior, not the forbidden
+//!    "hash collision as proof of equivalence" pattern.
+
+use std::collections::HashSet;
+
+use chematic_core::{AtomIdx, BondIdx, BondOrder, Chirality, Molecule};
+
+pub(crate) type CellId = u32;
+
+/// Every molecule attribute the SMILES writer (`crate::canonical::
+/// CanonicalWriter` and the plain `crate::writer`) distinguishes in its
+/// output, for one atom. Two atoms with different `VertexColor` values can
+/// NEVER be automorphic for canonicalization purposes.
+///
+/// `stereo_unique`, when `Some(atom_index)`, forces this atom's color to be
+/// globally unique (bakes its own index in) -- the deliberate conservative
+/// simplification this PR uses for every atom whose stereo meaning
+/// (tetrahedral parity, or E/Z direction) is not cheaply provable to be
+/// preserved by a candidate mapping. See the design doc, "judgment call:
+/// stereo-bearing atoms are never merged". A false negative here (failing to
+/// prune two genuinely-automorphic stereo atoms) only costs performance; it
+/// can never cause a false merge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct VertexColor {
+    wildcard: bool,
+    atomic_number: u8,
+    isotope: u32,
+    charge: i8,
+    aromatic: bool,
+    h_state: u16,
+    atom_map: u32,
+    chirality: u8,
+    stereo_unique: Option<u32>,
+}
+
+/// Every bond attribute the writer distinguishes, queried from one
+/// endpoint's perspective (`from`) so directional meaning (dative
+/// donor/acceptor) is preserved correctly by an automorphism check that
+/// always compares `edge_color(u, ..)` against `edge_color(phi(u), ..)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct EdgeColor {
+    order_class: u8,
+    /// `true` only for a `Dative` bond whose donor (`bond.atom1`, per
+    /// `chematic_core::BondOrder::Dative`'s own doc) is the queried-from
+    /// atom. Always `false` for non-dative bonds.
+    from_is_donor: bool,
+}
+
+fn order_class(order: BondOrder) -> u8 {
+    match order {
+        BondOrder::Single => 0,
+        BondOrder::Double => 1,
+        BondOrder::Triple => 2,
+        BondOrder::Quadruple => 3,
+        BondOrder::Aromatic => 4,
+        BondOrder::Up => 5,
+        BondOrder::Down => 6,
+        BondOrder::Zero => 7,
+        BondOrder::Dative => 8,
+        BondOrder::QueryAny => 9,
+        BondOrder::QuerySingleOrDouble => 10,
+        BondOrder::QuerySingleOrAromatic => 11,
+        BondOrder::QueryDoubleOrAromatic => 12,
+    }
+}
+
+/// `true` when `bidx` carries any real-or-potential stereo direction
+/// information: a literal `Up`/`Down` bond order, or a stashed direction
+/// (`Molecule::bond_direction`, used e.g. for a ring bond next to an
+/// exocyclic stereo double bond). Mirrors the raw-direction check
+/// `crate::canonical::CanonicalWriter::raw_input_direction`/`crate::writer::
+/// raw_bond_direction` use, minus the `resolve_ez_markers` carrier-choice
+/// overlay (which depends on fully-resolved ranks, not available yet at
+/// vertex-color-construction time -- irrelevant here since this function
+/// only needs to decide "is this atom stereo-sensitive at all", not which
+/// specific bond ends up carrying the marker).
+fn bond_has_direction_info(mol: &Molecule, bidx: BondIdx) -> bool {
+    matches!(mol.bond(bidx).order, BondOrder::Up | BondOrder::Down)
+        || mol.bond_direction(bidx).is_some()
+}
+
+/// Every atom whose stereo meaning is not handled by this PR's exact
+/// automorphism machinery, so it (and, critically, its direct neighbors)
+/// must never be merged with any other atom -- see `VertexColor::
+/// stereo_unique` and the design doc's "judgment call" section.
+///
+/// **Why 1-hop, not just the stereo atom itself**: a tetrahedral center's
+/// chirality tag (`@`/`@@`) is defined relative to the *order* of its direct
+/// neighbors (`Molecule::stereo_neighbor_order`); transposing two of those
+/// neighbors with each other inverts the encoded configuration even though
+/// the stereocenter atom itself never moves. Pinning the stereocenter alone
+/// (mapping it only to itself) does NOT stop an automorphism from
+/// transposing two of *its own neighbors* with each other -- caught by this
+/// PR's own idempotence regression test on a stereocenter inside a ring
+/// (`ring_digit_reuse_inside_stereocenter_branch_minimal`): a candidate
+/// automorphism swapping the stereocenter's two ring-neighbor CH2 atoms
+/// passed every per-atom color/edge check yet silently inverted the
+/// encoded chirality. Pinning every direct neighbor too makes any accepted
+/// automorphism fix the stereocenter's whole neighbor list pointwise, which
+/// is sufficient (chirality parity depends only on that direct neighbor
+/// list, never on anything further away). The same 1-hop rule is applied
+/// uniformly to E/Z-direction-bearing bonds for the analogous reason (a
+/// stereogenic alkene end's *un-marked* substituent, implied via
+/// substituent-count rather than an explicit bond marker, must also stay
+/// pinned) rather than deriving a separate, narrower rule for each case.
+///
+/// False negative (conservatively pinning an atom that, with more careful
+/// analysis, could safely have been pruned) only costs performance. See
+/// section 8/19: this is the sanctioned trade.
+fn stereo_sensitive_atoms(mol: &Molecule) -> HashSet<AtomIdx> {
+    let mut base: HashSet<AtomIdx> = HashSet::new();
+    for i in 0..mol.atom_count() {
+        let idx = AtomIdx(i as u32);
+        if mol.atom(idx).chirality != Chirality::None {
+            base.insert(idx);
+        }
+    }
+    for bidx in 0..mol.bond_count() {
+        let bidx = BondIdx(bidx as u32);
+        if bond_has_direction_info(mol, bidx) {
+            let bond = mol.bond(bidx);
+            base.insert(bond.atom1);
+            base.insert(bond.atom2);
+        }
+    }
+
+    let mut expanded = base.clone();
+    for &idx in &base {
+        for (nb, _) in mol.neighbors(idx) {
+            expanded.insert(nb);
+        }
+    }
+    expanded
+}
+
+fn vertex_color(mol: &Molecule, idx: AtomIdx, force_unique: bool) -> VertexColor {
+    let atom = mol.atom(idx);
+    let stereo_unique = if force_unique { Some(idx.0) } else { None };
+    VertexColor {
+        wildcard: atom.wildcard,
+        atomic_number: if atom.wildcard {
+            0
+        } else {
+            atom.element.atomic_number()
+        },
+        isotope: atom.isotope.map(|i| i as u32 + 1).unwrap_or(0),
+        charge: atom.charge,
+        aromatic: atom.aromatic,
+        h_state: atom.hydrogen_count.map(|h| h as u16 + 1).unwrap_or(0),
+        atom_map: atom.atom_map.map(|m| m as u32 + 1).unwrap_or(0),
+        chirality: match atom.chirality {
+            Chirality::None => 0,
+            Chirality::CounterClockwise => 1,
+            Chirality::Clockwise => 2,
+        },
+        stereo_unique,
+    }
+}
+
+/// The molecular graph plus its (precomputed, static) writer-visible
+/// coloring, shared read-only across one `canonical_smiles` call's whole
+/// search.
+pub(crate) struct CanonicalColoredGraph<'a> {
+    mol: &'a Molecule,
+    vcolor: Vec<VertexColor>,
+}
+
+impl<'a> CanonicalColoredGraph<'a> {
+    pub(crate) fn new(mol: &'a Molecule) -> Self {
+        let sensitive = stereo_sensitive_atoms(mol);
+        let vcolor = (0..mol.atom_count())
+            .map(|i| {
+                let idx = AtomIdx(i as u32);
+                vertex_color(mol, idx, sensitive.contains(&idx))
+            })
+            .collect();
+        Self { mol, vcolor }
+    }
+
+    pub(crate) fn mol(&self) -> &'a Molecule {
+        self.mol
+    }
+
+    pub(crate) fn n(&self) -> usize {
+        self.vcolor.len()
+    }
+
+    pub(crate) fn vertex_color(&self, a: AtomIdx) -> VertexColor {
+        self.vcolor[a.0 as usize]
+    }
+
+    pub(crate) fn edge_color(&self, from: AtomIdx, bidx: BondIdx) -> EdgeColor {
+        let bond = self.mol.bond(bidx);
+        let from_is_donor = bond.order == BondOrder::Dative && bond.atom1 == from;
+        EdgeColor {
+            order_class: order_class(bond.order),
+            from_is_donor,
+        }
+    }
+
+    pub(crate) fn neighbors(&self, a: AtomIdx) -> impl Iterator<Item = (AtomIdx, BondIdx)> + '_ {
+        self.mol.neighbors(a)
+    }
+}
+
+/// A partition of atom indices into cells, `cell_of[i]` = the cell of atom
+/// `i`. Cell ids are gap-free ordinals; a lower cell id does not carry any
+/// meaning beyond "distinct from every other cell id" for this module's own
+/// purposes (unlike `crate::canonical`'s `ranks`, which additionally encodes
+/// a *search-order* preference -- this partition is never itself handed to
+/// `CanonicalWriter`).
+#[derive(Debug, Clone)]
+pub(crate) struct Partition {
+    pub(crate) cell_of: Vec<CellId>,
+}
+
+impl Partition {
+    /// Group atom indices by cell, cell ids ascending; atoms within a cell
+    /// in ascending atom-index order. Test-only utility (production code
+    /// only ever needs `cell_of[atom_index]` lookups, see
+    /// `canonical_search.rs`).
+    #[cfg(test)]
+    pub(crate) fn cell_members(&self) -> Vec<Vec<AtomIdx>> {
+        let max_cell = self
+            .cell_of
+            .iter()
+            .copied()
+            .max()
+            .map(|m| m as usize + 1)
+            .unwrap_or(0);
+        let mut cells: Vec<Vec<AtomIdx>> = vec![Vec::new(); max_cell];
+        for (i, &c) in self.cell_of.iter().enumerate() {
+            cells[c as usize].push(AtomIdx(i as u32));
+        }
+        cells
+    }
+}
+
+fn assign_cell_ids<K: Ord + Clone>(keys: &[K]) -> Vec<CellId> {
+    let mut distinct: Vec<K> = keys.to_vec();
+    distinct.sort();
+    distinct.dedup();
+    keys.iter()
+        .map(|k| {
+            distinct
+                .binary_search(k)
+                .expect("key present in distinct set") as CellId
+        })
+        .collect()
+}
+
+fn count_distinct_cells(cell_of: &[CellId]) -> usize {
+    let mut seen: Vec<CellId> = cell_of.to_vec();
+    seen.sort_unstable();
+    seen.dedup();
+    seen.len()
+}
+
+/// Build the initial (pre-refinement) partition for the current search node:
+/// combine the current Morgan-derived `ranks` (already gap-free ordinals,
+/// encoding every individualization done so far) with the full exact
+/// `VertexColor` (which additionally distinguishes atom-map/stereo/isotope/
+/// charge differences the hash-based `initial_invariant` does not carry) so
+/// a subsequent exact refinement pass can never wrongly merge two atoms
+/// `ranks` alone would conflate.
+pub(crate) fn initial_partition(graph: &CanonicalColoredGraph, ranks: &[u64]) -> Partition {
+    let keys: Vec<(u64, VertexColor)> = (0..ranks.len())
+        .map(|i| (ranks[i], graph.vertex_color(AtomIdx(i as u32))))
+        .collect();
+    Partition {
+        cell_of: assign_cell_ids(&keys),
+    }
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone)]
+struct RefineSignature {
+    own: CellId,
+    neighbors: Vec<(u8, bool, CellId)>,
+}
+
+/// Refine `partition` to a fixpoint using an exact structural signature
+/// (own cell + sorted multiset of (edge color, neighbor cell)), comparing
+/// full signatures via real equality -- never a hash-collision shortcut.
+/// Mirrors `crate::canonical::refine_ranks`'s neighbor-aggregation shape.
+pub(crate) fn exact_refine(graph: &CanonicalColoredGraph, mut partition: Partition) -> Partition {
+    let n = partition.cell_of.len();
+    let max_iter = n + 2;
+    for _ in 0..max_iter {
+        let old_cells = count_distinct_cells(&partition.cell_of);
+
+        let sigs: Vec<RefineSignature> = (0..n)
+            .map(|i| {
+                let idx = AtomIdx(i as u32);
+                let mut neighbors: Vec<(u8, bool, CellId)> = graph
+                    .neighbors(idx)
+                    .map(|(nb, bidx)| {
+                        let ec = graph.edge_color(idx, bidx);
+                        (
+                            ec.order_class,
+                            ec.from_is_donor,
+                            partition.cell_of[nb.0 as usize],
+                        )
+                    })
+                    .collect();
+                neighbors.sort_unstable();
+                RefineSignature {
+                    own: partition.cell_of[i],
+                    neighbors,
+                }
+            })
+            .collect();
+
+        let new_cell_of = assign_cell_ids(&sigs);
+        let new_cells = count_distinct_cells(&new_cell_of);
+        partition.cell_of = new_cell_of;
+
+        if new_cells <= old_cells {
+            break;
+        }
+    }
+    partition
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::parse;
+
+    #[test]
+    fn benzene_all_one_cell_before_refine_after_refine() {
+        let mol = parse("c1ccccc1").unwrap();
+        let graph = CanonicalColoredGraph::new(&mol);
+        let ranks = crate::canonical::morgan_ranks(&mol);
+        let p = exact_refine(&graph, initial_partition(&graph, &ranks));
+        let cells = p.cell_members();
+        let nonempty: Vec<_> = cells.into_iter().filter(|c| !c.is_empty()).collect();
+        assert_eq!(nonempty.len(), 1, "plain benzene: all 6 atoms in one cell");
+        assert_eq!(nonempty[0].len(), 6);
+    }
+
+    #[test]
+    fn isotope_difference_splits_cell() {
+        // One ring carbon isotope-labeled -- must land in its own cell even
+        // though morgan_ranks (initial_invariant has no isotope bit at the
+        // Morgan-search-heuristic layer... actually it does include iso, but
+        // this exercises the exact-refine path independently of that).
+        let mol = parse("[13cH]1ccccc1").unwrap();
+        let graph = CanonicalColoredGraph::new(&mol);
+        let ranks = crate::canonical::morgan_ranks(&mol);
+        let p = exact_refine(&graph, initial_partition(&graph, &ranks));
+        let cells = p.cell_members();
+        let iso_cell = cells.iter().find(|c| c.contains(&AtomIdx(0))).unwrap();
+        assert_eq!(
+            iso_cell.len(),
+            1,
+            "isotope-labeled atom must be alone in its cell"
+        );
+    }
+}

--- a/crates/chematic-smiles/src/canonical_search.rs
+++ b/crates/chematic-smiles/src/canonical_search.rs
@@ -320,8 +320,43 @@ fn search_canonical(
 /// Union-Find; only merges pairs an actual verified automorphism test
 /// proved equivalent (`has_colored_automorphism_mapping`). A false negative
 /// (failing to merge a genuinely-automorphic pair) only costs performance;
-/// a false positive is structurally impossible here since every union is
-/// gated on a real, independently-reverified bijection.
+/// a false positive is structurally impossible here **given `ranks` (and
+/// therefore `coloring`, seeded from it in `initial_partition`) correctly
+/// reflects every individualization already committed in an ancestor call**
+/// -- every union really is gated on a real, independently-reverified
+/// bijection over `graph`'s own color/edge data, which never merges two
+/// atoms that differ in any writer-visible attribute.
+///
+/// That parenthetical is not free, though (independent Round-2 false-prune
+/// audit, PR #193): `ranks` comes from `crate::canonical::individualize` +
+/// `refine_ranks`. `individualize` itself is exact integer arithmetic --
+/// the atom it distinguishes provably gets a rank no other atom in the
+/// vector holds, zero collision risk. But `refine_ranks` immediately
+/// re-hashes from that point (`fnv_hash_sequence`, pre-existing, unchanged
+/// by this PR) and `normalize_ranks` groups by raw hash-value *equality* --
+/// so a genuine 64-bit FNV-1a collision there could in principle re-merge
+/// an already-individualized atom back in with a formerly-tied sibling,
+/// and `coloring` would inherit that error (nothing downstream re-derives
+/// "was this atom individualized" independently of `ranks` -- `VertexColor`
+/// deliberately does not encode search-time individualization history, only
+/// intrinsic atom attributes). This dependency is not new: `refine_ranks`
+/// rank-equality is *already* the sole basis for the crate's pre-existing
+/// `equivalent_atom_classes`/`are_atoms_equivalent` public APIs, with
+/// identical collision exposure, unrelated to orbit pruning. What this PR
+/// changes is the *consequence* of a hypothetical collision: in the legacy
+/// exhaustive engine it would cause redundant-but-still-correct
+/// over-exploration (every member of a wrongly-merged cell still gets
+/// individualized and compared); here it could instead cause a genuinely
+/// distinct branch to be silently skipped. Not observed on any fixture, the
+/// n<=5 exhaustive suite, hundreds of randomized fuzz trials, or the
+/// 5,000-molecule corpus; would require a correlated 64-bit hash collision
+/// reconstructing an entire real symmetry's cell structure to manifest.
+/// Judged not worth threading a parallel, hash-free individualization-state
+/// vector through the hot path to close (a bigger change than this PR's
+/// scope, defending against a risk already implicitly accepted crate-wide)
+/// -- documented here and in `docs/canonical_automorphism_pruning.md`
+/// instead of silently left as an unqualified "structurally impossible"
+/// claim.
 fn exact_orbit_representatives(
     graph: &CanonicalColoredGraph,
     coloring: &Partition,
@@ -450,11 +485,18 @@ mod tests {
             // Atom-mapped reaction fragment (SMIRKS-style atom maps),
             // exercising the atom-map-is-writer-visible policy.
             "[CH3:1][C:2]([CH3:3])([CH3:4])[CH3:5]",
-            // Repeated disconnected fragment (independent components,
-            // no cross-component automorphism should ever be proposed
-            // between DIFFERENT physical copies for pruning -- each is
-            // still correctly recognized as its own separate 3-fold CF3
-            // orbit within itself).
+            // Repeated disconnected fragment (independent, structurally
+            // identical components). Correction (independent Round-2
+            // false-prune audit, PR #193): cross-component automorphism
+            // pruning between different physical copies of the same
+            // fragment DOES fire here, correctly and safely (measured:
+            // leaves_written=1, orbit_unions=14 with
+            // --features canonical-search-instrumentation) -- an earlier
+            // version of this comment claimed the opposite, which was
+            // factually backwards. The oracle check below still holds
+            // regardless of which orbits get merged, since it only
+            // constrains the final string, not the search's internal
+            // merge decisions.
             "FC(F)(F)C.FC(F)(F)C.FC(F)(F)C",
         ] {
             let mol = parse(smi).unwrap_or_else(|e| panic!("{smi}: {e:?}"));
@@ -462,6 +504,59 @@ mod tests {
                 canonical_smiles_with_limits(&mol, &CanonicalizationLimits::unbounded()).unwrap();
             let oracle = canonical_smiles_exhaustive_oracle(&mol);
             assert_eq!(got, oracle, "mismatch for {smi}");
+        }
+    }
+
+    /// Independent Round-1 correctness audit (PR #193) found a real
+    /// verification gap: every oracle cross-check above only ever compares
+    /// the winning canonical *string*, never the *rank vector*
+    /// `winning_individualized_ranks_with_limits` also returns and the
+    /// public `canonical_atom_order` API consumes. Two branches within one
+    /// automorphism orbit can legitimately share a minimal string via
+    /// different rank vectors, so string equality does not imply
+    /// rank-vector equality. Compares against the unbounded exhaustive
+    /// oracle's rank vector (`canonical_smiles_exhaustive_oracle_with_ranks`)
+    /// -- not the legacy engine's single winning leaf, which can also
+    /// legitimately differ for the same reason (Round 2 flagged this too).
+    #[test]
+    fn rank_vector_matches_exhaustive_oracle_not_just_string() {
+        for smi in [
+            "c1ccccc1",
+            "C1CCCCC1",
+            "CC(C)(C)C",
+            "FC(F)(F)C",
+            "C12CC3CC(CC(C3)C1)C2",
+            "F/C=C/C(F)(F)F",
+            "F/C=C\\C(F)(F)F",
+            "CC(C)(C)[13CH3]",
+            "[NH4+]",
+            "C[N+](C)(C)C",
+            "CC(C)(C)[CH3]",
+            "CC(C)(C)[C@H](N)O",
+            "[CH3:1][C:2]([CH3:3])([CH3:4])[CH3:5]",
+            "FC(F)(F)C.FC(F)(F)C.FC(F)(F)C",
+            // Independent fixtures added by the Round-1 audit, not
+            // previously exercised by this test suite.
+            "C1CCC2(CCCC2)C1",                      // spiro[4.4]nonane
+            "c1ncncn1",                             // 1,3,5-triazine
+            "Nc1nc(N)nc(N)n1",                      // melamine
+            "Cc1c(C)c(C)c(C)c(C)c1C",               // hexamethylbenzene
+            "C1CN2CCC1CC2",                         // quinuclidine
+            "C1CC2(CC1)OCCO2",                      // 1,4-dioxaspiro[4.5]decane
+            "C12C3C4C1C5C4C3C25", // cubane (this repo's existing fixture spelling)
+            "CC(C)(C)c1cc(C(C)(C)C)cc(C(C)(C)C)c1", // 1,3,5-tri-tert-butylbenzene
+            "C1CN2CCN1CC2",       // DABCO
+        ] {
+            let mol = parse(smi).unwrap_or_else(|e| panic!("{smi}: {e:?}"));
+            let (got_ranks, got_string) = winning_individualized_ranks_with_limits(
+                &mol,
+                &CanonicalizationLimits::unbounded(),
+            )
+            .unwrap();
+            let (oracle_ranks, oracle_string) =
+                crate::canonical::canonical_smiles_exhaustive_oracle_with_ranks(&mol);
+            assert_eq!(got_string, oracle_string, "string mismatch for {smi}");
+            assert_eq!(got_ranks, oracle_ranks, "rank-vector mismatch for {smi}");
         }
     }
 

--- a/crates/chematic-smiles/src/canonical_search.rs
+++ b/crates/chematic-smiles/src/canonical_search.rs
@@ -1,0 +1,572 @@
+//! Streaming, automorphism-orbit-pruned canonical search.
+//!
+//! Replaces full branch enumeration (`crate::canonical::
+//! enumerate_discrete_ranks`, still kept for the test-only exhaustive
+//! oracle and as a last-resort fallback -- see below) with a DFS that:
+//! 1. Never explores more than one representative per PROVEN automorphism
+//!    orbit within a target cell (`canonical_automorphism::
+//!    has_colored_automorphism_mapping` decides "proven").
+//! 2. Never collects the full leaf set into memory -- it streams leaves
+//!    into a single running incumbent (lexicographically smallest string).
+//!
+//! Every leaf's `ranks` vector is produced by the exact same
+//! `crate::canonical::individualize` + `crate::canonical::refine_ranks`
+//! primitives the legacy enumeration uses. Pruning only ever *skips*
+//! sibling branches; it never perturbs the rank vector of a branch it does
+//! explore. So any surviving branch is byte-for-byte identical to what
+//! unpruned enumeration would have produced for that same individualization
+//! sequence -- see `docs/canonical_automorphism_pruning.md`, "why pruning
+//! cannot change surviving output", for the full argument and its
+//! `canonical_smiles_exhaustive_oracle` cross-check.
+
+use chematic_core::{AtomIdx, Molecule};
+
+use crate::canonical::{CanonicalWriter, group_by_rank, individualize, refine_ranks};
+use crate::canonical_automorphism::has_colored_automorphism_mapping;
+use crate::canonical_partition::{
+    CanonicalColoredGraph, Partition, exact_refine, initial_partition,
+};
+
+mod stats {
+    //! Feature-gated internal work counters, following the exact pattern
+    //! established by `chematic-rxn`'s `perf_counters.rs`
+    //! (`docs/reaction_transform_perf.md`): process-global `AtomicUsize`s,
+    //! zero cost (every bump compiles to an empty inline fn) unless the
+    //! `canonical-search-instrumentation` feature is enabled.
+    #[cfg(feature = "canonical-search-instrumentation")]
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[cfg(feature = "canonical-search-instrumentation")]
+    static NODES_VISITED: AtomicUsize = AtomicUsize::new(0);
+    #[cfg(feature = "canonical-search-instrumentation")]
+    static LEAVES_WRITTEN: AtomicUsize = AtomicUsize::new(0);
+    #[cfg(feature = "canonical-search-instrumentation")]
+    static ORBIT_TESTS: AtomicUsize = AtomicUsize::new(0);
+    #[cfg(feature = "canonical-search-instrumentation")]
+    static ORBIT_UNIONS: AtomicUsize = AtomicUsize::new(0);
+    #[cfg(feature = "canonical-search-instrumentation")]
+    static CHILDREN_PRUNED: AtomicUsize = AtomicUsize::new(0);
+    #[cfg(feature = "canonical-search-instrumentation")]
+    static MAX_DEPTH: AtomicUsize = AtomicUsize::new(0);
+    #[cfg(feature = "canonical-search-instrumentation")]
+    static LARGEST_TARGET_CELL: AtomicUsize = AtomicUsize::new(0);
+    #[cfg(feature = "canonical-search-instrumentation")]
+    static BUDGET_EXHAUSTIONS: AtomicUsize = AtomicUsize::new(0);
+
+    /// Snapshot of every counter. All-zero when the feature is disabled.
+    #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+    pub struct CanonicalSearchStats {
+        pub nodes_visited: usize,
+        pub leaves_written: usize,
+        pub orbit_tests: usize,
+        pub orbit_unions: usize,
+        pub children_pruned: usize,
+        pub max_depth: usize,
+        pub largest_target_cell: usize,
+        pub budget_exhaustions: usize,
+    }
+
+    #[cfg(feature = "canonical-search-instrumentation")]
+    pub fn snapshot() -> CanonicalSearchStats {
+        CanonicalSearchStats {
+            nodes_visited: NODES_VISITED.load(Ordering::Relaxed),
+            leaves_written: LEAVES_WRITTEN.load(Ordering::Relaxed),
+            orbit_tests: ORBIT_TESTS.load(Ordering::Relaxed),
+            orbit_unions: ORBIT_UNIONS.load(Ordering::Relaxed),
+            children_pruned: CHILDREN_PRUNED.load(Ordering::Relaxed),
+            max_depth: MAX_DEPTH.load(Ordering::Relaxed),
+            largest_target_cell: LARGEST_TARGET_CELL.load(Ordering::Relaxed),
+            budget_exhaustions: BUDGET_EXHAUSTIONS.load(Ordering::Relaxed),
+        }
+    }
+    #[cfg(not(feature = "canonical-search-instrumentation"))]
+    pub fn snapshot() -> CanonicalSearchStats {
+        CanonicalSearchStats::default()
+    }
+
+    #[cfg(feature = "canonical-search-instrumentation")]
+    pub fn reset() {
+        NODES_VISITED.store(0, Ordering::Relaxed);
+        LEAVES_WRITTEN.store(0, Ordering::Relaxed);
+        ORBIT_TESTS.store(0, Ordering::Relaxed);
+        ORBIT_UNIONS.store(0, Ordering::Relaxed);
+        CHILDREN_PRUNED.store(0, Ordering::Relaxed);
+        MAX_DEPTH.store(0, Ordering::Relaxed);
+        LARGEST_TARGET_CELL.store(0, Ordering::Relaxed);
+        BUDGET_EXHAUSTIONS.store(0, Ordering::Relaxed);
+    }
+    #[cfg(not(feature = "canonical-search-instrumentation"))]
+    pub fn reset() {}
+
+    #[cfg(feature = "canonical-search-instrumentation")]
+    pub(crate) fn record_node(depth: usize) {
+        NODES_VISITED.fetch_add(1, Ordering::Relaxed);
+        MAX_DEPTH.fetch_max(depth, Ordering::Relaxed);
+    }
+    #[cfg(not(feature = "canonical-search-instrumentation"))]
+    #[inline(always)]
+    pub(crate) fn record_node(_depth: usize) {}
+
+    #[cfg(feature = "canonical-search-instrumentation")]
+    pub(crate) fn record_leaf() {
+        LEAVES_WRITTEN.fetch_add(1, Ordering::Relaxed);
+    }
+    #[cfg(not(feature = "canonical-search-instrumentation"))]
+    #[inline(always)]
+    pub(crate) fn record_leaf() {}
+
+    #[cfg(feature = "canonical-search-instrumentation")]
+    pub(crate) fn record_orbit_test(succeeded: bool) {
+        ORBIT_TESTS.fetch_add(1, Ordering::Relaxed);
+        if succeeded {
+            ORBIT_UNIONS.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+    #[cfg(not(feature = "canonical-search-instrumentation"))]
+    #[inline(always)]
+    pub(crate) fn record_orbit_test(_succeeded: bool) {}
+
+    #[cfg(feature = "canonical-search-instrumentation")]
+    pub(crate) fn record_target_cell(cell_size: usize, representatives: usize) {
+        LARGEST_TARGET_CELL.fetch_max(cell_size, Ordering::Relaxed);
+        CHILDREN_PRUNED.fetch_add(cell_size.saturating_sub(representatives), Ordering::Relaxed);
+    }
+    #[cfg(not(feature = "canonical-search-instrumentation"))]
+    #[inline(always)]
+    pub(crate) fn record_target_cell(_cell_size: usize, _representatives: usize) {}
+
+    #[cfg(feature = "canonical-search-instrumentation")]
+    pub(crate) fn record_budget_exhaustion() {
+        BUDGET_EXHAUSTIONS.fetch_add(1, Ordering::Relaxed);
+    }
+    #[cfg(not(feature = "canonical-search-instrumentation"))]
+    #[inline(always)]
+    pub(crate) fn record_budget_exhaustion() {}
+}
+
+pub use stats::CanonicalSearchStats;
+pub use stats::{reset as reset_search_stats, snapshot as search_stats_snapshot};
+
+/// Budget for the fallible, bounded canonicalization API
+/// ([`canonical_smiles_with_limits`]). `None` on either field means "no cap
+/// on that dimension".
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CanonicalizationLimits {
+    pub max_search_nodes: Option<usize>,
+    pub max_automorphism_tests: Option<usize>,
+}
+
+impl CanonicalizationLimits {
+    /// No cap on either dimension. This is the policy the existing
+    /// infallible `canonical_smiles`/`canonical_atom_order` use (see their
+    /// doc comments): with automorphism-orbit pruning removing the
+    /// combinatorial blowup that made the old fixed 10,000-branch cap
+    /// necessary, an unbounded search over the (now much smaller) set of
+    /// *necessary* branches is safe in practice -- termination is still
+    /// mathematically guaranteed (individualize-refine recursion depth is
+    /// bounded by atom count regardless of branching factor), just not
+    /// bounded in wall-clock for a theoretical adversarial worst case that
+    /// has not been observed on this project's fixtures or 5,000-molecule
+    /// corpus.
+    pub fn unbounded() -> Self {
+        Self {
+            max_search_nodes: None,
+            max_automorphism_tests: None,
+        }
+    }
+}
+
+/// Errors from the bounded canonicalization API. Never silently substituted
+/// for a correct answer: budget exhaustion is always `Err`, never a
+/// partial-search result returned as if it were the true minimum.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CanonicalizationError {
+    /// The configured `CanonicalizationLimits` were exceeded before the
+    /// search could complete and prove its result correct.
+    SearchBudgetExceeded {
+        nodes_visited: usize,
+        automorphism_tests: usize,
+    },
+    /// An internal invariant was violated (e.g. the search produced no leaf
+    /// at all for a non-empty molecule). Should never happen; surfaced as a
+    /// typed error rather than a panic or a silently-wrong string so a
+    /// caller can detect and report it.
+    InvalidInternalMapping { detail: String },
+}
+
+impl std::fmt::Display for CanonicalizationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SearchBudgetExceeded {
+                nodes_visited,
+                automorphism_tests,
+            } => write!(
+                f,
+                "canonicalization search budget exceeded ({nodes_visited} nodes, {automorphism_tests} automorphism tests)"
+            ),
+            Self::InvalidInternalMapping { detail } => {
+                write!(f, "internal canonicalization invariant violated: {detail}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CanonicalizationError {}
+
+struct Incumbent {
+    ranks: Vec<u64>,
+    string: String,
+}
+
+#[derive(Default)]
+struct SearchBudget {
+    nodes_visited: usize,
+    automorphism_tests: usize,
+}
+
+/// Return the canonical SMILES for `mol`, respecting `limits`. `Err` on
+/// budget exhaustion -- never a partial/truncated string.
+pub fn canonical_smiles_with_limits(
+    mol: &Molecule,
+    limits: &CanonicalizationLimits,
+) -> Result<String, CanonicalizationError> {
+    if mol.atom_count() == 0 {
+        return Ok(String::new());
+    }
+    let (_, s) = winning_individualized_ranks_with_limits(mol, limits)?;
+    Ok(s)
+}
+
+/// Same search as [`canonical_smiles_with_limits`], but also returns the
+/// winning fully-discrete rank vector (used by `canonical_atom_order`).
+pub(crate) fn winning_individualized_ranks_with_limits(
+    mol: &Molecule,
+    limits: &CanonicalizationLimits,
+) -> Result<(Vec<u64>, String), CanonicalizationError> {
+    let graph = CanonicalColoredGraph::new(mol);
+    let ranks = crate::canonical::morgan_ranks(mol);
+    let mut budget = SearchBudget::default();
+    let mut incumbent: Option<Incumbent> = None;
+    search_canonical(mol, &graph, ranks, 0, limits, &mut budget, &mut incumbent)?;
+    match incumbent {
+        Some(Incumbent { ranks, string }) => Ok((ranks, string)),
+        None => Err(CanonicalizationError::InvalidInternalMapping {
+            detail: "orbit-pruned search produced no leaf for a non-empty molecule".to_string(),
+        }),
+    }
+}
+
+fn search_canonical(
+    mol: &Molecule,
+    graph: &CanonicalColoredGraph,
+    ranks: Vec<u64>,
+    depth: usize,
+    limits: &CanonicalizationLimits,
+    budget: &mut SearchBudget,
+    incumbent: &mut Option<Incumbent>,
+) -> Result<(), CanonicalizationError> {
+    budget.nodes_visited += 1;
+    stats::record_node(depth);
+    if let Some(max) = limits.max_search_nodes
+        && budget.nodes_visited > max
+    {
+        stats::record_budget_exhaustion();
+        return Err(CanonicalizationError::SearchBudgetExceeded {
+            nodes_visited: budget.nodes_visited,
+            automorphism_tests: budget.automorphism_tests,
+        });
+    }
+
+    let cells = group_by_rank(&ranks);
+    // Same heuristic as the legacy enumeration (section 10: unchanged in
+    // this PR): the lowest-ranked non-singleton cell.
+    let Some(members) = cells.iter().find(|m| m.len() > 1) else {
+        let s = CanonicalWriter::new(mol, &ranks).write_all();
+        stats::record_leaf();
+        let is_better = incumbent.as_ref().is_none_or(|c| s < c.string);
+        if is_better {
+            *incumbent = Some(Incumbent { ranks, string: s });
+        }
+        return Ok(());
+    };
+
+    // Exact partition (full writer-visible chemical color, intersected with
+    // the current individualization state carried by `ranks`), refined to a
+    // fixpoint. Used only to decide which members of `members` are provably
+    // in the same automorphism orbit -- NEVER used to alter `ranks` itself
+    // (see module docs).
+    let partition = exact_refine(graph, initial_partition(graph, &ranks));
+    let representatives = exact_orbit_representatives(graph, &partition, members, limits, budget)?;
+    stats::record_target_cell(members.len(), representatives.len());
+
+    for rep in representatives {
+        let individualized = individualize(&ranks, rep);
+        let re_refined = refine_ranks(mol, individualized);
+        search_canonical(mol, graph, re_refined, depth + 1, limits, budget, incumbent)?;
+    }
+    Ok(())
+}
+
+/// Partition `members` (raw atom indices, ascending) into automorphism
+/// orbits under the current node's coloring, and return one representative
+/// per orbit -- the minimum-index member, ascending across orbits. This
+/// exactly mirrors the legacy `enumerate_discrete_ranks`'s traversal order
+/// (`for &atom_idx in members` in ascending-index order) restricted to
+/// orbit representatives, so that whenever every relevant cell turns out to
+/// be a genuine orbit, the very first leaf this search reaches is identical
+/// to the first leaf the legacy exhaustive enumeration would have reached
+/// (see the design doc for why this matters for tie-break determinism).
+///
+/// Union-Find; only merges pairs an actual verified automorphism test
+/// proved equivalent (`has_colored_automorphism_mapping`). A false negative
+/// (failing to merge a genuinely-automorphic pair) only costs performance;
+/// a false positive is structurally impossible here since every union is
+/// gated on a real, independently-reverified bijection.
+fn exact_orbit_representatives(
+    graph: &CanonicalColoredGraph,
+    coloring: &Partition,
+    members: &[usize],
+    limits: &CanonicalizationLimits,
+    budget: &mut SearchBudget,
+) -> Result<Vec<usize>, CanonicalizationError> {
+    // Union-Find is indexed by POSITION within `members` (0..members.len()),
+    // not by atom index -- `members` are raw atom indices which may be
+    // sparse/non-contiguous (e.g. a target cell of atoms 3 and 7), so
+    // `parent` must never store a raw atom index as if it were a position.
+    let mut parent: Vec<usize> = (0..members.len()).collect();
+
+    fn find(parent: &mut [usize], mut x: usize) -> usize {
+        while parent[x] != x {
+            parent[x] = parent[parent[x]];
+            x = parent[x];
+        }
+        x
+    }
+
+    for i in 0..members.len() {
+        for j in (i + 1)..members.len() {
+            let ri = find(&mut parent, i);
+            let rj = find(&mut parent, j);
+            if ri == rj {
+                continue;
+            }
+            budget.automorphism_tests += 1;
+            if let Some(max) = limits.max_automorphism_tests
+                && budget.automorphism_tests > max
+            {
+                stats::record_budget_exhaustion();
+                return Err(CanonicalizationError::SearchBudgetExceeded {
+                    nodes_visited: budget.nodes_visited,
+                    automorphism_tests: budget.automorphism_tests,
+                });
+            }
+            let equivalent = has_colored_automorphism_mapping(
+                graph,
+                coloring,
+                AtomIdx(members[i] as u32),
+                AtomIdx(members[j] as u32),
+            );
+            stats::record_orbit_test(equivalent);
+            if equivalent {
+                parent[ri] = rj;
+            }
+        }
+    }
+
+    // One representative (minimum atom index) per orbit, orbits ordered by
+    // that minimum ascending.
+    let mut by_root: std::collections::BTreeMap<usize, usize> = std::collections::BTreeMap::new();
+    for (i, &atom_idx) in members.iter().enumerate() {
+        let r = find(&mut parent, i);
+        by_root
+            .entry(r)
+            .and_modify(|min_idx| {
+                if atom_idx < *min_idx {
+                    *min_idx = atom_idx;
+                }
+            })
+            .or_insert(atom_idx);
+    }
+    let mut reps: Vec<usize> = by_root.into_values().collect();
+    reps.sort_unstable();
+    Ok(reps)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::canonical::canonical_smiles_exhaustive_oracle;
+    use crate::parser::parse;
+
+    #[test]
+    fn unbounded_matches_exhaustive_oracle_on_symmetric_molecules() {
+        for smi in [
+            "c1ccccc1",
+            "C1CCCCC1",
+            "CC(C)(C)C",
+            "FC(F)(F)C",
+            "C12CC3CC(CC(C3)C1)C2", // adamantane-shaped
+            // E/Z alkene with an unrelated CF3 group elsewhere -- the
+            // stereo-neighbor-pinning judgment call (see design doc) must
+            // not disable pruning for symmetry unrelated to the stereo
+            // system.
+            "F/C=C/C(F)(F)F",
+            "F/C=C\\C(F)(F)F",
+            "c2c3c4c1c6c(ccc7ccc5ccc(c4c5c67)cc3)ccc1c2", // coronene (C24H12, 24 atoms, 7 aromatic rings, verified geometrically -- see canonical_orbit_perf.rs)
+        ] {
+            let mol = parse(smi).unwrap();
+            let got =
+                canonical_smiles_with_limits(&mol, &CanonicalizationLimits::unbounded()).unwrap();
+            let oracle = canonical_smiles_exhaustive_oracle(&mol);
+            assert_eq!(got, oracle, "mismatch for {smi}");
+        }
+    }
+
+    /// Section 14 chemical fixtures: a molecule whose otherwise-symmetric
+    /// skeleton is broken at exactly one position by isotope / formal
+    /// charge / explicit H / tetrahedral stereo, plus an atom-mapped
+    /// reaction fragment and a repeated disconnected fragment. Each must
+    /// match the unbounded exhaustive oracle exactly (no false prune could
+    /// survive that check) -- the single broken position must never be
+    /// silently merged back into its formerly-symmetric siblings.
+    #[test]
+    fn single_position_symmetry_breaks_match_oracle() {
+        for smi in [
+            // Neopentane, one methyl isotope-labeled.
+            "CC(C)(C)[13CH3]",
+            // Neopentane-like center, one arm bearing a formal + charge
+            // (via a quaternary ammonium analog) -- otherwise-identical
+            // substituents, one distinguished by charge alone.
+            "[NH4+]",
+            "C[N+](C)(C)C",
+            // Explicit-H bracket forcing on one of four otherwise-identical
+            // substituents (still the same effective H count, but
+            // `needs_bracket` differs -- see design doc's vertex-color
+            // audit).
+            "CC(C)(C)[CH3]",
+            // Tetrahedral stereo breaking an otherwise symmetric skeleton
+            // at exactly one position.
+            "CC(C)(C)[C@H](N)O",
+            // Atom-mapped reaction fragment (SMIRKS-style atom maps),
+            // exercising the atom-map-is-writer-visible policy.
+            "[CH3:1][C:2]([CH3:3])([CH3:4])[CH3:5]",
+            // Repeated disconnected fragment (independent components,
+            // no cross-component automorphism should ever be proposed
+            // between DIFFERENT physical copies for pruning -- each is
+            // still correctly recognized as its own separate 3-fold CF3
+            // orbit within itself).
+            "FC(F)(F)C.FC(F)(F)C.FC(F)(F)C",
+        ] {
+            let mol = parse(smi).unwrap_or_else(|e| panic!("{smi}: {e:?}"));
+            let got =
+                canonical_smiles_with_limits(&mol, &CanonicalizationLimits::unbounded()).unwrap();
+            let oracle = canonical_smiles_exhaustive_oracle(&mol);
+            assert_eq!(got, oracle, "mismatch for {smi}");
+        }
+    }
+
+    #[test]
+    fn ez_pinning_does_not_disable_unrelated_cf3_pruning() {
+        // E and Z isomers of the same skeleton must still produce different
+        // canonical strings (the stereo information itself must never be
+        // lost or pruned away)...
+        let e = parse("F/C=C/C(F)(F)F").unwrap();
+        let z = parse("F/C=C\\C(F)(F)F").unwrap();
+        let e_out = canonical_smiles_with_limits(&e, &CanonicalizationLimits::unbounded()).unwrap();
+        let z_out = canonical_smiles_with_limits(&z, &CanonicalizationLimits::unbounded()).unwrap();
+        assert_ne!(
+            e_out, z_out,
+            "E and Z isomers must not canonicalize to the same string"
+        );
+
+        // ...while the CF3 group's three (mutually automorphic, chemically
+        // unrelated to the E/Z system) fluorines still get pruned to a
+        // single explored orbit representative rather than 3 separate
+        // individualize branches. Checked via the exhaustive oracle
+        // cross-check above (equality holds) plus a direct node-count
+        // sanity bound here: a plain CF3-only molecule needs few search
+        // nodes, and adding an unrelated, already-fully-discrete E/Z system
+        // must not multiply that cost by 3 (which is what NOT pruning the
+        // CF3 fluorines would look like).
+        let (_, budget_nodes) = {
+            let mut budget = SearchBudget::default();
+            let mut incumbent = None;
+            let graph = CanonicalColoredGraph::new(&e);
+            let ranks = crate::canonical::morgan_ranks(&e);
+            search_canonical(
+                &e,
+                &graph,
+                ranks,
+                0,
+                &CanonicalizationLimits::unbounded(),
+                &mut budget,
+                &mut incumbent,
+            )
+            .unwrap();
+            (incumbent, budget.nodes_visited)
+        };
+        // Without CF3 pruning, the 3 fluorines alone would force >= 3! / (orbit) branch
+        // multiplicity layered on top of the E/Z system; with pruning, a
+        // handful of nodes suffices (well under a naive-enumeration-scale
+        // count). This is a coarse regression guard, not a precise bound.
+        assert!(
+            budget_nodes < 20,
+            "expected CF3 pruning to keep node count small, got {budget_nodes}"
+        );
+    }
+
+    #[test]
+    fn tiny_node_budget_fails_closed_not_empty_string() {
+        let mol = parse("c1ccccc1").unwrap();
+        let limits = CanonicalizationLimits {
+            max_search_nodes: Some(1),
+            max_automorphism_tests: None,
+        };
+        let result = canonical_smiles_with_limits(&mol, &limits);
+        assert!(
+            matches!(
+                result,
+                Err(CanonicalizationError::SearchBudgetExceeded { .. })
+            ),
+            "expected SearchBudgetExceeded, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn tiny_automorphism_test_budget_fails_closed() {
+        let mol = parse("c1ccccc1").unwrap();
+        let limits = CanonicalizationLimits {
+            max_search_nodes: None,
+            max_automorphism_tests: Some(0),
+        };
+        let result = canonical_smiles_with_limits(&mol, &limits);
+        assert!(matches!(
+            result,
+            Err(CanonicalizationError::SearchBudgetExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn generous_budget_succeeds_on_benzene() {
+        let mol = parse("c1ccccc1").unwrap();
+        let limits = CanonicalizationLimits {
+            max_search_nodes: Some(1000),
+            max_automorphism_tests: Some(1000),
+        };
+        assert!(canonical_smiles_with_limits(&mol, &limits).is_ok());
+    }
+
+    // --- Negative control: never return Ok on budget exhaustion -----------
+    #[test]
+    fn budget_exceeded_is_always_err_never_ok_with_wrong_string() {
+        let mol = parse("C1CC2CCC1CC2").unwrap(); // bicyclic, has real ties
+        let limits = CanonicalizationLimits {
+            max_search_nodes: Some(1),
+            max_automorphism_tests: Some(1),
+        };
+        match canonical_smiles_with_limits(&mol, &limits) {
+            Err(CanonicalizationError::SearchBudgetExceeded { .. }) => {}
+            other => panic!("expected SearchBudgetExceeded, got {other:?}"),
+        }
+    }
+}

--- a/crates/chematic-smiles/src/lib.rs
+++ b/crates/chematic-smiles/src/lib.rs
@@ -27,6 +27,9 @@
 //! - WASM-compatible (no filesystem I/O, no threads).
 
 pub mod canonical;
+mod canonical_automorphism;
+mod canonical_partition;
+pub mod canonical_search;
 pub mod cx;
 pub mod error;
 pub mod parser;
@@ -37,6 +40,10 @@ pub mod writer;
 pub use canonical::are_atoms_equivalent;
 pub use canonical::{
     canonical_atom_order, canonical_smiles, equivalent_atom_classes, morgan_ranks,
+};
+pub use canonical_search::{
+    CanonicalSearchStats, CanonicalizationError, CanonicalizationLimits,
+    canonical_smiles_with_limits, reset_search_stats, search_stats_snapshot,
 };
 pub use cx::{CxAtomProp, CxSmiles, parse_cxsmiles, write_cxsmiles};
 pub use error::SmilesError;

--- a/crates/chematic-smiles/tests/canonical_robustness.rs
+++ b/crates/chematic-smiles/tests/canonical_robustness.rs
@@ -326,14 +326,34 @@ fn large_fused_pah_stable() {
     );
 }
 
-/// Coronene canonical SMILES is not yet idempotent for the 7-ring PAH system.
-/// Morgan rank ties in highly symmetric graphs can produce oscillating ring-closure
-/// numbering. Tracked as a known limitation (analogous to RDKit issue #8775).
+/// Coronene canonical SMILES was not idempotent for this 7-ring fused PAH
+/// system prior to `fix/canonical-automorphism-pruning`: Morgan rank ties in
+/// this highly symmetric graph could produce oscillating ring-closure
+/// numbering (tracked as a known limitation, analogous to RDKit issue
+/// #8775). Fixed as a verified side effect of that PR's automorphism-
+/// orbit-pruned canonical search -- confirmed (not just "the test happens
+/// to pass now") against the unbounded exhaustive individualize-refine
+/// oracle in both directions (original parse and re-parse-of-canonical) and
+/// across 32 relabelings of the same molecule, see
+/// `crates/chematic-smiles/src/canonical_search.rs`'s
+/// `unbounded_matches_exhaustive_oracle_on_symmetric_molecules` test. No
+/// longer `#[ignore]`d.
+///
+/// **Fixture correction**: the SMILES string this test originally used
+/// (`c1ccc2ccc3ccc4ccc5ccc6ccccc6c5c4c3c2c1`) parses to **26** atoms, not
+/// the 24 a real coronene (C24H12, 7 fused hexagons) has -- the same class
+/// of mislabeled-fixture problem this project was warned about for its
+/// "cubane" fixture elsewhere in this repo. Replaced with a coronene
+/// skeleton independently verified geometrically (7-hexagon flower
+/// construction, Kekule-matched, then aromatized: 24 atoms, 30 bonds, 7
+/// aromatic rings -- see `crates/chematic-smiles/examples/
+/// canonical_orbit_perf.rs`'s `coronene_smiles()`). The bug this test
+/// guards was real and reproduced on both the old (26-atom) and the
+/// corrected (24-atom) molecule.
 #[test]
-#[ignore = "known: coronene (7-ring PAH) canonical SMILES oscillates — needs Morgan rank tie-breaking fix"]
 fn coronene_canonical_known_bug() {
     assert!(
-        check_canonical_stable("c1ccc2ccc3ccc4ccc5ccc6ccccc6c5c4c3c2c1").is_ok(),
+        check_canonical_stable("c2c3c4c1c6c(ccc7ccc5ccc(c4c5c67)cc3)ccc1c2").is_ok(),
         "coronene should be idempotent"
     );
 }

--- a/docs/canonical_automorphism_pruning.md
+++ b/docs/canonical_automorphism_pruning.md
@@ -273,8 +273,39 @@ well-scoped future refinement if a real molecule is found where it matters.
    to`.
 5. A false negative (missing a real orbit) only costs performance --
    `exact_orbit_representatives` still explores that branch. A false
-   positive is prevented structurally: every union is gated on an
-   independently re-verified bijection, never rank/hash equality alone.
+   positive is prevented **given step 1's `ranks` correctly reflects every
+   individualization already committed** -- every union is gated on an
+   independently re-verified bijection over `VertexColor`/`EdgeColor`, never
+   rank/hash equality alone.
+
+   That qualification is not vacuous (independent Round-2 false-prune
+   audit, PR #193): `ranks` is produced by the pre-existing, unchanged
+   `individualize` + `refine_ranks`. `individualize` itself is exact integer
+   arithmetic (zero collision risk), but `refine_ranks`'s subsequent
+   `fnv_hash_sequence`/`normalize_ranks` groups by raw 64-bit hash-value
+   *equality* -- so a genuine hash collision there could in principle
+   re-merge an already-individualized atom with a formerly-tied sibling,
+   and step 1's `VertexColor` alone cannot catch that (it deliberately
+   carries no search-time individualization history, only intrinsic atom
+   attributes). This exposure is not new: `refine_ranks` rank-equality is
+   *already* the sole basis for this crate's pre-existing
+   `equivalent_atom_classes`/`are_atoms_equivalent` public APIs, with
+   identical collision risk, unrelated to orbit pruning. What this PR
+   changes is the *consequence*: the legacy exhaustive engine would turn a
+   hypothetical collision into redundant-but-still-correct
+   over-exploration (every member of a wrongly-merged cell still gets
+   individualized); this PR's pruned engine could instead silently skip a
+   genuinely distinct branch. Not observed on any fixture, the `n<=5`
+   exhaustive suite, hundreds of randomized fuzz trials, or the
+   5,000-molecule corpus; would require a correlated 64-bit FNV-1a collision
+   reconstructing an entire real symmetry's cell structure to manifest.
+   Closing it fully would mean threading a parallel, hash-free
+   individualization-state vector through the search's hot path --
+   judged out of this PR's scope (a bigger change, defending against a risk
+   already implicitly accepted crate-wide), so disclosed here instead of
+   left as an unqualified "structurally impossible" claim. See
+   `canonical_search::exact_orbit_representatives`'s doc comment for the
+   same account in the code itself.
 
 ## Old vs. new budget semantics
 

--- a/docs/canonical_automorphism_pruning.md
+++ b/docs/canonical_automorphism_pruning.md
@@ -1,0 +1,323 @@
+# Canonical SMILES: automorphism-orbit-aware branch pruning
+
+Date: 2026-07-29. Branch: `fix/canonical-automorphism-pruning`. Trigger: RENKIN
+(external sibling project) reported `apply_retro`/`run_reactants` at up to a
+45x slowdown between chematic 0.4.25 and later versions, traced to
+`canonical_smiles()`'s individualize-refine branch-and-minimize search
+introduced by `be5dbb1` (2026-07-10). PR #189 (merged `97c87e3`) fixed a
+narrower, real bug (a redundant second `write_all()` call, ~13.4% measured
+improvement) but explicitly left the combinatorial branch explosion itself
+unfixed (`docs/reaction_transform_perf.md`, "Remaining gap"). This is that
+follow-up.
+
+## Root cause, precisely
+
+`be5dbb1` fixed a genuine correctness bug (`canonical_smiles(parse(x))` could
+disagree with `canonical_smiles(parse(y))` for two spellings of the same
+molecule) by adding individualize-refine branch-and-minimize: whenever plain
+Morgan-rank refinement (`morgan_ranks`) plateaus with ties, every possible
+tie-resolution is tried (`enumerate_discrete_ranks`) and the
+lexicographically smallest resulting string kept. This is *necessary* for
+correctness, but the enumeration is combinatorially blind to *why* a cell is
+tied: a 1-WL / Morgan-rank refinement cell can be tied because it is a
+genuine automorphism orbit (every choice of representative yields an
+identical result -- provably redundant to explore more than one) or because
+it merely *contains* an orbit alongside genuinely different candidates (every
+choice must be explored). The old code always assumed the latter,
+unconditionally, for every tied cell -- hence the documented up-to-168,219
+branches on real ChEMBL molecules with independent 3-fold-symmetric Boc/tBu
+groups.
+
+**Why Morgan-rank-only pruning would be unsound** (the naive "fix" this PR
+does NOT take): merging two atoms into one orbit merely because they share
+the same Morgan rank conflates "same 1-WL cell" with "same automorphism
+orbit". These are NOT equivalent -- a 1-WL refinement cell can contain
+multiple distinct orbits (a standard, well-known limitation of
+color-refinement algorithms; see McKay & Piperno 2014 and Piperno
+arXiv:0804.4881, used here for algorithmic design inspiration only, not
+ported). `canonical_automorphism.rs`'s own exhaustive test suite pins a
+concrete witness of this: the disjoint union of a triangle (C3) and a square
+(C4) is 2-regular throughout, so 1-WL/Morgan-rank refinement can never split
+it into more than one cell (both components look identical to purely local
+neighbor-hash iteration) -- yet no automorphism can map a triangle vertex to
+a square vertex (components of different order can never correspond under a
+graph automorphism). A rank-hash-only pruning scheme would wrongly treat all
+7 vertices as one interchangeable orbit.
+
+## Algorithm overview
+
+Four new/changed files, matching the required layer split:
+
+- `crates/chematic-smiles/src/canonical_partition.rs` -- the writer-visible
+  vertex/edge coloring (`VertexColor`/`EdgeColor`/`CanonicalColoredGraph`)
+  and an *exact* partition refinement (`exact_refine`) that never merges two
+  cells on hash-collision alone (full signature equality, only using a
+  hash/sort for lookup speed -- standard `HashMap`/`sort`/`dedup` behavior,
+  not the forbidden pattern).
+- `crates/chematic-smiles/src/canonical_automorphism.rs` -- an exact,
+  backtracking bijection search (`has_colored_automorphism_mapping`):
+  verifies a full graph automorphism (never a partial or subgraph match),
+  forces `from -> to`, keeps already-individualized singleton cells fixed
+  (via cell-restricted candidate search), and independently re-verifies the
+  complete mapping from scratch before returning `true`.
+- `crates/chematic-smiles/src/canonical_search.rs` -- `exact_orbit_representatives`
+  (pairwise union-find over one target cell's members, gated on an actual
+  verified automorphism test per pair, never Morgan-rank equality) and
+  `search_canonical` (streaming DFS: exact refinement, singleton check,
+  orbit partition of the target cell, individualize-refine exactly one
+  representative per orbit, recurse). Also the fallible bounded API
+  (`CanonicalizationLimits`/`CanonicalizationError`/
+  `canonical_smiles_with_limits`) and feature-gated instrumentation
+  counters.
+- `crates/chematic-smiles/src/canonical.rs` -- unchanged in its public
+  meaning (`morgan_ranks`, `equivalent_atom_classes`, `are_atoms_equivalent`
+  all still the old hash-based refinement, per this PR's own constraint).
+  `winning_individualized_ranks` (the shared internal helper used by both
+  `canonical_smiles` and `canonical_atom_order`) now calls the new
+  orbit-pruned search by default, with the original exhaustive enumeration
+  (`legacy_winning_individualized_ranks`, unchanged) kept as (a) a
+  last-resort fallback for the new engine's own internal-invariant error and
+  (b) the implementation behind the test-only exhaustive oracle
+  (`canonical_smiles_exhaustive_oracle`).
+
+## Why pruning cannot change surviving output
+
+The rank vectors handed to `CanonicalWriter` (and therefore every byte of the
+output string) are produced by the *exact same* `individualize` +
+`refine_ranks` primitives the legacy enumeration used, unchanged. Orbit
+pruning only ever decides *which atoms in a target cell get individualized
+at all* -- it selects a subset of the same candidate branches the legacy
+enumeration would visit; it never perturbs what a surviving branch computes.
+So any leaf this engine reaches is byte-for-byte identical to what the
+unpruned exhaustive enumeration would have produced for that same
+individualization sequence. This is why the engine can be directly
+cross-checked against `canonical_smiles_exhaustive_oracle` per molecule
+(section "Small-graph and chemical fixture results" below) rather than
+merely "look plausible".
+
+**Why skipping proven-redundant branches cannot change the *minimum*
+either**: if atoms `x` and `y` are in the same automorphism orbit (a real,
+verified graph automorphism `phi` fixes everything already individualized
+and maps `x -> y`), then the subtree reachable by individualizing `x` and
+the subtree reachable by individualizing `y` are related by `phi`: every leaf
+string reachable from one subtree is reachable from the other (composing
+with `phi`). So the *set* of leaf strings under `x` equals the *set* of leaf
+strings under `y`, and in particular their minima are equal to each other
+and to the true global minimum from that cell. Exploring only one
+representative therefore never removes the global minimum from
+consideration -- it only removes duplicate copies of it.
+
+## Why Morgan-rank equality is not proof, and what replaces it
+
+`initial_invariant` (in `canonical.rs`, unchanged) packs atomic number,
+degree, charge, isotope, aromaticity, and explicit-H flag into a `u64`, then
+`refine_ranks` iterates FNV-hash-based neighbor aggregation to a fixpoint.
+Two atoms sharing a Morgan rank means no *local, hash-summarized* feature
+distinguishes them within the number of refinement rounds run -- it does
+**not** mean a genuine graph automorphism relates them (the triangle/square
+witness above proves this can fail even for the *whole graph*, not just one
+cell). This PR never treats Morgan-rank equality as license to prune; every
+orbit union in `exact_orbit_representatives` is gated on an independently
+re-verified `has_colored_automorphism_mapping` call.
+
+## The writer-visible graph coloring
+
+Audited directly from `CanonicalWriter`'s `emit_atom`/`write_chain`/
+`find_ring_closures`/`corrected_chirality` and the plain writer's
+`crate::writer` (same crate, same rules per `raw_bond_direction`'s own doc
+comment: the two writers are kept from silently disagreeing).
+
+**Vertex color** (`VertexColor` in `canonical_partition.rs`) includes:
+- `wildcard` (the SMILES `*` atom always emits `[*]`, element is irrelevant)
+- `atomic_number` (0 when wildcard)
+- `isotope` (bracket-forcing; written verbatim when present)
+- `charge` (bracket-forcing; written verbatim)
+- `aromatic` (lowercase vs uppercase element symbol)
+- `h_state` (`atom.hydrogen_count.is_some()`/value -- `needs_bracket` is
+  keyed on this being `Some` at all, independent of the numeric H count
+  `implicit_hcount()` would separately compute, so `Some(0)` and `None` are
+  writer-distinguishable even when the *effective* H count matches)
+- `atom_map` (always emitted verbatim when present -- see "atom-map policy"
+  below)
+- `chirality` (`@`/`@@`/none discriminant)
+- `stereo_unique` (see "judgment call" below -- not itself a literal writer
+  attribute, but the mechanism this PR uses to stay sound around chirality
+  and E/Z without deriving full parity-aware automorphism math)
+
+**Edge color** (`EdgeColor`) includes:
+- `order_class`: all 13 `BondOrder` variants mapped to distinct classes
+  (Single/Double/Triple/Quadruple/Aromatic/Up/Down/Zero/Dative/QueryAny/
+  QuerySingleOrDouble/QuerySingleOrAromatic/QueryDoubleOrAromatic) -- never
+  collapsed the way `canonical.rs`'s *separate* `bond_order_value` (used
+  only for Morgan-rank neighbor hashing, unchanged) collapses Single/Up/
+  Down/Dative into one value; this module needs the finer distinction to
+  avoid false automorphisms between e.g. a plain single bond and a dative
+  bond.
+- `from_is_donor`: for a `Dative` bond only, `true` when the atom queried
+  *from* is `bond.atom1` (`chematic_core::BondOrder::Dative`'s own doc:
+  `atom1 -> atom2` is donor -> acceptor). Always computed relative to the
+  query side (`edge_color(from, bidx)`), so comparing `edge_color(u, ..)`
+  against `edge_color(phi(u), ..)` for the *same* relative direction
+  correctly preserves donor/acceptor identity under a candidate mapping,
+  without needing a separate direction-normalization step.
+
+**Excluded attributes, and why each is provably safe to exclude**:
+- `cip_code` (assigned CIP R/S/E/Z label): never read by `CanonicalWriter`
+  or `crate::writer` (grep-verified -- `chematic-chem`'s `assign_cip` writes
+  it, but this crate never emits it in `canonical_smiles`/`write` output). Not
+  writer-visible, safe to exclude.
+- `Molecule::stereo_groups` (enhanced-stereo `|&1:0,3|`-style annotations):
+  never referenced anywhere in `crate::canonical` or `crate::writer`
+  (grep-verified). Enhanced-stereo group output is a CXSMILES-specific
+  concern (`crate::cx`), out of scope for plain `canonical_smiles`. Not
+  writer-visible for this module's purposes, safe to exclude.
+- Raw stored `/`/`\` position/orientation as a literal attribute of one
+  specific bond: per this PR's task spec, "the raw stored position of `/`/
+  `\` is a spelling detail, not a chemical difference" -- `CanonicalWriter`
+  itself re-derives/re-orients direction per write-order via
+  `effective_order`/`normalize_ez`/`resolve_ez_markers`, so encoding the
+  *raw* literal Up-vs-Down value as an immutable per-bond color (rather
+  than its real cis/trans meaning) would be over-fitting to spelling. This
+  PR does not attempt to derive the fully resolved, write-order-independent
+  E/Z meaning ahead of the search (see the judgment call below for why);
+  instead of building a shortcut that could be wrong, it takes the strictly
+  conservative route of never pruning around such bonds at all, which is
+  safe (never a false merge) at the cost of some missed optimization
+  opportunity in molecules that mix E/Z stereo with unrelated symmetric
+  groups (verified NOT to disable pruning of unrelated groups --
+  `ez_pinning_does_not_disable_unrelated_cf3_pruning` in
+  `canonical_search.rs`).
+
+## Atom-map policy
+
+`CanonicalWriter::emit_atom` always writes `:{map}` when `atom.atom_map` is
+`Some`, unconditionally -- canonical SMILES **preserves** atom maps verbatim,
+it never strips or renumbers them. `VertexColor::atom_map` therefore
+participates in vertex color like every other writer-visible attribute: two
+atoms with different (or present-vs-absent) atom-map numbers are never
+considered automorphic.
+
+## Judgment call: stereo-bearing atoms and their direct neighbors are pinned
+
+**The call**: any atom with `chirality != Chirality::None`, or incident to a
+bond carrying real-or-potential direction information (`BondOrder::Up`/
+`Down`, or a non-`None` `Molecule::bond_direction` stash), together with
+*all of that atom's direct graph neighbors*, gets a globally unique vertex
+color (`stereo_unique: Some(atom_index)`) -- i.e. such an atom can only ever
+be mapped to itself by any accepted automorphism.
+
+**Why this is necessary, not just convenient** (found empirically, not
+predicted up front): an earlier version of this PR pinned *only* the
+stereo-bearing atom itself, reasoning "the tag is on that one atom, so
+forcing it to map to itself is enough". This is wrong. A tetrahedral
+center's `@`/`@@` tag is defined relative to the *order* of its direct
+neighbors (`Molecule::stereo_neighbor_order`); transposing two of those
+neighbors with each other inverts the encoded configuration even though the
+stereocenter atom itself never moves anywhere. This was caught by an
+*existing* regression test,
+`ring_digit_reuse_inside_stereocenter_branch_minimal` (a stereocenter with
+two topologically-swappable ring-neighbor `CH2` atoms): the atom-only pin
+passed every per-atom color/edge check yet a candidate automorphism swapping
+the two ring neighbors silently inverted the written chirality tag between
+the first and second canonicalization of the same molecule (an idempotence
+break, i.e. a real false-prune bug). Pinning every direct neighbor too
+closes this: chirality parity depends only on the stereocenter's direct
+neighbor list, never on anything further away, so pinning that whole list
+pointwise is sufficient (not merely convenient) to prevent any accepted
+automorphism from touching it. The same 1-hop rule is applied uniformly to
+E/Z-direction-bearing bonds (a stereogenic alkene end's *unmarked*
+substituent -- implied via substituent count rather than an explicit bond
+marker -- is one hop from the marked bond's endpoint and must stay pinned
+too, for the analogous reason).
+
+**Cost**: false negatives only (section 8's sanctioned trade) -- a
+stereocenter's own neighbors, and the stereo-bearing bond's endpoints, are
+never pruned even in cases where a more careful (full parity-aware
+automorphism check) analysis might prove it safe. Verified this does not
+regress the required performance targets: none of benzene/adamantane/
+coronene/CF3/tBu/Boc/pivaloyl carry any chirality or E/Z bonds, so the pin is
+a complete no-op for the high-symmetry performance corpus. Verified the pin
+does not *disable* pruning of an unrelated symmetric group sharing a
+molecule with an E/Z system (`ez_pinning_does_not_disable_unrelated_cf3_pruning`).
+
+**Alternative considered and rejected**: deriving a full parity-aware
+automorphism check (permutation-parity of the mapped neighbor order via the
+existing `permutation_is_odd` machinery, mirroring `corrected_chirality`'s
+own trick) would recover the strictly-necessary rather than
+strictly-sufficient pruning boundary. Not implemented in this PR: the
+1-hop-pin is simple, easy to verify by exhaustive small-graph and chemical
+fixture testing, has zero cost on every performance-gated fixture, and the
+false-negative cost (per section 8) is explicitly sanctioned. Left as a
+well-scoped future refinement if a real molecule is found where it matters.
+
+## Orbit-pruning safety argument (summary)
+
+1. `initial_partition` combines the current node's Morgan-derived `ranks`
+   (already encoding every individualization done so far) with the full,
+   static `VertexColor` -- so an already-individualized singleton, or an
+   atom distinguished only by an attribute `initial_invariant` doesn't carry
+   (isotope/charge/atom-map/stereo), is never merged into a larger cell by
+   this step.
+2. `exact_refine` refines that composite partition to a fixpoint using full
+   signature equality (own color + sorted multiset of (edge color, neighbor
+   cell)) -- never a hash-collision shortcut.
+3. `exact_orbit_representatives` only merges two members of the *current*
+   target cell when `has_colored_automorphism_mapping` returns `true` for
+   that specific pair, under the *current node's* coloring (not a
+   global/root-only symmetry group) -- so previously-individualized
+   singletons are automatically respected (the cell-restricted candidate
+   search in `extend_mapping` can only ever map a singleton to itself).
+4. `has_colored_automorphism_mapping` builds a complete bijection (never a
+   partial/subgraph match), independently re-verifies it in full
+   (`verify_full_bijection`) before returning `true`, and forces `from ->
+   to`.
+5. A false negative (missing a real orbit) only costs performance --
+   `exact_orbit_representatives` still explores that branch. A false
+   positive is prevented structurally: every union is gated on an
+   independently re-verified bijection, never rank/hash equality alone.
+
+## Old vs. new budget semantics
+
+Old: `enumerate_discrete_ranks` capped at `MAX_INDIVIDUALIZE_BRANCHES =
+10_000`; on exhaustion, the child loop silently `break`s and the caller
+takes `.min_by`/`.min_by_key` over whatever prefix of branches had been
+explored, presented as if it were the true answer. A sufficiently small
+budget (unreachable at 10_000 for any real molecule so far, but directly
+reachable once a caller can configure the budget) can make the *very first*
+node return an empty `Vec`, which `.unwrap_or_default()` turns into an empty
+canonical SMILES string -- silently wrong, not merely slow.
+
+New: `canonical_smiles`/`canonical_atom_order` (the existing infallible
+signatures, kept source-compatible) use
+`CanonicalizationLimits::unbounded()` -- no cap on search nodes or
+automorphism tests. This is safe specifically *because* orbit pruning
+removes the combinatorial blowup that made the old fixed cap necessary:
+recursion depth is bounded by atom count regardless of branching factor
+(mathematical termination was never actually at risk, only wall-clock cost
+was), and with orbit-redundant branches pruned away, the *necessary*
+branch count for every fixture and the 5,000-molecule corpus measured here
+stays small. `CanonicalizationError::InvalidInternalMapping` (should never
+happen) falls back to the original, unchanged exhaustive enumeration
+(`legacy_winning_individualized_ranks`) so a hypothetical internal-invariant
+bug in the new engine degrades to "slow but correct" rather than a panic or
+silently wrong output. New callers that want a hard ceiling instead should
+use the new fallible `canonical_smiles_with_limits`, which returns
+`Err(CanonicalizationError::SearchBudgetExceeded { .. })` -- never `Ok` with
+a truncated/wrong string, never an empty string, never an input-order-
+dependent silent fallback.
+
+## A verified side effect: coronene idempotence
+
+`tests/canonical_robustness.rs`'s `coronene_canonical_known_bug` was
+`#[ignore]`d as a known limitation ("coronene canonical SMILES oscillates").
+It now passes under this engine. Before un-ignoring it, this was verified
+(not assumed): the engine's output matches
+`canonical_smiles_exhaustive_oracle` for coronene in *both* directions
+(parsing the original aromatic SMILES, and re-parsing the resulting
+canonical string), the two canonicalizations agree with each other
+(idempotence), and the result is stable across 32 rotated/reflected
+relabelings of the same molecule (all in
+`canonical_search::tests::unbounded_matches_exhaustive_oracle_on_symmetric_molecules`
+and the `coronene_canonical_known_bug` update itself). This is reported
+individually and explicitly, per this PR's own requirement for any
+previously-broken case whose output changes.


### PR DESCRIPTION
## Summary

Root-cause fix for the RENKIN-reported `apply_retro`/`run_reactants` regression (up to 45x on symmetric molecules, base SHA `ebb796639a27887acd9993ef397245dce59848d9`; head SHA `57cc8025beaefaecdc2136cf36d6d5e4a83dcd7b`). PR #189 (merged `97c87e36951ae4b316bb893d434292f41ba65968`) fixed a narrower, real bug (a redundant second `write_all()` call, ~13.4% measured improvement) but explicitly left the combinatorial branch explosion itself unfixed (`docs/reaction_transform_perf.md`, "Remaining gap"). This PR is that follow-up: exact color-preserving automorphism-orbit pruning inside chematic's existing individualization-refinement canonical search.

**This PR does not implement nauty/Traces, does not achieve polynomial-time canonicalization for all symmetric molecules, and is not RDKit-canonical-SMILES compatible.** It prunes provably-redundant branches of the existing search using McKay & Piperno's orbit-pruning idea (DOI 10.1016/j.jsc.2013.09.003; arXiv:0804.4881) as *design inspiration only* -- no nauty/Traces code was ported.

## Root cause

`be5dbb1` (2026-07-10) fixed a genuine correctness bug by adding individualize-refine branch-and-minimize (`enumerate_discrete_ranks`): when Morgan-rank refinement plateaus with ties, every possible tie-resolution is tried and the lexicographically smallest resulting string is kept. This is *necessary* for correctness, but a 1-WL/Morgan-rank refinement cell can be tied because it's a genuine automorphism orbit (every choice yields an identical result -- redundant to explore more than one) **or** because it merely *contains* an orbit (genuinely different candidates, must explore all). The old code always assumed the latter, for every tied cell -- hence the documented up-to-168,219 branches on real ChEMBL molecules with multiple Boc/tBu groups.

## Why Morgan-rank-only pruning is unsound

Merging atoms into one orbit because they share a Morgan rank conflates "same 1-WL cell" with "same automorphism orbit" -- not equivalent. Concrete witness (`canonical_automorphism.rs`, `triangle_and_square_same_wl_cell_different_orbits`): the disjoint union of a triangle (C3) and a square (C4) is 2-regular throughout, so 1-WL/Morgan-rank refinement can never split it into more than one cell -- yet no automorphism can map a triangle vertex to a square vertex (components of different order can never correspond under a graph automorphism). A rank-hash-only scheme would wrongly treat all 7 vertices as one orbit.

## Algorithm overview

Four files (`crates/chematic-smiles/src/canonical.rs`, `canonical_partition.rs`, `canonical_automorphism.rs`, `canonical_search.rs`):

- **`canonical_partition.rs`**: `VertexColor`/`EdgeColor`/`CanonicalColoredGraph` (the writer-visible coloring, see below) + `exact_refine` (partition refinement via full signature *equality*, never a hash-collision shortcut -- a `u64`/sort is only ever used for lookup speed, exactly like ordinary `HashMap`/`sort`/`dedup` collision handling). **Qualification found by independent Round-2 review, see "Known remaining worst cases" below**: this is true of `exact_refine`'s own iterations; its *starting point* (`initial_partition`'s `ranks` component) is seeded from the pre-existing, unchanged `refine_ranks`, which does group by raw hash-value equality.
- **`canonical_automorphism.rs`**: `has_colored_automorphism_mapping` -- a real backtracking bijection search (never a substructure/subgraph match), forcing `from -> to`, respecting already-individualized singleton cells (via cell-restricted candidates), independently re-verifying the complete mapping from scratch (`verify_full_bijection`) before returning `true`.
- **`canonical_search.rs`**: `exact_orbit_representatives` (union-find over one target cell's members, gated on an actual verified automorphism test per pair -- never Morgan-rank equality) + `search_canonical` (streaming DFS: exact refine -> singleton check -> orbit partition of the target cell -> individualize exactly one representative per orbit -> recurse). Also the new fallible bounded API and feature-gated instrumentation.
- **`canonical.rs`**: `morgan_ranks`/`equivalent_atom_classes`/`are_atoms_equivalent` unchanged in public meaning. `winning_individualized_ranks` (shared by `canonical_smiles`/`canonical_atom_order`) now calls the new engine by default; the original exhaustive enumeration is kept as `legacy_winning_individualized_ranks` (last-resort fallback + test-only oracle support).

**Why pruning cannot change surviving output**: leaf rank vectors are produced by the *exact same* `individualize`+`refine_ranks` primitives the legacy enumeration used, unperturbed -- pruning only ever *skips* branches. Any surviving branch is byte-for-byte identical to what unpruned enumeration would have produced for that individualization sequence. And since an automorphism orbit's branches all reach the *same* leaf string (composing with the automorphism maps one subtree's leaves onto the other's), skipping duplicates never removes the true global minimum from consideration.

## The writer-visible graph coloring

Audited from `CanonicalWriter`/`crate::writer` directly (full detail + per-attribute justification in `docs/canonical_automorphism_pruning.md`):

- **Vertex color**: wildcard, atomic number, isotope, formal charge, aromatic flag, explicit-bracket-H state (`hydrogen_count.is_some()`/value -- distinct from computed `implicit_hcount()`), atom-map (always emitted verbatim when present -- canonical SMILES **preserves** atom maps, see the atom-map policy section of the design doc), chirality tag, and a `stereo_unique` field (see judgment call below).
- **Edge color**: all 13 `BondOrder` variants as distinct classes (never collapsed the way the *separate*, unchanged `bond_order_value` used only for Morgan-rank hashing collapses Single/Up/Down/Dative), plus a `from_is_donor` flag for `Dative` bonds (direction relative to the query side, so comparing `edge_color(u,..)` vs `edge_color(phi(u),..)` correctly preserves donor/acceptor identity).
- **Excluded, with justification**: `cip_code` (never read by the writer -- grep-verified) and `Molecule::stereo_groups` (enhanced-stereo annotations, never read by `crate::canonical`/`crate::writer` -- grep-verified, CXSMILES-only concern).

## Judgment call: stereo-bearing atoms and their direct neighbors are pinned

Any atom with `chirality != None`, or incident to a bond with real-or-potential direction info, **plus all of its direct neighbors**, gets a globally-unique color (never merged with anything). This was **found necessary, not just convenient**: an earlier version pinned only the stereo atom itself, and an existing idempotence regression test (`ring_digit_reuse_inside_stereocenter_branch_minimal`) caught a candidate automorphism transposing a stereocenter's two ring-neighbor `CH2` atoms -- passing every per-atom color/edge check yet silently inverting the encoded chirality between two canonicalizations of the same molecule. Verified this conservative choice costs nothing on the required performance corpus (none of benzene/adamantane/coronene/CF3/tBu/Boc/pivaloyl carry stereo) and does not disable pruning of an *unrelated* symmetric group sharing a molecule with an E/Z system (`ez_pinning_does_not_disable_unrelated_cf3_pruning`).

## Old vs. new budget semantics

Old: `enumerate_discrete_ranks` capped at `MAX_INDIVIDUALIZE_BRANCHES = 10_000`; on exhaustion, silently truncates and the caller's `.min_by(..).unwrap_or_default()` presents a partial-branch minimum as if true -- and with `budget=0` (directly reachable once a caller can configure it), yields an **empty canonical SMILES string**, not an error (`canonical::tests::old_design_zero_budget_silently_returns_empty_string_not_an_error`, a direct positive control against the legacy code path itself).

New: `canonical_smiles`/`canonical_atom_order` (existing infallible signatures, kept source-compatible) use `CanonicalizationLimits::unbounded()` -- no cap on search nodes or automorphism tests. Safe specifically because orbit pruning removes the combinatorial blowup that made the old cap necessary: recursion depth is bounded by atom count regardless of branching factor (termination was never actually at risk, only wall-clock cost). `CanonicalizationError::InvalidInternalMapping` (should never happen) falls back to `legacy_winning_individualized_ranks` so a hypothetical internal-invariant bug degrades to "slow but correct," never a panic or wrong output. New callers wanting a hard ceiling use `canonical_smiles_with_limits`, which returns `Err(SearchBudgetExceeded)` -- never `Ok` with a truncated string, never empty, never a silent input-order-dependent fallback (verified: `tiny_node_budget_fails_closed_not_empty_string`, `tiny_automorphism_test_budget_fails_closed`, `budget_exceeded_is_always_err_never_ok_with_wrong_string`).

## Small-graph exhaustive/randomized results

- All simple graphs `n<=5` (every edge subset, `1024` graphs total) x every vertex pair, cross-checked against a brute-force `O(n!)` ground truth: 0 mismatches.
- Random colored + edge-colored graphs, `n` in `6..=8`, 40 trials each (seeded xorshift PRNG, no `rand` dependency added), including disconnected trials: 0 mismatches against the same brute-force ground truth. **This fuzz test caught a real bug during development**: `extend_mapping`'s candidate filter checked partition-cell membership but not vertex color directly, so under a coarser-than-production partition the search could commit to a color-mismatched candidate, have final verification correctly reject it, and give up instead of backtracking to try other candidates -- a false negative (reachable only when the caller passes a partition coarser than production's, which always bakes vertex color into the composite cell key; still fixed, since this function must not rely on that caller invariant silently). Fixed in this PR (not a separate review-round commit, since found before any review).
- Structured graphs: cycles `n<=8`, complete graphs `n<=6`, complete bipartite (3,4), and the triangle+square same-cell/different-orbit witness -- all match expectations.
- Explicitly disconnected graphs (unequal-size components): 0 mismatches.

## 5,000-molecule corpus differential

`~/Downloads/SMILES.csv` (not committed to this repo, per the project's existing "external corpus, read-only" convention): **0 canonical-string differences, 0 new parse failures, 0 empty outputs, 0 panics**, comparing old (`legacy_canonical_smiles_for_benchmark`) vs new (`canonical_smiles`) on all 5,000 molecules. Leaf count 69,037 -> 5,220 (92.4% reduction). **Per-molecule geomean speedup is only ~1.09-1.10x** -- most molecules have little or no symmetry, so pruning has nothing to remove; the ~5x figure below is a *sum*, dominated by a small tail of severely-symmetric molecules where the old engine explodes combinatorially. Total elapsed 1529.85ms -> 304.19ms (~5.0x, tail-dominated, not typical-case). p95 486us -> 158us; max 216.13ms -> 2.12ms.

Budget-exhaustion counts of `0` throughout this PR (here and in the tables below) are measured on the *default, unbounded* path (`canonical_smiles`/`canonical_atom_order`), which by construction can never report an exhaustion -- `CanonicalizationLimits::unbounded()` never checks either budget, so "0 exhaustions" there is a tautology, not evidence. The real evidence for this PR's claims is the leaf-count reduction (algorithm-deterministic, reproduced exactly on every run) and the correctness differential (0 mismatches). The bounded API's fail-closed behavior *is* independently exercised and non-tautological: `canonical_smiles_with_limits` under a deliberately tiny cap does return `Err(SearchBudgetExceeded)` (`tiny_node_budget_fails_closed_not_empty_string`, `tiny_automorphism_test_budget_fails_closed`).

## High-/low-symmetry benchmarks (`cargo run --release -p chematic-smiles --example canonical_orbit_perf`)

| Tier | Leaves (old -> new) | Reduction | Geomean speedup | Mismatches | Budget exhaustions |
|---|---|---|---|---|---|
| A: high symmetry (13 fixtures) | 6625 -> 13 | 99.8% | ~5x | 0 | 0 |
| B: low symmetry (6 fixtures, negative control) | 153 -> 6 | 96.1% | ~1.1-1.2x (improvement, not regression) | 0 | 0 |
| C: 5,000-molecule corpus | 69037 -> 5220 | 92.4% | ~1.1x geomean, ~5x total elapsed | 0 | 0 |

Individually: benzene 12->1 (91.7%), adamantane 24->1 (95.8%), coronene 12->1 (91.7%) -- all clear the required >=80% bar. Multi-Boc/multi-pivaloyl fixtures: 432->1 leaves each, 0 budget exhaustions.

Fixtures built programmatically and verified (not reused from this repo's own pre-existing, differently-shaped fixtures): a real cube-graph cubane (8 atoms/12 bonds, `|Aut(Q3)|=48` -- NOT this repo's existing `C12C3C4C1C1C2C3C41`, which is an 11-bond graph) and a geometrically-constructed, Kekule-matched, aromatized 24-atom/30-bond/7-ring coronene (C24H12) -- this repo's existing `coronene_canonical_known_bug` fixture parses to 26 atoms, the same class of mislabeling; fixed in this PR (see below).

## RENKIN-shaped benchmark (`RAYON_NUM_THREADS=2 cargo run --release -p chematic-rxn --features perf-instrumentation --example reaction_transform_perf_report`)

RENKIN's own corpus is not available on this machine; used the existing hand-authored witness fixtures (7 templates x 11 molecules x depth 2, same harness PR #189 used).

**Correction (found by independent Round-3 performance audit, see "Independent verification" below): the comparison against PR #189's documented 596-598ms figure does not hold up and is withdrawn.** The auditor re-measured the exact parent commit (`ebb7966`, `git worktree`-checked-out fresh, harness+fixtures diff-verified byte-identical against HEAD, dependency versions checked) in the same session as HEAD and got 410-423ms (mean 418.4ms, n=5) at that commit today -- not the 596-598ms `docs/reaction_transform_perf.md` records from a prior session. `docs/reaction_transform_perf.md` is PR #189's own record and is out of this PR's file scope, so it has not been edited; the discrepancy is disclosed here instead. Comparing HEAD against that same fresh same-session baseline instead of the stale doc figure: `ebb7966` mean 418.4ms (n=5, range 410-423ms) -> HEAD mean 369.0ms (n=6, range 361-378ms) -- **~11.8% total-elapsed, ~20.5% p99, ~18.0% max, non-overlapping ranges on both sides**, 5-9x this project's own documented ~2.2% same-binary codegen noise floor, so real signal. This is a smaller, more defensible number than the withdrawn ~38-41%/~48-51% claim, and is the one this PR now stands behind.

## A verified side effect: coronene idempotence fixed

`tests/canonical_robustness.rs`'s `coronene_canonical_known_bug` was `#[ignore]`d ("coronene canonical SMILES oscillates"). It now passes. Verified before un-ignoring (not just "the test happens to pass"): engine output matches `canonical_smiles_exhaustive_oracle` in both directions (original parse and re-parse-of-canonical), the two canonicalizations agree (idempotence), and stable across 32 relabelings. **While verifying this, found the fixture's SMILES parses to 26 atoms, not the 24 a real coronene has** -- same class of mislabeling this task was warned about for "cubane." Fixed with a geometrically-verified 24-atom coronene in this PR; the bug is confirmed real and fixed on both the old (26-atom) and corrected (24-atom) molecule.

## Cap-hit fixture resolution

The 3 previously-documented ChEMBL molecules exceeding the old 10,000-branch cap (docs/reaction_transform_perf.md) are exactly the multi-Boc/pivaloyl-tBu shape this PR's Tier A fixtures reproduce (432 old leaves -> 1 new leaf each here); with orbit pruning, genuine automorphism-orbit-only cells collapse to O(1) regardless of how many redundant branches the old cap-hit cases needed, so this class of exhaustion no longer occurs on any fixture or the 5,000-molecule corpus (0 budget exhaustions measured throughout, unbounded default).

## Known remaining worst cases

- The stereo-pinning judgment call (see above) leaves some theoretically-safe symmetric prunes unexploited when stereo and unrelated symmetry are adjacent (1 hop) rather than distant -- false-negative only, never wrong output.
- A cell that genuinely *contains* an orbit alongside distinct non-automorphic candidates (not just a pure orbit) is still fully explored, same complexity as before -- this PR closes the *redundant*-exploration case, not the inherently-combinatorial one; no fixture or corpus molecule exercising that worst case was found here.
- `CanonicalizationLimits::unbounded()`'s only remaining theoretical risk is an adversarially-constructed molecule with a huge non-orbit tie cell; not observed on any fixture or the 5,000-molecule corpus, and callers needing a hard ceiling have `canonical_smiles_with_limits`.
- Orbit detection itself is not free: within a target cell of size *k*, `exact_orbit_representatives` runs up to O(k^2) pairwise automorphism tests, each an O(n)-per-candidate backtracking search. Tier A's largest observed target cell is 12, and this cost is paid instead of (not in addition to) the branch enumeration those candidates would otherwise have triggered, so it's a net win everywhere measured (5,000-molecule corpus, 0 budget exhaustions). A molecule with a very large *non-orbit* tie cell (see previous bullet) would pay this quadratic orbit-testing cost on top of the same combinatorial branch enumeration the old engine already paid for that cell -- not a regression path, but not yet stress-tested at large-k, so named here rather than left implicit.
- **The "never a hash-collision shortcut" framing above needs one qualification (found by independent Round-2 false-prune review, not a blocker, but the earlier framing was too absolute and is corrected here).** `exact_refine`'s own iterations really are hash-free (full signature `Eq`/`Ord`, never a hash value as proof). But `initial_partition`'s seed (the `ranks` component) comes from `crate::canonical`'s pre-existing, unchanged `individualize` + `refine_ranks`: `individualize` is exact integer arithmetic (zero collision risk), but `refine_ranks`'s `normalize_ranks` step groups by raw 64-bit FNV-1a hash-value *equality*. A genuine hash collision there could in principle re-merge an already-individualized atom with a formerly-tied sibling, and nothing downstream would catch it -- `VertexColor` deliberately carries no search-time individualization history, only intrinsic atom attributes, so `has_colored_automorphism_mapping`'s "independent" re-verification isn't independent of this specific failure mode. This is not a new dependency: `refine_ranks` rank-equality is *already* the sole basis for this crate's pre-existing `equivalent_atom_classes`/`are_atoms_equivalent` public APIs, with identical exposure, unrelated to orbit pruning -- a collision would already break those today, on `main`, with no pruning involved. What this PR changes is the *consequence*: the legacy exhaustive engine turns a hypothetical collision into redundant-but-still-correct over-exploration (every member of a wrongly-merged cell still gets individualized and compared); this PR's pruned engine could instead silently skip a genuinely distinct branch. Not observed on any fixture, the exhaustive `n<=5` suite, hundreds of randomized fuzz trials, or the 5,000-molecule corpus; would require a correlated 64-bit hash collision reconstructing an entire real symmetry's cell structure to manifest. Closing it fully means threading a parallel, hash-free individualization-state vector through the search's hot path -- judged out of scope for this PR (a bigger change, defending against a risk already implicitly accepted crate-wide); documented instead, here and in both `canonical_search::exact_orbit_representatives`'s doc comment and `docs/canonical_automorphism_pruning.md`'s safety-argument section, rather than left as an unqualified "structurally impossible"/"never a hash-collision shortcut" claim.

## Commit structure (deviation disclosed)

This repo has a pre-commit hook enforcing `cargo clippy -D warnings` per commit. The originally-planned 5-commit split (partition+automorphism as its own commit, search as another, budget API as another) would leave several `pub(crate)` items with no caller across commit boundaries (dead-code errors, hook-blocked) since `canonical_search.rs` is the sole consumer of the partition/automorphism modules. Consolidated to 2 commits instead, each independently clippy-clean and full-test-suite-green:
1. `e361b19` -- the complete engine (partition + automorphism + search + budget API + canonical.rs wiring), verified standalone before committing.
2. `23092c3` -- fixtures, the `canonical_orbit_perf` benchmark example, the coronene fixture fix, and the design doc.

Two bugs found via testing (union-find indexed by atom index instead of cell position; the vertex-color candidate-filter gap above) were caught and fixed *before* any independent review round, so folded into commit 1 rather than presented as separate "review-round" commits (both self-caught during initial implementation, not via a separate reviewing agent).

## Verification commands run (all foreground, all green except a pre-existing, unrelated environment issue noted below)

```
cargo fmt --all -- --check                                                   # clean
cargo clippy --workspace --all-targets -- -D warnings                        # clean
cargo clippy --workspace --all-targets --all-features -- -D warnings         # blocked WORKSPACE-WIDE by a PRE-EXISTING,
                                                                              # unrelated chematic-chem include_bytes!()
                                                                              # path bug under --all-features (confirmed
                                                                              # via git stash to reproduce on origin/main
                                                                              # too; chematic-chem is out of this PR's
                                                                              # file scope)
cargo clippy -p chematic-smiles --all-targets --all-features -- -D warnings  # this is the only invocation that lints the
                                                                              # new canonical-search-instrumentation feature's
                                                                              # code path; re-run as a final gate below
                                                                              # (see "Independent verification") once
                                                                              # in-progress reviewer scratch files are
                                                                              # cleaned out of the working tree
cargo test -p chematic-smiles --lib                                          # 180 passed
cargo test -p chematic-smiles --tests                                        # 22+1+4 passed across 3 integration files
cargo test --workspace --lib                                                 # all green (17 crates; chematic-py
                                                                              # excluded from --workspace build due to
                                                                              # the same pre-existing local venv/pyo3
                                                                              # linker issue, unrelated to this PR)
cargo test --workspace --tests                                               # all green
bash scripts/check.sh                                                        # "All checks passed."
cargo run --release -p chematic-smiles --example canonical_orbit_perf        # see benchmark tables above
cargo run --release -p chematic-rxn --features perf-instrumentation \
    --example reaction_transform_perf_report                                 # see RENKIN-shaped benchmark above
```

Not touched: `chematic-rxn`'s reaction logic, any 3D-related crate, Python/WASM/MCP behavior, workspace version, CHANGELOG's release section, `Cargo.lock`.

## Independent verification

All 3 rounds commissioned (correctness, false-prune, performance-claim) are complete -- each a separate agent re-deriving claims from scratch, not checking this PR's own numbers. All findings below were addressed by fix commit **`57cc802`** ("fix(smiles): address independent review findings on PR #193"). No round found a bug in this PR's actual pruning logic; all three found real gaps in this PR's own claims/tests/tooling, now fixed or explicitly documented.

**Round 1 (correctness audit) -- no bug found in this PR's own code; one verification gap found and one pre-existing out-of-scope bug found.** Independently re-derived all 7 checklist items in `docs/canonical_automorphism_pruning.md` from scratch (own SMILES fixtures not in the existing corpus, own `MoleculeBuilder`-based permutation tests re-implemented rather than reusing this PR's helper, own 160-case fuzz test over attributes -- isotope/charge/atom_map/hydrogen_count/`Dative`+donor-side -- the PR's own fuzz coverage didn't exercise). All passed: writer-visible-attribute coverage, exact (non-hash) refinement, automorphism-mapping validity (including the adversarial attribute/Dative fuzz probe above, 160/160 matched), union-find indexed by position not atom-index, oracle string-equality (22+ independent fixtures), full permutation invariance (all 720 benzene permutations, cubane, aspirin), and stereo preservation across 4 fresh fixtures including a stereocenter with two constitutionally-identical phenyl arms.

Two things it found:
1. **Verification gap, fixed in `57cc802`**: the exhaustive-oracle tests only ever compared the winning canonical *string*, never the *rank vector* `winning_individualized_ranks_with_limits` also returns and `canonical_atom_order` (a public API) consumes -- two branches within one automorphism orbit can share a minimal string via different rank vectors, so string-equality alone doesn't prove rank-vector-equality. Added `canonical::canonical_smiles_exhaustive_oracle_with_ranks` and a new test `canonical_search::tests::rank_vector_matches_exhaustive_oracle_not_just_string` covering 22 fixtures (the auditor's own set plus this PR's), comparing against the *unbounded exhaustive oracle's* rank vector (not the legacy engine's single winning leaf, which can also legitimately differ for the same reason). Passes.
2. **Pre-existing, out-of-scope bug (not introduced or worsened by this PR, confirmed via `git diff main`)**: `canonical_smiles()` truncates a Dative bond's `"->"` token to a plain `'-'` (`CanonicalWriter` calls `bond.smiles_char()`, which takes only the token's first byte; the non-canonical `write()` path does this correctly). Filed separately as **issue #194**, not blocking this PR, not fixed here.

**Round 2 (false-prune audit) -- no false prune found; nothing blocks; one architectural caveat found and one factually-backwards comment found.** Independently constructed adversarial molecules (CF3-chain stabilizer-vs-global-group probes, disconnected-fragment pairs of differing/matching component sizes, isotope/charge/stereo asymmetry cases, dative-bond direction-symmetric and -asymmetric pairs, hypervalent phosphorus) and drove `search_canonical`'s own machinery directly (not just black-box `canonical_smiles`) to test the mechanism, not just the output. All matched the exhaustive oracle; the root-vs-stabilizer distinction, singleton-stays-fixed guarantee, and cross-component pruning were each independently confirmed correct.

Two things it found:
1. **Architectural caveat (not a bug, not blocking), fixed by documenting rather than re-engineering**: `initial_partition`'s seed (`ranks`) comes from the pre-existing, unchanged `refine_ranks`, whose `normalize_ranks` step groups by raw FNV-1a hash-value *equality* -- a hypothetical 64-bit hash collision there could in principle re-merge an already-individualized atom with a formerly-tied sibling, since `VertexColor` deliberately carries no search-time individualization history. The auditor demonstrated the mechanism directly by hand-corrupting the partition and showing `verify_full_bijection` would not catch it (it re-derives correctness from `graph`'s own color/edge data alone, which is genuinely symmetric once you ignore individualization history). This exposure is not new -- `equivalent_atom_classes`/`are_atoms_equivalent` already rely on the same hash-equality mechanism today, on `main`, unrelated to pruning -- but this PR changes the *consequence* of a hypothetical collision from "redundant exploration, still correct" (legacy engine) to "a silently skipped branch" (this PR's engine). Judged out of scope to fix (would require threading a parallel hash-free individualization-state vector through the search hot path, a bigger change defending a risk already accepted crate-wide, not observed on any fixture/exhaustive-suite/fuzz-trial/corpus). Fixed by qualifying the previously-absolute "never a hash-collision shortcut"/"structurally impossible" framing everywhere it appeared: `canonical_search.rs`'s `exact_orbit_representatives` doc comment, `canonical_partition.rs`'s module doc, `docs/canonical_automorphism_pruning.md`'s safety-argument section, and this PR body (see "Known remaining worst cases" above).
2. **Factually-backwards test comment, fixed**: the `FC(F)(F)C.FC(F)(F)C.FC(F)(F)C` fixture's comment claimed cross-component automorphism pruning between different physical copies of a disconnected fragment never happens. The auditor measured that it does fire, correctly and safely (`leaves_written=1`, `orbit_unions=14`). Comment corrected in `57cc802`.

**Round 3 (performance-claim audit) -- found and corrected, not just "passed."** Independently reproduced: all leaf-count claims (bit-exact, algorithm-deterministic), Tier A ~5x geomean / Tier B no regression / corpus ~5x total-elapsed-but-1.09-1.10x-geomean, 0/5000 corpus mismatches (verified against the true full denominator by explicitly setting `CANONICAL_ORBIT_PERF_RUN_LEGACY=1`), and the cap-hit collapse on two independently-constructed multi-protecting-group molecules not in this PR's own fixture set (1296->1 and 144->1 leaves).

Three things it found:
1. **The RENKIN-shaped 38-41%/48-51% improvement claim did not reproduce** -- traced to a stale, apparently noisier reference session behind PR #189's own documented 596-598ms figure, which the auditor could not reproduce at that exact parent commit today (measured 410-423ms instead, via a diff-verified identical harness, dependency versions checked). Corrected in this PR body's "RENKIN-shaped benchmark" section to a same-session comparison: ~11.8%/~20.5%/~18.0% (total/p99/max), real but smaller than originally claimed, non-overlapping ranges on both sides. Text-only correction, no code changed.
2. **The corpus benchmark's documented default invocation omitted `CANONICAL_ORBIT_PERF_RUN_LEGACY=1`**, so the correctness differential silently never ran while the harness still printed a passing message -- a real instance of this project's own previously-documented "failure denominator" bug class. **Fixed in `57cc802`**: `TierReport` now tracks `differential_ran`; when unset, the report explicitly prints "SKIPPED" instead of a misleading "0 mismatches," and the final summary line reflects it too. Doc-comment invocation examples updated to show both modes explicitly.
3. **`canonical_orbit_perf.rs`'s per-fixture timing always ran the new engine first, old engine second**, which the auditor showed (via a deleted throwaway microbench) biases whichever arm runs first by ~10-15% -- this fully explained an apparent "new engine is slower on typical molecules" signal the auditor initially saw and then correctly ruled out as a harness artifact. **Fixed in `57cc802`**: alternates which engine's timer starts first by fixture index.

**Gates re-run after `57cc802`** (all foreground, all green): `cargo test -p chematic-smiles --lib` (181 passed, +1 for the new rank-vector test), `cargo test -p chematic-smiles --tests` (22+1+4 passed), `cargo clippy -p chematic-smiles --all-targets --all-features -- -D warnings` (clean), `cargo clippy --workspace --all-targets -- -D warnings` (clean), `cargo fmt --all -- --check` (clean), `bash scripts/check.sh` ("All checks passed"), and a fresh `CANONICAL_ORBIT_PERF_CORPUS=~/Downloads/SMILES.csv CANONICAL_ORBIT_PERF_RUN_LEGACY=1 cargo run --release -p chematic-smiles --features canonical-search-instrumentation --example canonical_orbit_perf`: **0 mismatches across all 3 tiers (13+6+5000 molecules)**, leaf counts bit-identical to the original measurements (6625->13, 153->6, 69037->5220), confirming the fix commit's doc/test/harness-only changes did not alter the actual pruning decision logic.
