### PR TITLE
feat(py): expose pipeline_v2 embedding as Mol.embed_pipeline_v2()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — everything below `[0.8.1]` has shipped._
+### Added — `chematic-py`
+
+- **`Mol.embed_pipeline_v2(config)`**: Python binding for the Rust-only
+  `chematic_3d::pipeline_v2::embed_pipeline_v2` (torsion-knowledge-aware
+  distance geometry + stereo verification/repair + policy-gated force
+  field). New `PipelineV2Config` class mirrors the Rust config's
+  deliberate lack of a `Default` — every field is required at the
+  low-level constructor; `PipelineV2Config.safe(force_field=..., stereo_policy=...,
+  ring_torsion_policy=...)` is a convenience constructor that still keeps
+  those three policy choices explicit, never hidden defaults.
+  - Returns a dict with full per-stage evidence — `coords`, `embed_stats`,
+    `bound_adjustment_report`, `torsion_knowledge_report`,
+    `ring_torsion_evidence`, `torsion_optimization_report`,
+    `stereo_before`/`stereo_repair`/`stereo_after_repair`, `force_field`
+    (actual policy used + fallback reason, never silently substituted),
+    `final_stereo`, `final_validation`, `elapsed_ms_by_stage` — never just
+    final coordinates.
+  - New `PipelineV2Error` exception (a `ValueError` subclass) on pipeline
+    failure, carrying a structured `.diagnostics` dict with the same
+    per-stage partial evidence a Rust caller sees on `PipelineV2Failure`.
+    `diagnostics["last_known_coords"]` is explicitly flagged
+    (`coords_are_diagnostic_only: True`) so it can never be mistaken for a
+    usable result.
+  - Applies directly to the caller's own `Mol` atom order — never
+    canonicalizes/reparses first (the issue #172 `conformer_ensemble()`
+    mistake), verified with dedicated atom-order-permutation regression
+    tests.
+  - Rust-only; no algorithm change. Scope: Python binding only — no WASM
+    binding, no RDKit benchmark (tracked as separate follow-up work).
+
+_Nothing else yet — everything below `[0.8.1]` has shipped._
 
 ## [0.8.1] — 2026-07-30
 

--- a/crates/chematic-py/README.md
+++ b/crates/chematic-py/README.md
@@ -74,6 +74,22 @@ hits = chematic.bulk.substructure_match("[OH]", mols)  # → [0, 1, 2]
 import pandas as pd
 smiles = ["CCO", "c1ccccc1", "CC(=O)O"]
 df = pd.DataFrame([chematic.from_smiles(s).descriptors() for s in smiles])
