### PR TITLE
fix(smiles): unify explicit/implicit hydrogen-count canonicalization

### DIFF
--- a/crates/chematic-chem/src/mmp.rs
+++ b/crates/chematic-chem/src/mmp.rs
@@ -320,11 +320,11 @@ mod tests {
         let pairs = find_mmp(&[&a, &b]);
 
         // There must be exactly 1 MMP (the ring-chain cut).
-        // Canonical form of monosubstituted benzene core after the canonical-ranking
-        // individualize-refine rewrite (Round 10) -- same molecule as the prior
-        // "c1c([*])cccc1" oracle (RDKit-confirmed), wildcard now written last since
-        // its fixed low invariant places it last in rank-descending DFS order.
-        let matching: Vec<_> = pairs.iter().filter(|p| p.core == "c1c(cccc1)[*]").collect();
+        // Canonical form of monosubstituted benzene core updated (issue
+        // #205): `initial_invariant`'s explicit/implicit-H-count
+        // unification changed which atom the canonical DFS starts from for
+        // this ring -- same core molecule, same wildcard attachment point.
+        let matching: Vec<_> = pairs.iter().filter(|p| p.core == "c1cc([*])ccc1").collect();
         assert_eq!(
             matching.len(),
             1,
@@ -332,14 +332,14 @@ mod tests {
         );
 
         let pair = &matching[0];
-        // Oracle values: canonical SMILES updated for bond-order-aware Morgan ranks (#14).
+        // Oracle values updated for the same canonicalization change.
         assert_eq!(
-            pair.fragment_a, "C(C)[*]",
-            "ethylbenzene substituent should be C(C)[*]: {pair:?}"
+            pair.fragment_a, "[*]CC",
+            "ethylbenzene substituent should be [*]CC: {pair:?}"
         );
         assert_eq!(
-            pair.fragment_b, "[*]CCC",
-            "propylbenzene substituent should be [*]CCC: {pair:?}"
+            pair.fragment_b, "C(C)C[*]",
+            "propylbenzene substituent should be C(C)C[*]: {pair:?}"
         );
     }
 
@@ -384,7 +384,7 @@ mod tests {
         let pairs = find_mmp(&[&a, &b, &c]);
         // Expected: (a,b), (a,c), (b,c) — 3 pairs at minimum.
         // Canonical form updated for the individualize-refine ranking rewrite (Round 10).
-        let benzene_pairs: Vec<_> = pairs.iter().filter(|p| p.core == "c1c(cccc1)[*]").collect();
+        let benzene_pairs: Vec<_> = pairs.iter().filter(|p| p.core == "c1cc([*])ccc1").collect();
         assert_eq!(
             benzene_pairs.len(),
             3,
@@ -405,7 +405,7 @@ mod tests {
         let series = find_mms(&[&a, &b, &c]);
         let benzene_series: Vec<_> = series
             .iter()
-            .filter(|s| s.core == "c1c(cccc1)[*]")
+            .filter(|s| s.core == "c1cc([*])ccc1")
             .collect();
         assert_eq!(
             benzene_series.len(),
@@ -445,7 +445,7 @@ mod tests {
         let series = find_mms(&[&a, &b, &c]);
         let s = series
             .iter()
-            .find(|s| s.core == "c1c(cccc1)[*]")
+            .find(|s| s.core == "c1cc([*])ccc1")
             .expect("benzene-core series");
         // Members sorted ascending by MW: ethyl < propyl < butyl
         let ethyl_mw = s.members[0].mw;

--- a/crates/chematic-chem/src/stereo.rs
+++ b/crates/chematic-chem/src/stereo.rs
@@ -337,7 +337,16 @@ mod tests {
         // molecule either way. Guards against a future rewrite drifting
         // back to a numbering-dependent scheme (the exact failure mode
         // this fix replaces).
-        let m1 = mol(TWO_CENTER_SMILES);
+        //
+        // Uses a longer-chain variant of `TWO_CENTER_SMILES` rather than the
+        // shared constant: after the explicit/implicit-H-count Morgan-rank
+        // unification fix (issue #205), `TWO_CENTER_SMILES` itself no
+        // longer gets renumbered on canonicalization (its map-1 atom already
+        // had the correct, now-unified rank), which would make this
+        // precondition assert -- and the test meaningless -- rather than
+        // testing anything about `invert_stereocenter`. This variant still
+        // renumbers, confirmed empirically, so the precondition holds again.
+        let m1 = mol("CC[C@H:1](O)[C@@H:2](N)CC(=O)O");
         let m2 = mol(&chematic_smiles::canonical_smiles(&m1));
         assert_ne!(
             find_by_map(&m1, 1),

--- a/crates/chematic-chem/src/tautomer.rs
+++ b/crates/chematic-chem/src/tautomer.rs
@@ -2088,9 +2088,16 @@ mod tests {
             2,
             "propan-2-enol should enumerate to exactly 2 forms (enol + acetone)"
         );
+        // Golden string updated (issue #205): `initial_invariant`'s
+        // explicit/implicit-H-count unification changed Morgan ranks for
+        // some atoms, so `canonical_smiles`'s neighbor-branch-ordering
+        // shifted -- this is still the identical keto tautomer (acetone),
+        // just a different valid serialization of the same graph; the
+        // enumeration count above (2) is the actual regression pin for
+        // "logic unaffected" and did not change.
         assert_eq!(
             canonical_smiles(&canonical_tautomer(&mol)),
-            "C(C)(C)=O",
+            "C(C)(=O)C",
             "the canonical tautomer form must be unchanged (prefers the keto form)"
         );
     }
@@ -2110,9 +2117,12 @@ mod tests {
             2,
             "pyrazole should enumerate to exactly 2 forms"
         );
+        // Golden string updated (issue #205), same reason as the acetone
+        // test above: same tautomer (pyrazole's NH form), different valid
+        // canonical serialization; the count (2) is the unaffected pin.
         assert_eq!(
             canonical_smiles(&canonical_tautomer(&mol)),
-            "c1[nH]ncc1",
+            "c1c[nH]nc1",
             "pyrazole's canonical tautomer form must be unchanged"
         );
     }

--- a/crates/chematic-core/src/lib.rs
+++ b/crates/chematic-core/src/lib.rs
@@ -33,4 +33,6 @@ pub use molecule::{AtomIdx, BondIdx, MolError, Molecule, MoleculeBuilder, STEREO
 pub use stereo_group::{StereoGroup, StereoGroupKind};
 #[allow(deprecated)]
 pub use valence::total_hcount;
-pub use valence::{ValenceError, bond_order_sum, implicit_hcount, validate_valence};
+pub use valence::{
+    ValenceError, bond_order_sum, implicit_hcount, valence_inferred_hcount, validate_valence,
+};

--- a/crates/chematic-core/src/valence.rs
+++ b/crates/chematic-core/src/valence.rs
@@ -35,6 +35,28 @@ pub fn implicit_hcount(mol: &Molecule, idx: AtomIdx) -> u8 {
         return h;
     }
 
+    valence_inferred_hcount(mol, idx)
+}
+
+/// Compute the hydrogen count that organic-subset (unbracketed) valence
+/// inference would give for atom `idx`, **ignoring** any stored explicit
+/// `hydrogen_count` -- unlike [`implicit_hcount`], which returns the stored
+/// value directly for bracket atoms.
+///
+/// Used to decide whether a bracket atom's explicit H count is genuinely
+/// disambiguating information (differs from what organic-subset spelling
+/// would infer) or merely repeats it, in which case the atom can be
+/// canonically re-spelled without brackets for that reason -- see
+/// `chematic-smiles`'s `emit_atom`/`initial_invariant`, which both need
+/// "would this atom's H count survive being unbracketed" independent of
+/// whatever notation the atom happened to be parsed from.
+pub fn valence_inferred_hcount(mol: &Molecule, idx: AtomIdx) -> u8 {
+    let atom = mol.atom(idx);
+
+    if atom.wildcard {
+        return 0;
+    }
+
     // Only the organic subset gets implicit H.
     if !atom.element.is_organic_subset() {
         return 0;

--- a/crates/chematic-inchi/tests/dedup_fixtures.rs
+++ b/crates/chematic-inchi/tests/dedup_fixtures.rs
@@ -357,36 +357,48 @@ fn residual_row_relabeling_only_reconciled_via_native_inchi() {
 
 #[test]
 fn residual_row_idempotence_only_reconciled_via_native_inchi() {
-    // One of the 78 idempotence-only residual cases at this branch's base
+    // One of the 78 idempotence-only residual cases at the ORIGINAL base
     // commit (validation/results/canonical_residual_diagnosis_summary.json,
     // `detected_via_idempotence` && !`detected_via_random_relabeling`) --
-    // Root Cause 3 in the RFC (aromaticity-perception round-trip
-    // inconsistency), a different mechanism from the E/Z-carrier case above.
+    // catalogued as Root Cause 3 in the RFC (aromaticity-perception
+    // round-trip inconsistency), a different mechanism from the E/Z-carrier
+    // case above.
     //
-    // Derived directly from the original SMILES by chaining
-    // canonical_smiles twice (canonical(s) then canonical(canonical(s))),
-    // rather than copying the diagnosis script's recorded output strings --
-    // this way the "two different keys" property is reproduced fresh in
-    // Rust, not assumed to carry over unchanged from the Python-side JSON.
+    // Resolved as a side effect of the explicit/implicit-H-count Morgan-rank
+    // unification fix (chematic#205/#206): `canonical_smiles` is now
+    // idempotent for THIS specific fixture (confirmed below), so it no
+    // longer exercises the CanonicalSplit-reconciled-via-InChI path this
+    // test originally targeted -- `compare_molecules` now reports
+    // `VerifiedDuplicate` directly, since the fast canonical-key grouping
+    // itself no longer splits this molecule. This is a genuine improvement,
+    // not a loss of InChI-reconciliation coverage in general: other Root
+    // Cause fixtures in this file (e.g. the E/Z-carrier case above) are
+    // unrelated mechanisms and still exercise `CanonicalSplit`.
+    //
+    // Not re-verified against the full 5,000-molecule differential corpus
+    // (`scripts/canonical_residual_diagnosis.py` requires RDKit and the
+    // original `~/Downloads/SMILES.csv`, unavailable in this environment) --
+    // a maintainer should re-run that script post-merge to find a fresh
+    // still-residual "Root Cause 3" example if dedicated coverage for that
+    // exact mechanism is wanted going forward.
     let original = mol("O=C(NCCc1c2n(c3ccccc13)CCc1ccccc1-2)C1CCC1");
     let out1 = chematic_smiles::canonical_smiles(&original);
     let a = mol(&out1); // canonical_smiles(&a) == out1's own re-canonicalization
     let out2 = chematic_smiles::canonical_smiles(&a);
-    assert_ne!(
+    assert_eq!(
         out1, out2,
-        "this fixture is only meaningful if the idempotence residual still \
-         reproduces at this commit (canonical(canonical(s)) must differ from \
-         canonical(s))"
+        "canonical_smiles must now be idempotent for this fixture -- if this \
+         fails, the explicit/implicit-H-count unification fix regressed"
     );
 
-    // `original`'s own candidate key is out1; `a`'s own candidate key is
-    // out2 -- different keys, same molecule (just two different points along
-    // the same canonicalizer's non-fixed-point chain).
+    // Same molecule, now the same candidate key too -- the fast grouping
+    // correctly identifies these as duplicates on its own; native InChI
+    // agreement is still checked and expected to confirm it.
     assert_eq!(
         compare_molecules(&original, &a, IdentityPolicy::StandardInchiString),
-        DedupRelation::CanonicalSplit,
-        "same-molecule respelling (aromaticity round-trip residual) must be \
-         reconciled via native InChI, not reported as Distinct"
+        DedupRelation::VerifiedDuplicate,
+        "same-molecule respelling must be a verified duplicate now that its \
+         canonical keys agree directly"
     );
 }
 

--- a/crates/chematic-rxn/src/transform.rs
+++ b/crates/chematic-rxn/src/transform.rs
@@ -1037,16 +1037,68 @@ mod tests {
 
     #[test]
     fn product_preserves_explicit_h_from_template() {
-        // [NH2:1] in product template specifies 2H explicitly — must be kept.
-        use chematic_smiles::canonical_smiles;
+        // [NH2:1] in product template specifies 2H explicitly — the built
+        // atom's `hydrogen_count` must be `Some(2)`, not silently dropped or
+        // recomputed.
+        //
+        // Checks the data-level field directly rather than the canonical
+        // SMILES string's bracket notation (issue #205): after
+        // `initial_invariant`/`emit_atom`'s explicit/implicit-H-count
+        // unification fix, `canonical_smiles` correctly stops forcing
+        // brackets for an atom whose explicit H count merely repeats what
+        // organic-subset valence inference would already give -- this atom
+        // (N bonded to one carbon) infers to 2 implicit H anyway, so its
+        // canonical form is now the fully standard, bracket-free "CN"
+        // (methylamine), not "C[NH2]". The template's explicit
+        // specification is still honored -- it is what the "2" came from --
+        // just no longer forced into visible bracket notation once it's
+        // redundant with inference.
         let mol = parse("NC").unwrap();
         let results = run_reactants("[N:1]>>[NH2:1]", &[&mol]).unwrap();
         assert!(!results.is_empty(), "should match amine N");
-        let smi = canonical_smiles(&results[0][0]);
-        // With explicit H2, the N must be in brackets.
-        assert!(
-            smi.contains("[NH2]"),
-            "explicit [NH2:1] in product must keep [NH2], got: {smi}"
+        let product = &results[0][0];
+        let n_atom = product
+            .atoms()
+            .find(|(_, a)| a.element == chematic_core::Element::N)
+            .map(|(_, a)| a)
+            .expect("product must contain the templated N atom");
+        assert_eq!(
+            n_atom.hydrogen_count,
+            Some(2),
+            "explicit [NH2:1] in product must set hydrogen_count = Some(2)"
+        );
+    }
+
+    #[test]
+    fn reaction_derived_matches_direct_parse_chlorobenzene() {
+        // The exact fixture from kent-tokyo/renkin PR #65: a reaction-
+        // derived molecule (built via `run_reactants`, whose product-
+        // template atom comes from bracket notation `[Cl]` in the SMIRKS)
+        // must canonicalize identically to a directly-parsed organic-subset
+        // "Clc1ccccc1" of the same compound (issue #205).
+        use chematic_smiles::canonical_smiles;
+        let fwd = "[c:1][Br]>>[c:1][Cl]";
+        let known = parse("Brc1ccccc1").unwrap();
+        let results = run_reactants(fwd, &[&known]).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].len(), 1);
+        let reaction_derived = &results[0][0];
+        let direct = parse("Clc1ccccc1").unwrap();
+
+        // Structural sanity first: same atom count and element multiset,
+        // so canonical-string equality below is a real invariance proof,
+        // not an assumption that the two are the same molecule.
+        assert_eq!(reaction_derived.atom_count(), direct.atom_count());
+        let mut els_a: Vec<_> = reaction_derived.atoms().map(|(_, a)| a.element).collect();
+        let mut els_b: Vec<_> = direct.atoms().map(|(_, a)| a.element).collect();
+        els_a.sort();
+        els_b.sort();
+        assert_eq!(els_a, els_b, "same element multiset required");
+
+        assert_eq!(
+            canonical_smiles(reaction_derived),
+            canonical_smiles(&direct),
+            "reaction-derived and directly-parsed chlorobenzene must canonicalize identically"
         );
     }
 

--- a/crates/chematic-smiles/src/canonical.rs
+++ b/crates/chematic-smiles/src/canonical.rs
@@ -18,7 +18,10 @@
 
 use std::collections::{HashMap, HashSet};
 
-use chematic_core::{AtomIdx, BondIdx, BondOrder, Chirality, Molecule, STEREO_H_SENTINEL};
+use chematic_core::{
+    AtomIdx, BondIdx, BondOrder, Chirality, Molecule, STEREO_H_SENTINEL, implicit_hcount,
+    valence_inferred_hcount,
+};
 
 use crate::writer::{bond_token_from, emit_bracket_hydrogens, suppress_standalone_wedge};
 
@@ -427,7 +430,17 @@ fn initial_invariant(mol: &Molecule, idx: AtomIdx) -> u64 {
     let charge = (atom.charge as i64 + 128) as u64;
     let iso = atom.isotope.unwrap_or(0) as u64;
     let arom = atom.aromatic as u64;
-    let h_flag = atom.hydrogen_count.map(|h| h as u64 + 1).unwrap_or(0);
+    // The *effective* H count (explicit bracket value if present, else the
+    // valence-inferred implicit count -- the same unification
+    // `emit_bracket_hydrogens` already applies when writing) must seed the
+    // invariant, not raw `atom.hydrogen_count`. An explicit bracket atom
+    // whose stored H count merely repeats what valence inference would have
+    // produced anyway (e.g. `[Cl]` vs organic-subset `Cl`, both H=0) is the
+    // same chemical species and must get the same invariant; using
+    // `hydrogen_count.is_some()` as part of the seed instead let bracket
+    // "spelling" alone change Morgan ranks and therefore `canonical_smiles`'s
+    // output for two representations of one molecule (see issue #205).
+    let h_flag = implicit_hcount(mol, idx) as u64;
 
     (an << 56) | (degree << 48) | (charge << 40) | (iso << 24) | (h_flag << 16) | (arom << 8)
 }
@@ -1205,9 +1218,23 @@ impl<'a> CanonicalWriter<'a> {
             return;
         }
 
+        // An explicit `hydrogen_count` only forces bracket notation here if it
+        // carries genuine disambiguating information -- i.e. differs from
+        // what organic-subset valence inference would produce anyway if the
+        // atom were unbracketed. An atom whose stored H count merely repeats
+        // that inferred value (e.g. `[Cl]` vs organic-subset `Cl`, both H=0)
+        // is the same chemical species and must canonicalize to the same
+        // (unbracketed) spelling regardless of which notation it was parsed
+        // from -- unlike `writer.rs`'s plain (non-canonical) `emit_atom`,
+        // which intentionally preserves original notation and is unaffected
+        // by this distinction.
+        let h_is_disambiguating = atom
+            .hydrogen_count
+            .is_some_and(|h| h != valence_inferred_hcount(self.mol, idx));
+
         let needs_bracket = atom.isotope.is_some()
             || atom.charge != 0
-            || atom.hydrogen_count.is_some()
+            || h_is_disambiguating
             || !atom.element.is_organic_subset()
             || atom.atom_map.is_some()
             || chirality != Chirality::None;
@@ -2853,5 +2880,291 @@ mod tests {
             Some(ua != ub)
         };
         (ez(doubles[0]), ez(doubles[1]))
+    }
+}
+
+// ── Explicit-vs-implicit hydrogen-count canonicalization invariance ────────
+//
+// Regression suite for issue #205 (kent-tokyo/renkin PR #65 finding): an
+// atom's `hydrogen_count` field is `Some(n)` when it was written with
+// bracket notation and `None` when written organic-subset, but these can
+// represent the *same* chemical state (n happens to equal what valence
+// inference would give anyway). Before this fix, `initial_invariant`
+// treated `None` and `Some(n)` as different Morgan-rank seeds, and
+// `emit_atom` treated any `Some(_)` as forcing bracket notation regardless
+// of whether it was redundant -- so two representations of one molecule
+// (e.g. a bracket `[Cl]` substituent vs. organic-subset `Cl`) could
+// canonicalize to different strings. Fixed by routing both decisions
+// through `implicit_hcount`/`valence_inferred_hcount` instead of the raw
+// field. These tests prove the invariant mechanically (structural/data
+// comparisons), not by assuming two SMILES "look like" the same molecule.
+#[cfg(test)]
+mod explicit_implicit_h_invariance {
+    use super::*;
+    use crate::parser::parse;
+    use chematic_core::{Atom, Element, MoleculeBuilder};
+
+    fn atom_multiset(mol: &Molecule) -> Vec<(u8, i8, Option<u16>, bool, u8)> {
+        // (atomic_number, charge, isotope, aromatic, effective_h_count) --
+        // effective (not raw) H count, since that's the structural fact that
+        // must be invariant; two representations legitimately differ in
+        // whether hydrogen_count is None or Some(same value).
+        let mut v: Vec<_> = mol
+            .atoms()
+            .map(|(idx, a)| {
+                (
+                    a.element.atomic_number(),
+                    a.charge,
+                    a.isotope,
+                    a.aromatic,
+                    chematic_core::implicit_hcount(mol, idx),
+                )
+            })
+            .collect();
+        v.sort();
+        v
+    }
+
+    fn bond_multiset(mol: &Molecule) -> Vec<(u8, u8, u8)> {
+        // (min_atomic_number, max_atomic_number, bond_order) at each edge,
+        // order-independent identification of the bond multiset.
+        let mut v: Vec<_> = mol
+            .bonds()
+            .map(|(_, b)| {
+                let e1 = mol.atom(b.atom1).element.atomic_number();
+                let e2 = mol.atom(b.atom2).element.atomic_number();
+                (e1.min(e2), e1.max(e2), bond_order_value(b.order) as u8)
+            })
+            .collect();
+        v.sort();
+        v
+    }
+
+    /// Asserts `a` and `b` are the same chemical graph (same atom multiset,
+    /// same bond multiset) *before* checking canonical string equality --
+    /// this is what makes the string-equality assertions below a proof of
+    /// canonicalization invariance rather than an assumption that two
+    /// differently-written SMILES denote the same molecule.
+    fn assert_same_graph_then_same_canonical(a: &Molecule, b: &Molecule, label: &str) {
+        assert_eq!(
+            a.atom_count(),
+            b.atom_count(),
+            "{label}: atom count must match for this to be a meaningful test"
+        );
+        assert_eq!(
+            atom_multiset(a),
+            atom_multiset(b),
+            "{label}: atom multisets (element/charge/isotope/aromatic/effective-H) differ -- \
+             these are not actually the same molecule, so canonical equality would prove nothing"
+        );
+        assert_eq!(
+            bond_multiset(a),
+            bond_multiset(b),
+            "{label}: bond multisets differ -- not the same graph"
+        );
+        assert_eq!(
+            canonical_smiles(a),
+            canonical_smiles(b),
+            "{label}: same graph must canonicalize identically"
+        );
+    }
+
+    /// Isolated version of the kent-tokyo/renkin PR #65 fixture with zero
+    /// reaction machinery involved -- pure SMILES parsing, bracket vs
+    /// organic notation. `chematic-rxn`'s own test suite
+    /// (`transform.rs::reaction_derived_matches_direct_parse_chlorobenzene`)
+    /// covers the actual `run_reactants`-derived case, since chematic-smiles
+    /// cannot depend on chematic-rxn.
+    #[test]
+    fn bracket_vs_organic_notation_isolated_no_reaction() {
+        let cases = [
+            ("[Cl]c1ccccc1", "Clc1ccccc1"), // aromatic, symmetric ring
+            ("[Cl]CCC", "ClCCC"),           // aliphatic, asymmetric
+            ("[OH]CC", "OCC"),              // hydroxyl group
+            ("C[NH2]", "CN"),               // amine
+            ("[CH3]C", "CC"),               // methyl written explicit
+        ];
+        for (bracket, organic) in cases {
+            let a = parse(bracket).unwrap();
+            let b = parse(organic).unwrap();
+            assert_same_graph_then_same_canonical(&a, &b, &format!("{bracket} vs {organic}"));
+        }
+    }
+
+    /// Randomized atom relabeling: build the same graph via `MoleculeBuilder`
+    /// with atoms inserted in several different orders (including a
+    /// deterministic pseudo-random shuffle), holding chemistry fixed. Proves
+    /// insertion order alone -- independent of bracket/organic notation --
+    /// cannot change `canonical_smiles`'s output.
+    #[test]
+    fn randomized_atom_relabeling_does_not_change_canonical_form() {
+        // A 5-membered ring with a substituent breaking full symmetry:
+        // cyclopentane with one CH2 replaced conceptually by using a
+        // pendant Cl so every construction order is exercised meaningfully.
+        fn ring_with_substituent(insertion_order: &[usize]) -> Molecule {
+            // Logical atoms: 0..5 ring carbons, 5 = Cl substituent on ring atom 0.
+            let atoms: Vec<Atom> = (0..5)
+                .map(|_| Atom {
+                    element: Element::C,
+                    isotope: None,
+                    charge: 0,
+                    hydrogen_count: None,
+                    aromatic: false,
+                    chirality: Chirality::None,
+                    wildcard: false,
+                    atom_map: None,
+                    cip_code: None,
+                })
+                .chain(std::iter::once(Atom {
+                    element: Element::CL,
+                    isotope: None,
+                    charge: 0,
+                    hydrogen_count: None,
+                    aromatic: false,
+                    chirality: Chirality::None,
+                    wildcard: false,
+                    atom_map: None,
+                    cip_code: None,
+                }))
+                .collect();
+            // Logical bonds: ring 0-1-2-3-4-0, plus 0-5 (Cl).
+            let bonds = [
+                (0usize, 1usize, BondOrder::Single),
+                (1, 2, BondOrder::Single),
+                (2, 3, BondOrder::Single),
+                (3, 4, BondOrder::Single),
+                (4, 0, BondOrder::Single),
+                (0, 5, BondOrder::Single),
+            ];
+
+            let mut logical_to_new = [0u32; 6];
+            let mut b = MoleculeBuilder::new();
+            for (new_idx, &logical_idx) in insertion_order.iter().enumerate() {
+                logical_to_new[logical_idx] = new_idx as u32;
+                b.add_atom(atoms[logical_idx].clone());
+            }
+            for (l1, l2, order) in bonds {
+                let a1 = AtomIdx(logical_to_new[l1]);
+                let a2 = AtomIdx(logical_to_new[l2]);
+                let _ = b.add_bond(a1, a2, order);
+            }
+            b.build()
+        }
+
+        let orders: Vec<Vec<usize>> = vec![
+            vec![0, 1, 2, 3, 4, 5],
+            vec![5, 4, 3, 2, 1, 0],
+            vec![2, 0, 4, 1, 5, 3],
+            vec![5, 0, 1, 2, 3, 4],
+            vec![3, 1, 5, 0, 4, 2],
+        ];
+        let reference = canonical_smiles(&ring_with_substituent(&orders[0]));
+        for order in &orders[1..] {
+            let mol = ring_with_substituent(order);
+            assert_eq!(
+                canonical_smiles(&mol),
+                reference,
+                "insertion order {order:?} must not change canonical_smiles"
+            );
+        }
+    }
+
+    /// Disconnected structures: a salt/mixture where one fragment uses
+    /// bracket notation and the other uses organic-subset notation for
+    /// what is, on the relevant atom, the same effective H count.
+    #[test]
+    fn disconnected_structures_bracket_organic_mix() {
+        let a = parse("[Cl]CC.[Na+]").unwrap();
+        let b = parse("ClCC.[Na+]").unwrap();
+        assert_same_graph_then_same_canonical(&a, &b, "disconnected salt, bracket vs organic Cl");
+    }
+
+    /// A Kekulized ring (explicit alternating single/double bonds, no
+    /// aromaticity perception applied), combined with a bracket/organic
+    /// notation difference on its substituent, must still canonicalize
+    /// identically. Kept separate from the aromatic-flagged case in
+    /// `bracket_vs_organic_notation_isolated_no_reaction` -- raw `parse()`
+    /// does not itself perceive aromaticity from Kekulized input (that is a
+    /// separate, opt-in `chematic-perception` step), so an aromatic-flagged
+    /// molecule and a Kekulized one are genuinely different `Atom.aromatic`
+    /// states, not merely different spellings of the same data; comparing
+    /// them here would test aromaticity perception, not this fix.
+    #[test]
+    fn kekulized_ring_bracket_vs_organic_substituent() {
+        let bracket = parse("[Cl]C1=CC=CC=C1").unwrap();
+        let organic = parse("ClC1=CC=CC=C1").unwrap();
+        assert_same_graph_then_same_canonical(
+            &bracket,
+            &organic,
+            "Kekulized ring, bracket vs organic Cl substituent",
+        );
+    }
+
+    /// Isotope and charge must NOT be unified away -- only redundant
+    /// explicit H-count information is. An explicit isotope or nonzero
+    /// charge is always genuinely distinguishing (there is no "implicit
+    /// isotope"/"implicit charge" to fall back to), so these must still
+    /// force bracket notation and distinct canonical forms from their
+    /// natural-abundance/neutral counterparts.
+    #[test]
+    fn isotope_and_charge_remain_distinguishing_not_unified() {
+        let normal = parse("CCl").unwrap();
+        let isotopic = parse("C[37Cl]").unwrap();
+        assert_ne!(
+            canonical_smiles(&normal),
+            canonical_smiles(&isotopic),
+            "an explicit isotope must remain distinguishing"
+        );
+
+        let neutral = parse("CC(=O)[O-]").unwrap();
+        let anion_str = canonical_smiles(&neutral);
+        assert!(
+            anion_str.contains('-'),
+            "explicit negative charge must remain visible: {anion_str}"
+        );
+    }
+
+    /// A real stereocenter (explicit chirality) is unaffected by the
+    /// explicit/implicit-H unification: canonicalizing a chiral molecule
+    /// from two different atom orderings must still agree, and the
+    /// canonical form must still be stable under repeated canonicalization
+    /// (idempotence).
+    #[test]
+    fn stereocenter_canonicalization_idempotent_and_order_independent() {
+        let a = parse("N[C@@H](C)C(=O)O").unwrap(); // L-alanine
+        let b = parse("OC(=O)[C@H](C)N").unwrap(); // same molecule, other end first
+        assert_same_graph_then_same_canonical(&a, &b, "L-alanine, two parse orders");
+
+        let canon = canonical_smiles(&a);
+        let reparsed = parse(&canon).unwrap();
+        assert_eq!(
+            canonical_smiles(&reparsed),
+            canon,
+            "canonical_smiles must be idempotent: canonicalize(parse(canonicalize(x))) == canonicalize(x)"
+        );
+    }
+
+    /// General idempotence check across the bracket/organic pairs above:
+    /// canonicalizing an already-canonical string must reproduce it
+    /// byte-for-byte, regardless of which side of a bracket/organic pair it
+    /// started from.
+    #[test]
+    fn canonicalization_is_idempotent_for_all_bracket_organic_pairs() {
+        for (bracket, organic) in [
+            ("[Cl]c1ccccc1", "Clc1ccccc1"),
+            ("[Cl]CCC", "ClCCC"),
+            ("[OH]CC", "OCC"),
+        ] {
+            for smi in [bracket, organic] {
+                let mol = parse(smi).unwrap();
+                let canon = canonical_smiles(&mol);
+                let reparsed = parse(&canon).unwrap();
+                assert_eq!(
+                    canonical_smiles(&reparsed),
+                    canon,
+                    "not idempotent starting from {smi}: {canon}"
+                );
+            }
+        }
     }
 }

--- a/crates/chematic-smiles/tests/dative_bond_direction.rs
+++ b/crates/chematic-smiles/tests/dative_bond_direction.rs
@@ -217,6 +217,21 @@ fn dative_direction_round_trips_through_both_writers() {
 
 /// Same round trip for a dative bond that is a ring-closure back-edge
 /// rather than a tree edge, in both stored directions.
+///
+/// This molecule has two paths between N and Fe (the 3-single-bond chain,
+/// and the direct dative bond), so which one the DFS picks as the ring-
+/// closure "back edge" vs. a tree edge is incidental to canonical atom
+/// ordering, not a fixed property of the graph. `write` (plain, non-
+/// canonical, insertion-order-driven) always routes the dative bond through
+/// the ring closure for this builder-constructed molecule, so it keeps the
+/// stricter ring-closure-digit assertion. `canonical_smiles` legitimately
+/// changed which edge becomes the ring closure once `initial_invariant`'s
+/// explicit/implicit-H unification fix (issue #205) corrected this
+/// molecule's Morgan ranks -- the dative bond is now a tree edge, written
+/// inline right after Fe, rather than at the ring digit. Only the invariant
+/// that actually matters -- donor/acceptor direction survives the round
+/// trip, and the dative token itself is never dropped -- is asserted for
+/// `canonical_smiles`, not the incidental tree-edge-vs-ring-closure choice.
 #[test]
 fn dative_ring_closure_round_trips_through_both_writers() {
     for donor_is_n in [true, false] {
@@ -243,20 +258,25 @@ fn dative_ring_closure_round_trips_through_both_writers() {
             "builder precondition"
         );
 
-        for out in [write(&mol), canonical_smiles(&mol)] {
-            // Both writers really do route this bond through a ring-closure
-            // digit rather than a tree edge, and both ends of it print: the
-            // donor end `->`, the acceptor end `<-`, each immediately before
-            // its ring number.
-            assert!(
-                out.contains("->1") && out.contains("<-1"),
-                "ring-closure dative token truncated or not on the ring digit: {out}"
-            );
+        let plain = write(&mol);
+        assert!(
+            plain.contains("->1") && plain.contains("<-1"),
+            "plain writer must still route this dative bond through the ring-closure \
+             digit (insertion-order-driven, unaffected by canonical ranking): {plain}"
+        );
+
+        let canon = canonical_smiles(&mol);
+        assert!(
+            canon.contains("->") || canon.contains("<-"),
+            "dative bond token lost entirely canonicalizing {canon}"
+        );
+
+        for out in [plain, canon] {
             let reparsed = parse(&out).unwrap_or_else(|e| panic!("re-parse of {out}: {e}"));
             assert_eq!(
                 dative_donor_acceptor(&reparsed),
                 expected,
-                "donor/acceptor lost writing ring closure {out}"
+                "donor/acceptor lost writing {out}"
             );
         }
     }
@@ -291,14 +311,26 @@ fn canonical_smiles_is_stable_for_dative_molecules() {
 }
 
 /// Guard against misreading the test above: a molecule built through
-/// `MoleculeBuilder` (rather than parsed) can shift once on its first
-/// canonicalization, because the builder and the parser do not populate
-/// every atom field identically. That is pre-existing and has nothing to do
-/// with dative bonds — the same ring with an ordinary single bond in place
-/// of the dative one shifts in exactly the same way — so it must not be
-/// "fixed" by reshaping the dative writer.
+/// `MoleculeBuilder` (rather than parsed) used to be able to shift once on
+/// its first canonicalization, because the builder and the parser did not
+/// populate every atom field identically -- specifically, `hydrogen_count`
+/// (`None` from a builder-constructed atom vs. an explicit `Some(_)` after a
+/// bracket atom like `[Fe]` is written and re-parsed). That was pre-existing
+/// and had nothing to do with dative bonds -- the same ring with an ordinary
+/// single bond in place of the dative one shifted in exactly the same way --
+/// so it must never be "fixed" by reshaping the dative writer specifically.
+///
+/// Fixed at the root (issue #205): `initial_invariant`'s Morgan-rank seed
+/// and `emit_atom`'s bracket-necessity check now both go through
+/// `implicit_hcount`/`valence_inferred_hcount` instead of raw
+/// `atom.hydrogen_count`, so an explicit H count that merely repeats what
+/// valence inference would already give (e.g. bracket `[Fe]` with H=0,
+/// implicit-organic-subset atoms aside since Fe isn't organic-subset) no
+/// longer changes ranking or bracket emission. Builder- and parser-
+/// constructed molecules of the same graph now canonicalize identically on
+/// the very first call -- this test now asserts convergence, not the shift.
 #[test]
-fn builder_first_shift_is_not_dative_specific() {
+fn builder_first_canonicalization_matches_parser_no_shift() {
     let ring = |closing: BondOrder| {
         let mut b = MoleculeBuilder::new();
         let n = b.add_atom(atom(Element::N));
@@ -317,12 +349,13 @@ fn builder_first_shift_is_not_dative_specific() {
 
     let (single_first, single_second) = ring(BondOrder::Single);
     let (dative_first, dative_second) = ring(BondOrder::Dative);
-    assert_ne!(
+    assert_eq!(
         single_first, single_second,
-        "control: the shift is expected without any dative bond"
+        "builder- and parser-constructed molecules must canonicalize identically \
+         (no more first-call shift) -- not dative-specific, same fix for both"
     );
-    assert_ne!(dative_first, dative_second, "same shift, same cause");
-    // And in both cases it settles after one parse.
+    assert_eq!(dative_first, dative_second, "same invariant, same cause");
+    // Stable under repeated round-trips too.
     assert_eq!(
         canonical_smiles(&parse(&single_second).unwrap()),
         single_second

--- a/crates/chematic-wasm/src/tests.rs
+++ b/crates/chematic-wasm/src/tests.rs
@@ -1035,9 +1035,12 @@ fn mmp_pairs_json_ethylbenzene_propylbenzene() {
         "should have core key: {result}"
     );
     assert!(
-        // Canonical form updated for the individualize-refine ranking rewrite
-        // (Round 10) -- same molecule as the prior oracle strings (RDKit-confirmed).
-        result.contains("c1c(cccc1)[*]"),
+        // Canonical form updated (issue #205/#206): the explicit/implicit-
+        // H-count Morgan-rank unification fix changed which atom the
+        // canonical DFS starts from for this ring -- same core molecule,
+        // same wildcard attachment point, mirrors chematic-chem::mmp's
+        // equivalent test.
+        result.contains("c1cc([*])ccc1"),
         "core should be benzene: {result}"
     );
     assert!(


### PR DESCRIPTION
## Summary

Fixes #205: `canonical_smiles()` returned different strings for two
representations of the same molecule when one atom's H count came from
explicit bracket notation (`[Cl]`) vs. organic-subset notation (`Cl`),
even when the explicit value merely repeated what valence inference would
give anyway.

Root cause: `initial_invariant`'s Morgan-rank seed and
`CanonicalWriter::emit_atom`'s bracket-necessity check both read the raw
`Atom.hydrogen_count: Option<u8>` field directly instead of going through
the crate's own `implicit_hcount()` unification helper (which the plain,
non-canonical writer already used correctly).

Mechanically distinct from #14's fix (commit `3e6fcb78`, bond-order-driven
ties like acetic acid's two oxygens) — this reproduces with **zero**
atom-insertion-order or reaction-application involvement:

```rust
use chematic::smiles::{canonical_smiles, parse};

assert_eq!(
    canonical_smiles(&parse("[Cl]c1ccccc1").unwrap()),
    canonical_smiles(&parse("Clc1ccccc1").unwrap()),
);
// fails on main: "c1c(cccc1)[Cl]" vs "c1c(Cl)cccc1"
```

Found via [kent-tokyo/renkin PR #65](https://github.com/kent-tokyo/renkin/pull/65),
where a `run_reactants` product built from a bracket-notation SMIRKS
template (`[c:1][Cl]`) diverged from a directly user-typed SMILES of the
identical compound — breaking candidate-identity merging downstream.

## Fix

- **`chematic-core`**: extracts `valence_inferred_hcount()` from
  `implicit_hcount()` — same valence computation, but ignoring any stored
  explicit `hydrogen_count` (i.e. "what would this atom's H count be if
  unbracketed"). Needed to answer "is this atom's explicit H count
  genuinely disambiguating" independent of "what is its effective H count."
- **`chematic-smiles`**:
  - `initial_invariant` now seeds from `implicit_hcount(mol, idx)` (the
    *effective* H count) instead of a flag derived from
    `hydrogen_count.is_some()`.
  - `CanonicalWriter::emit_atom` now only lets an explicit `hydrogen_count`
    force bracket notation when it **differs** from
    `valence_inferred_hcount` — i.e. is genuinely disambiguating (e.g.
    `[CH2]` on an atom whose organic-subset inference would differ).
  - The plain (non-canonical) `writer.rs::emit_atom` is deliberately
    **untouched** — it intentionally preserves original notation
    (documented in its own comments), unlike the canonical writer, which
    promises construction/spelling invariance.

## Test-suite impact

Applying the fix and running `cargo test --workspace` (eventually with no
crate exclusions and `chematic-inchi --features native-inchi`, see
Verification below) surfaced 11 pre-existing tests whose hardcoded
canonical-SMILES/dedup-relation golden values depended on the old
behavior. Each was traced individually (not just patched to make CI
pass) via atom/bond multiset comparisons, tautomer counts, MMP
pair/series counts, and (for the InChI case) the actual
`compare_molecules` output, to confirm every one is a **stale value for
the identical molecule/logic**, never a behavioral regression:

- `chematic-chem::mmp` (4 tests): monosubstituted-benzene MMP core and
  fragment strings — same core/fragment molecules, different valid
  serialization; pair/series *counts* (the actual logic being tested)
  unaffected.
- `chematic-chem::tautomer` (2 tests): acetone and pyrazole canonical
  tautomer forms — same tautomer choice (enumeration count unaffected),
  different serialization.
- `chematic-chem::stereo` (1 test): `TWO_CENTER_SMILES`'s specific fixture
  no longer gets renumbered by canonicalization now that its bracket
  stereocenter's redundant explicit H count is unified — swapped in a
  longer-chain variant that still exercises the "renumbering" precondition
  this test needs.
- `chematic-rxn::transform` (1 test): `product_preserves_explicit_h_from_template`
  asserted the *canonical string* contained `[NH2]`; updated to assert the
  *data-level* `hydrogen_count == Some(2)` directly — the template's
  explicit H count is still 100% honored in the built atom, it's just no
  longer forced into visible bracket notation once the canonical writer
  correctly recognizes it as redundant (methylamine canonicalizes to the
  fully standard "CN", not "C[NH2]").
- `chematic-smiles::dative_bond_direction` (2 tests):
  `builder_first_shift_is_not_dative_specific` **explicitly documented
  this exact defect** as a known, pre-existing, accepted limitation
  ("builder and parser do not populate every atom field identically")
  with a regression test pinning that the resulting canonical-form
  "shift" *continued to happen* on first canonicalization — renamed to
  `builder_first_canonicalization_matches_parser_no_shift` and now asserts
  convergence, since the root cause is fixed. The companion
  ring-closure test's stylistic assertion (dative arrow specifically at
  the ring-closure digit) was over-specified — donor/acceptor direction
  still round-trips correctly, the DFS just legitimately picked a
  different (equally valid) spanning tree of the same graph once ranks
  changed; updated to assert the invariant that actually matters.
- `chematic-wasm::tests` (1 test): `mmp_pairs_json_ethylbenzene_propylbenzene`
  — same stale monosubstituted-benzene MMP core string as the
  `chematic-chem::mmp` case above, fixed identically. Only found once
  `chematic-wasm`'s own (host-native, no wasm build required) unit tests
  were actually run — see the correction under Verification.
- `chematic-inchi::tests` (1 test, `--features native-inchi`):
  `residual_row_idempotence_only_reconciled_via_native_inchi` — this
  fixture (cataloged as "Root Cause 3, aromaticity-perception round-trip
  inconsistency" in the project's own residual diagnosis corpus) is now
  genuinely idempotent under this fix; `compare_molecules` reports
  `VerifiedDuplicate` (the fast canonical-key grouping alone now
  correctly unifies the pair) rather than `CanonicalSplit` (needing InChI
  reconciliation to fix a key mismatch). Updated to assert the corrected,
  improved state. Not re-verified against the full 5,000-molecule
  differential corpus (`scripts/canonical_residual_diagnosis.py` needs
  RDKit + the original corpus file, unavailable in this environment) — a
  maintainer may want to re-run that script to find a fresh
  still-residual "Root Cause 3" fixture if dedicated coverage for that
  exact mechanism is wanted going forward. The unrelated E/Z-carrier
  residual fixture in the same file needed no change and still
  reproduces correctly.

## New permanent regression coverage

- `chematic-smiles::canonical::explicit_implicit_h_invariance` (7 tests):
  isolated bracket-vs-organic pairs (aromatic, aliphatic, hydroxyl, amine,
  methyl), randomized atom-relabeling insertion order (5 different
  `MoleculeBuilder` insertion orders of the same graph), disconnected
  structures, Kekulized rings, isotope/charge/stereo confirmed to remain
  genuinely distinguishing (not unified away), and
  canonicalize→parse→canonicalize idempotence.
- `chematic-rxn::transform::reaction_derived_matches_direct_parse_chlorobenzene`:
  the exact renkin PR #65 fixture, with structural-identity checks
  (atom count, element multiset) before the canonical-string assertion.

## Verification

- `cargo fmt --check`: clean.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean (full
  workspace, no crate exclusions).
- `cargo test --workspace` (no exclusions — includes `chematic-py` and
  `chematic-wasm`'s own unit/integration test suites, which run natively
  on the host target without needing an actual Python wheel build or
  `wasm-pack`/wasm32 target): 71/71 test binaries green, 0 failures.
- `cargo test -p chematic-inchi --features native-inchi`: 25/25 green.
- **Not yet done as part of this PR**, to avoid conflating "native
  workspace tests pass" with "the real published-package targets work":
  an actual `maturin build`-produced Python wheel installed and imported
  in a clean venv, and an actual `wasm-pack build` for the wasm32 target.
  Both should be run as part of post-merge/pre-release verification.

## Scope

`chematic-smiles` + one small `chematic-core` addition only. No changes to
parsing, reaction application/`run_reactants`, or SMARTS matching.
`chematic-py`/`chematic-wasm` source was not modified beyond the one
stale-test fix listed above; their full native test suites now pass in
this environment, but the actual Python wheel and wasm32 build/package
targets have not been separately smoke-tested here (see Verification) —
recommended before publishing a release that includes those packages.

Opening as **draft** given the size of the blast radius (any downstream
code with hardcoded canonical-SMILES golden strings may need re-baselining)
— please review before merge.

