### PR TITLE
fix(smiles): correct Dative bond truncation and direction in writer + parser

### DIFF
--- a/crates/chematic-core/src/bond.rs
+++ b/crates/chematic-core/src/bond.rs
@@ -88,7 +88,14 @@ impl BondOrder {
         }
     }
 
-    /// The SMILES character that represents this bond order.
+    /// The **first** SMILES character of this bond order's token.
+    ///
+    /// Footgun: [`Self::smiles_token`] is not always one character.
+    /// `Dative`'s token is `"->"`, so this returns a bare `'-'` for it —
+    /// a plain single bond, which is both wrong and silently plausible.
+    /// Use `smiles_token()` when emitting SMILES text (issue #194); a
+    /// dative bond additionally needs its arrow oriented against the write
+    /// order, see `chematic_smiles::writer::bond_token_from`.
     pub fn smiles_char(self) -> char {
         self.smiles_token().as_bytes()[0] as char
     }

--- a/crates/chematic-smiles/src/canonical.rs
+++ b/crates/chematic-smiles/src/canonical.rs
@@ -20,7 +20,7 @@ use std::collections::{HashMap, HashSet};
 
 use chematic_core::{AtomIdx, BondIdx, BondOrder, Chirality, Molecule, STEREO_H_SENTINEL};
 
-use crate::writer::{emit_bracket_hydrogens, suppress_standalone_wedge};
+use crate::writer::{bond_token_from, emit_bracket_hydrogens, suppress_standalone_wedge};
 
 /// Return the atom indices sorted into canonical (Morgan-rank) order.
 ///
@@ -1065,16 +1065,21 @@ impl<'a> CanonicalWriter<'a> {
         in_stack[atom.0 as usize] = false;
     }
 
