### PR TITLE
diag(cip): rank_children heavy-tail diagnosis for issue #107 (no fix)

### DIFF
--- a/crates/chematic-cip/examples/rank_children_heavy_tail_diagnosis.rs
+++ b/crates/chematic-cip/examples/rank_children_heavy_tail_diagnosis.rs
@@ -1,0 +1,491 @@
+//! CIP-Perf-A1 (issue #107): diagnosis-only instrumentation of the heavy tail
+//! `cip_perf_diagnosis.rs` (CIP-Perf-A0) found -- a small minority of stereocenters
+//! that resolve "trivially" at Rules 1a/1b/2 do 40-3700x the median comparator work.
+//! Answers the issue's own suggested investigation order, in order, using two named
+//! worst-case fixtures plus a full-corpus aggregate. Ships **no production behavior
+//! change** -- the only non-test-only production edit this required was adding
+//! `left_node`/`right_node: NodeId` to `DecisionStep` (trace.rs), a pure data-carrying
+//! addition to an already debug-only struct; every counting/aggregation policy lives
+//! here.
+//!
+//! Usage:
+//!   cargo run -p chematic-cip --release --example rank_children_heavy_tail_diagnosis
+//!   cargo run -p chematic-cip --release --example rank_children_heavy_tail_diagnosis -- <SMILES.csv>
+
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::time::Instant;
+
+use chematic_cip::{
+    BranchComparison, CipBudget, CipDigraph, CipNodeKind, CompareContext, ComparisonTrace, NodeId,
+    prepare_kekule_form, rank_children,
+};
+use chematic_core::{AtomIdx, Chirality, Molecule};
+
+/// The two worst-offender fixtures named directly in issue #107.
+const WORST_PASS1: &str = "O=C1OCC2OC(=O)c3cc(O)c(O)c(O)c3-c3c(O)c(O)c(O)c4c3C(=O)OC(C2OC(=O)c2cc(O)c(O)c(O)c2-c2c1cc(O)c(O)c2O)C1OC(=O)c2c-4c(O)c(O)c(O)c2[C@@H]1c1c(O)cc(O)c2c1O[C@H](c1ccc(O)c(O)c1)[C@@H](O)C2";
+const WORST_NEEDS_MORE: &str =
+    "O=C(NCCCCN1CCN(c2cccc3ccccc23)CC1)C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3";
+
+fn is_leaf_kind(kind: CipNodeKind) -> bool {
+    matches!(
+        kind,
+        CipNodeKind::MultipleBondDuplicate { .. }
+            | CipNodeKind::RingDuplicate { .. }
+            | CipNodeKind::ImplicitHydrogen
+    )
+}
+
+/// Builds the digraph for one stereocenter and returns the full trace of every
+/// pairwise `compare_ligands` call made while ranking its root's children (mirrors
+/// `cip_perf_diagnosis.rs`'s Q2 setup exactly).
+fn trace_for_center<'a>(
+    mol: &'a Molecule,
+    idx: AtomIdx,
+    budget: CipBudget,
+    kekule: &'a Option<(Molecule, chematic_cip::MancudeContext)>,
+) -> Option<(CipDigraph<'a>, ComparisonTrace, u128, u128)> {
+    let build_start = Instant::now();
+    let mut graph = match kekule {
+        Some((kekule_mol, ctx)) => {
+            CipDigraph::new_with_mancude(kekule_mol, idx, budget, ctx).ok()?
+        }
+        None => CipDigraph::new(mol, idx, budget).ok()?,
+    };
+    let root = graph.root();
+    let root_children = graph.expand_children(root).ok()?;
+    let build_nanos = build_start.elapsed().as_nanos();
+
+    // Finding 5: cost split. Fully materialize the whole reachable digraph *before*
+    // timing the comparison pass, so `expand_children`'s lazy node-materialization
+    // cost (molecule traversal, Kekule-context lookups, duplicate-node synthesis) is
+    // charged to construction, not to comparison -- every node touched by
+    // `rank_children`'s recursive descent is already resident by the time comparison
+    // starts.
+    let expand_start = Instant::now();
+    let _ = graph.expand_all(root);
+    let expand_nanos = expand_start.elapsed().as_nanos();
+
+    let mut trace = ComparisonTrace::new(root, root);
+    let mut ctx = CompareContext::with_trace(&mut trace);
+    let compare_start = Instant::now();
+    rank_children(&mut graph, &root_children, &mut ctx).ok()?;
+    let compare_nanos = compare_start.elapsed().as_nanos();
+
+    Some((graph, trace, build_nanos + expand_nanos, compare_nanos))
+}
+
+/// Unordered key so (a, b) and (b, a) collapse to one bucket.
+fn unordered<T: Ord + Copy>(a: T, b: T) -> (T, T) {
+    if a <= b { (a, b) } else { (b, a) }
+}
+
+/// `NodeId` doesn't derive `Ord` (it's an opaque arena index, not meant to be
+/// compared for anything but identity elsewhere in the crate) -- order on the raw
+/// `u32` here, purely for this diagnostic's own unordered-pair bucketing.
+fn unordered_node(a: NodeId, b: NodeId) -> (NodeId, NodeId) {
+    if a.0 <= b.0 { (a, b) } else { (b, a) }
+}
+
+fn invert_outcome(cmp: BranchComparison) -> BranchComparison {
+    match cmp {
+        BranchComparison::Higher => BranchComparison::Lower,
+        BranchComparison::Lower => BranchComparison::Higher,
+        BranchComparison::Equal => BranchComparison::Equal,
+        BranchComparison::Unresolved => BranchComparison::Unresolved,
+    }
+}
+
+struct HeavyTailReport {
+    total_comparisons: usize,
+    distinct_nodeid_pairs: usize,
+    max_nodeid_pair_repeats: usize,
+    distinct_signature_pairs: usize,
+    max_signature_pair_repeats: usize,
+    comparisons_saved_if_signature_memoized: usize,
+    // `branch_signature` hashes atomic number + isotope only -- it does not encode
+    // MANCUDE fractional atomic numbers or which ancestor a `RingDuplicate` closes
+    // back to, both of which are real inputs to `compare_ligands`'s actual outcome.
+    // Equal signatures are therefore a *candidate* cache key, not a proven-safe one.
+    // These two counts are the actual discriminating check: among repeated
+    // (signature, signature) buckets, how many always produced the same canonical
+    // outcome (a signature-keyed cache would have been correct) vs. produced more
+    // than one distinct outcome across their repeats (a signature-keyed cache would
+    // have been wrong at least once).
+    signature_buckets_with_repeats: usize,
+    signature_buckets_outcome_homogeneous: usize,
+    signature_buckets_outcome_mixed: usize,
+    comparisons_in_mixed_buckets: usize,
+    leaf_involved_comparisons: usize,
+    both_leaf_comparisons: usize,
+    distinct_ranking_parents: usize,
+    parents_sharing_a_signature_set_with_another_parent: usize,
+}
+
+/// Runs findings 1, 2, 3, and 4 against one already-collected trace.
+fn analyze(graph: &mut CipDigraph, trace: &ComparisonTrace) -> HeavyTailReport {
+    let total_comparisons = trace.decisions.len();
+
+    // Finding 1: same-NodeId-pair re-comparison.
+    let mut nodeid_pair_counts: HashMap<(NodeId, NodeId), usize> = HashMap::new();
+    for step in &trace.decisions {
+        let key = unordered_node(step.left_node, step.right_node);
+        *nodeid_pair_counts.entry(key).or_default() += 1;
+    }
+    let distinct_nodeid_pairs = nodeid_pair_counts.len();
+    let max_nodeid_pair_repeats = nodeid_pair_counts.values().copied().max().unwrap_or(0);
+
+    // Finding 2: isomorphic-subtree-pair re-comparison, via the already-existing,
+    // already-correct `branch_signature` (order/numbering-invariant structural hash).
+    // Memoize per NodeId -- each node's signature is queried at most once regardless
+    // of how many comparisons involve it.
+    let mut sig_cache: HashMap<NodeId, u64> = HashMap::new();
+    let mut signature_of = |graph: &mut CipDigraph, n: NodeId| -> u64 {
+        *sig_cache
+            .entry(n)
+            .or_insert_with(|| graph.branch_signature(n).unwrap_or(0))
+    };
+    let mut signature_pair_counts: HashMap<(u64, u64), usize> = HashMap::new();
+    // Canonical (order-normalized) outcomes observed per signature-pair bucket, to
+    // check whether `branch_signature` alone is actually a safe cache key (see the
+    // report struct's doc comment) rather than assuming it from the raw repeat count.
+    let mut signature_pair_outcomes: HashMap<(u64, u64), Vec<BranchComparison>> = HashMap::new();
+    let mut leaf_involved_comparisons = 0usize;
+    let mut both_leaf_comparisons = 0usize;
+    let mut parent_signature_sets: HashMap<NodeId, Vec<u64>> = HashMap::new();
+    for step in &trace.decisions {
+        let ls = signature_of(graph, step.left_node);
+        let rs = signature_of(graph, step.right_node);
+        *signature_pair_counts.entry(unordered(ls, rs)).or_default() += 1;
+        let canonical_outcome = if ls <= rs {
+            step.outcome
+        } else {
+            invert_outcome(step.outcome)
+        };
+        signature_pair_outcomes
+            .entry(unordered(ls, rs))
+            .or_default()
+            .push(canonical_outcome);
+
+        let left_leaf = is_leaf_kind(graph.node(step.left_node).kind);
+        let right_leaf = is_leaf_kind(graph.node(step.right_node).kind);
+        if left_leaf || right_leaf {
+            leaf_involved_comparisons += 1;
+        }
+        if left_leaf && right_leaf {
+            both_leaf_comparisons += 1;
+        }
+
+        if let Some(parent) = step.ranking_parent {
+            let set = parent_signature_sets.entry(parent).or_default();
+            if !set.contains(&ls) {
+                set.push(ls);
+            }
+            if !set.contains(&rs) {
+                set.push(rs);
+            }
+        }
+    }
+    let distinct_signature_pairs = signature_pair_counts.len();
+    let max_signature_pair_repeats = signature_pair_counts.values().copied().max().unwrap_or(0);
+    // Upper bound only -- see the report struct's doc comment. Real savings depend on
+    // `signature_buckets_outcome_mixed` being zero; a mixed bucket means this key is
+    // not by itself a correct cache key for those repeats.
+    let comparisons_saved_if_signature_memoized = signature_pair_counts
+        .values()
+        .map(|&c| c.saturating_sub(1))
+        .sum();
+
+    let mut signature_buckets_with_repeats = 0usize;
+    let mut signature_buckets_outcome_homogeneous = 0usize;
+    let mut signature_buckets_outcome_mixed = 0usize;
+    let mut comparisons_in_mixed_buckets = 0usize;
+    for (key, count) in &signature_pair_counts {
+        if *count <= 1 {
+            continue;
+        }
+        signature_buckets_with_repeats += 1;
+        let outcomes = &signature_pair_outcomes[key];
+        let distinct: std::collections::HashSet<_> =
+            outcomes.iter().map(|o| format!("{o:?}")).collect();
+        if distinct.len() <= 1 {
+            signature_buckets_outcome_homogeneous += 1;
+        } else {
+            signature_buckets_outcome_mixed += 1;
+            comparisons_in_mixed_buckets += count;
+        }
+    }
+
+    // Finding 3: does the same *set* of sibling signatures recur across different
+    // `rank_children` calls (different parents) within this one center's resolution?
+    // If so, the whole pairwise matrix for that sibling group is redundant work the
+    // second (and later) time it's built, not just individual pair comparisons.
+    for sigs in parent_signature_sets.values_mut() {
+        sigs.sort_unstable();
+    }
+    let mut set_counts: HashMap<Vec<u64>, usize> = HashMap::new();
+    for sigs in parent_signature_sets.values() {
+        if sigs.len() > 1 {
+            *set_counts.entry(sigs.clone()).or_default() += 1;
+        }
+    }
+    let parents_sharing_a_signature_set_with_another_parent =
+        set_counts.values().filter(|&&c| c > 1).copied().sum();
+
+    HeavyTailReport {
+        total_comparisons,
+        distinct_nodeid_pairs,
+        max_nodeid_pair_repeats,
+        distinct_signature_pairs,
+        max_signature_pair_repeats,
+        comparisons_saved_if_signature_memoized,
+        signature_buckets_with_repeats,
+        signature_buckets_outcome_homogeneous,
+        signature_buckets_outcome_mixed,
+        comparisons_in_mixed_buckets,
+        leaf_involved_comparisons,
+        both_leaf_comparisons,
+        distinct_ranking_parents: parent_signature_sets.len(),
+        parents_sharing_a_signature_set_with_another_parent,
+    }
+}
+
+fn print_report(label: &str, r: &HeavyTailReport, build_nanos: u128, compare_nanos: u128) {
+    println!("--- {label} ---");
+    println!(
+        "total_comparisons={}  build+expand_all={:.2}ms  rank_children(compare only)={:.2}ms",
+        r.total_comparisons,
+        build_nanos as f64 / 1_000_000.0,
+        compare_nanos as f64 / 1_000_000.0,
+    );
+    println!(
+        "[1] distinct (NodeId,NodeId) pairs compared={}  max repeats of one pair={}  \
+         -- expected/structural: `rank_children`'s own pairwise fill visits each (i,j) \
+         exactly once per call, so a repeat here means the SAME descendant pair was \
+         reached again from a DIFFERENT ancestor comparison elsewhere in the digraph, \
+         not a bug in the fill loop itself. This is the same phenomenon [2] measures \
+         with a coarser (isomorphism, not identity) key.",
+        r.distinct_nodeid_pairs, r.max_nodeid_pair_repeats,
+    );
+    println!(
+        "[2] distinct isomorphic (signature,signature) pairs={}  max repeats={}  \
+         UPPER BOUND comparisons_saved_if_memoized={} ({:.1}% of total) -- \
+         branch_signature hashes atomic number + isotope only, NOT MANCUDE fractional \
+         atomic numbers or ring-closure ancestor identity, so equal signatures are a \
+         *candidate* cache key, not a proven-safe one. Discriminating check: of {} \
+         signature-pair buckets that repeat, {} always produced the SAME canonical \
+         outcome (safe to memoize) and {} produced MORE THAN ONE distinct outcome \
+         across their repeats ({} comparisons live in those unsafe buckets -- a \
+         signature-only cache would have returned a wrong answer for at least one of \
+         them).",
+        r.distinct_signature_pairs,
+        r.max_signature_pair_repeats,
+        r.comparisons_saved_if_signature_memoized,
+        100.0 * r.comparisons_saved_if_signature_memoized as f64
+            / r.total_comparisons.max(1) as f64,
+        r.signature_buckets_with_repeats,
+        r.signature_buckets_outcome_homogeneous,
+        r.signature_buckets_outcome_mixed,
+        r.comparisons_in_mixed_buckets,
+    );
+    println!(
+        "[3] distinct rank_children calls (ranking_parents)={}  parents whose own \
+         sibling-signature SET recurs elsewhere in this trace={}",
+        r.distinct_ranking_parents, r.parents_sharing_a_signature_set_with_another_parent,
+    );
+    println!(
+        "[4] comparisons with >=1 leaf-kind (dup/H) operand={} ({:.1}%)  both-leaf={} \
+         ({:.1}%) -- both-leaf comparisons are decidable by atomic number alone, no \
+         recursion needed",
+        r.leaf_involved_comparisons,
+        100.0 * r.leaf_involved_comparisons as f64 / r.total_comparisons.max(1) as f64,
+        r.both_leaf_comparisons,
+        100.0 * r.both_leaf_comparisons as f64 / r.total_comparisons.max(1) as f64,
+    );
+    println!();
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let budget = CipBudget::default_budget();
+
+    println!("=== Named worst-case fixtures (from issue #107 directly) ===\n");
+    for (label, smi) in [
+        (
+            "worst pass1_resolved (89,250 comparisons reported)",
+            WORST_PASS1,
+        ),
+        (
+            "worst needs_pass2_or_3 (36,198 comparisons reported)",
+            WORST_NEEDS_MORE,
+        ),
+    ] {
+        let mol = match chematic_smiles::parse(smi) {
+            Ok(m) => m,
+            Err(e) => {
+                println!("{label}: FAILED TO PARSE ({e:?}) -- skipping\n");
+                continue;
+            }
+        };
+        let kekule = prepare_kekule_form(&mol).ok();
+        let mut found_any = false;
+        for i in 0..mol.atom_count() {
+            let idx = AtomIdx(i as u32);
+            if mol.atom(idx).chirality == Chirality::None {
+                continue;
+            }
+            let Some(stereo_order) = mol.stereo_neighbor_order(idx) else {
+                continue;
+            };
+            if stereo_order.len() != 4 {
+                continue;
+            }
+            let Some((mut graph, trace, build_nanos, compare_nanos)) =
+                trace_for_center(&mol, idx, budget, &kekule)
+            else {
+                continue;
+            };
+            // Only the worst center per molecule is interesting for a targeted trace.
+            if trace.decisions.len() < 1000 {
+                continue;
+            }
+            found_any = true;
+            let report = analyze(&mut graph, &trace);
+            print_report(
+                &format!("{label} [atom {}]", idx.0),
+                &report,
+                build_nanos,
+                compare_nanos,
+            );
+        }
+        if !found_any {
+            println!(
+                "{label}: no stereocenter in this molecule crossed the 1000-comparison threshold this run (budget/heuristics may differ from the original A0 run) -- skipping\n"
+            );
+        }
+    }
+
+    // Full-corpus aggregate, same denominator as cip_perf_diagnosis.rs, if a corpus
+    // path was given -- otherwise the two named fixtures above already answer the
+    // issue's investigation order on its own worst-case evidence.
+    let Some(csv_path) = args.get(1) else {
+        println!(
+            "(no corpus path given -- pass `~/Downloads/SMILES.csv` or similar as arg 1 \
+             for a full-corpus aggregate; named-fixture findings above stand on their own)"
+        );
+        return;
+    };
+    let content = match fs::read_to_string(csv_path) {
+        Ok(c) => c,
+        Err(e) => {
+            println!("could not read corpus at {csv_path}: {e}");
+            return;
+        }
+    };
+    let smis: Vec<&str> = content
+        .lines()
+        .skip(1)
+        .filter(|l| !l.trim().is_empty())
+        .collect();
+
+    let mut agg_total_comparisons = 0u64;
+    let mut agg_saved_if_memoized = 0u64;
+    let mut agg_leaf_involved = 0u64;
+    let mut agg_both_leaf = 0u64;
+    let mut agg_build_nanos: u128 = 0;
+    let mut agg_compare_nanos: u128 = 0;
+    let mut centers_examined = 0u64;
+    // Homogeneity check, aggregated per-center (matching the realistic cache scope:
+    // one CompareContext/graph/MancudeContext per stereocenter resolution -- issue
+    // #107's own "First implementation candidate" already scopes the cache key to
+    // include MancudeContext identity, i.e. no cross-molecule/cross-center cache is
+    // being proposed, so pooling buckets *within* one center's own trace, then summing
+    // across centers, is the correct check -- not pooling signatures globally).
+    let mut agg_buckets_with_repeats = 0u64;
+    let mut agg_buckets_homogeneous = 0u64;
+    let mut agg_buckets_mixed = 0u64;
+    let mut agg_comparisons_in_mixed_buckets = 0u64;
+    let mut centers_with_any_mixed_bucket = 0u64;
+
+    for smi in &smis {
+        let Ok(mol) = chematic_smiles::parse(smi) else {
+            continue;
+        };
+        let has_chirality =
+            (0..mol.atom_count()).any(|i| mol.atom(AtomIdx(i as u32)).chirality != Chirality::None);
+        if !has_chirality {
+            continue;
+        }
+        let kekule = prepare_kekule_form(&mol).ok();
+        for i in 0..mol.atom_count() {
+            let idx = AtomIdx(i as u32);
+            if mol.atom(idx).chirality == Chirality::None {
+                continue;
+            }
+            let Some(stereo_order) = mol.stereo_neighbor_order(idx) else {
+                continue;
+            };
+            if stereo_order.len() != 4 {
+                continue;
+            }
+            let Some((mut graph, trace, build_nanos, compare_nanos)) =
+                trace_for_center(&mol, idx, budget, &kekule)
+            else {
+                continue;
+            };
+            centers_examined += 1;
+            agg_build_nanos += build_nanos;
+            agg_compare_nanos += compare_nanos;
+            let report = analyze(&mut graph, &trace);
+            agg_total_comparisons += report.total_comparisons as u64;
+            agg_saved_if_memoized += report.comparisons_saved_if_signature_memoized as u64;
+            agg_leaf_involved += report.leaf_involved_comparisons as u64;
+            agg_both_leaf += report.both_leaf_comparisons as u64;
+            agg_buckets_with_repeats += report.signature_buckets_with_repeats as u64;
+            agg_buckets_homogeneous += report.signature_buckets_outcome_homogeneous as u64;
+            agg_buckets_mixed += report.signature_buckets_outcome_mixed as u64;
+            agg_comparisons_in_mixed_buckets += report.comparisons_in_mixed_buckets as u64;
+            if report.signature_buckets_outcome_mixed > 0 {
+                centers_with_any_mixed_bucket += 1;
+            }
+        }
+    }
+
+    println!("=== Full-corpus aggregate (centers_examined={centers_examined}) ===");
+    println!(
+        "total_comparisons={agg_total_comparisons}  \
+         UPPER BOUND comparisons_saved_if_signature_memoized={agg_saved_if_memoized} ({:.1}%)  \
+         leaf_involved={agg_leaf_involved} ({:.1}%)  both_leaf={agg_both_leaf} ({:.1}%)",
+        100.0 * agg_saved_if_memoized as f64 / agg_total_comparisons.max(1) as f64,
+        100.0 * agg_leaf_involved as f64 / agg_total_comparisons.max(1) as f64,
+        100.0 * agg_both_leaf as f64 / agg_total_comparisons.max(1) as f64,
+    );
+    println!(
+        "[2, corpus-wide] discriminating check, summed per-center (matching the \
+         realistic per-resolution cache scope, not a pooled-across-molecules cache): \
+         {agg_buckets_with_repeats} repeating signature-pair buckets total, \
+         {agg_buckets_homogeneous} homogeneous (safe) / {agg_buckets_mixed} mixed \
+         (unsafe) -- {agg_comparisons_in_mixed_buckets} comparisons \
+         ({:.2}% of total_comparisons) live in a mixed bucket somewhere. \
+         {centers_with_any_mixed_bucket}/{centers_examined} centers have >=1 mixed \
+         bucket.",
+        100.0 * agg_comparisons_in_mixed_buckets as f64 / agg_total_comparisons.max(1) as f64,
+    );
+    println!(
+        "[5] construction (digraph build + expand_all) = {:.1}ms total   \
+         comparison (rank_children pairwise fill on an already-fully-expanded graph) = {:.1}ms total   \
+         ratio compare/construct = {:.2}x   \
+         CAVEAT: 'construction' here forces expand_all() on the WHOLE reachable digraph \
+         before timing comparison, specifically so lazy materialization isn't charged \
+         to the comparison timer. Production's actual expand_children() is lazy and \
+         only ever materializes nodes the comparator truly visits -- this split is 'cost \
+         if eagerly built' vs 'compare cost given an already-fully-built graph', NOT two \
+         disjoint slices of one real production run. Do not read the ratio as \
+         'construction dominates production cost' without measuring lazy production \
+         cost separately.",
+        agg_build_nanos as f64 / 1_000_000.0,
+        agg_compare_nanos as f64 / 1_000_000.0,
+        agg_compare_nanos as f64 / agg_build_nanos.max(1) as f64,
+    );
+}

