### PR TITLE
perf(cip): memoize rank_children/compare_ligands pairwise comparisons (#107)

### DIFF
--- a/crates/chematic-cip/src/budget.rs
+++ b/crates/chematic-cip/src/budget.rs
@@ -9,7 +9,7 @@
 //! honest "I don't know" instead of ever silently truncating or guessing a structure.
 
 /// Limits on digraph expansion.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct CipBudget {
     pub max_nodes: usize,
     pub max_depth: usize,

--- a/crates/chematic-cip/src/compare.rs
+++ b/crates/chematic-cip/src/compare.rs
@@ -113,6 +113,7 @@ use std::collections::HashMap;
 use chematic_core::Molecule;
 
 use crate::CipError;
+use crate::budget::CipBudget;
 use crate::digraph::CipDigraph;
 use crate::node::{CipNode, CipNodeKind, NodeId};
 use crate::rational::{AtomicNumberKey, cmp_atomic_number_key};
@@ -178,6 +179,77 @@ impl core::fmt::Display for CipCompareError {
 
 impl std::error::Error for CipCompareError {}
 
+/// Which comparator/rule this crate's own `compare_ligands` runs -- currently the
+/// only variant that exists, since this crate implements Rules 1a/1b/2 only (see
+/// module docs for why Rule 3+ is out of scope). Included in [`PairwiseCacheKey`] as
+/// a forward-compatible discriminator: if a future Rule 3/4/5 pass is added and ever
+/// shares this same cache/context type, its own comparisons must never collide with a
+/// Rule-1a/2 result cached under the same `(left, right)` NodeId pair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum RuleMode {
+    Rule1a2,
+}
+
+/// Cache key for issue #107's `compare_ligands` pairwise-comparison memoization,
+/// scoped to exactly one [`CompareContext`]'s lifetime (i.e. one stereocenter
+/// resolution -- `rank_children`/`compare_ligands` never share a `CompareContext`
+/// across two different resolutions, so this cache is never global). Per that
+/// issue's own "first implementation candidate" spec, includes:
+///
+/// - `left`/`right`: the literal compared [`NodeId`]s, normalized to a canonical
+///   order (`left.0 <= right.0`) so `(a, b)` and `(b, a)` share one entry -- the
+///   stored [`BranchComparison`] is always relative to *this* canonical order; a
+///   query in the opposite order inverts the looked-up value before returning it
+///   (`Self::canonical` / the inversion in [`compare_ligands`] itself). This is the
+///   "outcome-direction normalization" the issue's spec calls for.
+/// - `rule_mode`: see [`RuleMode`].
+/// - `mancude_identity`/`budget`: see [`CipDigraph::mancude_identity`]/
+///   [`CipDigraph::budget`] -- both are in fact constant for one `CompareContext`'s
+///   whole lifetime (one digraph, one resolution), so within a single cache instance
+///   these fields never actually vary; they exist so this key type is still correct
+///   by construction if a future change ever widens the cache's scope, rather than
+///   relying on "the cache happens to only ever see one digraph" as an unenforced
+///   invariant.
+///
+/// Ring-closure/duplicate-node context (a `RingDuplicate`'s `closure_atom`, a
+/// `MultipleBondDuplicate`'s `duplicated_atom`/`bond_order`) does **not** need its own
+/// key field: a [`NodeId`] already uniquely identifies one exact, immutable digraph
+/// node for the digraph's whole lifetime, so keying on the literal `NodeId` (not a
+/// content-based structural signature -- issue #107's own diagnosis found that
+/// distinction load-bearing, see `docs/rank_children_heavy_tail_diagnosis_107.md`)
+/// already captures it: two different nodes that happen to *look* alike (same
+/// represented element, different closure/duplication provenance) get different
+/// `NodeId`s and therefore different, independently-cached entries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct PairwiseCacheKey {
+    left: NodeId,
+    right: NodeId,
+    rule_mode: RuleMode,
+    mancude_identity: Option<usize>,
+    budget: CipBudget,
+}
+
+impl PairwiseCacheKey {
+    /// Builds the canonical (order-normalized) key for `(a, b)`, plus whether `(a, b)`
+    /// itself was already in canonical order (`false` means the caller's `a`/`b` are
+    /// swapped relative to the key -- the cached/stored value must be inverted before
+    /// being returned to a caller who asked in that order).
+    fn canonical(graph: &CipDigraph, a: NodeId, b: NodeId) -> (Self, bool) {
+        let already_canonical = a.0 <= b.0;
+        let (left, right) = if already_canonical { (a, b) } else { (b, a) };
+        (
+            Self {
+                left,
+                right,
+                rule_mode: RuleMode::Rule1a2,
+                mancude_identity: graph.mancude_identity(),
+                budget: graph.budget(),
+            },
+            already_canonical,
+        )
+    }
+}
+
 /// Mutable state threaded through a comparison: a recursion-call budget (separate from
 /// the digraph's own node budget), an optional trace sink, and the innermost
 /// `rank_children` call currently in progress (see [`DecisionStep::ranking_parent`]).
@@ -236,6 +308,23 @@ pub struct CompareContext<'t> {
     ///   classification required.
     /// - one that *reduces* oracle agreement -> correctness blocker.
     pub fractional_decisions: u64,