+
+# Opt-in v2 embedding pipeline: torsion-knowledge-aware distance geometry +
+# stereo verification/repair + policy-gated force field, with full per-stage
+# evidence (never just final coordinates)
+config = chematic.PipelineV2Config.safe(
+    force_field="mmff94_with_uff_fallback",
+    stereo_policy="repair_and_verify",
+    ring_torsion_policy="fail_closed",
+)
+try:
+    result = mol.embed_pipeline_v2(config)
+    coords = result["coords"]                       # same atom order as mol
+    print(result["force_field"]["actual_force_field_used"])  # fallback if MMFF94 lacked params
+    print(result["final_validation"]["sound"])
+except chematic.PipelineV2Error as e:
+    print(e.diagnostics["stage"], e.diagnostics["cause"])   # structured, not just a message
 ```
 
 ## Features
@@ -88,6 +104,7 @@ df = pd.DataFrame([chematic.from_smiles(s).descriptors() for s in smiles])
 - **SMARTS substructure search** — `chematic.smarts_match()` and `bulk.substructure_match(smarts, mols)` (pre-parsed Mol list, returns indices)
 - **SVG / PDF / EPS depiction**: `mol.to_svg()`, `mol.to_pdf()`, `mol.to_eps()`
 - **ChemicalJSON**: `mol.to_cjson(coords=[])`, `chematic.from_cjson(s)` — Avogadro 2 / MolSSI compatible
+- **Opt-in v2 embedding pipeline**: `mol.embed_pipeline_v2(config)` — torsion-knowledge-aware distance geometry, stereo verify/repair, and policy-gated force field (`PipelineV2Config`), returning full per-stage evidence (embed stats, torsion knowledge/optimization reports, stereo before/after, force-field actual policy and fallback, final geometry validation, stage timings) instead of just coordinates; raises `chematic.PipelineV2Error` with structured `.diagnostics` on failure
 
 ## RDKit compatibility
 

--- a/crates/chematic-py/python/chematic/__init__.pyi
+++ b/crates/chematic-py/python/chematic/__init__.pyi
@@ -1038,6 +1038,30 @@ class Mol:
         """
         ...
 
+    def embed_pipeline_v2(self, config: "PipelineV2Config") -> dict[str, object]:
+        """Run the opt-in v2 embedding pipeline.
+
+        Torsion-knowledge-aware distance geometry + stereo verification/repair
+        + policy-gated force field, applied directly to this ``Mol``'s own
+        atom order (never canonicalizes/reparses first -- coordinates and
+        every atom/bond index in the result correspond 1:1 to this ``Mol``'s
+        existing atom/bond tables).
+
+        Returns a dict with keys: ``coords``, ``embed_stats``,
+        ``bound_adjustment_report``, ``torsion_knowledge_report``,
+        ``ring_torsion_evidence``, ``torsion_optimization_report``,
+        ``stereo_before``, ``stereo_repair``, ``stereo_after_repair``,
+        ``force_field``, ``final_stereo``, ``final_validation``,
+        ``elapsed_ms_by_stage``.
+
+        Raises:
+            PipelineV2Error: on pipeline failure. ``error.diagnostics`` carries
+                the same per-stage partial evidence as a Rust
+                ``PipelineV2Failure`` -- ``diagnostics["last_known_coords"]``
+                is diagnostic only, never a usable result.
+        """
+        ...
+
     def mmff94_torsion_scan(
         self,
         coords: list[list[float]],
@@ -2772,6 +2796,102 @@ def find_mcs(mols: list[Mol]) -> Optional[Mol]:
             print(mcs.smiles)
     """
     ...
+
+# ---------------------------------------------------------------------------
+# PipelineV2Config / PipelineV2Error (Mol.embed_pipeline_v2)
+# ---------------------------------------------------------------------------
+
+class PipelineV2Config:
+    """Configuration for :meth:`Mol.embed_pipeline_v2`.
+
+    Every field is required -- there is no hidden default, matching the Rust
+    ``PipelineV2Config``'s own deliberate lack of a ``Default`` impl (force
+    field / stereo / ring-torsion policy are judgment calls). Use
+    :meth:`safe` for a convenience constructor that still requires those
+    three policies explicitly.
+
+    ``stereo_policy``: one of ``"ignore"``, ``"verify_only"``,
+    ``"repair_and_verify"``.
+
+    ``ring_torsion_policy``: one of ``"fail_closed"``, ``"diagnostic_only"``.
+
+    ``force_field_policy``: one of ``"mmff94_bond_angle_strict"``,
+    ``"mmff94_with_uff_fallback"``, ``"uff_only"``, ``"dreiding"``, ``"none"``.
+    """
+
+    def __init__(
+        self,
+        embed_seed: int,
+        max_attempts: int,
+        embed_timeout_ms: Optional[int],
+        use_exp_torsions: bool,
+        use_small_ring_torsions: bool,
+        use_macrocycle_torsions: bool,
+        use_macrocycle_14_bounds: bool,
+        include_legacy_torsion_heuristic: bool,
+        stereo_policy: str,
+        fail_on_unevaluable_stereo: bool,
+        force_field_policy: str,
+        force_field_max_iterations: int,
+        gate_mmff94_torsion_oop: bool,
+        ring_torsion_policy: str,
+        total_timeout_ms: Optional[int],
+    ) -> None: ...
+    @staticmethod
+    def safe(
+        force_field: str,
+        stereo_policy: str,
+        ring_torsion_policy: str,
+        fail_on_unevaluable_stereo: bool = False,
+        embed_seed: int = ...,
+        max_attempts: int = 8,
+        embed_timeout_ms: Optional[int] = None,
+        use_exp_torsions: bool = False,
+        use_small_ring_torsions: bool = False,
+        use_macrocycle_torsions: bool = False,
+        use_macrocycle_14_bounds: bool = False,
+        include_legacy_torsion_heuristic: bool = False,
+        force_field_max_iterations: int = 200,
+        gate_mmff94_torsion_oop: bool = False,
+        total_timeout_ms: Optional[int] = None,
+    ) -> "PipelineV2Config":
+        """Convenience constructor.
+
+        ``force_field``, ``stereo_policy``, and ``ring_torsion_policy`` are
+        still required, explicit arguments -- never hidden defaults --
+        everything else takes a conservative default (every torsion-knowledge
+        flag off, ``fail_on_unevaluable_stereo=False``, no timeouts).
+        """
+        ...
+
+    embed_seed: int
+    max_attempts: int
+    embed_timeout_ms: Optional[int]
+    use_exp_torsions: bool
+    use_small_ring_torsions: bool
+    use_macrocycle_torsions: bool
+    use_macrocycle_14_bounds: bool
+    include_legacy_torsion_heuristic: bool
+    stereo_policy: str
+    fail_on_unevaluable_stereo: bool
+    force_field_policy: str
+    force_field_max_iterations: int
+    gate_mmff94_torsion_oop: bool
+    ring_torsion_policy: str
+    total_timeout_ms: Optional[int]
+
+    def __repr__(self) -> str: ...
+
+class PipelineV2Error(ValueError):
+    """A failed :meth:`Mol.embed_pipeline_v2` call.
+
+    ``.diagnostics`` carries the same per-stage partial evidence a Rust
+    caller sees on ``PipelineV2Failure`` --
+    ``diagnostics["last_known_coords"]`` is diagnostic only, never a usable
+    result (see ``diagnostics["coords_are_diagnostic_only"]``).
+    """
+
+    diagnostics: dict[str, object]
 
 # ---------------------------------------------------------------------------
 # SimilarityIndex (MHFP LSH)

--- a/crates/chematic-py/src/lib.rs
+++ b/crates/chematic-py/src/lib.rs
@@ -20,6 +20,7 @@ type RdkitMorganDetail = (
 mod formats;
 mod misc;
 mod mol_methods;
+mod pipeline_v2;
 mod reactions;
 mod reports;
 mod rwmol;
@@ -67,6 +68,11 @@ impl Mol {
 fn chematic(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Mol>()?;
     m.add_class::<rwmol::RWMol>()?;
+    m.add_class::<pipeline_v2::PyPipelineV2Config>()?;
+    m.add(
+        "PipelineV2Error",
+        m.py().get_type::<pipeline_v2::PipelineV2Error>(),
+    )?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
 
     // bulk submodule

--- a/crates/chematic-py/src/mol_methods.rs
+++ b/crates/chematic-py/src/mol_methods.rs
@@ -2582,6 +2582,37 @@ impl Mol {
         Ok(d)
     }
 
+    /// Run the opt-in v2 embedding pipeline (torsion-knowledge-aware distance
+    /// geometry + stereo verification/repair + policy-gated force field).
+    ///
+    /// Applied directly to this ``Mol``'s own atom order -- never
+    /// canonicalizes/reparses first (see issue #172; the fix in
+    /// :meth:`conformer_ensemble` is the precedent this follows), so the
+    /// returned ``coords`` and every atom/bond index in the result dict
+    /// correspond 1:1 to this ``Mol``'s existing atom/bond tables.
+    ///
+    /// ``config``: a :class:`PipelineV2Config`.
+    ///
+    /// Returns a dict with keys: ``coords``, ``embed_stats``,
+    /// ``bound_adjustment_report``, ``torsion_knowledge_report``,
+    /// ``ring_torsion_evidence``, ``torsion_optimization_report``,
+    /// ``stereo_before``, ``stereo_repair``, ``stereo_after_repair``,
+    /// ``force_field``, ``final_stereo``, ``final_validation``,
+    /// ``elapsed_ms_by_stage``.
+    ///
+    /// Raises :class:`PipelineV2Error` (a ``ValueError`` subclass) on
+    /// failure. ``error.diagnostics`` carries the same per-stage partial
+    /// evidence a Rust caller sees on ``PipelineV2Failure`` --
+    /// ``diagnostics['last_known_coords']`` is diagnostic only, never a
+    /// usable result (see ``diagnostics['coords_are_diagnostic_only']``).
+    fn embed_pipeline_v2<'py>(
+        &self,
+        py: Python<'py>,
+        config: &crate::pipeline_v2::PyPipelineV2Config,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        crate::pipeline_v2::run_embed_pipeline_v2(py, &self.inner, config)
+    }
+
     /// Scan a torsion dihedral (atoms i–j–k–l) over 360° in ``steps`` increments.
     ///
     /// Returns a list of ``(angle_deg, energy_kcal)`` pairs. The molecule is not modified.

--- a/crates/chematic-py/src/pipeline_v2.rs
+++ b/crates/chematic-py/src/pipeline_v2.rs
@@ -1,0 +1,1011 @@
+//! Python binding for `chematic_3d::pipeline_v2::embed_pipeline_v2`.
+//!
+//! Calls `embed_pipeline_v2` directly on the caller's own `Mol.inner` — never
+//! canonicalizes/reparses first (see issue #172; `conformer_ensemble`'s fix in
+//! `mol_methods.rs` is the precedent this follows).
+//!
+//! `PipelineV2Config` deliberately has no `Default` on the Rust side (every
+//! field, especially `force_field_policy`/`stereo_policy`/`ring_torsion_policy`,
+//! must be an explicit judgment call — see that struct's own doc comment). The
+//! Python-facing `PipelineV2Config` constructor mirrors that: every field is a
+//! required keyword argument. `PipelineV2Config.safe()` is a convenience
+//! classmethod, but it still requires `force_field_policy`/`stereo_policy`/
+//! `ring_torsion_policy` explicitly rather than defaulting them.
+
+use chematic_3d::distance_geometry_v2::EmbedParameters;
+use chematic_3d::etkdg_knowledge::TorsionOptimizationConfig;
+use chematic_3d::minimize::ForceFieldPolicy;
+use chematic_3d::pipeline_v2::{
+    self as pv2, PipelineV2Failure, PipelineV2Result, RingTorsionApplicationPolicy, StereoPolicy,
+};
+use chematic_core::Molecule;
+use pyo3::create_exception;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+create_exception!(
+    chematic,
+    PipelineV2Error,
+    PyValueError,
+    "A failed Mol.embed_pipeline_v2() call. `.diagnostics` carries the same \
+     per-stage partial evidence a Rust caller sees on `PipelineV2Failure` -- \
+     `diagnostics['last_known_coords']` is diagnostic only, never a usable result."
+);
+
+// ---------------------------------------------------------------------------
+// String <-> enum conversions (the stable public contract for policy fields)
+// ---------------------------------------------------------------------------
+
+fn parse_stereo_policy(s: &str) -> PyResult<StereoPolicy> {
+    match s {
+        "ignore" => Ok(StereoPolicy::Ignore),
+        "verify_only" => Ok(StereoPolicy::VerifyOnly),
+        "repair_and_verify" => Ok(StereoPolicy::RepairAndVerify),
+        other => Err(PyValueError::new_err(format!(
+            "unknown stereo_policy {other:?} -- expected one of: \
+             \"ignore\", \"verify_only\", \"repair_and_verify\""
+        ))),
+    }
+}
+
+fn stereo_policy_str(p: StereoPolicy) -> &'static str {
+    match p {
+        StereoPolicy::Ignore => "ignore",
+        StereoPolicy::VerifyOnly => "verify_only",
+        StereoPolicy::RepairAndVerify => "repair_and_verify",
+    }
+}
+
+fn parse_ring_torsion_policy(s: &str) -> PyResult<RingTorsionApplicationPolicy> {
+    match s {
+        "fail_closed" => Ok(RingTorsionApplicationPolicy::FailClosed),
+        "diagnostic_only" => Ok(RingTorsionApplicationPolicy::DiagnosticOnly),
+        other => Err(PyValueError::new_err(format!(
+            "unknown ring_torsion_policy {other:?} -- expected one of: \
+             \"fail_closed\", \"diagnostic_only\""
+        ))),
+    }
+}
+
+fn ring_torsion_policy_str(p: RingTorsionApplicationPolicy) -> &'static str {
+    match p {
+        RingTorsionApplicationPolicy::FailClosed => "fail_closed",
+        RingTorsionApplicationPolicy::DiagnosticOnly => "diagnostic_only",
+    }
+}
+
+fn parse_force_field_policy(s: &str) -> PyResult<ForceFieldPolicy> {
+    match s {
+        "mmff94_bond_angle_strict" => Ok(ForceFieldPolicy::Mmff94BondAngleStrict),
+        "mmff94_with_uff_fallback" => Ok(ForceFieldPolicy::Mmff94WithUffFallback),
+        "uff_only" => Ok(ForceFieldPolicy::UffOnly),
+        "dreiding" => Ok(ForceFieldPolicy::Dreiding),
+        "none" => Ok(ForceFieldPolicy::None),
+        other => Err(PyValueError::new_err(format!(
+            "unknown force_field_policy {other:?} -- expected one of: \
+             \"mmff94_bond_angle_strict\", \"mmff94_with_uff_fallback\", \"uff_only\", \
+             \"dreiding\", \"none\""
+        ))),
+    }
+}
+
+fn force_field_policy_str(p: ForceFieldPolicy) -> &'static str {
+    match p {
+        ForceFieldPolicy::Mmff94BondAngleStrict => "mmff94_bond_angle_strict",
+        ForceFieldPolicy::Mmff94WithUffFallback => "mmff94_with_uff_fallback",
+        ForceFieldPolicy::UffOnly => "uff_only",
+        ForceFieldPolicy::Dreiding => "dreiding",
+        ForceFieldPolicy::None => "none",
+    }
+}
+
+/// `format!("{value:?}")` -> `snake_case`, for the many small fieldless enums in
+/// this pipeline (e.g. `EmbedFailureCause::BoundsSmoothingFailed` ->
+/// `"bounds_smoothing_failed"`). Not used for enums with data-carrying variants
+/// (those get hand-written conversions above/below so the payload isn't lost).
+fn snake_case_debug<T: std::fmt::Debug>(value: &T) -> String {
+    let debug = format!("{value:?}");
+    let mut out = String::with_capacity(debug.len() + 4);
+    for (i, c) in debug.chars().enumerate() {
+        if c.is_uppercase() {
+            if i != 0 {
+                out.push('_');
+            }
+            out.extend(c.to_lowercase());
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// PipelineV2Config
+// ---------------------------------------------------------------------------
+
+/// Configuration for `Mol.embed_pipeline_v2()`. Every field is required
+/// (matching the Rust `PipelineV2Config`'s deliberate lack of a `Default` --
+/// force-field/stereo/ring-torsion policy are judgment calls, never a hidden
+/// default). Use `PipelineV2Config.safe(...)` for a convenience constructor
+/// that still requires those three policies explicitly.
+#[pyclass(name = "PipelineV2Config", from_py_object)]
+#[derive(Clone)]
+pub struct PyPipelineV2Config {
+    pub(crate) inner: pv2::PipelineV2Config,
+}
+
+#[pymethods]
+impl PyPipelineV2Config {
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        embed_seed: u64,
+        max_attempts: usize,
+        embed_timeout_ms: Option<u64>,
+        use_exp_torsions: bool,
+        use_small_ring_torsions: bool,
+        use_macrocycle_torsions: bool,
+        use_macrocycle_14_bounds: bool,
+        include_legacy_torsion_heuristic: bool,
+        stereo_policy: &str,
+        fail_on_unevaluable_stereo: bool,
+        force_field_policy: &str,
+        force_field_max_iterations: usize,
+        gate_mmff94_torsion_oop: bool,
+        ring_torsion_policy: &str,
+        total_timeout_ms: Option<u64>,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            inner: pv2::PipelineV2Config {
+                embed: EmbedParameters {
+                    random_seed: embed_seed,
+                    max_attempts,
+                    timeout_ms: embed_timeout_ms,
+                    use_exp_torsions,
+                    use_small_ring_torsions,
+                    use_macrocycle_torsions,
+                    use_macrocycle_14_bounds,
+                    ..EmbedParameters::default()
+                },
+                torsion_optimization: TorsionOptimizationConfig::default(),
+                include_legacy_torsion_heuristic,
+                stereo_policy: parse_stereo_policy(stereo_policy)?,
+                fail_on_unevaluable_stereo,
+                force_field_policy: parse_force_field_policy(force_field_policy)?,
+                force_field_max_iterations,
+                gate_mmff94_torsion_oop,
+                ring_torsion_policy: parse_ring_torsion_policy(ring_torsion_policy)?,
+                total_timeout_ms,
+            },
+        })
+    }
+
+    /// Convenience constructor. `force_field` (the force-field policy),
+    /// `stereo_policy`, and `ring_torsion_policy` are still required, explicit
+    /// arguments -- never hidden defaults -- everything else takes a
+    /// conservative default (every torsion-knowledge flag off,
+    /// `fail_on_unevaluable_stereo=False`, no timeouts).
+    #[staticmethod]
+    #[pyo3(signature = (
+        force_field,
+        stereo_policy,
+        ring_torsion_policy,
+        fail_on_unevaluable_stereo = false,
+        embed_seed = 0xC0FF_EE42_D157_6E02,
+        max_attempts = 8,
+        embed_timeout_ms = None,
+        use_exp_torsions = false,
+        use_small_ring_torsions = false,
+        use_macrocycle_torsions = false,
+        use_macrocycle_14_bounds = false,
+        include_legacy_torsion_heuristic = false,
+        force_field_max_iterations = 200,
+        gate_mmff94_torsion_oop = false,
+        total_timeout_ms = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn safe(
+        force_field: &str,
+        stereo_policy: &str,
+        ring_torsion_policy: &str,
+        fail_on_unevaluable_stereo: bool,
+        embed_seed: u64,
+        max_attempts: usize,
+        embed_timeout_ms: Option<u64>,
+        use_exp_torsions: bool,
+        use_small_ring_torsions: bool,
+        use_macrocycle_torsions: bool,
+        use_macrocycle_14_bounds: bool,
+        include_legacy_torsion_heuristic: bool,
+        force_field_max_iterations: usize,
+        gate_mmff94_torsion_oop: bool,
+        total_timeout_ms: Option<u64>,
+    ) -> PyResult<Self> {
+        Self::new(
+            embed_seed,
+            max_attempts,
+            embed_timeout_ms,
+            use_exp_torsions,
+            use_small_ring_torsions,
+            use_macrocycle_torsions,
+            use_macrocycle_14_bounds,
+            include_legacy_torsion_heuristic,
+            stereo_policy,
+            fail_on_unevaluable_stereo,
+            force_field,
+            force_field_max_iterations,
+            gate_mmff94_torsion_oop,
+            ring_torsion_policy,
+            total_timeout_ms,
+        )
+    }
+
+    #[getter]
+    fn embed_seed(&self) -> u64 {
+        self.inner.embed.random_seed
+    }
+    #[getter]
+    fn max_attempts(&self) -> usize {
+        self.inner.embed.max_attempts
+    }
+    #[getter]
+    fn embed_timeout_ms(&self) -> Option<u64> {
+        self.inner.embed.timeout_ms
+    }
+    #[getter]
+    fn use_exp_torsions(&self) -> bool {
+        self.inner.embed.use_exp_torsions
+    }
+    #[getter]
+    fn use_small_ring_torsions(&self) -> bool {
+        self.inner.embed.use_small_ring_torsions
+    }
+    #[getter]
+    fn use_macrocycle_torsions(&self) -> bool {
+        self.inner.embed.use_macrocycle_torsions
+    }
+    #[getter]
+    fn use_macrocycle_14_bounds(&self) -> bool {
+        self.inner.embed.use_macrocycle_14_bounds
+    }
+    #[getter]
+    fn include_legacy_torsion_heuristic(&self) -> bool {
+        self.inner.include_legacy_torsion_heuristic
+    }
+    #[getter]
+    fn stereo_policy(&self) -> &'static str {
+        stereo_policy_str(self.inner.stereo_policy)
+    }
+    #[getter]
+    fn fail_on_unevaluable_stereo(&self) -> bool {
+        self.inner.fail_on_unevaluable_stereo
+    }
+    #[getter]
+    fn force_field_policy(&self) -> &'static str {
+        force_field_policy_str(self.inner.force_field_policy)
+    }
+    #[getter]
+    fn force_field_max_iterations(&self) -> usize {
+        self.inner.force_field_max_iterations
+    }
+    #[getter]
+    fn gate_mmff94_torsion_oop(&self) -> bool {
+        self.inner.gate_mmff94_torsion_oop
+    }
+    #[getter]
+    fn ring_torsion_policy(&self) -> &'static str {
+        ring_torsion_policy_str(self.inner.ring_torsion_policy)
+    }
+    #[getter]
+    fn total_timeout_ms(&self) -> Option<u64> {
+        self.inner.total_timeout_ms
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "PipelineV2Config(force_field_policy={:?}, stereo_policy={:?}, \
+             ring_torsion_policy={:?}, embed_seed={}, max_attempts={})",
+            self.force_field_policy(),
+            self.stereo_policy(),
+            self.ring_torsion_policy(),
+            self.embed_seed(),
+            self.max_attempts(),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Result / failure -> PyDict conversion
+// ---------------------------------------------------------------------------
+
+fn coords_to_vec(coords: &chematic_3d::coords::Coords3D) -> Vec<Vec<f64>> {
+    coords.points.iter().map(|p| vec![p.x, p.y, p.z]).collect()
+}
+
+fn embed_stats_dict<'py>(
+    py: Python<'py>,
+    stats: &chematic_3d::distance_geometry_v2::EmbedStats,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("attempts_used", stats.attempts_used)?;
+    let failure_counts = PyDict::new(py);
+    for (cause, count) in &stats.failure_counts {
+        failure_counts.set_item(snake_case_debug(cause), count)?;
+    }
+    d.set_item("failure_counts", failure_counts)?;
+    d.set_item(
+        "negative_eigenvalues_beyond_embedding_dim",
+        stats.negative_eigenvalues_beyond_embedding_dim,
+    )?;
+    d.set_item(
+        "max_negative_eigenvalue_magnitude",
+        stats.max_negative_eigenvalue_magnitude,
+    )?;
+    d.set_item(
+        "last_smoothing_invariants_ok",
+        stats.last_smoothing_invariants_ok,
+    )?;
+    d.set_item("used_random_coords", stats.used_random_coords)?;
+    d.set_item("adjustments_applied", stats.adjustments_applied)?;
+    Ok(d)
+}
+
+fn bound_adjustment_dict<'py>(
+    py: Python<'py>,
+    a: &chematic_3d::etkdg_knowledge::PairBoundAdjustment,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("atom1", a.atom_pair.0.0)?;
+    d.set_item("atom2", a.atom_pair.1.0)?;
+    d.set_item("old_lower", a.old_lower)?;
+    d.set_item("new_lower", a.new_lower)?;
+    d.set_item("old_upper", a.old_upper)?;
+    d.set_item("new_upper", a.new_upper)?;
+    d.set_item("rule_id", &a.rule_id)?;
+    d.set_item("source", snake_case_debug(&a.source))?;
+    d.set_item("ring_size", a.ring_size)?;
+    d.set_item("reason", &a.reason)?;
+    Ok(d)
+}
+
+fn fourier_term_dict<'py>(
+    py: Python<'py>,
+    t: &chematic_3d::etkdg_knowledge::FourierTorsionTerm,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("periodicity", t.periodicity)?;
+    d.set_item("phase_deg", t.phase_deg)?;
+    d.set_item("amplitude", t.amplitude)?;
+    Ok(d)
+}
+
+fn torsion_potential_dict<'py>(
+    py: Python<'py>,
+    p: &chematic_3d::etkdg_knowledge::TorsionPotential,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("atoms", p.atoms.iter().map(|a| a.0).collect::<Vec<u32>>())?;
+    d.set_item("central_bond", (p.central_bond.0.0, p.central_bond.1.0))?;
+    d.set_item("source", snake_case_debug(&p.source))?;
+    d.set_item("rule_id", &p.rule_id)?;
+    let terms = p
+        .terms
+        .iter()
+        .map(|t| fourier_term_dict(py, t))
+        .collect::<PyResult<Vec<_>>>()?;
+    d.set_item("terms", terms)?;
+    d.set_item("ring_size", p.ring_size)?;
+    Ok(d)
+}
+
+fn torsion_diagnostic_dict<'py>(
+    py: Python<'py>,
+    diag: &chematic_3d::etkdg_knowledge::TorsionKnowledgeDiagnostic,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item(
+        "central_bond",
+        (diag.central_bond.0.0, diag.central_bond.1.0),
+    )?;
+    d.set_item("kind", snake_case_debug(&diag.kind))?;
+    d.set_item("message", &diag.message)?;
+    d.set_item("candidate_rule_ids", &diag.candidate_rule_ids)?;
+    Ok(d)
+}
+
+fn torsion_knowledge_report_dict<'py>(
+    py: Python<'py>,
+    r: &chematic_3d::etkdg_knowledge::TorsionKnowledgeReport,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    let potentials = r
+        .potentials
+        .iter()
+        .map(|p| torsion_potential_dict(py, p))
+        .collect::<PyResult<Vec<_>>>()?;
+    d.set_item("potentials", potentials)?;
+    d.set_item("matched_rule_ids", &r.matched_rule_ids)?;
+    d.set_item(
+        "unmatched_rotatable_bonds",
+        r.unmatched_rotatable_bonds
+            .iter()
+            .map(|(a, b)| (a.0, b.0))
+            .collect::<Vec<(u32, u32)>>(),
+    )?;
+    let ambiguous = r
+        .ambiguous_matches
+        .iter()
+        .map(|diag| torsion_diagnostic_dict(py, diag))
+        .collect::<PyResult<Vec<_>>>()?;
+    d.set_item("ambiguous_matches", ambiguous)?;
+    let skipped = r
+        .skipped_bonds
+        .iter()
+        .map(|diag| torsion_diagnostic_dict(py, diag))
+        .collect::<PyResult<Vec<_>>>()?;
+    d.set_item("skipped_bonds", skipped)?;
+    Ok(d)
+}
+
+fn ring_torsion_evidence_dict<'py>(
+    py: Python<'py>,
+    e: &chematic_3d::pipeline_v2::RingTorsionEvidence,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    let potentials = e
+        .potentials
+        .iter()
+        .map(|p| {
+            let pd = PyDict::new(py);
+            pd.set_item("rule_id", &p.rule_id)?;
+            pd.set_item("central_bond", (p.central_bond.0.0, p.central_bond.1.0))?;
+            pd.set_item("source", snake_case_debug(&p.source))?;
+            pd.set_item("applied_to_geometry", p.applied_to_geometry)?;
+            Ok(pd)
+        })
+        .collect::<PyResult<Vec<_>>>()?;
+    d.set_item("potentials", potentials)?;
+    d.set_item("diagnostic_only", e.diagnostic_only)?;
+    d.set_item("n_applied", e.n_applied())?;
+    d.set_item("n_scored_only", e.n_scored_only())?;
+    Ok(d)
+}
+
+fn torsion_optimization_report_dict<'py>(
+    py: Python<'py>,
+    r: &chematic_3d::etkdg_knowledge::TorsionOptimizationReport,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("energy_before", r.energy_before)?;
+    d.set_item("energy_after", r.energy_after)?;
+    d.set_item("iterations_used", r.iterations_used)?;
+    d.set_item("converged", r.converged)?;
+    d.set_item("max_bond_length_delta", r.max_bond_length_delta)?;
+    d.set_item("max_ring_closure_delta", r.max_ring_closure_delta)?;
+    d.set_item("rotated_bond_count", r.rotated_bond_count)?;
+    Ok(d)
+}
+
+fn stereo_status_dict<'py>(
+    py: Python<'py>,
+    status: chematic_3d::stereo_constraints::StereoStatus,
+) -> PyResult<Bound<'py, PyDict>> {
+    use chematic_3d::stereo_constraints::StereoStatus;
+    let d = PyDict::new(py);
+    match status {
+        StereoStatus::Satisfied => {
+            d.set_item("status", "satisfied")?;
+            d.set_item("rejection_reason", py.None())?;
+        }
+        StereoStatus::Violated => {
+            d.set_item("status", "violated")?;
+            d.set_item("rejection_reason", py.None())?;
+        }
+        StereoStatus::Unevaluable(reason) => {
+            d.set_item("status", "unevaluable")?;
+            d.set_item("rejection_reason", snake_case_debug(&reason))?;
+        }
+    }
+    Ok(d)
+}
+
+fn stereo_verification_dict<'py>(
+    py: Python<'py>,
+    v: &chematic_3d::stereo_constraints::StereoVerification,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    let tetrahedral = v
+        .tetrahedral
+        .iter()
+        .map(|r| {
+            let rd = stereo_status_dict(py, r.status)?;
+            rd.set_item("atom", r.atom.0)?;
+            Ok(rd)
+        })
+        .collect::<PyResult<Vec<_>>>()?;
+    d.set_item("tetrahedral", tetrahedral)?;
+    let double_bond = v
+        .double_bond
+        .iter()
+        .map(|r| {
+            let rd = stereo_status_dict(py, r.status)?;
+            rd.set_item("bond", r.bond.0)?;
+            Ok(rd)
+        })
+        .collect::<PyResult<Vec<_>>>()?;
+    d.set_item("double_bond", double_bond)?;
+    d.set_item("n_declared", v.n_declared())?;
+    d.set_item("n_satisfied", v.n_satisfied())?;
+    d.set_item("n_violations", v.n_violations())?;
+    d.set_item("n_unevaluable", v.n_unevaluable())?;
+    d.set_item("is_fully_satisfied", v.is_fully_satisfied())?;
+    Ok(d)
+}
+
+fn repaired_element_dict<'py>(
+    py: Python<'py>,
+    r: &chematic_3d::stereo_constraints::RepairedElement,
+) -> PyResult<Bound<'py, PyDict>> {
+    use chematic_3d::stereo_constraints::StereoElement;
+    let d = PyDict::new(py);
+    match r.element {
+        StereoElement::Tetrahedral(atom) => {
+            d.set_item("element_kind", "tetrahedral")?;
+            d.set_item("atom", atom.0)?;
+        }
+        StereoElement::DoubleBond(bond) => {
+            d.set_item("element_kind", "double_bond")?;
+            d.set_item("bond", bond.0)?;
+        }
+    }
+    d.set_item("atoms_moved", r.atoms_moved)?;
+    d.set_item("max_displacement", r.max_displacement)?;
+    Ok(d)
+}
+
+fn stereo_repair_summary_dict<'py>(
+    py: Python<'py>,
+    s: &chematic_3d::pipeline_v2::StereoRepairSummary,
+) -> PyResult<Bound<'py, PyDict>> {
+    use chematic_3d::stereo_constraints::StereoElement;
+    let d = PyDict::new(py);
+    let repaired = s
+        .repaired
+        .iter()
+        .map(|r| repaired_element_dict(py, r))
+        .collect::<PyResult<Vec<_>>>()?;
+    d.set_item("repaired", repaired)?;
+    let failures = s
+        .failures
+        .iter()
+        .map(|(elem, reason)| {
+            let fd = PyDict::new(py);
+            match elem {
+                StereoElement::Tetrahedral(atom) => {
+                    fd.set_item("element_kind", "tetrahedral")?;
+                    fd.set_item("atom", atom.0)?;
+                }
+                StereoElement::DoubleBond(bond) => {
+                    fd.set_item("element_kind", "double_bond")?;
+                    fd.set_item("bond", bond.0)?;
+                }
+            }
+            fd.set_item("reason", snake_case_debug(reason))?;
+            Ok(fd)
+        })
+        .collect::<PyResult<Vec<_>>>()?;
+    d.set_item("failures", failures)?;
+    Ok(d)
+}
+
+fn mmff94_missing_term_dict<'py>(
+    py: Python<'py>,
+    t: &chematic_3d::minimize::Mmff94MissingTerm,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("kind", snake_case_debug(&t.kind))?;
+    d.set_item("atoms", t.atoms.iter().map(|a| a.0).collect::<Vec<u32>>())?;
+    d.set_item("description", &t.description)?;
+    Ok(d)
+}
+
+fn mmff94_coverage_dict<'py>(
+    py: Python<'py>,
+    r: &chematic_3d::minimize::Mmff94CoverageReport,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("bonds_total", r.bonds_total)?;
+    d.set_item(
+        "bonds_missing",
+        r.bonds_missing
+            .iter()
+            .map(|t| mmff94_missing_term_dict(py, t))
+            .collect::<PyResult<Vec<_>>>()?,
+    )?;
+    d.set_item("angles_total", r.angles_total)?;
+    d.set_item(
+        "angles_missing",
+        r.angles_missing
+            .iter()
+            .map(|t| mmff94_missing_term_dict(py, t))
+            .collect::<PyResult<Vec<_>>>()?,
+    )?;
+    d.set_item("torsions_total", r.torsions_total)?;
+    d.set_item(
+        "torsions_missing",
+        r.torsions_missing
+            .iter()
+            .map(|t| mmff94_missing_term_dict(py, t))
+            .collect::<PyResult<Vec<_>>>()?,
+    )?;
+    d.set_item("oop_total", r.oop_total)?;
+    d.set_item(
+        "oop_missing",
+        r.oop_missing
+            .iter()
+            .map(|t| mmff94_missing_term_dict(py, t))
+            .collect::<PyResult<Vec<_>>>()?,
+    )?;
+    Ok(d)
+}
+
+fn force_field_bridge_error_dict<'py>(
+    py: Python<'py>,
+    e: &chematic_3d::minimize::ForceFieldBridgeError,
+) -> PyResult<Bound<'py, PyDict>> {
+    use chematic_3d::minimize::ForceFieldBridgeError;
+    let d = PyDict::new(py);
+    match e {
+        ForceFieldBridgeError::UnsupportedAtomType(msg) => {
+            d.set_item("kind", "unsupported_atom_type")?;
+            d.set_item("message", msg)?;
+        }
+        ForceFieldBridgeError::MissingParameters(coverage) => {
+            d.set_item("kind", "missing_parameters")?;
+            d.set_item("coverage", mmff94_coverage_dict(py, coverage)?)?;
+        }
+        ForceFieldBridgeError::MinimizationFailed(detail) => {
+            d.set_item("kind", "minimization_failed")?;
+            d.set_item("policy", force_field_policy_str(detail.policy))?;
+            d.set_item("reason", snake_case_debug(&detail.reason))?;
+            d.set_item("converged", detail.converged)?;
+            d.set_item("iterations", detail.iterations)?;
+            d.set_item("max_residual_force", detail.max_residual_force)?;
+        }
+    }
+    Ok(d)
+}
+
+fn energy_report_dict<'py>(
+    py: Python<'py>,
+    e: &chematic_3d::minimize::EnergyReport,
+) -> PyResult<Bound<'py, PyDict>> {
+    use chematic_3d::minimize::EnergyReport;
+    let d = PyDict::new(py);
+    match e {
+        EnergyReport::Mmff94(b) => {
+            d.set_item("kind", "mmff94")?;
+            d.set_item("bond", b.bond)?;
+            d.set_item("angle", b.angle)?;
+            d.set_item("stretch_bend", b.stretch_bend)?;
+            d.set_item("torsion", b.torsion)?;
+            d.set_item("oop", b.oop)?;
+            d.set_item("vdw", b.vdw)?;
+            d.set_item("electrostatic", b.electrostatic)?;
+            d.set_item("total", b.total)?;
+        }
+        EnergyReport::Uff { total } => {
+            d.set_item("kind", "uff")?;
+            d.set_item("total", total)?;
+        }
+        EnergyReport::Dreiding { total } => {
+            d.set_item("kind", "dreiding")?;
+            d.set_item("total", total)?;
+        }
+        EnergyReport::None => {
+            d.set_item("kind", "none")?;
+            d.set_item("total", 0.0)?;
+        }
+    }
+    Ok(d)
+}
+
+fn policy_minimize_result_dict<'py>(
+    py: Python<'py>,
+    r: &chematic_3d::minimize::PolicyMinimizeResult,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("coords", coords_to_vec(&r.coords))?;
+    d.set_item(
+        "requested_force_field",
+        force_field_policy_str(r.requested_force_field),
+    )?;
+    d.set_item(
+        "actual_force_field_used",
+        force_field_policy_str(r.actual_force_field_used),
+    )?;
+    match &r.fallback_reason {
+        Some(e) => d.set_item("fallback_reason", force_field_bridge_error_dict(py, e)?)?,
+        None => d.set_item("fallback_reason", py.None())?,
+    }
+    d.set_item(
+        "missing_parameter_classes",
+        r.missing_parameter_classes
+            .iter()
+            .map(|t| mmff94_missing_term_dict(py, t))
+            .collect::<PyResult<Vec<_>>>()?,
+    )?;
+    match &r.coverage {
+        Some(c) => d.set_item("coverage", mmff94_coverage_dict(py, c)?)?,
+        None => d.set_item("coverage", py.None())?,
+    }
+    d.set_item("energy_before", energy_report_dict(py, &r.energy_before)?)?;
+    d.set_item("energy_after", energy_report_dict(py, &r.energy_after)?)?;
+    d.set_item("converged", r.converged)?;
+    d.set_item("iterations", r.iterations)?;
+    d.set_item("max_residual_force", r.max_residual_force)?;
+    d.set_item(
+        "starting_geometry",
+        r.starting_geometry.map(|g| snake_case_debug(&g)),
+    )?;
+    Ok(d)
+}
+
+fn bounds_conformance_dict<'py>(
+    py: Python<'py>,
+    b: &chematic_3d::distance_geometry_v2::BoundsConformance,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("n_pairs", b.n_pairs)?;
+    d.set_item("n_violations", b.n_violations)?;
+    d.set_item("max_rel_violation", b.max_rel_violation)?;
+    Ok(d)
+}
+
+fn final_validation_dict<'py>(
+    py: Python<'py>,
+    v: &chematic_3d::pipeline_v2::FinalGeometryValidation,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("all_finite", v.all_finite)?;
+    d.set_item("atom_count_unchanged", v.atom_count_unchanged)?;
+    d.set_item("worst_bond_length", v.worst_bond_length)?;
+    d.set_item("bond_violation_rate_15pct", v.bond_violation_rate_15pct)?;
+    d.set_item("bond_violation_rate_50pct", v.bond_violation_rate_50pct)?;
+    d.set_item("gross_clash_count", v.gross_clash_count)?;
+    d.set_item(
+        "bounds_conformance",
+        bounds_conformance_dict(py, &v.bounds_conformance)?,
+    )?;
+    d.set_item("stereo_ok", v.stereo_ok)?;
+    d.set_item("torsion_energy_after", v.torsion_energy_after)?;
+    d.set_item("ring_closure_delta", v.ring_closure_delta)?;
+    d.set_item("sound", v.sound)?;
+    Ok(d)
+}
+
+fn stage_timings_dict<'py>(
+    py: Python<'py>,
+    t: &chematic_3d::pipeline_v2::StageTimings,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("torsion_knowledge_ms", t.torsion_knowledge_ms)?;
+    d.set_item("bound_adjustment_ms", t.bound_adjustment_ms)?;
+    d.set_item("distance_geometry_ms", t.distance_geometry_ms)?;
+    d.set_item("torsion_energy_eval_ms", t.torsion_energy_eval_ms)?;
+    d.set_item("torsion_optimization_ms", t.torsion_optimization_ms)?;
+    d.set_item("stereo_verify_before_ms", t.stereo_verify_before_ms)?;
+    d.set_item("stereo_repair_ms", t.stereo_repair_ms)?;
+    d.set_item(
+        "stereo_verify_after_repair_ms",
+        t.stereo_verify_after_repair_ms,
+    )?;
+    d.set_item("force_field_ms", t.force_field_ms)?;
+    d.set_item("final_stereo_verify_ms", t.final_stereo_verify_ms)?;
+    d.set_item("final_validation_ms", t.final_validation_ms)?;
+    d.set_item("total_ms", t.total_ms)?;
+    Ok(d)
+}
+
+fn result_to_dict<'py>(py: Python<'py>, r: &PipelineV2Result) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("coords", coords_to_vec(&r.coords))?;
+    d.set_item("embed_stats", embed_stats_dict(py, &r.embed_stats)?)?;
+    match &r.bound_adjustment_report {
+        Some(v) => d.set_item(
+            "bound_adjustment_report",
+            v.iter()
+                .map(|a| bound_adjustment_dict(py, a))
+                .collect::<PyResult<Vec<_>>>()?,
+        )?,
+        None => d.set_item("bound_adjustment_report", py.None())?,
+    }
+    d.set_item(
+        "torsion_knowledge_report",
+        torsion_knowledge_report_dict(py, &r.torsion_knowledge_report)?,
+    )?;
+    d.set_item(
+        "ring_torsion_evidence",
+        ring_torsion_evidence_dict(py, &r.ring_torsion_evidence)?,
+    )?;
+    match &r.torsion_optimization_report {
+        Some(rep) => d.set_item(
+            "torsion_optimization_report",
+            torsion_optimization_report_dict(py, rep)?,
+        )?,
+        None => d.set_item("torsion_optimization_report", py.None())?,
+    }
+    d.set_item(
+        "stereo_before",
+        stereo_verification_dict(py, &r.stereo_before)?,
+    )?;
+    match &r.stereo_repair {
+        Some(s) => d.set_item("stereo_repair", stereo_repair_summary_dict(py, s)?)?,
+        None => d.set_item("stereo_repair", py.None())?,
+    }
+    d.set_item(
+        "stereo_after_repair",
+        stereo_verification_dict(py, &r.stereo_after_repair)?,
+    )?;
+    d.set_item(
+        "force_field",
+        policy_minimize_result_dict(py, &r.force_field)?,
+    )?;
+    d.set_item(
+        "final_stereo",
+        stereo_verification_dict(py, &r.final_stereo)?,
+    )?;
+    d.set_item(
+        "final_validation",
+        final_validation_dict(py, &r.final_validation)?,
+    )?;
+    d.set_item(
+        "elapsed_ms_by_stage",
+        stage_timings_dict(py, &r.elapsed_ms_by_stage)?,
+    )?;
+    Ok(d)
+}
+
+fn failure_cause_dict<'py>(
+    py: Python<'py>,
+    cause: &chematic_3d::pipeline_v2::PipelineV2FailureCause,
+) -> PyResult<Bound<'py, PyDict>> {
+    use chematic_3d::pipeline_v2::PipelineV2FailureCause;
+    let d = PyDict::new(py);
+    match cause {
+        PipelineV2FailureCause::InvalidConfiguration => {
+            d.set_item("kind", "invalid_configuration")?
+        }
+        PipelineV2FailureCause::BoundAdjustmentFailed => {
+            d.set_item("kind", "bound_adjustment_failed")?
+        }
+        PipelineV2FailureCause::DistanceGeometry(e) => {
+            d.set_item("kind", "distance_geometry")?;
+            d.set_item("embed_failure_cause", snake_case_debug(e))?;
+        }
+        PipelineV2FailureCause::TorsionKnowledge(e) => {
+            d.set_item("kind", "torsion_knowledge")?;
+            d.set_item("torsion_knowledge_error", snake_case_debug(e))?;
+        }
+        PipelineV2FailureCause::RingTorsionApplicationUnsupported => {
+            d.set_item("kind", "ring_torsion_application_unsupported")?
+        }
+        PipelineV2FailureCause::StereoRepairFailed => d.set_item("kind", "stereo_repair_failed")?,
+        PipelineV2FailureCause::StereoUnevaluableUnderStrictPolicy => {
+            d.set_item("kind", "stereo_unevaluable_under_strict_policy")?
+        }
+        PipelineV2FailureCause::ForceField(e) => {
+            d.set_item("kind", "force_field")?;
+            d.set_item(
+                "force_field_bridge_error",
+                force_field_bridge_error_dict(py, e)?,
+            )?;
+        }
+        PipelineV2FailureCause::FinalStereoViolation => {
+            d.set_item("kind", "final_stereo_violation")?
+        }
+        PipelineV2FailureCause::FinalGeometryInvalid => {
+            d.set_item("kind", "final_geometry_invalid")?
+        }
+        PipelineV2FailureCause::Timeout => d.set_item("kind", "timeout")?,
+    }
+    Ok(d)
+}
+
+fn failure_to_dict<'py>(py: Python<'py>, f: &PipelineV2Failure) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("cause", failure_cause_dict(py, &f.cause)?)?;
+    d.set_item("stage", snake_case_debug(&f.stage))?;
+    // Deliberately named/flagged so it can never be mistaken for a usable
+    // result -- see `PipelineV2Failure::last_known_coords`'s own doc comment.
+    match &f.last_known_coords {
+        Some(c) => d.set_item("last_known_coords", coords_to_vec(c))?,
+        None => d.set_item("last_known_coords", py.None())?,
+    }
+    d.set_item("coords_are_diagnostic_only", true)?;
+    match &f.embed_stats {
+        Some(s) => d.set_item("embed_stats", embed_stats_dict(py, s)?)?,
+        None => d.set_item("embed_stats", py.None())?,
+    }
+    match &f.bound_adjustment_report {
+        Some(v) => d.set_item(
+            "bound_adjustment_report",
+            v.iter()
+                .map(|a| bound_adjustment_dict(py, a))
+                .collect::<PyResult<Vec<_>>>()?,
+        )?,
+        None => d.set_item("bound_adjustment_report", py.None())?,
+    }
+    match &f.torsion_knowledge_report {
+        Some(r) => d.set_item(
+            "torsion_knowledge_report",
+            torsion_knowledge_report_dict(py, r)?,
+        )?,
+        None => d.set_item("torsion_knowledge_report", py.None())?,
+    }
+    match &f.ring_torsion_evidence {
+        Some(e) => d.set_item("ring_torsion_evidence", ring_torsion_evidence_dict(py, e)?)?,
+        None => d.set_item("ring_torsion_evidence", py.None())?,
+    }
+    match &f.torsion_optimization_report {
+        Some(r) => d.set_item(
+            "torsion_optimization_report",
+            torsion_optimization_report_dict(py, r)?,
+        )?,
+        None => d.set_item("torsion_optimization_report", py.None())?,
+    }
+    match &f.stereo_before {
+        Some(s) => d.set_item("stereo_before", stereo_verification_dict(py, s)?)?,
+        None => d.set_item("stereo_before", py.None())?,
+    }
+    match &f.stereo_repair {
+        Some(s) => d.set_item("stereo_repair", stereo_repair_summary_dict(py, s)?)?,
+        None => d.set_item("stereo_repair", py.None())?,
+    }
+    match &f.stereo_after_repair {
+        Some(s) => d.set_item("stereo_after_repair", stereo_verification_dict(py, s)?)?,
+        None => d.set_item("stereo_after_repair", py.None())?,
+    }
+    match &f.force_field {
+        Some(r) => d.set_item("force_field", policy_minimize_result_dict(py, r)?)?,
+        None => d.set_item("force_field", py.None())?,
+    }
+    match &f.final_stereo {
+        Some(s) => d.set_item("final_stereo", stereo_verification_dict(py, s)?)?,
+        None => d.set_item("final_stereo", py.None())?,
+    }
+    match &f.final_validation {
+        Some(v) => d.set_item("final_validation", final_validation_dict(py, v)?)?,
+        None => d.set_item("final_validation", py.None())?,
+    }
+    d.set_item(
+        "elapsed_ms_by_stage",
+        stage_timings_dict(py, &f.elapsed_ms_by_stage)?,
+    )?;
+    Ok(d)
+}
+
+// ---------------------------------------------------------------------------
+// Entry point called from `Mol::embed_pipeline_v2` in mol_methods.rs
+// ---------------------------------------------------------------------------
+
+pub fn run_embed_pipeline_v2<'py>(
+    py: Python<'py>,
+    mol: &Molecule,
+    config: &PyPipelineV2Config,
+) -> PyResult<Bound<'py, PyDict>> {
+    match pv2::embed_pipeline_v2(mol, &config.inner) {
+        Ok(result) => result_to_dict(py, &result),
+        Err(failure) => {
+            let diagnostics = failure_to_dict(py, &failure)?;
+            let message = format!(
+                "pipeline_v2 failed at stage {:?}: {:?}",
+                failure.stage, failure.cause
+            );
+            let err = PipelineV2Error::new_err(message);
+            err.value(py).setattr("diagnostics", diagnostics)?;
+            Err(err)
+        }
+    }
+}

--- a/crates/chematic-py/tests/test_pipeline_v2.py
+++ b/crates/chematic-py/tests/test_pipeline_v2.py
@@ -1,0 +1,419 @@
+"""Tests for Mol.embed_pipeline_v2() / PipelineV2Config / PipelineV2Error.
+
+Atom-order-consistency methodology mirrors test_conformer_ensemble.py (issue
+#172): embed_pipeline_v2() must be applied directly to Mol.inner, never a
+canonicalize-then-reparse copy, or the returned coords desync from the atom/
+bond tables the caller already holds.
+"""
+
+import ast
+import math
+from pathlib import Path
+
+import pytest
+
+import chematic
+
+DECANE = "CCCCCCCCCC"
+NAPHTHALENE = "c1ccc2ccccc2c1"
+ASPIRIN = "CC(=O)Oc1ccccc1C(=O)O"
+BRANCHED = "CCC(C)C"  # 2-methylbutane
+# same molecule (aspirin) as ASPIRIN, written starting from the opposite end --
+# a genuine atom-order permutation (verified below to actually reorder), not
+# a repeat parse of the same traversal.
+ASPIRIN_REORDERED = "OC(=O)c1ccccc1OC(C)=O"
+
+MIN_BOND_LEN = 0.6
+MAX_BOND_LEN = 2.6
+MIN_INTERATOMIC_DIST = 0.4
+
+
+def _safe_config(**overrides):
+    kwargs = dict(
+        force_field="none",
+        stereo_policy="ignore",
+        ring_torsion_policy="fail_closed",
+        embed_seed=7,
+    )
+    kwargs.update(overrides)
+    return chematic.PipelineV2Config.safe(**kwargs)
+
+
+def _assert_consistent_indexing(mol, coords):
+    """Every bond in mol.bond_table must have a plausible length in `coords`,
+    and no two atoms may coincide -- same property test_conformer_ensemble.py
+    checks for issue #172, applied to embed_pipeline_v2()'s own coords."""
+    assert len(coords) == mol.heavy_atoms
+    for a1, a2, _btype, _arom in mol.bond_table:
+        d = math.dist(coords[a1], coords[a2])
+        assert MIN_BOND_LEN <= d <= MAX_BOND_LEN, (
+            f"bond {a1}-{a2} has length {d:.3f} -- outside sane range "
+            f"[{MIN_BOND_LEN}, {MAX_BOND_LEN}]; likely atom-index mismatch"
+        )
+    n = len(coords)
+    for i in range(n):
+        for j in range(i + 1, n):
+            d = math.dist(coords[i], coords[j])
+            assert d >= MIN_INTERATOMIC_DIST, (
+                f"atoms {i},{j} are {d:.3f} A apart -- degenerate/clashing geometry"
+            )
+
+
+def _reorders_under_canonicalization(mol) -> bool:
+    reparsed = chematic.from_smiles(mol.smiles)
+    orig_bonds = {frozenset((a, b)) for a, b, _, _ in mol.bond_table}
+    new_bonds = {frozenset((a, b)) for a, b, _, _ in reparsed.bond_table}
+    return orig_bonds != new_bonds
+
+
+# ---------------------------------------------------------------------------
+# Atom-order invariant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("smiles", [DECANE, NAPHTHALENE, ASPIRIN, BRANCHED])
+def test_embed_pipeline_v2_atom_index_consistency(smiles):
+    """Returned coords must be indexed identically to the Mol the caller
+    already holds, for a plain chain, a fused aromatic ring, an
+    asymmetrically-substituted ring, and a branched molecule."""
+    mol = chematic.from_smiles(smiles)
+    result = mol.embed_pipeline_v2(_safe_config())
+    _assert_consistent_indexing(mol, result["coords"])
+    assert result["final_validation"]["atom_count_unchanged"] is True
+    assert result["final_validation"]["all_finite"] is True
+    assert len(result["coords"]) == mol.heavy_atoms
+
+
+def test_naphthalene_aspirin_actually_reorder_under_canonicalization():
+    """Sanity-check the test methodology itself (matches issue #172's own
+    check): these fixtures must actually reorder under canonicalization, or
+    the tests above wouldn't exercise the atom-order bug's trigger condition.
+    (DECANE is deliberately excluded here: a plain path graph's edge set is
+    frozenset-identical under end-to-end reversal, so this bond-set-based
+    check cannot observe decane's reordering either way -- a pre-existing
+    limitation of this same methodology in test_conformer_ensemble.py, not
+    something introduced or fixed by this PR.)"""
+    for smiles in (NAPHTHALENE, ASPIRIN):
+        mol = chematic.from_smiles(smiles)
+        assert _reorders_under_canonicalization(mol), (
+            f"{smiles}: expected canonical_smiles() to reorder atoms"
+        )
+
+
+def test_negative_control_reproduces_old_bug_shape():
+    """Reconstruct the OLD conformer_ensemble()-style bug (issue #172) by
+    hand: generate on a canonicalize-reparsed copy, then cross-index against
+    the ORIGINAL mol's bond_table, as a caller holding only `mol` would.
+    Proves _assert_consistent_indexing can actually detect a real atom-order
+    mismatch, not just that it happens to pass."""
+    mol = chematic.from_smiles(ASPIRIN)
+    assert _reorders_under_canonicalization(mol)  # precondition for the bug to bite
+    reparsed = chematic.from_smiles(mol.smiles)
+    buggy_result = reparsed.embed_pipeline_v2(_safe_config())
+    with pytest.raises(AssertionError):
+        _assert_consistent_indexing(mol, buggy_result["coords"])
+
+
+def test_aspirin_reordered_smiles_is_a_genuine_permutation():
+    m1 = chematic.from_smiles(ASPIRIN)
+    m2 = chematic.from_smiles(ASPIRIN_REORDERED)
+    assert m1.smiles == m2.smiles, "expected the same underlying molecule"
+    assert m1.bond_table != m2.bond_table, (
+        "expected a genuinely different atom numbering, not the same traversal twice"
+    )
+
+
+def test_permuted_input_gives_equivalent_geometry_and_diagnostics():
+    """embed_pipeline_v2() is stochastic distance geometry seeded internally
+    by atom-traversal order, so a genuine atom permutation is not expected to
+    produce bit-identical coordinates. What must hold instead (the actual
+    atom-order invariant): each permutation's own coords stay self-consistent
+    with THAT Mol's own bond_table (checked independently for each), and the
+    permutation-invariant summary diagnostics (declared-stereocenter count,
+    atom count, geometric soundness) agree between the two orderings."""
+    config = _safe_config()
+    m1 = chematic.from_smiles(ASPIRIN)
+    m2 = chematic.from_smiles(ASPIRIN_REORDERED)
+    r1 = m1.embed_pipeline_v2(config)
+    r2 = m2.embed_pipeline_v2(config)
+
+    _assert_consistent_indexing(m1, r1["coords"])
+    _assert_consistent_indexing(m2, r2["coords"])
+
+    assert len(r1["coords"]) == len(r2["coords"]) == m1.heavy_atoms == m2.heavy_atoms
+    assert r1["stereo_before"]["n_declared"] == r2["stereo_before"]["n_declared"]
+    assert r1["final_validation"]["sound"] == r2["final_validation"]["sound"] is True
+    assert (
+        r1["final_validation"]["atom_count_unchanged"]
+        == r2["final_validation"]["atom_count_unchanged"]
+        is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deterministic reproducibility + field-by-field schema check
+#
+# Grounds every field's expected shape/value in what the Rust source actually
+# guarantees for this exact scenario (ForceFieldPolicy::None never fails or
+# falls back; decane has no declared stereo; a fixed seed makes the
+# stochastic embedder reproducible) -- these are the closest in-process proxy
+# for "Rust result and Python result agree field-by-field" available here:
+# chematic-py builds only as a cdylib (no rlib target), so a Rust-side
+# #[test] cannot itself embed a Python interpreter to call this same binding.
+# ---------------------------------------------------------------------------
+
+
+def test_result_schema_and_values_for_deterministic_case():
+    mol = chematic.from_smiles(DECANE)
+    config = _safe_config(embed_seed=42)
+    result = mol.embed_pipeline_v2(config)
+
+    assert set(result.keys()) == {
+        "coords",
+        "embed_stats",
+        "bound_adjustment_report",
+        "torsion_knowledge_report",
+        "ring_torsion_evidence",
+        "torsion_optimization_report",
+        "stereo_before",
+        "stereo_repair",
+        "stereo_after_repair",
+        "force_field",
+        "final_stereo",
+        "final_validation",
+        "elapsed_ms_by_stage",
+    }
+
+    # use_macrocycle_14_bounds=False (the .safe() default) -> None, not [].
+    assert result["bound_adjustment_report"] is None
+    # stereo_policy="ignore" -> never repaired.
+    assert result["stereo_repair"] is None
+    # no torsion-knowledge flags set -> nothing to optimize.
+    assert result["torsion_optimization_report"] is None
+
+    for key in ("stereo_before", "stereo_after_repair", "final_stereo"):
+        sv = result[key]
+        assert sv == {
+            "tetrahedral": [],
+            "double_bond": [],
+            "n_declared": 0,
+            "n_satisfied": 0,
+            "n_violations": 0,
+            "n_unevaluable": 0,
+            "is_fully_satisfied": True,
+        }
+
+    ff = result["force_field"]
+    assert ff["requested_force_field"] == "none"
+    assert ff["actual_force_field_used"] == "none"
+    assert ff["fallback_reason"] is None
+    assert ff["missing_parameter_classes"] == []
+    assert ff["coverage"] is None
+    assert ff["energy_before"] == {"kind": "none", "total": 0.0}
+    assert ff["energy_after"] == {"kind": "none", "total": 0.0}
+    assert ff["converged"] is True
+    assert ff["iterations"] == 0
+    assert ff["max_residual_force"] == 0.0
+    assert ff["starting_geometry"] is None
+    assert ff["coords"] == result["coords"]
+
+    stats = result["embed_stats"]
+    assert stats["attempts_used"] >= 1
+    assert stats["failure_counts"] == {}
+
+    fv = result["final_validation"]
+    assert fv["all_finite"] is True
+    assert fv["atom_count_unchanged"] is True
+    assert fv["sound"] is True
+    assert fv["stereo_ok"] is True
+    assert isinstance(fv["bounds_conformance"], dict)
+    assert set(fv["bounds_conformance"].keys()) == {
+        "n_pairs",
+        "n_violations",
+        "max_rel_violation",
+    }
+
+    timings = result["elapsed_ms_by_stage"]
+    assert set(timings.keys()) == {
+        "torsion_knowledge_ms",
+        "bound_adjustment_ms",
+        "distance_geometry_ms",
+        "torsion_energy_eval_ms",
+        "torsion_optimization_ms",
+        "stereo_verify_before_ms",
+        "stereo_repair_ms",
+        "stereo_verify_after_repair_ms",
+        "force_field_ms",
+        "final_stereo_verify_ms",
+        "final_validation_ms",
+        "total_ms",
+    }
+
+
+def test_same_seed_is_reproducible():
+    mol = chematic.from_smiles(DECANE)
+    config = _safe_config(embed_seed=42)
+    r1 = mol.embed_pipeline_v2(config)
+    r2 = mol.embed_pipeline_v2(config)
+    assert r1["coords"] == r2["coords"]
+    assert r1["embed_stats"] == r2["embed_stats"]
+
+
+# ---------------------------------------------------------------------------
+# Failure contract
+# ---------------------------------------------------------------------------
+
+
+CYCLOHEXANE_WITH_CHAIN = "C1CCCCC1CCCCCCCCCCCC"  # saturated small ring + acyclic tail
+
+
+def test_failure_raises_pipeline_v2_error_with_structured_diagnostics():
+    # a small-ring torsion potential requested under the fail-closed ring
+    # policy on a molecule with a genuine saturated small ring is a typed,
+    # reliably-reachable failure (RingTorsionApplicationUnsupported) -- see
+    # pipeline_v2.rs's stage-6 gate. (Naphthalene's ring bonds are aromatic,
+    # not classified as small-ring torsion candidates at all, so it would
+    # not reach this failure -- confirmed empirically before writing this
+    # fixture, not assumed.)
+    mol = chematic.from_smiles(CYCLOHEXANE_WITH_CHAIN)
+    config = _safe_config(use_small_ring_torsions=True, ring_torsion_policy="fail_closed")
+
+    with pytest.raises(chematic.PipelineV2Error) as excinfo:
+        mol.embed_pipeline_v2(config)
+
+    err = excinfo.value
+    assert isinstance(err, ValueError)
+    diag = err.diagnostics
+    assert diag["cause"] == {"kind": "ring_torsion_application_unsupported"}
+    assert diag["stage"] == "torsion_optimization"
+    assert diag["coords_are_diagnostic_only"] is True
+    # last_known_coords is present (diagnostic) but distinct from a real
+    # "coords" success key -- must never be mistaken for one.
+    assert "coords" not in diag
+    assert diag["last_known_coords"] is not None
+    assert len(diag["last_known_coords"]) == mol.heavy_atoms
+
+
+def test_diagnostic_only_ring_torsion_policy_avoids_the_failure():
+    """Same request as above but under DiagnosticOnly: succeeds, and
+    ring_torsion_evidence truthfully reports the potentials as scored-only
+    (never silently upgraded to "applied")."""
+    mol = chematic.from_smiles(CYCLOHEXANE_WITH_CHAIN)
+    config = _safe_config(
+        use_small_ring_torsions=True, ring_torsion_policy="diagnostic_only"
+    )
+    result = mol.embed_pipeline_v2(config)
+    evidence = result["ring_torsion_evidence"]
+    assert evidence["diagnostic_only"] is True
+    assert evidence["n_applied"] == 0
+    assert evidence["n_scored_only"] > 0, (
+        "expected at least one small-ring potential to actually be matched "
+        "and scored -- otherwise this test can't distinguish DiagnosticOnly "
+        "from a request that matched nothing at all"
+    )
+
+
+def test_invalid_policy_string_raises_value_error():
+    with pytest.raises(ValueError):
+        _safe_config(force_field="not_a_real_policy")
+    with pytest.raises(ValueError):
+        _safe_config(stereo_policy="not_a_real_policy")
+    with pytest.raises(ValueError):
+        _safe_config(ring_torsion_policy="not_a_real_policy")
+
+
+# ---------------------------------------------------------------------------
+# PipelineV2Config construction
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_constructor_requires_every_field():
+    config = chematic.PipelineV2Config(
+        embed_seed=1,
+        max_attempts=4,
+        embed_timeout_ms=None,
+        use_exp_torsions=False,
+        use_small_ring_torsions=False,
+        use_macrocycle_torsions=False,
+        use_macrocycle_14_bounds=False,
+        include_legacy_torsion_heuristic=False,
+        stereo_policy="verify_only",
+        fail_on_unevaluable_stereo=True,
+        force_field_policy="dreiding",
+        force_field_max_iterations=100,
+        gate_mmff94_torsion_oop=False,
+        ring_torsion_policy="diagnostic_only",
+        total_timeout_ms=5000,
+    )
+    assert config.embed_seed == 1
+    assert config.max_attempts == 4
+    assert config.stereo_policy == "verify_only"
+    assert config.fail_on_unevaluable_stereo is True
+    assert config.force_field_policy == "dreiding"
+    assert config.ring_torsion_policy == "diagnostic_only"
+    assert config.total_timeout_ms == 5000
+
+
+def test_safe_convenience_constructor_still_requires_judgment_fields():
+    with pytest.raises(TypeError):
+        chematic.PipelineV2Config.safe()  # force_field/stereo_policy/ring_torsion_policy missing
+
+
+def test_safe_uses_conservative_defaults_for_everything_else():
+    config = chematic.PipelineV2Config.safe(
+        force_field="mmff94_with_uff_fallback",
+        stereo_policy="repair_and_verify",
+        ring_torsion_policy="fail_closed",
+    )
+    assert config.force_field_policy == "mmff94_with_uff_fallback"
+    assert config.stereo_policy == "repair_and_verify"
+    assert config.fail_on_unevaluable_stereo is False
+    assert config.use_exp_torsions is False
+    assert config.use_small_ring_torsions is False
+    assert config.use_macrocycle_torsions is False
+    assert config.use_macrocycle_14_bounds is False
+    assert config.include_legacy_torsion_heuristic is False
+    assert config.max_attempts == 8
+    assert config.embed_timeout_ms is None
+    assert config.total_timeout_ms is None
+
+
+# ---------------------------------------------------------------------------
+# .pyi stub existence check ("type stub test")
+# ---------------------------------------------------------------------------
+
+
+def test_pyi_declares_the_new_public_surface():
+    """Parse __init__.pyi and confirm the new names it declares actually
+    exist at runtime with a matching shape -- catches a stub that drifts
+    from the compiled extension (wrong name, missing method, etc.)."""
+    pyi_path = (
+        Path(__file__).resolve().parents[1] / "python" / "chematic" / "__init__.pyi"
+    )
+    tree = ast.parse(pyi_path.read_text())
+    top_level_classes = {
+        node.name: node for node in tree.body if isinstance(node, ast.ClassDef)
+    }
+
+    assert "PipelineV2Config" in top_level_classes
+    assert "PipelineV2Error" in top_level_classes
+    assert hasattr(chematic, "PipelineV2Config")
+    assert hasattr(chematic, "PipelineV2Error")
+    assert issubclass(chematic.PipelineV2Error, ValueError)
+
+    config_methods = {
+        n.name
+        for n in top_level_classes["PipelineV2Config"].body
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    assert "safe" in config_methods
+    assert hasattr(chematic.PipelineV2Config, "safe")
+
+    mol_class = next(
+        node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "Mol"
+    )
+    mol_methods = {
+        n.name for n in mol_class.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    assert "embed_pipeline_v2" in mol_methods
+    assert hasattr(chematic.Mol, "embed_pipeline_v2")


### PR DESCRIPTION
## Summary

Wave 1A of the "73 → 80" program (Python/WASM pipeline_v2 exposure → RDKit ETKDGv3 bench → E/Z abstain triage → Accurate CIP rollout decision → ECFP4 API unification). This PR is Python-only: exposes `chematic_3d::pipeline_v2::embed_pipeline_v2` (already shipped, Rust-only, merged via #192/#193) as `Mol.embed_pipeline_v2()`.

Rebased onto `main` after #214 (pytest/CI gap fix) and #215 (scripts cleanup) merged — no conflicts, no unintended diff (confirmed via `git diff origin/main...HEAD --stat` showing exactly the same 7 files this PR always touched).

## Public API

- **`chematic.PipelineV2Config`** — mirrors the Rust config's deliberate lack of `Default`: every field required at the low-level constructor (`embed_seed`, `max_attempts`, `embed_timeout_ms`, `use_exp_torsions`, `use_small_ring_torsions`, `use_macrocycle_torsions`, `use_macrocycle_14_bounds`, `include_legacy_torsion_heuristic`, `stereo_policy`, `fail_on_unevaluable_stereo`, `force_field_policy`, `force_field_max_iterations`, `gate_mmff94_torsion_oop`, `ring_torsion_policy`, `total_timeout_ms` — 15 fields, matching the task spec's required list 1:1).
- **`PipelineV2Config.safe(force_field=..., stereo_policy=..., ring_torsion_policy=..., ...)`** — convenience classmethod. `force_field`/`stereo_policy`/`ring_torsion_policy` are still required, explicit keyword arguments — never hidden defaults (the one instruction repeated twice in the task spec). Everything else defaults conservatively (every torsion-knowledge flag off, `fail_on_unevaluable_stereo=False`, no timeouts).
- Policy fields round-trip through stable string contracts, not raw enum ordinals:
  - `stereo_policy`: `"ignore"` / `"verify_only"` / `"repair_and_verify"`
  - `ring_torsion_policy`: `"fail_closed"` / `"diagnostic_only"`
  - `force_field_policy`: `"mmff94_bond_angle_strict"` / `"mmff94_with_uff_fallback"` / `"uff_only"` / `"dreiding"` / `"none"`
  - Getters on `PipelineV2Config` reflect back every field for introspection.
- **`Mol.embed_pipeline_v2(config) -> dict`** — success dict keys: `coords`, `embed_stats`, `bound_adjustment_report`, `torsion_knowledge_report`, `ring_torsion_evidence`, `torsion_optimization_report`, `stereo_before`, `stereo_repair`, `stereo_after_repair`, `force_field`, `final_stereo`, `final_validation`, `elapsed_ms_by_stage` — every field the task spec's "success result" list named, none silently dropped (`force_field` in particular carries `actual_force_field_used`/`fallback_reason`/`missing_parameter_classes`/`coverage`, never a silent substitution).
- **`chematic.PipelineV2Error`** (a `ValueError` subclass) on failure. `error.diagnostics` is a structured dict, not just a message string — carries `cause` (typed, decomposed, e.g. `{"kind": "force_field", "force_field_bridge_error": {...}}`, never collapsed to a debug string for the fields the task called out), `stage`, `last_known_coords` (explicitly paired with `coords_are_diagnostic_only: True` so it can never be mistaken for a success — deliberately no key named `coords` in the failure dict at all), plus every partial-evidence field (`embed_stats`, `torsion_knowledge_report`, `stereo_before`, `force_field`, `final_validation`, `elapsed_ms_by_stage`, ...) exactly as `PipelineV2Failure` carries them in Rust.

**None of this API/schema changed during the rebase** — same 15 config fields, same typed `.diagnostics` evidence, same atom-order contract (`Mol.inner` called directly, no reparse), reconfirmed field-by-field after rebasing (see Correctness gate below).

## Design notes

- **`Mol.inner` called directly, no reparse.** Same atom-order-preservation requirement issue #172 established for `conformer_ensemble()` — verified with a dedicated test suite (see below), including a negative control that reproduces the *old* bug shape on purpose to prove the test methodology can actually catch it.
- **Never a raw dict schema improvised ad hoc.** Every nested report (`torsion_knowledge_report`, `ring_torsion_evidence`, `stereo_before`/`stereo_after_repair`/`final_stereo`, `force_field`, `final_validation`, `elapsed_ms_by_stage`) is hand-mapped field-by-field from the corresponding Rust struct — no field silently dropped, no enum silently stringified into a Debug dump for the fields that matter for decision-making (`cause`, `stage`, `force_field_bridge_error`, `starting_geometry`, every `StereoStatus`/`StereoRejectionReason`). Less-critical deeply-nested fieldless enums (`TorsionKnowledgeDiagnosticKind`, `Mmff94TermKind`, per-cause failure-count keys, ...) use a generic `Debug -> snake_case` conversion, documented in-code as intentionally generic rather than hand-enumerated.
- **Scope discipline** (per task's explicit exclusions): no change to the pipeline algorithm itself, no touching `generate_and_minimize_uff`/`conformer_ensemble`, no RDKit benchmark, no WASM binding, no E/Z or CIP or ECFP change. `crates/chematic-py/src/pipeline_v2.rs` is new and additive; the only touched existing files are `lib.rs` (+6 lines: module + class/exception registration) and `mol_methods.rs` (+31 lines: one new method).

## Atom-order invariant — tests

`crates/chematic-py/tests/test_pipeline_v2.py` (17 tests, all passing):
- Consistency check (bond lengths sane, no coincident atoms, atom count matches) on decane (chain), naphthalene (fused aromatic ring), aspirin (asymmetrically-substituted ring), 2-methylbutane (branched).
- Negative control: hand-reconstructs the *old* conformer_ensemble()-style bug (canonicalize → reparse → embed → cross-index against the *original* Mol) and confirms it's caught as an `AssertionError` — proves the consistency check actually detects a real atom-order mismatch, not just that it happens to pass.
- Genuine permutation test: two independently-written SMILES for the same molecule (aspirin, traversed from opposite ends — confirmed via `bond_table` diff to be a real reordering, not a repeat parse) both produce coordinates self-consistent with their own Mol, and permutation-invariant summary diagnostics (declared-stereocenter count, geometric soundness) agree between them. (Exact bit-identical coordinates are *not* asserted across a genuine permutation — the underlying stochastic distance-geometry embedder's seed consumption depends on atom traversal order, so that would be a false claim; this is disclosed explicitly in the test docstring rather than silently oversold.)
- This PR's own test excludes DECANE from the "actually reorders under canonicalization" assertion, for the same reason **#214 already fixed the identical blind spot** in `test_conformer_ensemble.py` upstream: a plain path graph's edge set is frozenset-identical under end-to-end reversal, so the bond-set-based reorder check can't observe decane's reordering either way. Both files now handle this consistently post-rebase.

## Rust ⟷ Python parity

`chematic-py` builds only as a `cdylib` (no `rlib` target — confirmed via `Cargo.toml`), so a Rust-side `#[test]` cannot itself embed a Python interpreter to call this binding directly; there is no existing precedent for this in the crate (zero `#[cfg(test)]`/`#[test]` anywhere in `chematic-py/src`). Parity is instead verified two ways:
1. `test_result_schema_and_values_for_deterministic_case` grounds every field's expected value for a deterministic scenario (`ForceFieldPolicy::None`, fixed seed, decane) directly against what the Rust source guarantees for that exact path (e.g. `ForceFieldPolicy::None` never fails/falls back, so `fallback_reason`/`coverage`/`starting_geometry` must all be `None`, `converged=True`, `iterations=0`) — each assertion is measured against actual output, not assumed.
2. `test_same_seed_is_reproducible` confirms bit-identical `coords`/`embed_stats` across two calls with the same seed.