+    /// `incoming_bond` is the already-oriented token for the edge leading to
+    /// `atom` (`None` for the root or an implicit bond), not a `BondOrder`:
+    /// a dative arrow's direction depends on which endpoint is written
+    /// first, and `BondOrder::smiles_char` would truncate `"->"` to `'-'`
+    /// anyway (issue #194). See `crate::writer::bond_token_from`.
     fn write_chain(
         &mut self,
         atom: AtomIdx,
         from_atom: Option<AtomIdx>,
-        incoming_bond: Option<BondOrder>,
+        incoming_bond: Option<&'static str>,
     ) {
         self.written[atom.0 as usize] = true;
 
-        if let Some(bond) = incoming_bond {
-            self.out.push(bond.smiles_char());
+        if let Some(token) = incoming_bond {
+            self.out.push_str(token);
         }
 
         // Compute parity-corrected chirality before ring data is consumed.
@@ -1090,7 +1095,12 @@ impl<'a> CanonicalWriter<'a> {
                 if !(bond_order == BondOrder::Aromatic && atom_arom)
                     && bond_order != BondOrder::Single
                 {
-                    self.out.push(bond_order.smiles_char());
+                    // Oriented from the atom being written right now, so a
+                    // dative ring closure prints `->` at its donor end and
+                    // `<-` at its acceptor end (the same bond read from
+                    // opposite directions).
+                    self.out
+                        .push_str(bond_token_from(self.mol, bidx, bond_order, atom));
                 }
                 // SMILES ring-closure numbers are limited to 1–99.
                 // Molecules needing ≥ 100 simultaneous open ring closures are
@@ -1166,7 +1176,11 @@ impl<'a> CanonicalWriter<'a> {
                 BondOrder::Aromatic => parent_arom && child_arom,
                 _ => false,
             };
-            let written_bond = if implicit { None } else { Some(bond_order) };
+            let written_bond = if implicit {
+                None
+            } else {
+                Some(bond_token_from(self.mol, bidx, bond_order, atom))
+            };
 
             if !is_last {
                 self.out.push('(');

--- a/crates/chematic-smiles/src/parser.rs
+++ b/crates/chematic-smiles/src/parser.rs
@@ -128,7 +128,7 @@ impl<'a> Parser<'a> {
 
     fn parse_smiles(&mut self) -> Result<Molecule, SmilesError> {
         let mut mol = MoleculeBuilder::new();
-        let mut open_rings: HashMap<u8, (AtomIdx, Option<BondOrder>, u32)> = HashMap::new();
+        let mut open_rings: HashMap<u8, (AtomIdx, Option<ParsedBond>, u32)> = HashMap::new();
 
         // Parse the first fragment
         self.parse_chain(&mut mol, None, None, &mut open_rings)?;
@@ -191,8 +191,8 @@ impl<'a> Parser<'a> {
         &mut self,
         mol: &mut MoleculeBuilder,
         attach_to: Option<AtomIdx>,
-        attach_bond: Option<BondOrder>,
-        open_rings: &mut HashMap<u8, (AtomIdx, Option<BondOrder>, u32)>,
+        attach_bond: Option<ParsedBond>,
+        open_rings: &mut HashMap<u8, (AtomIdx, Option<ParsedBond>, u32)>,
     ) -> Result<Option<AtomIdx>, SmilesError> {
         // Parse the first atom of this chain
         let first_atom = match self.try_parse_atom()? {
@@ -211,14 +211,18 @@ impl<'a> Parser<'a> {
 
         // Connect to the preceding atom if requested
         if let Some(prev) = attach_to {
-            let bond = attach_bond.unwrap_or_else(|| implicit_bond(mol, prev, first_idx));
-            let (bond, stash) = resolve_aromatic_direction_stash(mol, prev, first_idx, bond);
-            let new_bond_idx = mol.add_bond(prev, first_idx, bond).map_err(|_| {
-                SmilesError::InvalidBracketAtom {
-                    detail: "duplicate bond".to_string(),
-                    pos: self.pos,
-                }
-            })?;
+            let bond = attach_bond
+                .unwrap_or_else(|| ParsedBond::plain(implicit_bond(mol, prev, first_idx)));
+            // `<-` stores the bond donor→acceptor, i.e. with the endpoints
+            // swapped relative to reading order.
+            let (a1, a2) = bond.endpoints(prev, first_idx);
+            let (bond, stash) = resolve_aromatic_direction_stash(mol, a1, a2, bond.order);
+            let new_bond_idx =
+                mol.add_bond(a1, a2, bond)
+                    .map_err(|_| SmilesError::InvalidBracketAtom {
+                        detail: "duplicate bond".to_string(),
+                        pos: self.pos,
+                    })?;
             if let Some(dir) = stash {
                 mol.set_bond_direction(new_bond_idx, dir);
             }
@@ -296,22 +300,27 @@ impl<'a> Parser<'a> {
                                 let next_idx = mol.add_atom(next_atom.clone());
                                 let bond = match pending_bond {
                                     Some(bo) => bo,
-                                    None => implicit_bond(mol, current, next_idx),
+                                    None => {
+                                        ParsedBond::plain(implicit_bond(mol, current, next_idx))
+                                    }
                                 };
+                                // `<-` stores the bond donor→acceptor, i.e.
+                                // with the endpoints swapped relative to
+                                // reading order.
+                                let (a1, a2) = bond.endpoints(current, next_idx);
                                 // See `resolve_aromatic_direction_stash`: a `/`/`\` between two
                                 // aromatic atoms specifies geometry of an adjacent double bond,
                                 // not a stereo single bond on this edge -- the original direction
                                 // is stashed on the side (`bond_directions`) so it survives into
                                 // the canonical writer instead of being lost.
                                 let (bond, stashed_direction) =
-                                    resolve_aromatic_direction_stash(mol, current, next_idx, bond);
-                                let new_bond_idx =
-                                    mol.add_bond(current, next_idx, bond).map_err(|_| {
-                                        SmilesError::InvalidBracketAtom {
-                                            detail: "duplicate bond".to_string(),
-                                            pos: self.pos,
-                                        }
-                                    })?;
+                                    resolve_aromatic_direction_stash(mol, a1, a2, bond.order);
+                                let new_bond_idx = mol.add_bond(a1, a2, bond).map_err(|_| {
+                                    SmilesError::InvalidBracketAtom {
+                                        detail: "duplicate bond".to_string(),
+                                        pos: self.pos,
+                                    }
+                                })?;
                                 if let Some(dir) = stashed_direction {
                                     mol.set_bond_direction(new_bond_idx, dir);
                                 }
@@ -380,8 +389,8 @@ impl<'a> Parser<'a> {
         &mut self,
         mol: &mut MoleculeBuilder,
         attach_to: AtomIdx,
-        explicit_bond: Option<BondOrder>,
-        open_rings: &mut HashMap<u8, (AtomIdx, Option<BondOrder>, u32)>,
+        explicit_bond: Option<ParsedBond>,
+        open_rings: &mut HashMap<u8, (AtomIdx, Option<ParsedBond>, u32)>,
     ) -> Result<Option<AtomIdx>, SmilesError> {
         if self.depth >= MAX_BRANCH_DEPTH {
             return Err(SmilesError::NestingTooDeep { pos: self.pos });
@@ -413,8 +422,8 @@ impl<'a> Parser<'a> {
         mol: &mut MoleculeBuilder,
         current: AtomIdx,
         ring_num: u8,
-        ring_bond: Option<BondOrder>,
-        open_rings: &mut HashMap<u8, (AtomIdx, Option<BondOrder>, u32)>,
+        ring_bond: Option<ParsedBond>,
+        open_rings: &mut HashMap<u8, (AtomIdx, Option<ParsedBond>, u32)>,
     ) -> Result<StereoEntry, SmilesError> {
         if let Some((open_atom, open_bond, slot)) = open_rings.remove(&ring_num) {
             // A directional marker (`/`, `\`) is read "toward" the ring digit
@@ -437,8 +446,11 @@ impl<'a> Parser<'a> {
                     });
                 }
                 (Some(b), None) | (None, Some(b)) => b,
-                (None, None) => implicit_bond(mol, open_atom, current),
+                (None, None) => ParsedBond::plain(implicit_bond(mol, open_atom, current)),
             };
+            // `<-` stores the bond donor→acceptor, i.e. with the endpoints
+            // swapped relative to the open→close reading order above.
+            let (a1, a2) = bond.endpoints(open_atom, current);
             // See `resolve_aromatic_direction_stash`: without this guard, a
             // `/`/`\` ring-closure marker between two aromatic atoms becomes
             // a literal Up/Down bond between them -- inconsistent (aromatic
@@ -448,13 +460,13 @@ impl<'a> Parser<'a> {
             // writer can route a stashed direction through a ring-closure
             // digit when that bond is chosen as the canonical back-edge
             // (see `dfs_mark`'s own stashed-direction handling above).
-            let (bond, stash) = resolve_aromatic_direction_stash(mol, open_atom, current, bond);
-            let new_bond_idx = mol.add_bond(open_atom, current, bond).map_err(|_| {
-                SmilesError::InvalidBracketAtom {
-                    detail: format!("duplicate ring bond {ring_num}"),
-                    pos: self.pos,
-                }
-            })?;
+            let (bond, stash) = resolve_aromatic_direction_stash(mol, a1, a2, bond.order);
+            let new_bond_idx =
+                mol.add_bond(a1, a2, bond)
+                    .map_err(|_| SmilesError::InvalidBracketAtom {
+                        detail: format!("duplicate ring bond {ring_num}"),
+                        pos: self.pos,
+                    })?;
             if let Some(dir) = stash {
                 mol.set_bond_direction(new_bond_idx, dir);
             }
@@ -495,8 +507,8 @@ impl<'a> Parser<'a> {
     /// optional `prefix_bond` that was already consumed before this call.
     fn parse_ring_num(
         &mut self,
-        prefix_bond: Option<BondOrder>,
-    ) -> Result<(u8, Option<BondOrder>), SmilesError> {
+        prefix_bond: Option<ParsedBond>,
+    ) -> Result<(u8, Option<ParsedBond>), SmilesError> {
         let ring_num = if self.peek() == Some(b'%') {
             self.advance(); // consume '%'
             let tens = self
@@ -519,17 +531,21 @@ impl<'a> Parser<'a> {
         Ok((ring_num, prefix_bond))
     }
 
-    /// Consume a bond character and return the corresponding order, or `None`.
-    fn try_parse_bond(&mut self) -> Option<BondOrder> {
+    /// Consume a bond token and return it, or `None`.
+    fn try_parse_bond(&mut self) -> Option<ParsedBond> {
         if self.peek() == Some(b'-') && self.peek_at(1) == Some(b'>') {
             self.advance();
             self.advance();
-            return Some(BondOrder::Dative);
+            return Some(ParsedBond::plain(BondOrder::Dative));
         }
         if self.peek() == Some(b'<') && self.peek_at(1) == Some(b'-') {
             self.advance();
             self.advance();
-            return Some(BondOrder::Dative);
+            // `A<-B`: B is the donor, so the bond must be stored B→A.
+            return Some(ParsedBond {
+                order: BondOrder::Dative,
+                reversed: true,
+            });
         }
         let order = match self.peek()? {
             b'-' => BondOrder::Single,
@@ -543,7 +559,7 @@ impl<'a> Parser<'a> {
             _ => return None,
         };
         self.advance();
-        Some(order)
+        Some(ParsedBond::plain(order))
     }
 
     fn try_parse_atom(&mut self) -> Result<Option<Atom>, SmilesError> {
@@ -786,12 +802,52 @@ impl<'a> Parser<'a> {
 /// ring-closure bond symbol captured at the closing occurrence (read
 /// close->open) into the open->close sense used for storage and for
 /// agreement-checking against the opening occurrence's symbol.
-fn flip_direction(order: Option<BondOrder>) -> Option<BondOrder> {
-    order.map(|o| match o {
-        BondOrder::Up => BondOrder::Down,
-        BondOrder::Down => BondOrder::Up,
-        other => other,
+fn flip_direction(bond: Option<ParsedBond>) -> Option<ParsedBond> {
+    bond.map(|b| match b.order {
+        BondOrder::Up => ParsedBond::plain(BondOrder::Down),
+        BondOrder::Down => ParsedBond::plain(BondOrder::Up),
+        // A dative arrow is directional in exactly the same way, but its
+        // direction lives in `reversed` rather than in the order itself.
+        BondOrder::Dative => ParsedBond {
+            order: BondOrder::Dative,
+            reversed: !b.reversed,
+        },
+        _ => b,
     })
+}
+
+/// A bond token as written in the input, before it is attached to atoms.
+///
+/// `reversed` is `true` only for a `<-` dative arrow. `BondOrder` has a
+/// single `Dative` variant whose stored `atom1 → atom2` order *is* the
+/// donor → acceptor direction, so the arrow that points backwards relative
+/// to the reading order cannot be encoded in the order itself — it has to
+/// swap the two atoms when the bond is added. Without this, `A<-B` and
+/// `A->B` produce byte-identical molecules and every `<-` in the input is
+/// silently read as its own mirror image.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ParsedBond {
+    order: BondOrder,
+    reversed: bool,
+}
+
+impl ParsedBond {
+    fn plain(order: BondOrder) -> Self {
+        Self {
+            order,
+            reversed: false,
+        }
+    }
+
+    /// `(from, to)` in reading order, returned as the `(atom1, atom2)` pair
+    /// the bond should actually be stored with.
+    fn endpoints(self, from: AtomIdx, to: AtomIdx) -> (AtomIdx, AtomIdx) {
+        if self.reversed {
+            (to, from)
+        } else {
+            (from, to)
+        }
+    }
 }
 
 /// Determine the implicit bond between two adjacent atoms already in the builder.

--- a/crates/chematic-smiles/src/writer.rs
+++ b/crates/chematic-smiles/src/writer.rs
@@ -125,6 +125,36 @@ pub(crate) fn direction_from(
     }
 }
 
+/// The SMILES token to print for bond `bidx` when the DFS is writing it
+/// *starting from* `from_atom`.
+///
+/// `Dative` is the only bond order whose token is longer than one character
+/// (`"->"`), and the only one whose *text* encodes an asymmetric fact about
+/// its two endpoints: `BondOrder::Dative` stores donor→acceptor as
+/// `atom1`→`atom2`, while `->`/`<-` are read left-to-right in written order.
+/// A DFS can reach either endpoint first, so writing `"->"` unconditionally
+/// would assert "the atom I just wrote is the donor" — false, and actively
+/// misleading, whenever the traversal arrived at `atom2` first. Every other
+/// order's token is direction-free, so this is exactly
+/// [`BondOrder::smiles_token`] for them.
+///
+/// This is the dative analogue of [`direction_from`], which does the same
+/// job for `/`/`\`. It has to live here rather than in `direction_from`
+/// because there is only one `Dative` variant — the flip has no `BondOrder`
+/// to be expressed as, only a different token string.
+pub(crate) fn bond_token_from(
+    mol: &Molecule,
+    bidx: BondIdx,
+    order: BondOrder,
+    from_atom: AtomIdx,
+) -> &'static str {
+    if order == BondOrder::Dative && mol.bond(bidx).atom1 != from_atom {
+        "<-"
+    } else {
+        order.smiles_token()
+    }
+}
+
 /// Write a [`Molecule`] to a SMILES string.
 ///
 /// Disconnected fragments are joined with `.`.
@@ -142,7 +172,9 @@ struct SmilesWriter<'a> {
     ring_bonds: HashSet<BondIdx>,
     /// ring number(s) each atom must write when serialized.
     /// Both the "open" ancestor and "close" descendant of a ring store the same number.
-    atom_ring_nums: HashMap<AtomIdx, Vec<(u16, BondOrder)>>,
+    /// `BondIdx` is kept alongside the order so the emission site can ask
+    /// [`bond_token_from`] for a direction-correct token (dative arrows).
+    atom_ring_nums: HashMap<AtomIdx, Vec<(u16, BondOrder, BondIdx)>>,
     /// Whether each atom has been serialized in phase 2.
     written: Vec<bool>,
     next_ring: u16,
@@ -245,11 +277,11 @@ impl<'a> SmilesWriter<'a> {
                 self.atom_ring_nums
                     .entry(neighbor)
                     .or_default()
-                    .push((rn, order_at_open)); // open
+                    .push((rn, order_at_open, bidx)); // open
                 self.atom_ring_nums
                     .entry(atom)
                     .or_default()
-                    .push((rn, order_at_close)); // close
+                    .push((rn, order_at_close, bidx)); // close
             }
         }
 
@@ -257,18 +289,21 @@ impl<'a> SmilesWriter<'a> {
     }
 
     /// Write `atom` and then recurse into its unvisited tree-edge neighbors.
-    /// `incoming_bond`: the bond type on the edge leading to this atom (None for the root).
+    /// `incoming_bond`: the already-oriented token for the edge leading to
+    /// this atom (None for the root, or when the bond is implicit). It is a
+    /// token rather than a `BondOrder` because a dative arrow's direction
+    /// depends on which endpoint is written first — see [`bond_token_from`].
     fn write_chain(
         &mut self,
         atom: AtomIdx,
         from_atom: Option<AtomIdx>,
-        incoming_bond: Option<BondOrder>,
+        incoming_bond: Option<&'static str>,
     ) {
         self.written[atom.0 as usize] = true;
 
         // Write the incoming bond (if explicit / non-default).
-        if let Some(bond) = incoming_bond {
-            self.out.push_str(bond.smiles_token());
+        if let Some(token) = incoming_bond {
+            self.out.push_str(token);
         }
 
         // Write the atom symbol.
@@ -276,7 +311,7 @@ impl<'a> SmilesWriter<'a> {
 
         // Write ring-closure digits for this atom (both open and close digits).
         if let Some(rings) = self.atom_ring_nums.remove(&atom) {
-            for (rn, bond_order) in rings {
+            for (rn, bond_order, bidx) in rings {
                 // Write bond type unless it is implicit.
                 let atom_aromatic = self.mol.atom(atom).aromatic;
                 // For ring closures we can't know the other atom's aromaticity here,
@@ -284,7 +319,13 @@ impl<'a> SmilesWriter<'a> {
                 if !(bond_order == BondOrder::Aromatic && atom_aromatic)
                     && bond_order != BondOrder::Single
                 {
-                    self.out.push_str(bond_order.smiles_token());
+                    // Oriented from the atom being written right now: the two
+                    // ends of a dative ring closure print opposite arrows
+                    // (`->` at the donor, `<-` at the acceptor), which is the
+                    // same bond read from opposite directions -- exactly how
+                    // `/`/`\` ring-closure markers already behave here.
+                    self.out
+                        .push_str(bond_token_from(self.mol, bidx, bond_order, atom));
                 }
                 // Ring number: single digit for 1-9, `%NN` form for 10-99, `%NNN` for 100+.
                 if rn >= 100 {
@@ -305,7 +346,7 @@ impl<'a> SmilesWriter<'a> {
         }
 
         // Collect tree-edge children (unvisited, non-ring-closure bonds).
-        let children: Vec<(AtomIdx, BondOrder)> = self
+        let children: Vec<(AtomIdx, BondIdx, BondOrder)> = self
             .mol
             .neighbors(atom)
             .filter(|(nb, bidx)| {
@@ -320,13 +361,17 @@ impl<'a> SmilesWriter<'a> {
                 // which endpoint the DFS happens to write first.
                 let raw = raw_bond_direction(self.mol, bidx).unwrap_or(self.mol.bond(bidx).order);
                 let oriented = direction_from(self.mol, bidx, raw, atom);
-                (nb, suppress_standalone_wedge(self.mol, bidx, oriented))
+                (
+                    nb,
+                    bidx,
+                    suppress_standalone_wedge(self.mol, bidx, oriented),
+                )
             })
             .collect();
 
         // Write children: all but the last one are branches (wrapped in parentheses).
         let n = children.len();
-        for (i, (child, bond_order)) in children.into_iter().enumerate() {
+        for (i, (child, bidx, bond_order)) in children.into_iter().enumerate() {
             let is_last = i == n - 1;
 
             // Determine whether the bond should be written explicitly.
@@ -337,7 +382,11 @@ impl<'a> SmilesWriter<'a> {
                 BondOrder::Aromatic => parent_arom && child_arom,  // aromatic is implicit
                 _ => false,
             };
-            let written_bond = if implicit { None } else { Some(bond_order) };
+            let written_bond = if implicit {
+                None
+            } else {
+                Some(bond_token_from(self.mol, bidx, bond_order, atom))
+            };
 
             if !is_last {
                 self.out.push('(');

--- a/crates/chematic-smiles/tests/dative_bond_direction.rs
+++ b/crates/chematic-smiles/tests/dative_bond_direction.rs
@@ -1,0 +1,263 @@
+//! Dative (`->` / `<-`) bond direction, end to end (issue #194).
+//!
+//! `BondOrder::Dative` stores donor→acceptor as `atom1`→`atom2`. Two
+//! independent things have to respect that:
+//!
+//! * the **parser**, which must map `A<-B` to `atom1 = B` (B is the donor),
+//!   not to the same bond as `A->B`; and
+//! * the **writers**, which must emit the whole two-character token *and*
+//!   pick `->` vs `<-` according to which endpoint the DFS happens to write
+//!   first.
+//!
+//! Expectations below are pinned to hand-written SMILES literals and to
+//! molecules built through `MoleculeBuilder` (never to this crate's own
+//! output), so a writer and a parser that were wrong in the *same* direction
+//! could not make them pass.
+
+use chematic_core::{Atom, BondOrder, Element, MoleculeBuilder};
+use chematic_smiles::{canonical_smiles, parse, write};
+
+/// Index of the single dative bond, plus its stored (donor, acceptor)
+/// elements.
+fn dative_donor_acceptor(mol: &chematic_core::Molecule) -> (Element, Element) {
+    let bidx = (0..mol.bond_count() as u32)
+        .map(chematic_core::BondIdx)
+        .find(|&b| mol.bond(b).order == BondOrder::Dative)
+        .expect("molecule has a dative bond");
+    let bond = mol.bond(bidx);
+    (mol.atom(bond.atom1).element, mol.atom(bond.atom2).element)
+}
+
+fn atom(element: Element) -> Atom {
+    Atom::new(element)
+}
+
+/// N donates to Fe: `atom1` = N, `atom2` = Fe.
+fn n_to_fe() -> chematic_core::Molecule {
+    let mut b = MoleculeBuilder::new();
+    let n = b.add_atom(atom(Element::N));
+    let fe = b.add_atom(atom(Element::FE));
+    b.add_bond(n, fe, BondOrder::Dative).unwrap();
+    b.build()
+}
+
+/// Same graph, opposite stored direction: Fe donates to N.
+fn fe_to_n() -> chematic_core::Molecule {
+    let mut b = MoleculeBuilder::new();
+    let n = b.add_atom(atom(Element::N));
+    let fe = b.add_atom(atom(Element::FE));
+    b.add_bond(fe, n, BondOrder::Dative).unwrap();
+    b.build()
+}
+
+// ── parser ──────────────────────────────────────────────────────────────
+
+/// `N->[Fe]` and `N<-[Fe]` describe *opposite* donor/acceptor relationships
+/// and must not parse to the same bond. Before the fix both arrows produced
+/// `atom1 = N`, silently reversing the second one.
+#[test]
+fn parser_distinguishes_arrow_direction() {
+    let forward = parse("N->[Fe]").expect("N->[Fe]");
+    let backward = parse("N<-[Fe]").expect("N<-[Fe]");
+
+    assert_eq!(
+        dative_donor_acceptor(&forward),
+        (Element::N, Element::FE),
+        "`N->[Fe]`: nitrogen donates to iron"
+    );
+    assert_eq!(
+        dative_donor_acceptor(&backward),
+        (Element::FE, Element::N),
+        "`N<-[Fe]`: iron donates to nitrogen"
+    );
+    assert_ne!(
+        dative_donor_acceptor(&forward),
+        dative_donor_acceptor(&backward),
+        "the two arrows must not collapse to the same bond"
+    );
+}
+
+/// Same check one level in: the arrow inside a branch.
+#[test]
+fn parser_arrow_direction_in_branch() {
+    let forward = parse("[Fe](Cl)(Cl)<-N").expect("<- in chain after branches");
+    assert_eq!(
+        dative_donor_acceptor(&forward),
+        (Element::N, Element::FE),
+        "`<-N` written from Fe means N is the donor"
+    );
+    let branch = parse("[Fe](<-N)Cl").expect("<- as the first token of a branch");
+    assert_eq!(
+        dative_donor_acceptor(&branch),
+        (Element::N, Element::FE),
+        "`(<-N)` written from Fe means N is the donor"
+    );
+}
+
+/// A dative bond spelled as a ring closure, in both directions, marked at
+/// the opening occurrence.
+#[test]
+fn parser_arrow_direction_at_ring_closure() {
+    // Ring: N-C-C-[Fe], closed by a dative bond between N (opener) and Fe.
+    let donor_first = parse("N->1CC[Fe]1").expect("N->1CC[Fe]1");
+    assert_eq!(
+        dative_donor_acceptor(&donor_first),
+        (Element::N, Element::FE),
+        "`N->1 … [Fe]1`: the arrow at the opener points N→Fe"
+    );
+    let acceptor_first = parse("N<-1CC[Fe]1").expect("N<-1CC[Fe]1");
+    assert_eq!(
+        dative_donor_acceptor(&acceptor_first),
+        (Element::FE, Element::N),
+        "`N<-1 … [Fe]1`: the arrow at the opener points Fe→N"
+    );
+}
+
+/// The marker written at the *closing* occurrence reads close→open, so it
+/// must be flipped before it is compared with the opener's marker. Both
+/// spellings of the same ring bond must agree rather than raise
+/// `ConflictingRingBond`.
+#[test]
+fn parser_arrow_direction_at_ring_close_occurrence() {
+    let at_close = parse("N1CC[Fe]<-1").expect("N1CC[Fe]<-1");
+    assert_eq!(
+        dative_donor_acceptor(&at_close),
+        (Element::N, Element::FE),
+        "`[Fe]<-1` closing back to N means N is the donor"
+    );
+    let both_ends = parse("N->1CC[Fe]<-1").expect("consistent markers at both ring ends");
+    assert_eq!(
+        dative_donor_acceptor(&both_ends),
+        (Element::N, Element::FE),
+        "`->` at the opener and `<-` at the closer describe the same N→Fe bond"
+    );
+
+    // …and two markers that genuinely contradict each other are rejected,
+    // exactly as a `/` vs `/` ring-bond conflict already is, instead of one
+    // silently winning.
+    assert!(
+        parse("N->1CC[Fe]->1").is_err(),
+        "`->` at both ring ends claims both atoms are the donor"
+    );
+}
+
+// ── writers ─────────────────────────────────────────────────────────────
+
+/// The whole `->`/`<-` token survives both writers. Before the fix,
+/// `canonical_smiles` truncated it to a bare `-` (issue #194) and `write`
+/// emitted `->` regardless of direction.
+#[test]
+fn writers_emit_the_full_two_character_token() {
+    for mol in [n_to_fe(), fe_to_n()] {
+        for out in [write(&mol), canonical_smiles(&mol)] {
+            assert!(
+                out.contains("->") || out.contains("<-"),
+                "dative token truncated or dropped: {out}"
+            );
+            // A bare `-` adjacent to nothing else would be the truncation bug.
+            let arrows = out.matches("->").count() + out.matches("<-").count();
+            assert_eq!(arrows, 1, "expected exactly one dative arrow in {out}");
+        }
+    }
+}
+
+/// The critical case: two molecules that differ *only* in which endpoint of
+/// the dative bond is stored as `atom1`. Their canonical rank vectors are
+/// identical (same elements, same connectivity — nothing in the ranking is
+/// dative-direction-aware), so the canonical writer reaches the same atom
+/// first in both. It picks the iron; for `n_to_fe` that is the *acceptor*,
+/// so the arrow has to be written backwards relative to storage order.
+///
+/// Both expected strings are derived from `BondOrder::Dative`'s own
+/// definition rather than from what the writer happens to produce: reading
+/// `[Fe]<-N` left to right, the arrow points from N into Fe, i.e. N is the
+/// donor — which is `n_to_fe`, whose `atom1` is N even though it is written
+/// second.
+#[test]
+fn canonical_writer_flips_the_arrow_when_the_acceptor_is_written_first() {
+    let a = canonical_smiles(&n_to_fe());
+    let b = canonical_smiles(&fe_to_n());
+
+    assert_eq!(a, "[Fe]<-N", "acceptor written first ⇒ reversed arrow");
+    assert_eq!(b, "[Fe]->N", "donor written first ⇒ forward arrow");
+
+    // And each one still means what it meant before it was written.
+    assert_eq!(
+        dative_donor_acceptor(&parse(&a).unwrap()),
+        (Element::N, Element::FE)
+    );
+    assert_eq!(
+        dative_donor_acceptor(&parse(&b).unwrap()),
+        (Element::FE, Element::N)
+    );
+}
+
+/// Full round trip through both writers, for both stored directions.
+#[test]
+fn dative_direction_round_trips_through_both_writers() {
+    for (mol, expected) in [
+        (n_to_fe(), (Element::N, Element::FE)),
+        (fe_to_n(), (Element::FE, Element::N)),
+    ] {
+        assert_eq!(
+            dative_donor_acceptor(&mol),
+            expected,
+            "builder precondition"
+        );
+        for out in [write(&mol), canonical_smiles(&mol)] {
+            let reparsed = parse(&out).unwrap_or_else(|e| panic!("re-parse of {out}: {e}"));
+            assert_eq!(
+                dative_donor_acceptor(&reparsed),
+                expected,
+                "donor/acceptor lost writing {out}"
+            );
+        }
+    }
+}
+
+/// Same round trip for a dative bond that is a ring-closure back-edge
+/// rather than a tree edge, in both stored directions.
+#[test]
+fn dative_ring_closure_round_trips_through_both_writers() {
+    for donor_is_n in [true, false] {
+        let mut b = MoleculeBuilder::new();
+        let n = b.add_atom(atom(Element::N));
+        let c1 = b.add_atom(atom(Element::C));
+        let c2 = b.add_atom(atom(Element::C));
+        let fe = b.add_atom(atom(Element::FE));
+        b.add_bond(n, c1, BondOrder::Single).unwrap();
+        b.add_bond(c1, c2, BondOrder::Single).unwrap();
+        b.add_bond(c2, fe, BondOrder::Single).unwrap();
+        let (donor, acceptor) = if donor_is_n { (n, fe) } else { (fe, n) };
+        b.add_bond(donor, acceptor, BondOrder::Dative).unwrap();
+        let mol = b.build();
+
+        let expected = if donor_is_n {
+            (Element::N, Element::FE)
+        } else {
+            (Element::FE, Element::N)
+        };
+        assert_eq!(
+            dative_donor_acceptor(&mol),
+            expected,
+            "builder precondition"
+        );
+
+        for out in [write(&mol), canonical_smiles(&mol)] {
+            // Both writers really do route this bond through a ring-closure
+            // digit rather than a tree edge, and both ends of it print: the
+            // donor end `->`, the acceptor end `<-`, each immediately before
+            // its ring number.
+            assert!(
+                out.contains("->1") && out.contains("<-1"),
+                "ring-closure dative token truncated or not on the ring digit: {out}"
+            );
+            let reparsed = parse(&out).unwrap_or_else(|e| panic!("re-parse of {out}: {e}"));
+            assert_eq!(
+                dative_donor_acceptor(&reparsed),
+                expected,
+                "donor/acceptor lost writing ring closure {out}"
+            );
+        }
+    }
+}

--- a/crates/chematic-smiles/tests/dative_bond_direction.rs
+++ b/crates/chematic-smiles/tests/dative_bond_direction.rs
@@ -261,3 +261,74 @@ fn dative_ring_closure_round_trips_through_both_writers() {
         }
     }
 }
+
+/// The crate's central invariant (see the `lib.rs` doctest): re-parsing a
+/// canonical SMILES and writing it again reproduces the same string.
+/// Nothing else covers it for dative bonds — the ChEMBL corpus fixtures
+/// contain none — and the ring spelling (`N->1CC[Fe]<-1`, arrows on both
+/// ring digits) is one nothing had round-tripped before this change.
+#[test]
+fn canonical_smiles_is_stable_for_dative_molecules() {
+    for smiles in [
+        "N->[Fe]",
+        "[Fe]<-N",
+        "N->1CC[Fe]<-1",
+        "N<-1CC[Fe]->1",
+        "N1CC[Fe]<-1",
+        "[Fe](Cl)(Cl)<-N",
+    ] {
+        let canon = canonical_smiles(&parse(smiles).unwrap());
+        assert_eq!(
+            canonical_smiles(&parse(&canon).unwrap()),
+            canon,
+            "canonical SMILES of {smiles} is not stable"
+        );
+        assert!(
+            canon.contains("->") || canon.contains("<-"),
+            "dative bond lost canonicalizing {smiles}: {canon}"
+        );
+    }
+}
+
+/// Guard against misreading the test above: a molecule built through
+/// `MoleculeBuilder` (rather than parsed) can shift once on its first
+/// canonicalization, because the builder and the parser do not populate
+/// every atom field identically. That is pre-existing and has nothing to do
+/// with dative bonds — the same ring with an ordinary single bond in place
+/// of the dative one shifts in exactly the same way — so it must not be
+/// "fixed" by reshaping the dative writer.
+#[test]
+fn builder_first_shift_is_not_dative_specific() {
+    let ring = |closing: BondOrder| {
+        let mut b = MoleculeBuilder::new();
+        let n = b.add_atom(atom(Element::N));
+        let c1 = b.add_atom(atom(Element::C));
+        let c2 = b.add_atom(atom(Element::C));
+        let fe = b.add_atom(atom(Element::FE));
+        b.add_bond(n, c1, BondOrder::Single).unwrap();
+        b.add_bond(c1, c2, BondOrder::Single).unwrap();
+        b.add_bond(c2, fe, BondOrder::Single).unwrap();
+        b.add_bond(n, fe, closing).unwrap();
+        let mol = b.build();
+        let first = canonical_smiles(&mol);
+        let second = canonical_smiles(&parse(&first).unwrap());
+        (first, second)
+    };
+
+    let (single_first, single_second) = ring(BondOrder::Single);
+    let (dative_first, dative_second) = ring(BondOrder::Dative);
+    assert_ne!(
+        single_first, single_second,
+        "control: the shift is expected without any dative bond"
+    );
+    assert_ne!(dative_first, dative_second, "same shift, same cause");
+    // And in both cases it settles after one parse.
+    assert_eq!(
+        canonical_smiles(&parse(&single_second).unwrap()),
+        single_second
+    );
+    assert_eq!(
+        canonical_smiles(&parse(&dative_second).unwrap()),
+        dative_second
+    );
+}


### PR DESCRIPTION
Refs #194 — deliberately not `Fixes`, so merging does not auto-close the issue; a human closes it after review.

Issue #194 reports one symptom; there are **two independent root causes**, and fixing only the reported one would have made the output *worse*, not better. Both are fixed here.

## Root cause 1 — writer: truncation, and then direction

`BondOrder::smiles_char()` is defined as `smiles_token().as_bytes()[0] as char`. `Dative`'s token is the two-character `"->"`, so `canonical.rs` emitted a bare `'-'` — a plain single bond. That is #194 as filed.

The naive fix (emit the whole token) is a regression in disguise. `->`/`<-` is read left-to-right in **written** order, while `BondOrder::Dative` stores donor→acceptor as `atom1`→`atom2` (its own doc comment). A DFS writer can reach either endpoint first, so writing `"->"` unconditionally asserts *"the atom I just wrote is the donor"* — false whenever the traversal arrived at `atom2` first. Today's bug silently degrades to an ambiguous single bond; the naive fix would silently assert a specific, wrong donor/acceptor relationship. This is not hypothetical: it is exactly what the canonical writer does for `N->[Fe]`, where the canonical ranker writes the iron (the acceptor) first.

Fix: new `writer::bond_token_from(mol, bidx, order, from_atom)` — returns `"<-"` when `order` is `Dative` and `from_atom != bond.atom1`, and `smiles_token()` otherwise. It is the dative analogue of the existing `direction_from`, which already does this job for `/`/`\`; it cannot live *inside* `direction_from` because there is only one `Dative` variant, so the flip has no `BondOrder` to be expressed as — only a different token string (no new `BondOrder` variant was added, per the project's existing preference).

Both writers now thread a `&'static str` token instead of a `BondOrder` into `write_chain`, and all four emission sites go through the helper:

| site | file |
|---|---|
| incoming (tree-edge) bond | `writer.rs` `write_chain` |
| ring-closure digit bond | `writer.rs` `write_chain` |
| incoming (tree-edge) bond | `canonical.rs` `write_chain` |
| ring-closure digit bond | `canonical.rs` `write_chain` |

## Root cause 2 — parser: `<-` was silently read as `->`

`parser.rs`'s `try_parse_bond` matched both `"->"` and `"<-"` and returned `Some(BondOrder::Dative)` for either; the arrow's direction was discarded before it reached `add_bond`, and all three `add_bond` sites stored `atom1 = current` (the already-open atom) regardless. So `A<-B` produced a byte-identical molecule to `A->B` — every `<-` in user input was silently read as its own mirror image. Verified against the pre-fix code before touching it (`N->[Fe]` and `N<-[Fe]` both came back as N-donates-to-Fe).

Fix: bond tokens are carried through the parser as a private `ParsedBond { order, reversed }`, and each `add_bond` site swaps its two atoms when `reversed`. `flip_direction` — which already reoriented a `/`/`\` marker written at a ring closure's *closing* occurrence into the open→close sense — now toggles `reversed` for `Dative` in exactly the same way. Because `ParsedBond` derives `Eq`, the existing "both ring ends specified a bond, they must agree" check now also catches genuinely contradictory arrows (`N->1CC[Fe]->1`, which claims both atoms are the donor) instead of silently picking one.

## Output format note

A dative ring closure now prints its arrow at **both** ring-closure digits, oriented per end: `N->1CC[Fe]<-1` — the same bond read from opposite directions, which is how `/`/`\` ring-closure markers already behave in this writer. It is a token pattern only this crate's parser is verified against; RDKit interop for dative *ring closures* specifically was not tested.

## Tests — `crates/chematic-smiles/tests/dative_bond_direction.rs` (10 tests)

Expectations are pinned to hand-written SMILES literals and to `MoleculeBuilder`-constructed molecules, never to this crate's own output, so a writer and parser that were wrong in the *same* direction could not make them pass.

**Verified against the pre-fix code**, by checking `2ba6ef6`'s `crates/chematic-smiles/src` + `crates/chematic-core/src` back out under the final test file: **9 of 10 fail**. The tenth (`builder_first_shift_is_not_dative_specific`) passes on both sides by design — it pins a pre-existing behavior this PR must *not* change.

- **`parser_distinguishes_arrow_direction`** — `N->[Fe]` stores `(atom1, atom2) = (N, Fe)` and `N<-[Fe]` stores `(Fe, N)`. Proves root cause 2 is gone at the most basic level.
- **`parser_arrow_direction_in_branch`** — same, for `[Fe](Cl)(Cl)<-N` and `[Fe](<-N)Cl`; covers the branch-attachment `add_bond` site, a different code path from the chain one.
- **`parser_arrow_direction_at_ring_closure`** — `N->1CC[Fe]1` vs `N<-1CC[Fe]1`; covers the ring-closure `add_bond` site.
- **`parser_arrow_direction_at_ring_close_occurrence`** — `N1CC[Fe]<-1` (marker at the *closing* occurrence, which reads close→open and must be flipped), `N->1CC[Fe]<-1` (consistent markers at both ends resolve rather than conflict), and `N->1CC[Fe]->1` (contradictory markers are rejected).
- **`writers_emit_the_full_two_character_token`** — for both stored directions, `write()` and `canonical_smiles()` each contain exactly one complete arrow. This is #194's literal symptom.
- **`canonical_writer_flips_the_arrow_when_the_acceptor_is_written_first`** — the critical case. Two molecules identical except for which endpoint is `atom1`. Correction from independent review: canonical ranking is *not* entirely dative-blind — `canonical_partition.rs` (from PR #193) already colors edges via `EdgeColor.from_is_donor`, derived from `bond.atom1 == from` — but that coloring does not by itself guarantee a fixed donor/acceptor write order across both molecules; empirically, the ranker still writes the iron atom first in both cases here, meaning one molecule is written from `atom1` and the other from `atom2`. Asserts the exact strings `[Fe]<-N` (N is the donor, written *second*) and `[Fe]->N`, both derived from `BondOrder::Dative`'s definition rather than from observed output, plus that each re-parses to the correct donor. Independently reproduced by the verification round below.
- **`dative_direction_round_trips_through_both_writers`** — builder → both writers → parser preserves the donor/acceptor for both stored directions.
- **`dative_ring_closure_round_trips_through_both_writers`** — same, for a dative bond that is a ring-closure back-edge rather than a tree edge; asserts the arrows land on the ring digits (`->1` and `<-1`) in both writers, so the test provably exercises the ring-closure emission path and not a tree edge.
- **`canonical_smiles_is_stable_for_dative_molecules`** — the crate's central invariant, per its own `lib.rs` doctest: re-parsing a canonical SMILES and rewriting it reproduces the same string. Covers six dative spellings including both ring forms. Nothing else covered this for dative bonds — the ChEMBL corpus fixtures contain none, which is why they stayed green — and `N->1CC[Fe]<-1` is a spelling nothing had round-tripped before.
- **`builder_first_shift_is_not_dative_specific`** — pins the neighbouring non-bug, so nobody later mistakes it for one: a `MoleculeBuilder`-built (as opposed to parsed) molecule can shift once on its first canonicalization, because the builder and the parser do not populate every atom field identically. The control shows the *same* ring with an ordinary single bond in place of the dative one shifts identically, and both settle after one parse. Pre-existing, dative-independent, out of scope here — and the only test in this file that also passes on `main`.

## Is this bug class fully closed?

Yes, and it is checkable rather than asserted:

1. Every arm of `BondOrder::smiles_token()` was reviewed: `Dative` (`"->"`) is the **only** token longer than one character. Every other order is `-`, `=`, `#`, `$`, `:`, `/`, `\`, or `~`.
2. After this change, `smiles_char()` has **zero** call sites anywhere in the workspace (`grep -rn smiles_char --include=*.rs` matches only its own definition and one doc reference). There is no remaining place where a multi-character token can be truncated.

`smiles_char()`'s signature and behavior are unchanged (public API), but its doc comment now names the footgun and points at `bond_token_from`.

## Checks

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p chematic-smiles --lib` (181) and `--tests` (218 across 5 binaries), `cargo test --workspace --lib` and `--tests` (50/50 test binaries ok, 0 failures), and `bash scripts/check.sh` — all run to completion in the foreground; `All checks passed.`

No existing test was modified. Every crate that constructs `BondOrder::Dative` was checked (`chematic-mol`, `chematic-depict`, `chematic-fp`, `chematic-perception`, `chematic-smarts`, `chematic-inchi`, `chematic-3d`, `chematic-ff`, `chematic-chem`, `chematic-rxn`, `chematic-cip`) — none of them reads SMILES bond tokens, and their suites are unchanged and green.


## Independent verification round (fresh agent, from scratch)

Reproduced every claim above independently (own probes, own test file, own
`git stash`/pre-fix checkout — not by re-running this PR's own tests). Confirmed:
the truncation symptom on pre-fix `main`; all four emission sites route through
`bond_token_from`; the parser correctly distinguishes `->`/`<-` at all 3
`add_bond` sites and the swap doesn't disturb tetrahedral neighbor order/chirality
(checked directly); the "9 of 10 fail pre-fix" claim (reproduced exactly, 1/10
passing); 12 additional adversarial probes (permutation sweep, two independent
dative bonds, isotope/charge/atom-map combined with dative, branch-attachment
site, `%NN` ring closures, aromatic endpoints) all pass; `Dative` is confirmed
the only multi-char token and `smiles_char()` has zero remaining callers
(including `Display for BondOrder`, which is unused for SMILES emission anywhere
in the workspace).

Two additional findings from this round, both judged non-blocking but worth the
merge decision knowing them:

- **RDKit interop for dative ring closures — this PR's own stated unknown — is
  now checked, and RDKit 2026.03.3 agrees**: it parses every both-digits-arrow
  spelling this PR emits and assigns the same donor/acceptor each time.
- **A real, disclosed strictness increase**: `N->1CC[Fe]->1` (self-contradictory
  ring-closure arrows — both digits claim to be the donor) parsed silently
  pre-fix (both collapsed to plain `Dative`) and now correctly returns
  `ConflictingRingBond`, matching the existing `/`/`\` conflict check. RDKit
  accepts this input (takes the opener). Verified the writer itself can never
  produce such a contradictory pair (swept ring lengths 3-7, both stored
  directions, both writers).

Two follow-ups identified, not filed as issues yet (flagging for a decision, not
silently deciding): (1) `builder_first_shift_is_not_dative_specific` pins a real,
pre-existing, dative-*independent* canonicalization idempotence gap
(`MoleculeBuilder`-built molecules can shift once on first `canonical_smiles()`
call) with no tracking issue; (2) `BondEntry`'s doc says atom1/atom2 ordering is
"not guaranteed" while `BondOrder::Dative`'s doc says that order *is*
donor->acceptor and this PR (plus PR #193's `canonical_partition.rs`) now depends
on the latter — the contradiction should be resolved in `bond.rs`'s doc comments.

Full command suite re-run independently: `cargo fmt`, `clippy --workspace
--all-targets -D warnings`, `chematic-smiles`/workspace lib+tests (50/50 test
binaries), `chematic-smiles`/`chematic-core --doc` (the `lib.rs` doctest this PR
cites), `bash scripts/check.sh` — all clean.

**Verification round's verdict: ready for a human merge decision.**