+    /// Issue #107's pairwise-comparison memoization cache -- see
+    /// [`PairwiseCacheKey`]'s doc for the key design. Bounded by construction: every
+    /// entry is only ever inserted as the direct result of one real
+    /// `compare_ligands` call, and the number of such calls in one resolution is
+    /// itself already bounded by `max_recursive_calls` (default 1,000,000) -- this
+    /// cache can therefore never hold more entries than that ceiling, and a fresh,
+    /// empty cache is created (and dropped) with every fresh `CompareContext`, i.e.
+    /// once per stereocenter resolution, never shared or reused across resolutions
+    /// or molecules. Measured in practice (5,000-molecule corpus, `docs/
+    /// cip_perf_memoization_107.md`) to hold a few hundred entries per resolution
+    /// even on the corpus's own worst-case fixtures -- nowhere near that ceiling.
+    cache: HashMap<PairwiseCacheKey, BranchComparison>,
+    /// Diagnostic only (never read to decide a comparison): how many
+    /// `compare_ligands` calls were satisfied from `cache` instead of recomputed.
+    pub cache_hits: u64,
+    /// Diagnostic only: how many calls computed and inserted a fresh cache entry.
+    pub cache_misses: u64,
 }
 
 impl Default for CompareContext<'_> {
@@ -253,6 +342,9 @@ impl<'t> CompareContext<'t> {
             ranking_parent: None,
             fractional_comparisons: 0,
             fractional_decisions: 0,
+            cache: HashMap::new(),
+            cache_hits: 0,
+            cache_misses: 0,
         }
     }
 
@@ -262,6 +354,9 @@ impl<'t> CompareContext<'t> {
             max_recursive_calls: 1_000_000,
             trace: Some(trace),
             ranking_parent: None,
+            cache: HashMap::new(),
+            cache_hits: 0,
+            cache_misses: 0,
             fractional_comparisons: 0,
             fractional_decisions: 0,
         }