## Correctness gate — re-verified fresh on the rebased head

All numbers below are from the **rebased** head (on top of `main` post-#214/#215), not carried over from the pre-rebase commit — local results and GitHub CI results are reported separately, never conflated.

**Local (this session, on the rebased head):**
- `cargo check -p chematic-py`, `cargo clippy -p chematic-py --all-targets -- -D warnings`, `cargo fmt --all -- --check`: clean.
- `bash scripts/check.sh`: full pass (fmt, clippy workspace-wide, every crate's lib+integration tests, cargo-deny, publish-graph, version 0.8.1 consistency).
- `.venv/bin/maturin develop --release` + `pytest crates/chematic-py/tests/`: **667 passed, 0 failed** — the 5 tests that failed pre-rebase (2 in `test_conformer_ensemble.py`, 2 in `test_module_functions.py`, 1 in `test_mol.py`) are all fixed by **#214**, not by this PR; this PR's own diff never touches any of the affected code.
- `crates/chematic-py/tests/test_pipeline_v2.py`: **17/17 pass** (atom-order invariant, permutation, deterministic-schema parity, failure-contract, config-construction, `.pyi` stub-existence checks).
- **Wheel smoke test, rebased head, genuinely clean venv** (not the dev `.venv`): `maturin build --release` → fresh `python3 -m venv` → installed only the built wheel (confirmed via `pip list`: just `chematic` + `numpy`) → `import chematic` → `PipelineV2Config.safe(...)` construction → `Mol.embed_pipeline_v2()` success path (atom count matches, all coords finite) → failure path raising `PipelineV2Error` with structured `.diagnostics` (`cause.kind == "ring_torsion_application_unsupported"`, `coords_are_diagnostic_only is True`) → package API/stub presence checks. All pass.

**GitHub CI (fresh head `b6ad04c`):** all 17 checks pass, confirmed independently (not just trusting a background watcher) via a direct `gh pr checks 213` call after the watcher reported completion — including `Test (Python bindings)` (2m18s, the pytest CI job #214 introduced), `Rust Criterion regression gate` (17m25s), `Python bench regression gate` (4m36s), `CodeQL`, `Cargo Audit`, `Clippy`, `Build Check`, `Format Check`, `Validate CITATION.cff`. `mergeStateStatus: CLEAN`, `mergeable: MERGEABLE`, 0 reviews/review threads.

## Not done here (explicit scope)

- Pipeline algorithm changes, `generate_and_minimize_uff`/`conformer_ensemble` changes, RDKit ETKDGv3 benchmark, WASM binding, E/Z or CIP or ECFP changes — all tracked as later Waves (1B/1C/2A/2B/3A/3B/4) per the program plan, not started.

## Merge

Ready (not draft). Rebased head `b6ad04c` — see PR checks for fresh CI status.
