### PR TITLE
release: prepare v0.8.1 — canonical_smiles explicit/implicit H-count fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — everything below `[0.8.0]` has shipped._
+_Nothing yet — everything below `[0.8.1]` has shipped._
+
+## [0.8.1] — 2026-07-30
+
+### Fixed — `chematic-smiles` / `chematic-core`
+
+- **`canonical_smiles()` no longer treats a genuinely-redundant explicit
+  hydrogen count as distinguishing.** Two representations of the same
+  molecule that differ only in whether an atom's H count was written with
+  bracket notation (`[Cl]`) or organic-subset notation (`Cl`) — when the
+  explicit value merely repeats what valence inference would give anyway —
+  now canonicalize to the identical string. Previously they could diverge:
+  `initial_invariant`'s Morgan-rank seed and `CanonicalWriter::emit_atom`'s
+  bracket-necessity check both read the raw `Atom.hydrogen_count` field
+  directly instead of going through the crate's own `implicit_hcount()`
+  unification helper. Fixed by routing both decisions through
+  `implicit_hcount`/the new `valence_inferred_hcount` (#205, #206).
+  - **Isotope, formal charge, real stereochemistry, and any genuinely
+    disambiguating explicit H count (e.g. `[CH2]` where organic-subset
+    inference would give a different count) are unaffected and remain
+    fully distinguishing** — only the specific redundant-explicit-H case is
+    unified.
+  - **Some canonical SMILES output strings for existing inputs will change**
+    as a direct, intended consequence (e.g. a monosubstituted-benzene ring's
+    canonical traversal start point can shift). This is a correctness fix,
+    not a new feature — see Migration notes below for what downstream
+    consumers should check.
+  - Found via [kent-tokyo/renkin PR #65](https://github.com/kent-tokyo/renkin/pull/65):
+    a `run_reactants` product built from a bracket-notation SMIRKS template
+    diverged from a directly user-typed SMILES of the identical compound,
+    breaking candidate-identity merging downstream.
+  - New permanent regression coverage: `chematic-smiles::canonical::explicit_implicit_h_invariance`
+    (isolated bracket/organic pairs, randomized atom-relabeling insertion
+    order, disconnected structures, Kekulized rings, isotope/charge/stereo
+    non-regression, canonicalize→parse→canonicalize idempotence) and
+    `chematic-rxn::transform::reaction_derived_matches_direct_parse_chlorobenzene`.
+
+### Migration notes
+
+- If your code stores or compares hardcoded canonical SMILES strings
+  (golden-file tests, cached dedup keys, precomputed candidate IDs, etc.),
+  a small number of them may now differ from what this version produces.
+  This release itself needed to update 11 such pre-existing internal
+  fixtures after tracing each individually to confirm it was a stale
+  string for the identical molecule, never a behavioral regression — the
+  same audit is recommended for downstream golden strings before
+  upgrading in a context that depends on exact string stability across
+  versions.
+- `are_identical`/`compare_molecules` (`chematic-chem`/`chematic-inchi`)
+  benefit directly: pairs that previously required InChI reconciliation to
+  resolve a spurious canonical-key split may now be recognized as
+  duplicates by the fast canonical-key grouping alone.
 
 ## [0.8.0] — 2026-07-29
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,5 +23,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.8.0
+version: 0.8.1
 date-released: "2026-07-29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.85"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.8.0
+# chematic v0.8.1
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-07-17, v0.4.29 vs RDKit 2026.03.3 --
@@ -417,6 +417,10 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +1
 
 ## Recent Development
 
+**v0.8.1** (2026-07-30): **`canonical_smiles()` explicit/implicit hydrogen-count correctness fix**
+- `chematic-smiles`/`chematic-core`: two representations of the same molecule that differ only in whether an atom's H count came from bracket notation (`[Cl]`) or organic-subset notation (`Cl`) — when the explicit value merely repeats what valence inference gives anyway — now canonicalize identically; `initial_invariant`'s Morgan-rank seed and the canonical writer's bracket-necessity check previously read the raw `hydrogen_count` field directly instead of the crate's own `implicit_hcount()` unifier. Isotope, charge, real stereochemistry, and any genuinely disambiguating explicit H count remain fully distinguishing — only the redundant case is unified. Found via [kent-tokyo/renkin PR #65](https://github.com/kent-tokyo/renkin/pull/65) (a `run_reactants` product from a bracket-notation SMIRKS template diverging from a directly user-typed SMILES of the identical compound). Some canonical SMILES output strings for existing inputs will change as a direct, intended consequence — see `CHANGELOG.md`'s `[0.8.1]` Migration notes if you depend on exact string stability across versions
+- Full details in `CHANGELOG.md`'s `[0.8.1]` section
+
 **v0.8.0** (2026-07-29): **Opt-in fail-closed 3D embedding pipeline, canonical-SMILES automorphism-orbit pruning**
 - `chematic-3d`: new opt-in `pipeline_v2::embed_pipeline_v2` integrates stochastic distance geometry, macrocycle 1-4 distance-bound adjustments, validated ETKDG-style torsion knowledge, chiral-volume/E-Z stereo verification and repair, and typed force-field minimization into one 12-stage pipeline, with a fail-closed stereo re-check *after* force-field minimization (measured: UFF/DREIDING can reintroduce a stereo violation repair had just fixed). `RingTorsionApplicationPolicy::FailClosed` (default) rejects mechanically applying ring/macrocycle torsion potentials the current optimizer can only score, not apply — `DiagnosticOnly` is an explicit, non-default opt-in. Existing default behavior (Rust/Python/WASM/MCP) is unchanged
 - `chematic-smiles`: fixed the `canonical_smiles()` performance regression reported by RENKIN — canonicalization search now prunes branches via exact, independently-verified colored-graph automorphism checks, never rank/hash equality alone. Measured (audited, conservative figures): approximately 5x geomean speedup on high-symmetry molecules (search-leaf count 6625 → 13), approximately 1.1–1.2x geomean speedup on low-symmetry negative controls with no regression, approximately 1.09–1.10x per-molecule geomean speedup on a 5,000-molecule external corpus (approximately 5x total-elapsed improvement there, tail-dominated by a few high-symmetry molecules, not representative of typical per-molecule cost), 0 correctness mismatches. `canonical_smiles(&Molecule) -> String`'s public signature is unchanged; new fallible `canonical_smiles_with_limits` added alongside it. Also fixes a Dative-bond round-trip bug (issue #194): the writer was silently truncating `->` to a plain single bond, and — a deeper, separate root cause — the parser could not distinguish `->` from `<-` at all, silently collapsing both to the same donor/acceptor assignment; both are now correctly direction-aware
@@ -589,7 +593,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v0.8.0)
+├── Cargo.toml                    workspace root (v0.8.1)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)
@@ -642,7 +646,7 @@ If you use chematic in academic or research work, please cite:
   author    = {kent-tokyo},
   title     = {chematic: A pure-Rust cheminformatics toolkit},
   url       = {https://github.com/kent-tokyo/chematic},
-  version   = {0.8.0},
+  version   = {0.8.1},
   year      = {2026},
 }
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -106,7 +106,7 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.8.0
+# chematic v0.8.1
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-06, v0.4.22 vs RDKit 2026.03.3 --

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.8.0 | Yes | Current release — active support |
+| v0.8.1 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.8.0) receives all security updates.  
+**Active Support**: Latest release (v0.8.1) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -16,12 +16,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.8.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.8.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.8.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.8.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.8.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.8.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.8.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.8.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.8.1" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.8.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.8.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -16,14 +16,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.8.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.8.1" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.8.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.8.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.8.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.8.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.8.0" }
-chematic-cip        = { path = "../chematic-cip",        version = "0.8.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.8.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.8.1" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.8.1" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.8.1" }
+chematic-cip        = { path = "../chematic-cip",        version = "0.8.1" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.8.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.8.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.8.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -22,10 +22,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.8.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.8.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.8.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.8.0" }
+chematic-core = { path = "../chematic-core", version = "0.8.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.8.1" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.8.1" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.8.0" }
+chematic-core = { path = "../chematic-core", version = "0.8.1" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.8.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.8.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.8.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -22,13 +22,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.8.0" }
+chematic-core = { path = "../chematic-core", version = "0.8.1" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.8.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.8.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.8.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.8.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.8.1" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.8.1" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.8.1" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -18,10 +18,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.8.0", path = "../chematic-core" }
-chematic-smiles = { version = "0.8.0", path = "../chematic-smiles" }
-chematic-chem = { version = "0.8.0", path = "../chematic-chem" }
-chematic-rxn = { version = "0.8.0", path = "../chematic-rxn" }
+chematic-core = { version = "0.8.1", path = "../chematic-core" }
+chematic-smiles = { version = "0.8.1", path = "../chematic-smiles" }
+chematic-chem = { version = "0.8.1", path = "../chematic-chem" }
+chematic-rxn = { version = "0.8.1", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.8.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.8.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.8.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -17,15 +17,15 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.8.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.8.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.8.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.8.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.8.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.8.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.8.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.8.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.8.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.8.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.8.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.8.1", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.8.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.8.1" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.8.1" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.8.1" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.8.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
 
 [dev-dependencies]
 # Real JSON Schema 2020-12 validator, used only in tests to independently

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -16,10 +16,10 @@ documentation = "https://docs.rs/chematic-mol"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.8.0" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.8.0" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.8.0" }
-chematic-smiles      = { path = "../chematic-smiles",      version = "0.8.0" }
+chematic-core        = { path = "../chematic-core",        version = "0.8.1" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.8.1" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.8.1" }
+chematic-smiles      = { path = "../chematic-smiles",      version = "0.8.1" }
 serde_json           = "1.0"
 
 [dev-dependencies]

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.8.0" }
+chematic-core = { path = "../chematic-core", version = "0.8.1" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,16 +25,16 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.8.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.8.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.8.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.8.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.8.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.8.0", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.8.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.8.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.8.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.8.0" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.8.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.8.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.8.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.8.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.8.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.8.1" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.8.1" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.8.1", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.8.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.8.1" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.8.1" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.8.1" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.8.1" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.8.1" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.8.1" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -22,9 +22,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 perf-instrumentation = []
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.8.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.8.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.8.0" }
+chematic-core   = { path = "../chematic-core",   version = "0.8.1" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.8.1" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.8.1" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.8.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.8.0" }
+chematic-core = { path = "../chematic-core", version = "0.8.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.8.0" }
+chematic-core = { path = "../chematic-core", version = "0.8.1" }
 
 [features]
 # Feature-gated internal work counters for the orbit-pruning canonical

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -25,16 +25,16 @@ crate-type = ["cdylib", "rlib"]
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["console"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.8.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.8.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.8.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.8.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.8.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.8.0", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.8.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.8.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.8.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.8.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.8.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.8.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.8.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.8.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.8.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.8.1", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.8.1" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.8.1", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.8.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.8.1" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.8.1" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.8.1" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.8.1" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.8.1" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.8.1" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -33,15 +33,15 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.8.0", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.8.0", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.8.0", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.8.0", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.8.0", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.8.0", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.8.0", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.8.0", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.8.0", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.8.0", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.8.0", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.8.0", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.8.1", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.8.1", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.8.1", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.8.1", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.8.1", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.8.1", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.8.1", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.8.1", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.8.1", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.8.1", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.8.1", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.8.1", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Version-bump-and-sync release PR for **v0.8.1**: 0.8.0 → 0.8.1, a
correctness patch release (`canonical_smiles()` explicit/implicit
hydrogen-count unification, #205/#206). No public API additions.

## Why 0.8.1, not 0.9.0

- No public API additions.
- A canonicalization correctness bug fix.
- Resolves a construction-path/notation divergence
  (`[Cl]` vs `Cl`-style redundant explicit H) rather than adding capability.
- Some canonical SMILES strings intentionally change as a result — covered
  in CHANGELOG.md's Migration notes.

## Changes

- `Cargo.toml` (workspace version) + all path-dependency versions across
  `crates/*/Cargo.toml`, synced via `scripts/bump_version.py`.
- `README.md`/`README_ja.md`/`CITATION.cff`/`SECURITY.md`/`demo/pkg/package.json`
  version references.
- `CHANGELOG.md`: new `[0.8.1]` section (root cause, what remains
  distinguishing, migration notes for downstream golden-string consumers).
- `README.md`'s "Recent Development" section: new v0.8.1 entry.

## Verification

`bash scripts/check.sh` (fmt, clippy, full test suite, `cargo-deny`,
publish-graph check, version-consistency check across every synced file):
all green, `Version consistent: 0.8.1`.

## Next steps (not in this PR)

After merge: annotated tag `v0.8.1` on the resulting commit → triggers
`release.yml` (GitHub Release notes), `publish-pypi.yml`, `publish-npm.yml`
automatically. crates.io publishing for the 18 publishable Rust crates is
manual, in the topological order `scripts/check_publish_graph.py` reports.