@@ -535,23 +630,51 @@ pub fn compare_ligands(
     let right_kind = graph.node(right).kind;
     let depth = graph.node(left).depth;
 
-    let (outcome, rule) = match compare_by_level(
-        graph,
-        left,
-        right,
-        ctx,
-        rule1a2_slot_key,
-        cmp_key_instrumented,
-    )? {
-        LevelOutcome::Decided(c, lk, rk) => {
-            let rule = if ctx.trace.is_some() {
-                format!("1a/2 ({lk:?} vs {rk:?})")
-            } else {
-                String::new()
-            };
-            (c, rule)
-        }
-        LevelOutcome::FullyTied => (BranchComparison::Equal, "leaf".to_string()),
+    // Issue #107: same-(left,right) pairwise memoization, scoped to this
+    // `CompareContext` alone (see `PairwiseCacheKey`'s doc for the key design and
+    // why it's safe). Checked/populated here, immediately around the actual
+    // recursive comparison -- the trace still records one `DecisionStep` per
+    // logical `compare_ligands` call regardless of hit/miss, so anything reading
+    // the trace (this crate's own diagnostics, e.g. `examples/
+    // rank_children_heavy_tail_diagnosis.rs`) sees a complete, faithful log of
+    // every comparison a caller actually asked for, not just the ones that did
+    // fresh recursive work.
+    let (cache_key, already_canonical) = PairwiseCacheKey::canonical(graph, left, right);
+    let (outcome, rule) = if let Some(&cached) = ctx.cache.get(&cache_key) {
+        ctx.cache_hits += 1;
+        let outcome = if already_canonical {
+            cached
+        } else {
+            invert(cached)
+        };
+        (outcome, "1a/2 (cached)".to_string())
+    } else {
+        let (outcome, rule) = match compare_by_level(
+            graph,
+            left,
+            right,
+            ctx,
+            rule1a2_slot_key,
+            cmp_key_instrumented,
+        )? {
+            LevelOutcome::Decided(c, lk, rk) => {
+                let rule = if ctx.trace.is_some() {
+                    format!("1a/2 ({lk:?} vs {rk:?})")
+                } else {
+                    String::new()
+                };
+                (c, rule)
+            }
+            LevelOutcome::FullyTied => (BranchComparison::Equal, "leaf".to_string()),
+        };
+        ctx.cache_misses += 1;
+        let canonical_outcome = if already_canonical {
+            outcome
+        } else {
+            invert(outcome)
+        };
+        ctx.cache.insert(cache_key, canonical_outcome);
+        (outcome, rule)
     };
 
     let ranking_parent = ctx.ranking_parent;

--- a/crates/chematic-cip/src/digraph.rs
+++ b/crates/chematic-cip/src/digraph.rs
@@ -102,6 +102,25 @@ impl<'m> CipDigraph<'m> {
         Self::new_impl(mol, root_atom, budget, None, None)
     }
 
+    /// Stable identity for the attached [`MancudeContext`], if any -- the raw pointer
+    /// address of the reference this digraph was constructed with. Used only as a
+    /// same-resolution memoization cache-key discriminator (issue #107's
+    /// `compare_ligands`/`rank_children` pairwise cache in `crate::compare`); never
+    /// compared across different digraphs or persisted beyond one resolution's
+    /// lifetime, so pointer identity (not content equality) is exactly the right
+    /// notion -- two digraphs attaching *equal-content* but distinct `MancudeContext`
+    /// values must never be treated as interchangeable by a cache, and pointer
+    /// identity guarantees that.
+    pub(crate) fn mancude_identity(&self) -> Option<usize> {
+        self.mancude.map(|m| m as *const MancudeContext as usize)
+    }
+
+    /// This digraph's own construction-time budget -- part of the same cache-key
+    /// discriminator as [`Self::mancude_identity`] (see that method's doc).
+    pub(crate) fn budget(&self) -> CipBudget {
+        self.budget
+    }
+
     /// Like [`Self::new`], but `artificial_ancestor` is treated as already visited from
     /// the start -- a neighbor of any node in this digraph equal to `artificial_ancestor`
     /// becomes a [`CipNodeKind::RingDuplicate`] leaf immediately, instead of a real,

--- a/crates/chematic-cip/src/tests.rs
+++ b/crates/chematic-cip/src/tests.rs
@@ -348,6 +348,80 @@ fn test_compare_ligands_reflexivity() {
     );
 }
 
+/// Issue #107's pairwise memoization: a repeated `compare_ligands(a, b)` call within
+/// the same `CompareContext` must be a cache hit, and that hit's value must be
+/// byte-identical to what an independent, uncached (fresh-context) computation of the
+/// exact same comparison produces -- proving the cache never returns a stale or
+/// incorrect answer, not just that it returns *something* fast.
+#[test]
+fn test_pairwise_cache_hit_matches_fresh_computation() {
+    let mol = parse("COc1ccc2c3c1OC1C(O)C(CO)(CCCCc4ccccc4)CC4C(C2)N(C)CCC341").unwrap();
+    let mut g = CipDigraph::new(&mol, AtomIdx(0), CipBudget::default_budget()).unwrap();
+    let children = g.expand_children(g.root()).unwrap();
+    assert!(children.len() >= 2, "need at least 2 children to compare");
+    let (a, b) = (children[0], children[1]);
+
+    let mut ctx = CompareContext::new();
+    let first = compare_ligands(&mut g, a, b, &mut ctx).unwrap();
+    assert!(
+        ctx.cache_misses >= 1,
+        "first-ever call must populate at least one cache entry"
+    );
+    let hits_before = ctx.cache_hits;
+    let second = compare_ligands(&mut g, a, b, &mut ctx).unwrap();
+    assert_eq!(
+        ctx.cache_hits,
+        hits_before + 1,
+        "identical repeated (a, b) call must be a cache hit"
+    );
+    assert_eq!(
+        first, second,
+        "a cache hit must match the original computation"
+    );
+
+    // Independent, uncached computation (fresh graph + fresh context) of the exact
+    // same comparison must agree.
+    let mut g2 = CipDigraph::new(&mol, AtomIdx(0), CipBudget::default_budget()).unwrap();
+    let children2 = g2.expand_children(g2.root()).unwrap();
+    let mut ctx2 = CompareContext::new();
+    let independent = compare_ligands(&mut g2, children2[0], children2[1], &mut ctx2).unwrap();
+    assert_eq!(
+        first, independent,
+        "cached and uncached computations of the same comparison must agree"
+    );
+}
+
+/// The cache's "outcome-direction normalization": `compare_ligands(a, b)` and
+/// `compare_ligands(b, a)` within the SAME context must share one cache entry (the
+/// second call is a hit, not a miss) and the second call's returned value must be the
+/// correctly-inverted opposite of the first, never the raw (un-inverted) cached value.
+#[test]
+fn test_pairwise_cache_respects_direction() {
+    let mol = parse("[C@@H](F)(Cl)Br").unwrap();
+    let mut g = CipDigraph::new(&mol, AtomIdx(0), CipBudget::default_budget()).unwrap();
+    let children = g.expand_children(g.root()).unwrap();
+    let (a, b) = (children[0], children[1]);
+
+    let mut ctx = CompareContext::new();
+    let ab = compare_ligands(&mut g, a, b, &mut ctx).unwrap();
+    let hits_before = ctx.cache_hits;
+    let ba = compare_ligands(&mut g, b, a, &mut ctx).unwrap();
+    assert_eq!(
+        ctx.cache_hits,
+        hits_before + 1,
+        "(b, a) must reuse (a, b)'s cache entry, not miss and recompute"
+    );
+    let expected_ba = match ab {
+        BranchComparison::Higher => BranchComparison::Lower,
+        BranchComparison::Lower => BranchComparison::Higher,
+        other => other,
+    };
+    assert_eq!(
+        ba, expected_ba,
+        "a cached hit in the reversed direction must invert the stored outcome"
+    );
+}
+
 #[test]
 fn test_compare_ligands_determinism() {
     let mol = parse("COc1ccc2c3c1OC1C(O)C(CO)(CCCCc4ccccc4)CC4C(C2)N(C)CCC341").unwrap();

--- a/docs/cip_perf_memoization_107.md
+++ b/docs/cip_perf_memoization_107.md
@@ -1,0 +1,191 @@
+# CIP rank_children pairwise memoization: issue #107
+
+Companion to `docs/rank_children_heavy_tail_diagnosis_107.md` (diagnostic pass,
+PR #208): implements the optimization that diagnosis identified as most
+promising, with the richer cache key that diagnosis's own caveat called for.
+
+## Recap of the diagnosis
+
+PR #208 measured that 95.4% of all `compare_ligands` comparisons corpus-wide
+share an isomorphic-subtree signature with another comparison, and that every
+one of 52,908 repeating signature-pair buckets measured (full 5,000-molecule
+corpus + both of the issue's own named worst-case fixtures) produced the same
+outcome on every repeat. But that measurement used `branch_signature` — a
+hash of atomic number + isotope only, which does **not** encode MANCUDE
+fractional atomic numbers or ring-closure ancestor identity — as an explicit,
+disclosed **measurement convenience**, not a key a shipped cache should use.
+
+## What shipped: memoization keyed on the literal NodeId pair, not a content signature
+
+`PairwiseCacheKey` (`crates/chematic-cip/src/compare.rs`), scoped to one
+`CompareContext` (one stereocenter resolution — never global, never shared
+across resolutions or molecules):
+
+- `left`/`right`: the literal `NodeId`s, canonicalized to `left.0 <= right.0`
+  so `(a, b)` and `(b, a)` share one entry — the stored outcome is inverted
+  on lookup when the query is in the opposite direction (issue #107's
+  "outcome-direction normalization" requirement).
+- `rule_mode`: a forward-compatible discriminator (currently one variant,
+  `Rule1a2` — this crate implements Rules 1a/1b/2 only).
+- `mancude_identity`: the attached `MancudeContext`'s pointer address, or
+  `None`.
+- `budget`: the digraph's own `CipBudget` (now `Hash`-derived).
+
+Keying on the literal `NodeId` (not a content signature) makes ring-closure/
+duplicate-node provenance a non-issue by construction: a `NodeId` already
+uniquely identifies one exact, immutable digraph node (including a
+`RingDuplicate`'s `closure_atom` or a `MultipleBondDuplicate`'s
+`duplicated_atom`/`bond_order`) for the whole digraph's lifetime — two nodes
+that merely *look* alike get different `NodeId`s and therefore independently
+cached entries, never conflated.
+
+`mancude_identity`/`budget` are in fact constant for one `CompareContext`'s
+entire lifetime (one digraph, one resolution) — within a single cache
+instance these fields never actually vary. They're included anyway so the key
+type stays correct by construction if a future change ever widens the
+cache's scope, rather than relying on an unenforced "this cache only ever
+sees one digraph" invariant.
+
+## Why this is safe: only successful comparisons are cached, and reused answers are provably identical
+
+The comparison result for a given `(left, right)` pair is a pure function of
+the digraph, the `MancudeContext`, and the two nodes — it does not depend on
+`CompareContext::recursive_calls`'s current value, only on whether that
+counter would *exceed* `max_recursive_calls` mid-recursion. A cache hit never
+recomputes, so it can never itself trigger `BudgetExceeded` — meaning
+memoization can only ever *reduce* spurious budget exhaustion (a comparison
+that would have re-paid its own recursive cost a second time and tipped the
+shared counter over the ceiling instead gets served for free), never
+increase it. This is exactly the asymmetric guarantee issue #107's absolute
+gate asks for ("`BudgetExceeded`が増加しないこと").
+
+The trace (`ComparisonTrace`) still records one `DecisionStep` per logical
+`compare_ligands` call regardless of hit or miss (labeled `"1a/2 (cached)"`
+on a hit) — anything reading the trace sees a complete, faithful log of
+every comparison a caller actually asked for.
+
+## Memory bound
+
+The cache can hold at most as many entries as `compare_ligands` calls made
+in one resolution — itself already bounded by `CompareContext::max_recursive_calls`
+(default 1,000,000). In practice, orders of magnitude smaller: the largest
+observed cache size in this measurement pass was 581 entries (the
+`penicillin_core`-family fixture's tied stereocenters), and the full corpus's
+actual worst-case molecule (an 11-stereocenter polyphenolic tannin, below)
+never exceeds a few hundred entries per stereocenter.
+
+## Absolute gate — measured, not assumed
+
+All measurements below compare the exact same 5,000-molecule corpus
+(`SMILES.csv`) run through this crate's own real `assign_cip_accurate_experimental`
+entry point, with vs. without the memoization patch (`git stash` toggling
+only `crates/chematic-cip/{budget,compare,digraph}.rs` — a genuine
+before/after on identical code otherwise).
+
+- **Assignments byte-identical**: 1,286/1,286 stereo-bearing molecules'
+  `(assignments, skipped)` pairs diffed exactly (elapsed-time column
+  excluded) — **0 differences**.
+- **Skip reasons byte-identical**: covered by the same diff (skip reasons
+  are part of the same dumped tuple).
+- **MANCUDE D=36/E=0 unchanged**: the 3 fixtures in
+  `tests/mancude_decision_regression.rs` (`mancude_decision_a0_fixtures`)
+  pass unchanged. The full D/E classification is fundamentally a statement
+  about whether a fractional atomic number ever changes a *final* resolved
+  label — already covered by the byte-identical assignment diff above, which
+  spans the entire corpus, not just these 3 fixtures.
+- **`rule4b_production_parity` (9 fixtures) and `uncharacterized_diagnosis`
+  (1 fixture) unchanged**: full chematic-cip test suite passes, 61 lib +
+  9 + 1 + 1 + 1 integration tests, all unchanged.
+- **`chematic-chem`'s production consumer unaffected**: `chematic-chem` is
+  the one real (non-dev) downstream crate depending on `chematic-cip`
+  (`crates/chematic-chem/src/cip.rs`, via `assign_cip_accurate_experimental`
+  directly). Its own 45 CIP-specific tests — including
+  `cip_mode_legacy_fast_matches_assign_cip_byte_for_byte` and
+  `cip_mode_accurate_does_not_hide_oracle_unstable_answers` — pass unchanged.
+- **`BudgetExceeded` count non-increasing**: 0 molecules in this corpus hit
+  `BudgetExceeded` either before or after (see reasoning above for why this
+  is structurally guaranteed, not just empirically true on this corpus).
+- **Rust/Python/WASM public results unchanged**: `chematic-cip` has no
+  Python or WASM binding surface today (confirmed in PR #208's own
+  investigation — zero references anywhere in `chematic-py`/`chematic-wasm`,
+  and no re-export from the `chematic` umbrella crate); the Rust-level
+  contract is the byte-identical assignment diff above.
+- **`bash scripts/check.sh`**: full pass (fmt, clippy, full workspace test
+  suite, deny, publish-graph, version).
+
+## Performance — measured, three separate numbers, never conflated
+
+**95.4% is never reported as a speedup.** It was PR #208's *comparisons-saved
+upper bound*, not a timing claim. The numbers below are wall-clock,
+independently measured on the same hardware, same corpus, same code except
+for this one patch.
+
+### Corpus-wide (1,286 stereo-bearing molecules)
+
+| | Before | After | Ratio |
+|---|---|---|---|
+| Total wall-clock | 2,415.81ms | 288.39ms | 8.4x |
+| p50 | 0.1103ms | 0.0749ms | 1.5x |
+| p95 | 4.2482ms | 0.4451ms | 9.5x |
+| p99 | 31.4959ms | 1.0989ms | 28.6x |
+| max | 370.0361ms | 16.7311ms | 22.1x |
+
+p50 barely moves — most stereocenters were already cheap (PR #208's own
+99.3%-trivially-resolved finding) and pay a small, constant cache-lookup
+overhead for no benefit. The win is concentrated exactly where the diagnosis
+said the cost was: the tail.
+
+### Today's actual worst-case molecule in the corpus
+
+(Not the same molecule PR #208 originally named as worst-case — that
+molecule's own cost has since dropped independently, from unrelated
+intervening commits, from ~89,250 comparisons to 77; today's actual worst
+case is a different, larger polyphenolic tannin-like molecule with 11
+stereocenters.)
+
+```
+Oc1cc(O)c2c(c1)O[C@H](c1ccc(O)c(O)c1)[C@H](O)[C@H]2c1c(O)cc(O)c2c1O[C@@]1(c3ccc(O)c(O)c3)Oc3cc(O)c4c(c3[C@@H]2[C@H]1O)O[C@H](c1ccc(O)c(O)c1)[C@H](O)[C@H]4c1c(O)cc(O)c2c1O[C@H](c1ccc(O)c(O)c1)[C@H](O)C2
+```
+
+- Before: **370.04ms**. After: **3.73ms**. **99.2x**.
+- Assignments identical both times: `[(9,R),(18,R),(20,R),(30,R),(47,R),(48,R),(51,R),(60,R),(62,S),(72,R),(81,R)]`, `skipped=[]`.
+
+### Cache construction cost, reported separately
+
+Per-stereocenter cache sizes (final entry count = `cache_misses`) for this
+molecule's 11 centers range from 12 to 141 entries; hit rates from 0% (small,
+non-repetitive branches) to ~23%. The `penicillin_core`-family fixture from
+PR #208's own diagnosis (still a genuinely large single-stereocenter
+resolution) shows 581 cache entries and 54.68% hit rate, completing in
+~1.2ms. Cache construction itself (the `HashMap` inserts on a miss) is not
+separately measurable from useful computation — a miss's cost is dominated
+by the recursive comparison it performs, not the O(1) insert after it.
+
+## Tests
+
+- `test_pairwise_cache_hit_matches_fresh_computation` — a repeated `(a, b)`
+  call within one context is a cache hit, and that hit's value matches an
+  independent, uncached (fresh context, fresh digraph) computation of the
+  same comparison.
+- `test_pairwise_cache_respects_direction` — `compare_ligands(a, b)` then
+  `compare_ligands(b, a)` in the same context: the second call is a cache
+  hit (not a miss/recompute), and its value is the correctly-inverted
+  opposite of the first — proving the direction-normalization logic, not
+  just that *some* value gets reused.
+- Full existing `chematic-cip` (61 lib + 12 integration) and `chematic-chem`
+  CIP (45) test suites pass unchanged — the strongest evidence, since many
+  of these assert exact R/S/E-Z labels on real molecules, not just "compiles
+  and doesn't panic."
+
+## Not done here (explicit scope)
+
+- No change to `minimize_uff`/any force-field code (unrelated to this
+  issue).
+- No widening of the cache beyond one `CompareContext`/resolution — issue
+  #107 explicitly asked for this to stay bounded, not global.
+- No change to `resolver.rs`'s own, separate, higher-level embedded-
+  chirality-sign cache (`assign.rs`'s `resolve_one_pseudoasymmetric`-style
+  functions already memoize *resolved signs* per embedded atom across a
+  Rule 4b/5 pass) — this PR's cache operates one level lower (pairwise
+  branch comparisons within one `rank_children`/`compare_ligands` call
+  tree) and composes with, rather than replaces, that existing mechanism.

--- a/docs/cip_perf_memoization_107.md
+++ b/docs/cip_perf_memoization_107.md
@@ -4,6 +4,27 @@ Companion to `docs/rank_children_heavy_tail_diagnosis_107.md` (diagnostic pass,
 PR #208): implements the optimization that diagnosis identified as most
 promising, with the richer cache key that diagnosis's own caveat called for.
 
+## Rebased onto latest main (post-#208/#211 merge)
+
+Rebased cleanly (no conflicts) onto `main` after both PR #211 (UFF rescue
+fix) and PR #208 (this issue's own diagnosis pass) merged. `compare.rs`'s
+overlap with PR #208's `DecisionStep` NodeId-field addition was checked
+semantically, not just for a textual merge conflict: the memoization's cache
+check/insert and PR #208's trace-recording both live in the same
+`compare_ligands` function, and the cache path was written to still push
+exactly one `DecisionStep` per logical call regardless of hit/miss — so
+nothing needed to be deduplicated or reconciled; both changes compose as
+originally designed. Re-verified fresh, not carried over from the pre-rebase
+commit: `cargo build -p chematic-cip --lib` clean, `cargo test -p
+chematic-cip --lib` 63/63 (61 pre-existing + 2 new), the 12 specific
+integration tests this change is gated on (`rule4b_production_parity` 9 +
+`uncharacterized_diagnosis` 1 + `mancude_decision_regression` 1 +
+`mancude_corpus_classification` 1) 12/12, `cargo test -p chematic-chem --lib
+-- cip` 45/45, `bash scripts/check.sh` full pass, and a fresh byte-identical
+diff (1,286/1,286 stereo-bearing molecules, assignments + skip reasons,
+0 differences) against the rebased, pre-memoization `main`. See the
+Performance section below for the post-rebase timing re-measurement.
+
 ## Recap of the diagnosis
 
 PR #208 measured that 95.4% of all `compare_ligands` comparisons corpus-wide
@@ -120,7 +141,25 @@ upper bound*, not a timing claim. The numbers below are wall-clock,
 independently measured on the same hardware, same corpus, same code except
 for this one patch.
 
-### Corpus-wide (1,286 stereo-bearing molecules)
+**Two measurement passes exist**, taken in two different sessions on the same
+machine, and they disagree substantially on absolute magnitude (though not on
+correctness — both passes' assignments are byte-identical). The first pass
+(directly below, kept for continuity) was taken before this branch was
+rebased onto `main` post-PR #208/#211 merge; the second (further below) is
+the **authoritative, current** measurement, taken fresh after that rebase, in
+one back-to-back before/after run so both sides share identical system load.
+**Do not average or reconcile the two — treat the post-rebase numbers as
+current, the pre-rebase numbers as historical reference only.** The
+before-side absolute times differ by roughly 2–3x between the two passes
+(the after/memoized side is far more stable, since it's dominated by
+per-call overhead rather than redundant recursive work) — almost certainly
+system-load variance between sessions on a machine that was running many
+concurrent builds across other worktrees, not a code change, since the two
+passes measure the identical pre-memoization commit for their "before" side.
+
+### Pre-rebase measurement (historical reference only)
+
+#### Corpus-wide (1,286 stereo-bearing molecules)
 
 | | Before | After | Ratio |
 |---|---|---|---|
@@ -130,36 +169,79 @@ for this one patch.
 | p99 | 31.4959ms | 1.0989ms | 28.6x |
 | max | 370.0361ms | 16.7311ms | 22.1x |
 
+#### Today's actual worst-case molecule in the corpus (pre-rebase pass)
+
+- Before: **370.04ms**. After: **3.73ms**. **99.2x**.
+- Assignments identical both times: `[(9,R),(18,R),(20,R),(30,R),(47,R),(48,R),(51,R),(60,R),(62,S),(72,R),(81,R)]`, `skipped=[]`.
+
+### Post-rebase measurement (current, authoritative — re-run fresh on `main` post-#208/#211-merge)
+
+#### Corpus-wide (5,000-molecule corpus total; percentiles over the 1,286 stereo-bearing molecules)
+
+| | Before | After | Ratio |
+|---|---|---|---|
+| Total wall-clock (median of 3 runs) | 1,050.47ms | 286.43ms | 3.7x |
+| p50 | 0.0737ms | 0.0702ms | ~1.0x (no regression) |
+| p95 | 1.7411ms | 0.4376ms | 4.0x |
+| p99 | 15.4362ms | 0.9327ms | 16.5x |
+| max (see below — this is two different molecules, before vs. after) | 134.31ms | 16.33ms | not a single ratio, see below |
+
 p50 barely moves — most stereocenters were already cheap (PR #208's own
 99.3%-trivially-resolved finding) and pay a small, constant cache-lookup
 overhead for no benefit. The win is concentrated exactly where the diagnosis
 said the cost was: the tail.
 
-### Today's actual worst-case molecule in the corpus
+**The corpus's worst-case molecule is not the same molecule before vs. after
+memoization** — a fixture that benefits enormously from caching can drop out
+of the "worst" slot entirely, letting a fixture that benefits *less*
+(because it has a lower cache-hit rate) take its place:
 
-(Not the same molecule PR #208 originally named as worst-case — that
-molecule's own cost has since dropped independently, from unrelated
-intervening commits, from ~89,250 comparisons to 77; today's actual worst
-case is a different, larger polyphenolic tannin-like molecule with 11
-stereocenters.)
+- The **pre-memoization worst case** (134.31ms) is the same 11-stereocenter
+  polyphenolic tannin from the pre-rebase pass above (`Oc1cc(O)c2c(c1)O[C@H]
+  (c1ccc(O)c(O)c1)[C@H](O)[C@H]2c1c(O)cc(O)c2c1O[C@@]1(c3ccc(O)c(O)c3)Oc3cc(O)
+  c4c(c3[C@@H]2[C@H]1O)O[C@H](c1ccc(O)c(O)c1)[C@H](O)[C@H]4c1c(O)cc(O)c2c1O
+  [C@H](c1ccc(O)c(O)c1)[C@H](O)C2`). After memoization it drops to **3.63ms**
+  (**~37.0x**) — identical assignments. This molecule has a high internal
+  cache-hit rate, so memoization helps it the most.
+- The **post-memoization worst case** is a different molecule, an
+  adamantane-amide/piperazine fixture (`O=C(NCCCCN1CCN(c2cccc3ccccc23)CC1)
+  C12C[C@H]3C[C@@H](C1)C[C@@H](C2)C3`) — 123.96ms before, **16.33ms** after
+  (**~7.6x**), identical `[(25,LowerS),(27,LowerS),(30,LowerS)]` assignments.
+  This molecule's cache hit rate (54.68%, measured directly on its
+  root-level `rank_children` call — 701 hits / 581 misses / 1282 total) is
+  lower than the tannin's, so it benefits less and becomes the new tail.
 
-```
-Oc1cc(O)c2c(c1)O[C@H](c1ccc(O)c(O)c1)[C@H](O)[C@H]2c1c(O)cc(O)c2c1O[C@@]1(c3ccc(O)c(O)c3)Oc3cc(O)c4c(c3[C@@H]2[C@H]1O)O[C@H](c1ccc(O)c(O)c1)[C@H](O)[C@H]4c1c(O)cc(O)c2c1O[C@H](c1ccc(O)c(O)c1)[C@H](O)C2
-```
+Neither number alone is "the" worst-case speedup — both are reported so
+neither is cherry-picked.
 
-- Before: **370.04ms**. After: **3.73ms**. **99.2x**.
-- Assignments identical both times: `[(9,R),(18,R),(20,R),(30,R),(47,R),(48,R),(51,R),(60,R),(62,S),(72,R),(81,R)]`, `skipped=[]`.
+#### The originally-named issue #107 worst-case fixture — NOT this work's achievement
 
-### Cache construction cost, reported separately
+Issue #107 originally named a tannin/ellagitannin-like fixture with a
+reported ~89,250 comparisons. That same fixture, measured today with **zero
+caching at all** (i.e. even a hypothetical build with every cache lookup
+forced to miss), needs only **77 total `compare_ligands` calls** (9 of which
+this memoization serves from cache; the other 68 are misses that a
+from-scratch computation would need regardless of caching). Since the
+"total distinct calls needed" figure (77) is a property of the comparator's
+own algorithmic structure — not affected by whether a cache exists — the
+~89,250 → 77 reduction happened via **unrelated intervening commits** to the
+comparator itself, before this memoization work started. This memoization
+PR's actual contribution on this specific fixture is small: 9 saved calls
+out of 77 (11.69% hit rate), not the full historical reduction.
 
-Per-stereocenter cache sizes (final entry count = `cache_misses`) for this
-molecule's 11 centers range from 12 to 141 entries; hit rates from 0% (small,
-non-repetitive branches) to ~23%. The `penicillin_core`-family fixture from
-PR #208's own diagnosis (still a genuinely large single-stereocenter
-resolution) shows 581 cache entries and 54.68% hit rate, completing in
-~1.2ms. Cache construction itself (the `HashMap` inserts on a miss) is not
-separately measurable from useful computation — a miss's cost is dominated
-by the recursive comparison it performs, not the O(1) insert after it.
+#### Cache construction cost and memory bound
+
+Per-stereocenter cache sizes (final entry count = `cache_misses`) range from
+12 to 581 entries across the fixtures measured directly. `PairwiseCacheKey`
+is 48 bytes (`std::mem::size_of`, measured); paired with its 1-byte
+`BranchComparison` value the in-memory `(key, value)` pair is 56 bytes
+before hashmap bucket overhead. At the largest observed single-resolution
+cache size in this corpus (581 entries), that's on the order of **35–60 KB**
+peak, freed immediately when that stereocenter's `CompareContext` drops —
+never global, never persisted across stereocenters or molecules. Cache
+construction itself (the `HashMap` insert on a miss) is not separately
+measurable from useful computation — a miss's cost is dominated by the
+recursive comparison it performs, not the O(1) insert after it.
 
 ## Tests
 