--- a/crates/chematic-cip/src/compare.rs
+++ b/crates/chematic-cip/src/compare.rs
@@ -558,6 +558,8 @@ pub fn compare_ligands(
     if let Some(trace) = ctx.trace.as_deref_mut() {
         trace.decisions.push(DecisionStep {
             depth,
+            left_node: left,
+            right_node: right,
             left_kind: kind_label(left_kind),
             right_kind: kind_label(right_kind),
             outcome,

--- a/crates/chematic-cip/src/trace.rs
+++ b/crates/chematic-cip/src/trace.rs
@@ -26,6 +26,14 @@ use crate::node::NodeId;
 #[derive(Debug, Clone)]
 pub struct DecisionStep {
     pub depth: u32,
+    /// The two compared nodes' own `NodeId`s -- not needed by any display/reporting
+    /// logic (which reads `left_kind`/`right_kind` instead), but required by
+    /// diagnostics that need real node identity, e.g. detecting whether the same
+    /// `NodeId` pair (or, via [`crate::digraph::CipDigraph::branch_signature`], the
+    /// same *isomorphic* subtree pair) gets re-compared redundantly across a single
+    /// resolution. See issue #107 (CIP-Perf-A1).
+    pub left_node: NodeId,
+    pub right_node: NodeId,
     pub left_kind: String,
     pub right_kind: String,
     pub outcome: BranchComparison,

--- a/docs/rank_children_heavy_tail_diagnosis_107.md
+++ b/docs/rank_children_heavy_tail_diagnosis_107.md
@@ -1,0 +1,172 @@
+# CIP `rank_children` heavy-tail diagnosis: issue #107 (CIP-Perf-A1)
+
+Diagnostic pass only — no optimization in this document or its companion PR,
+matching the issue's own explicit framing ("this issue is for
+tracking/discussion only"). The instrumentation tool this diagnosis is built
+on lives at `crates/chematic-cip/examples/rank_children_heavy_tail_diagnosis.rs`
+and ships no production behavior change.
+
+## Question
+
+CIP-Perf-A0 (PR #106) found that even among the 99.3% of stereocenters that
+resolve "trivially" at Rules 1a/1b/2 (no Rule 4b/5 needed), a small tail does
+40–3700x the median comparator work. Issue #107 asks five specific questions
+about *why*, in a suggested investigation order, before any optimization is
+attempted:
+
+1. Same-`NodeId`-pair re-comparison count
+2. Isomorphic-subtree-pair re-comparison count
+3. Whether `rank_children`'s comparison matrix is reusable across sibling groups
+4. Whether duplicate leaves can be collapsed into equivalence classes before comparison
+5. Cost split: digraph construction vs. comparison itself
+
+## Method
+
+`crates/chematic-cip/src/trace.rs`'s `DecisionStep` already records one entry
+per `compare_ligands` call (`left_kind`/`right_kind`/`outcome`/`rule`/
+`ranking_parent`), but not the compared nodes' own `NodeId`s. The only
+production edit this diagnosis required was adding `left_node`/
+`right_node: NodeId` to that struct (populated at its one construction site in
+`compare.rs`) — a pure data-carrying addition to an already debug-only trace
+type, no behavior change.
+
+With real `NodeId`s available, the diagnostic tool re-traces the two
+worst-case fixtures issue #107 names directly (the 89,250-comparison fused
+polyphenolic macrocycle and the 36,198-comparison adamantane-cage), plus a
+full-corpus aggregate over the same 5,000-molecule `SMILES.csv` CIP-Perf-A0
+used, computing, per stereocenter:
+
+- Exact repeated `(NodeId, NodeId)` pairs (finding 1).
+- Isomorphic-subtree pairs, via `CipDigraph::branch_signature` — an
+  already-existing, already-correct, order/numbering-invariant structural
+  hash (finding 2).
+- **A discriminating safety check on finding 2**, added after an advisor
+  review caught that raw signature-repeat counts only bound *candidate*
+  savings, not *safe* savings (see Caveats below): for every signature pair
+  that repeats, whether every occurrence produced the same canonical
+  comparison outcome (`Higher`/`Lower`/`Equal`/`Unresolved`, normalized for
+  which side is which), or whether the same signature pair produced more than
+  one distinct outcome somewhere in the corpus.
+- Whether a `rank_children` call's whole sibling-signature *set* recurs
+  elsewhere in the same resolution, i.e. whether the entire pairwise matrix —
+  not just individual pairs — is redundant (finding 3).
+- What fraction of comparisons involve a leaf node (`MultipleBondDuplicate`,
+  `RingDuplicate`, or `ImplicitHydrogen` — childless by construction, decidable
+  by atomic number alone) (finding 4).
+- Construction cost (digraph build + full `expand_all`) vs. comparison cost
+  (`rank_children`'s pairwise fill on an already-fully-materialized graph)
+  (finding 5).
+
+## Results
+
+### Named worst-case fixtures (from the issue directly)
+
+| Fixture | total comparisons | [1] distinct NodeId pairs / max repeats | [2] distinct signature pairs / max repeats | [2] safety check | [4] leaf-involved / both-leaf |
+|---|---|---|---|---|---|
+| Fused polyphenolic macrocycle (atom 65) | 89,250 | 453 / 640 | 239 / 8,695 | **233/233 buckets homogeneous, 0 mixed** | 77.2% / 10.6% |
+| Adamantane cage (atoms 25, 27, 30 — 3 equivalent centers) | 36,198 each | 1,093 / 118 | 84 / 10,448 | **82/82 buckets homogeneous, 0 mixed** | 98.5% / 50.1% |
+
+### Full-corpus aggregate (4,188 stereocenters examined)
+
+- Total comparisons: 2,096,066.
+- **Upper-bound** savings if every repeated isomorphic-subtree-pair comparison
+  were memoized: 2,000,261 (95.4%).
+- **Discriminating safety check, corpus-wide**: 52,908 repeating
+  signature-pair buckets total, **52,908 homogeneous / 0 mixed** — every
+  center's within-resolution signature-pair repeats produced the same
+  outcome every time, on this corpus. 0/4,188 centers had any mixed bucket.
+- Leaf-involved comparisons: 89.1% of all comparisons touch at least one
+  leaf node; 33.4% are leaf-vs-leaf (decidable by atomic number alone, no
+  recursion into either side needed).
+- Construction (digraph build + eager `expand_all`): 1,300.1ms total.
+  Comparison (pairwise fill on an already-fully-materialized graph): 759.7ms
+  total. Ratio 0.58x.
+
+## Answering the issue's five questions
+
+1. **Same-`NodeId`-pair re-comparison is real (up to 640 repeats of one pair)
+   but not itself a bug.** `rank_children`'s own pairwise fill visits each
+   `(i, j)` exactly once per call; a repeated `NodeId` pair means the *same*
+   descendant pair was reached again from a *different* ancestor comparison
+   elsewhere in the digraph — the same phenomenon finding 2 measures with a
+   coarser (isomorphism, not identity) key.
+2. **Isomorphic-subtree-pair re-comparison is the dominant cost pattern, and —
+   critically — it was empirically safe to collapse everywhere tested.**
+   95.4% of all comparisons corpus-wide share a signature pair with at least
+   one other comparison, and every one of the 52,908 repeating buckets
+   (across the full corpus and both named worst-case fixtures) produced the
+   same outcome on every repeat. This is the strongest, most directly
+   actionable finding in this diagnosis.
+3. **`rank_children`'s comparison matrix is reusable across sibling groups
+   most of the time.** In the polyphenolic fixture, 70/150 `rank_children`
+   calls share their exact sibling-signature set with another call in the
+   same trace; in the adamantane fixture, 367/374 do. A cache keyed on the
+   sibling set (not just individual pairs) would avoid rebuilding whole
+   matrices, not just individual cells.
+4. **Duplicate leaves dominate comparison volume and are cheap to special-case
+   without touching the general recursive path.** 89.1% of all comparisons
+   corpus-wide involve at least one leaf node; 33.4% involve two. A leaf vs.
+   leaf comparison is decidable by atomic number alone — no digraph
+   recursion, no `rank_children` call, no `compare_by_level` machinery needed
+   — making this the cheapest and least risky candidate for a narrow,
+   separately-gated fast path.
+5. **Construction (1,300.1ms) numerically exceeds comparison (759.7ms) in
+   this measurement, but this split does not represent two disjoint slices of
+   one real production run** (see Caveats).
+
+## Caveats — read before treating any number above as a target
+
+- **Finding 2's "upper bound" vs. "safe" distinction is the load-bearing
+  correction in this diagnosis.** `branch_signature` hashes atomic number and
+  isotope only. It does **not** encode MANCUDE fractional atomic numbers
+  (`CipNode::atomic_number`, a separate field the signature never reads) or
+  which ancestor a `RingDuplicate` closes back to (it hashes `closure_atom`'s
+  *element*, not its identity). Two subtrees with equal signatures are
+  therefore isomorphic *up to atom identity*, not proven identical for every
+  input this comparator can see — a signature-only cache is a **candidate**
+  key, not a **proven-safe** one. The 0-mixed-buckets result above is real,
+  corpus-measured evidence that the candidate key happens to be safe on every
+  case this diagnosis ran — it is not a proof that it is safe in general.
+  Issue #107's own "First implementation candidate" section already
+  anticipated this: it specifies the cache key must include comparison
+  rule/mode, `MancudeContext` identity, and budget semantics in addition to
+  the two `NodeId`s — a real implementation should use that richer key, not
+  the bare `branch_signature` this diagnosis used as a measurement
+  convenience.
+- **Finding 5's construction number is not production cost.** The tool calls
+  `expand_all(root)` to fully materialize the reachable digraph *before*
+  timing comparison, specifically so lazy node materialization isn't charged
+  to the comparison timer. Production's actual `expand_children` is lazy and
+  only ever materializes nodes the comparator truly visits during its
+  recursive descent — for centers that resolve early (most of them, per
+  CIP-Perf-A0's own 99.3% figure), the real construction cost is almost
+  certainly far below 1,300.1ms's implied per-center share. The 0.58x ratio
+  measured here is "comparison cost given an eagerly-built graph" vs. "cost
+  to eagerly build that graph" — not two disjoint slices of one real,
+  lazily-executed run. A future measurement of true lazy production cost
+  would need separate instrumentation of `expand_children` itself, not
+  attempted here.
+- Adamantane's three listed centers (atoms 25, 27, 30) are almost certainly
+  symmetry-equivalent (same molecule, same comparator-size numbers to the
+  last digit) — reported as three rows for completeness against the trace
+  output, not as three independent data points.
+- This diagnosis reuses CIP-Perf-A0's own corpus (`~/Downloads/SMILES.csv`,
+  5,000 molecules, same file referenced in `docs/cip_accurate_rfc.md`'s
+  MANCUDE-Decision-A0 entry) rather than a fresh draw, to keep this result
+  directly comparable to the issue's own baseline numbers.
+
+## What this does and doesn't authorize
+
+This diagnosis identifies isomorphic-subtree-pair memoization (finding 2) and
+leaf-vs-leaf fast-pathing (finding 4) as the two most promising, most
+directly evidenced optimization candidates, and rank_children-matrix reuse
+(finding 3) as a secondary candidate once pair-level memoization exists. It
+does **not** implement any of them. Per issue #107's own absolute gate for any
+future optimization PR (assignments byte-identical, skip_reasons
+byte-identical, MANCUDE-Decision-A0's D/E classification unchanged, the 3
+`mancude_decision_regression.rs` fixtures unchanged, RDKit oracle agreement
+unchanged, `BudgetExceeded` count non-increasing), any real implementation
+still needs its own correctness verification against a cache key that
+includes `MancudeContext` identity and budget semantics — the bare
+`branch_signature` key measured here is a diagnostic convenience, not the
+key a shipped cache should use unmodified.


### PR DESCRIPTION
## Summary

Diagnostic-only pass answering issue #107's own 5-question investigation order, before any optimization is attempted (matching the issue's explicit "no production optimization work has started -- this issue is for tracking/discussion only" framing).

- Only production edit: `DecisionStep` (`crates/chematic-cip/src/trace.rs`) gains `left_node`/`right_node: NodeId`, populated at its one construction site in `compare.rs`. Pure data-carrying addition to an already debug-only trace struct -- zero behavior change, verified via `cargo test -p chematic-cip --lib` (61/61 pass, unchanged). Confirmed `DecisionStep`/`ComparisonTrace` have zero references anywhere in `chematic-py`, `chematic-wasm`, or `chematic-mcp` source, and `chematic-cip` itself has no re-export in the `chematic` umbrella crate -- this diagnostic tooling has no public API, serialization, WASM, or Python surface today, by construction.
- New diagnostic tool: `crates/chematic-cip/examples/rank_children_heavy_tail_diagnosis.rs`, extending the existing `cip_perf_diagnosis.rs`/`ComparisonTrace`/`CipDigraph::branch_signature` infrastructure rather than duplicating it.
- Full write-up: `docs/rank_children_heavy_tail_diagnosis_107.md`.

## Headline finding

95.4% of all comparisons corpus-wide (2,096,066 total, 4,188 stereocenters, same 5,000-molecule corpus CIP-Perf-A0 used) share an isomorphic-subtree signature with another comparison -- an **upper bound** on memoization savings, not a claimed speedup (see caveat below). Critically, a **discriminating safety check** (added after this was initially over-claimed and caught before writeup) shows every one of the 52,908 repeating signature-pair buckets measured -- across the full corpus and both of the issue's own named worst-case fixtures -- produced the *same* comparison outcome on every repeat. 0 mixed buckets, 0/4,188 centers affected.

This is real, corpus-validated evidence that `branch_signature`-keyed memoization is safe everywhere tested -- explicitly **not** claimed as a general proof, and explicitly **not** a measured speedup number: `branch_signature` hashes atomic number + isotope only, not MANCUDE fractional atomic numbers or ring-closure ancestor identity, so it's a candidate cache key, not a proven-safe one in general, and "comparisons saved" is not the same claim as "wall-clock time saved." Issue #107's own "First implementation candidate" section already anticipated this and specifies the richer key a real implementation should use (NodeId pair + comparison rule/mode + MancudeContext identity + budget semantics) -- that richer-keyed, bounded (per-resolution, not global) implementation is tracked as a separate follow-up, gated on issue #107's own absolute correctness checklist, not part of this diagnostic PR.

All 5 of the issue's questions are answered with measured numbers -- see the doc for the full table, per-question answers, and caveats (in particular: finding 5's construction-vs-comparison cost split is measured against an eagerly-materialized graph and is explicitly flagged as not representative of production's lazy cost).

## Rebased onto latest main (2026-07-30)

Base updated from `ad2fcba0` to `5c51bbb` (2 new unrelated merges: #206 hydrogen-count canonicalization, #207's own follow-up test fixes). Rebase was clean, no conflicts (`chematic-cip`'s own files aren't touched by either upstream commit). Re-verified on the new base, not assumed carried-over:

- `cargo test -p chematic-cip --lib`: 61/61 pass, unchanged.
- Diagnostic tool re-run against the full corpus and both named fixtures: **numbers are byte-identical** to the pre-rebase measurement -- `total_comparisons=2,096,066`, `saved=2,000,261` (95.4%), `52,908/52,908` homogeneous buckets, `0` mixed, on both named fixtures (`233/233`, `82/82`) and the full-corpus aggregate.
- `bash scripts/check.sh`: full pass (fmt/clippy/71 test-result blocks all `0 failed`/deny/publish-graph/version 0.8.0).

New head: `6fd79d7` (was `f68b791`).

## Test plan

- [x] `cargo test -p chematic-cip --lib` -- 61/61 pass, unchanged
- [x] `bash scripts/check.sh` -- full pass (fmt/clippy/full workspace test suite/deny/publish-graph/version)
- [x] Diagnostic tool run against both of issue #107's named worst-case fixtures and the full 5,000-molecule corpus
- [x] Rebased onto latest main, re-verified byte-identical results, confirmed zero public/WASM/Python surface impact

## CI status (2026-07-30) — Criterion gate failure is advisory, not evidence of a regression

All checks pass except one:

| Check | Result |
|---|---|
| Analyze (actions/javascript-typescript/python/rust), Build Check, Cargo Audit, Cargo Deny, Clippy, Clippy Lints, CodeQL, Format Check, Test, Test (native-inchi), Validate CITATION.cff | ✅ pass |
| **Python bench regression gate** | ✅ **pass** |
| **Rust Criterion regression gate** | ❌ **fail** — `parse_smiles_10mol` only |

Detail on the one failure: Stage 1 routed only `parse_smiles_10mol` as a possible regression (every other registered benchmark — `smarts_compile_5pat`, `smarts_match_nocache_10mol`, `smarts_match_cached_10mol`, `smarts_recursive_10mol`, `canonical_smiles_10mol`, `ecfp4_10mol`, `tanimoto_ecfp4_pairs`, `descriptors_5x10mol`, `qed_10mol`, `pka_predict_10mol`, `pka_acid_base_10mol`, `admet_profile_10mol`, `find_sssr_10mol`, `find_sssr_polycyclic_5mol`, `count_aromatic_rings_10mol` — reported `no-route`). Stage 2 (reversed-order confirmation, 10 blocks) reproduced it: median ratio `1.0511868` against the `1.04` practical-effect fail threshold (≈5.1% slower).

This is treated as **advisory only, not evidence of a real regression**, for two independent reasons:

1. **Issue #70's standing policy**: this repo's own Criterion gate is measurement-broken by pseudo-replication — ~100 samples per side share one process's runner state and are not independent trials, so a gate failure alone (even a Stage-2-confirmed one) is not by itself regression evidence. Per that policy, the correct response is to investigate for a plausible causal link to the actual diff, not to tune thresholds, exclude the benchmark, or adjust code in response to the gate.
2. **No plausible causal link in this diff**: PR #208 is diagnosis-only. Its complete file list is `crates/chematic-cip/examples/rank_children_heavy_tail_diagnosis.rs` (new example), `crates/chematic-cip/src/compare.rs` (+2, `DecisionStep` construction site), `crates/chematic-cip/src/trace.rs` (+8, two new `NodeId` fields on a debug-only trace struct), and `docs/rank_children_heavy_tail_diagnosis_107.md`. Nothing in `chematic-smiles` (where `parse_smiles_10mol` and the SMILES parser live) is touched, and `chematic-cip` has no reverse dependency into `chematic-smiles`'s parse path. There is no code-level mechanism by which this diff could move `parse_smiles_10mol`'s timing.

**No threshold, benchmark registration, or code was changed in response to this failure**, per the same policy.

### Recommendation

CI/Security Audit/Python bench gate are green; the sole failing check is this out-of-scope, policy-classified-advisory Criterion result. Ready for review and merge at the user's discretion — merge is not being executed automatically and awaits explicit authorization.
