### PR TITLE
docs(core): resolve BondEntry vs BondOrder::Dative doc contradiction

### DIFF
--- a/crates/chematic-core/src/bond.rs
+++ b/crates/chematic-core/src/bond.rs
@@ -109,7 +109,9 @@ impl core::fmt::Display for BondOrder {
 
 /// A single bond edge in the molecular graph.
 ///
-/// The graph is undirected; `atom1`/`atom2` ordering is not guaranteed.
+/// The graph is undirected; for most bond orders, `atom1`/`atom2` ordering has
+/// no chemical meaning. For `BondOrder::Dative`, the ordering *is* meaningful:
+/// `atom1` is the donor and `atom2` is the acceptor (see its own doc comment).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BondEntry {
     pub atom1: crate::molecule::AtomIdx,


### PR DESCRIPTION
## Summary

Small, docs-only follow-up identified during PR #196's independent verification
round: `BondEntry`'s doc comment said `atom1`/`atom2` ordering is "not
guaranteed", while `BondOrder::Dative`'s own doc comment says that ordering *is*
meaningful (`atom1` is the donor, `atom2` is the acceptor). PR #196's writer/parser
fix and PR #193's `canonical_partition.rs` (`EdgeColor.from_is_donor`) both already
depend on the latter being true — this just resolves the contradiction in the doc
text, no behavior change.

## Change

```
- The graph is undirected; `atom1`/`atom2` ordering is not guaranteed.
+ The graph is undirected; for most bond orders, `atom1`/`atom2` ordering has
+ no chemical meaning. For `BondOrder::Dative`, the ordering *is* meaningful:
+ `atom1` is the donor and `atom2` is the acceptor (see its own doc comment).
```

No functional change. `cargo fmt --all -- --check` and `cargo clippy -p
chematic-core --all-targets -- -D warnings` both clean.