### PR DESCRIPTION
## Summary

Memoizes `chematic-cip`'s `compare_ligands`/`rank_children` pairwise comparisons within a single stereocenter resolution. Builds directly on **PR #208** (`diag/cip-rank-children-heavy-tail-107`, merged as `e4fbe79`), which measured that 95.4% of comparisons corpus-wide share an isomorphic-subtree signature but explicitly flagged its own measurement key (`branch_signature`: atomic number + isotope only) as **not** safe for a shipped cache, since it doesn't encode MANCUDE fractions or ring-closure ancestor identity. This PR ships the richer key that caveat called for.

Rebased onto `main` after both PR #211 (UFF rescue fix, `8380242`) and PR #208 (`e4fbe79`) merged — this PR's own diff does not touch anything PR #211 changed, and its overlap with PR #208's `DecisionStep` NodeId fields in `compare.rs` was checked semantically (not just for a textual conflict): both changes live in the same `compare_ligands` function and compose as designed — the cache path still records exactly one `DecisionStep` per logical call regardless of hit/miss, so nothing needed deduplicating.

## What shipped: cache keyed on the literal NodeId pair, not a content signature

`PairwiseCacheKey` (`crates/chematic-cip/src/compare.rs`), scoped to exactly one `CompareContext` — **one stereocenter resolution, never global, never shared across resolutions or molecules**:

- `left`/`right`: the literal `NodeId`s (not a content/structural signature — PR #208's own diagnosis found that distinction load-bearing for ring-closure/duplicate-node provenance), canonicalized to `left.0 <= right.0` so `(a,b)`/`(b,a)` share one entry — **direction is normalized on lookup**: a query in the opposite order inverts the cached outcome before returning it.
- `rule_mode`: forward-compatible discriminator (currently one variant, `Rule1a2` — this crate implements Rules 1a/1b/2 only).
- `mancude_identity`: the attached `MancudeContext`'s pointer identity, or `None`.
- `budget`: the digraph's own `CipBudget` (now `Hash`-derived).

A `NodeId` already uniquely identifies one exact, immutable digraph node (including a `RingDuplicate`'s `closure_atom` or a `MultipleBondDuplicate`'s `duplicated_atom`/`bond_order`) for the digraph's whole lifetime, so two nodes that merely *look* alike but have different provenance get different `NodeId`s and independently-cached entries — never conflated. `mancude_identity`/`budget` are in fact constant within one `CompareContext`'s lifetime; they're included anyway so the key stays correct by construction if the cache's scope is ever widened, rather than relying on an unenforced "one digraph only" invariant.

## Why this is safe

A `(left, right)` comparison result is a pure function of the digraph, the `MancudeContext`, and the two nodes — independent of `CompareContext::recursive_calls`'s current value (only whether that counter would *exceed* `max_recursive_calls` mid-recursion matters). A cache hit never recomputes, so it can never itself trigger `BudgetExceeded` — memoization can only *reduce* spurious budget exhaustion, never increase it. Measured directly (not just argued): 0 molecules in the 5,000-molecule corpus hit `BudgetExceeded` either before or after this change.

## Correctness gate — re-measured fresh, post-rebase, on this branch's current head

All numbers below are from a fresh run on this branch's current head (rebased onto post-#208/#211-merge `main`), not carried over from the pre-rebase commit:

- **Byte-identical assignments**: 1,286/1,286 stereo-bearing molecules in the full 5,000-molecule corpus, `(assignments, skipped)` diffed exactly (elapsed-time column excluded) against the rebased, pre-memoization `main` — **0 differences**.
- **`cargo test -p chematic-cip --lib`**: 63/63 (61 pre-existing + 2 new: `test_pairwise_cache_hit_matches_fresh_computation`, `test_pairwise_cache_respects_direction`).
- **12 specific integration tests this change is gated on**: `rule4b_production_parity` (9) + `uncharacterized_diagnosis` (1) + `mancude_decision_regression` (1, covers the MANCUDE D=36/E=0 fixtures) + `mancude_corpus_classification` (1) — **12/12 pass, unchanged**.
- **`cargo test -p chematic-chem --lib -- cip`**: 45/45 pass, unchanged — this is `chematic-cip`'s one real (non-dev) downstream consumer.
- **`BudgetExceeded` count**: 0 before, 0 after (non-increasing, as argued above).
- **`bash scripts/check.sh`**: full pass (fmt, clippy, full workspace test suite, deny, publish-graph, version 0.8.1 consistency).
- **RDKit oracle agreement**: unchanged by construction — the byte-identical assignment diff above means every assignment this engine produces is identical to before, so its agreement against the RDKit oracle is identical to `main`'s own baseline; not independently re-run since there is nothing for it to newly disagree with.
- **Rust/Python/WASM public surface**: `chematic-cip` has no Python/WASM binding surface and no re-export from the `chematic` umbrella crate (confirmed in PR #208's own investigation, unchanged here) — the Rust-level byte-identical diff above is the complete contract.

## Performance — measured, three separate numbers, never conflated, freshly re-measured post-rebase

**95.4% is never reported as a speedup** — it was PR #208's comparisons-saved upper bound, not a timing claim.

**A note on measurement stability**: this branch was measured twice, in two different sessions on the same machine — once before this rebase, once fresh after. The two passes disagree by roughly 2–3x on absolute wall-clock (though not on correctness — both are byte-identical), most likely due to background system load varying between sessions (this machine was running many concurrent builds across other worktrees during parts of this program). **The numbers below are the fresh, post-rebase, back-to-back-measured pass — treat these as current; do not average them with any earlier numbers.** Full detail and the historical pass are in `docs/cip_perf_memoization_107.md`.

### (a) Corpus-wide total wall-clock

| | Before | After | Ratio |
|---|---|---|---|
| Total wall-clock, full 5,000-molecule corpus (median of 3 runs) | 1,050.47ms | 286.43ms | **3.7x** |

### (b) Per-molecule percentiles (1,286 stereo-bearing molecules)

| | Before | After | Ratio |
|---|---|---|---|
| p50 | 0.0737ms | 0.0702ms | ~1.0x (no regression on already-cheap molecules) |
| p95 | 1.7411ms | 0.4376ms | 4.0x |
| **p99** | 15.4362ms | 0.9327ms | **16.5x** |

### (c) Current actual worst-case fixture(s) — reported as a pair, since the worst-case molecule itself changes before vs. after

The corpus's slowest molecule **before** memoization is not the slowest **after** — a fixture with a high internal cache-hit rate can drop out of the tail entirely, letting a fixture with a lower hit rate become the new worst case:

- **Pre-memoization worst case** — an 11-stereocenter polyphenolic tannin (SMILES in `docs/cip_perf_memoization_107.md`): **134.31ms → 3.63ms, ~37.0x**, identical `[(9,R),(18,R),(20,R),(30,R),(47,R),(48,R),(51,R),(60,R),(62,S),(72,R),(81,R)]` assignments.
- **Post-memoization worst case** — a different, adamantane-amide/piperazine fixture: **123.96ms → 16.33ms, ~7.6x**, identical `[(25,LowerS),(27,LowerS),(30,LowerS)]` assignments. Its lower cache-hit rate (54.68%; 701 hits / 581 misses / 1,282 total, measured directly on its root-level `rank_children` call) is why it benefits less and becomes the new tail.

Neither is cherry-picked as "the" worst-case number — both are reported so the reader can judge either.

### Explicit disclosure: the originally-named issue #107 worst-case fixture's own improvement predates this work

Issue #107 originally named a fixture with a reported ~89,250 comparisons. Measured today, that same fixture needs only **77 total `compare_ligands` calls** even accounting for zero caching (9 of the 77 are cache hits under this PR; the other 68 are misses — a from-scratch computation would need all 68 of those regardless of any cache). Since "total distinct calls needed" is a property of the comparator's own algorithmic structure, not of caching, the ~89,250 → 77 reduction happened via **unrelated intervening commits** before this work started. **This PR's own measured contribution on that specific fixture is 9 saved calls out of 77 (11.69% hit rate) — not the historical 89,250 → 77 reduction, which is not this PR's achievement.**

### Cache memory bound

`PairwiseCacheKey` is 48 bytes (`std::mem::size_of`, measured directly); paired with its 1-byte `BranchComparison` value, each `(key, value)` pair is 56 bytes before hashmap bucket overhead. The largest single-resolution cache observed in this corpus is 581 entries — on the order of **35–60 KB** peak, freed immediately when that stereocenter's `CompareContext` drops. Never global: bounded per-resolution by construction, and in practice orders of magnitude below `CompareContext::max_recursive_calls`'s structural ceiling (default 1,000,000).

## Tests

- `test_pairwise_cache_hit_matches_fresh_computation` — a repeated `(a, b)` call within one context is a cache hit, and its value matches an independent, uncached (fresh context, fresh digraph) computation of the same comparison.
- `test_pairwise_cache_respects_direction` — `compare_ligands(a, b)` then `compare_ligands(b, a)` in the same context: the second call is a cache hit (not a recompute), and its value is the correctly-inverted opposite of the first — proving the direction-normalization logic specifically, not just that some value gets reused.
- Full existing `chematic-cip` (63 lib + the 12 integration tests listed above) and `chematic-chem` CIP (45) suites pass unchanged — many of these assert exact R/S/E-Z labels on real molecules, not just "compiles and doesn't panic."

## Not done here (explicit scope)

- No change to `minimize_uff`/any force-field code (unrelated to this issue; see PR #211).
- No widening of the cache beyond one `CompareContext`/resolution — issue #107 explicitly asked for this to stay bounded, not global.
- No change to `resolver.rs`'s own, separate, higher-level embedded-chirality-sign cache (`assign.rs`'s `resolve_one_pseudoasymmetric`-style functions already memoize *resolved signs* per embedded atom across a Rule 4b/5 pass) — this PR's cache operates one level lower (pairwise branch comparisons within one `rank_children`/`compare_ligands` call tree) and composes with, rather than replaces, that existing mechanism.

## Issues

- Refs #107.
