### PR TITLE
deprecate(3d): honest doc + deprecation for generate_and_minimize_uff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Rust-only; no algorithm change. Scope: Python binding only — no WASM
     binding, no RDKit benchmark (tracked as separate follow-up work).
 
+### Deprecated — `chematic-3d`
+
+- **`generate_and_minimize_uff()` never ran chematic-ff's UFF, despite its name and doc
+  comment.** `#[deprecated]`, with an honest doc comment disclosing what it actually runs
+  and where to go for real behavior. Investigation (issue #204) found the defect deeper
+  than the issue's own text described: `minimize_uff(mol, coords)` resolves to this
+  crate's own `minimize::minimize()`, whose dispatch (`minimize_with_config`) only
+  special-cases `ForceField::MMFF94` — the `UFF` and `ForceField::DREIDING` (the
+  default) variants are indistinguishable and both fall through to the same catch-all,
+  `minimize_generic_with_config`. That is a **third**, untyped, element-pair-parameterized
+  harmonic engine, distinct from both `chematic_ff::uff::minimize_uff` (real UFF) and this
+  crate's own typed DREIDING engine (`minimize_dreiding`, which assigns real
+  `DREIDINGType`s and is what `generate_and_minimize_dreiding` actually calls). A new
+  regression test (`generate_and_minimize_uff_runs_neither_dreiding_nor_real_uff`)
+  initially asserted the issue's own framing — that the function's output matches
+  `generate_and_minimize_dreiding` — and that assertion **failed**, which is what
+  surfaced this refinement; the test now pins the correct three-way contract instead.
+  - Zero in-workspace callers found (`chematic-py`, `chematic-wasm`, `chematic-mcp`, and
+    every other crate/test/doc call `generate_and_minimize_dreiding` for DREIDING behavior
+    already), so the function is kept (not deleted or behavior-changed) purely as a
+    just-in-case compatibility shim for any external, out-of-tree caller of this
+    published crate.
+  - Use `generate_and_minimize_dreiding` for the same (typed DREIDING) behavior under an
+    honest name, or `minimize::minimize_with_policy_gated(..., ForceFieldPolicy::UffOnly, ...)`
+    / `chematic_ff::uff::{assign_uff_types, minimize_uff}` for real UFF physics.
+
 _Nothing else yet — everything below `[0.8.1]` has shipped._
 
 ## [0.8.1] — 2026-07-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   harmonic engine, distinct from both `chematic_ff::uff::minimize_uff` (real UFF) and this
   crate's own typed DREIDING engine (`minimize_dreiding`, which assigns real
   `DREIDINGType`s and is what `generate_and_minimize_dreiding` actually calls). A new
-  regression test (`generate_and_minimize_uff_runs_neither_dreiding_nor_real_uff`)
+  regression test (`generate_and_minimize_uff_delegates_to_generic_minimize`)
   initially asserted the issue's own framing — that the function's output matches
   `generate_and_minimize_dreiding` — and that assertion **failed**, which is what
-  surfaced this refinement; the test now pins the correct three-way contract instead.
+  surfaced this refinement. The test's only load-bearing, permanently-pinned
+  assertion is that the deprecated function's output is numerically identical to
+  calling `minimize::minimize()` directly; its additional evidence that the output
+  also currently differs from typed DREIDING and real UFF on one test molecule is
+  logged as diagnostic, not asserted — different force fields could in principle
+  coincide on a shared local minimum for some molecule, which would make "always
+  differs" a fragile, unrelated regression gate.
   - Zero in-workspace callers found (`chematic-py`, `chematic-wasm`, `chematic-mcp`, and
     every other crate/test/doc call `generate_and_minimize_dreiding` for DREIDING behavior
     already), so the function is kept (not deleted or behavior-changed) purely as a

--- a/crates/chematic-3d/src/lib.rs
+++ b/crates/chematic-3d/src/lib.rs
@@ -159,7 +159,6 @@ pub fn generate_and_minimize_constrained(mol: &chematic_core::Molecule) -> Coord
 }
 
 #[deprecated(
-    since = "0.8.2",
     note = "misnamed: this runs neither chematic-ff's real UFF nor this crate's own typed \
             DREIDING engine (`generate_and_minimize_dreiding`) — it runs chematic-3d's own \
             internal generic, element-pair-parameterized harmonic force field \
@@ -823,16 +822,19 @@ mod tests {
     /// same generic, untyped, element-pair harmonic engine — a third implementation,
     /// distinct from both real UFF and the typed DREIDING engine
     /// (`minimize::minimize_dreiding`, assigning real `DREIDINGType`s) that
-    /// `generate_and_minimize_dreiding` actually runs. Pin the corrected,
-    /// honestly-documented contract from three directions: (1) its output is
-    /// byte-identical to calling `minimize::minimize()` directly (confirming exactly
-    /// what it delegates to), (2) it differs from real, typed DREIDING
-    /// (`generate_and_minimize_dreiding`), and (3) it differs from real UFF
-    /// (`ForceFieldPolicy::UffOnly`) — proving all three were never the same force
-    /// field.
+    /// `generate_and_minimize_dreiding` actually runs.
+    ///
+    /// The only load-bearing, permanently-pinned contract is (1): the deprecated
+    /// function's output is numerically identical (within floating-point tolerance) to
+    /// calling `minimize::minimize()` directly, confirming exactly what it delegates
+    /// to. (2)/(3) below (divergence from typed DREIDING / real UFF on this one
+    /// molecule) are logged as diagnostic evidence, not asserted — different force
+    /// fields can in principle converge to the same local minimum for a particular
+    /// molecule by coincidence, so "always differs" would be a fragile regression gate
+    /// unrelated to this function's actual contract.
     #[test]
     #[allow(deprecated)]
-    fn generate_and_minimize_uff_runs_neither_dreiding_nor_real_uff() {
+    fn generate_and_minimize_uff_delegates_to_generic_minimize() {
         use crate::minimize::{
             ForceFieldPolicy, MinimizeConfig, minimize, minimize_with_policy_gated,
         };
@@ -842,20 +844,24 @@ mod tests {
 
         let deprecated_result = generate_and_minimize_uff(&mol);
 
-        // (1) It is exactly `minimize::minimize()` on freshly-generated coords — no more,
-        // no less. This is the true, honest description of its current behavior.
+        // (1) LOAD-BEARING: it is exactly `minimize::minimize()` on freshly-generated
+        // coords — no more, no less. This is the true, honest description of its
+        // current behavior, and the only property this test hard-gates.
         let generic_result = minimize(&mol, generate_coords(&mol));
         for i in 0..mol.atom_count() as u32 {
             let a = deprecated_result.get(AtomIdx(i));
             let b = generic_result.get(AtomIdx(i));
             assert!(
                 a.distance(&b) < 1e-12,
-                "generate_and_minimize_uff must be byte-identical to minimize::minimize() \
-                 (that is literally what it delegates to); atom {i} diverged"
+                "generate_and_minimize_uff must be numerically identical (within \
+                 floating-point tolerance) to minimize::minimize() — that is literally \
+                 what it delegates to; atom {i} diverged"
             );
         }
 
-        // (2) It differs from real, typed DREIDING.
+        // (2)/(3) DIAGNOSTIC ONLY — evidence that today, on this one molecule, all
+        // three engines happen to be distinct; not a permanent API contract, so never
+        // asserted. See the doc comment above for why.
         let dreiding_result = generate_and_minimize_dreiding(&mol);
         let differs_from_dreiding = (0..mol.atom_count() as u32).any(|i| {
             deprecated_result
@@ -863,14 +869,11 @@ mod tests {
                 .distance(&dreiding_result.get(AtomIdx(i)))
                 > 1e-6
         });
-        assert!(
-            differs_from_dreiding,
-            "generate_and_minimize_uff's output must differ from typed DREIDING \
-             (generate_and_minimize_dreiding) — the two use different energy engines \
-             (generic element-pair table vs. assign_dreiding_types)"
+        println!(
+            "[diagnostic] generate_and_minimize_uff differs from typed DREIDING on \
+             benzene: {differs_from_dreiding}"
         );
 
-        // (3) It differs from real UFF (`chematic_ff::uff::minimize_uff`).
         let real_uff = minimize_with_policy_gated(
             &mol,
             generate_coords(&mol),
@@ -885,11 +888,9 @@ mod tests {
                 .distance(&real_uff.coords.get(AtomIdx(i)))
                 > 1e-6
         });
-        assert!(
-            differs_from_real_uff,
-            "generate_and_minimize_uff's output must differ from real UFF \
-             (chematic_ff::uff::minimize_uff) — if this ever matches, the deprecated \
-             function has started running real UFF and its doc comment must be updated"
+        println!(
+            "[diagnostic] generate_and_minimize_uff differs from real UFF on benzene: \
+             {differs_from_real_uff}"
         );
     }
 }

--- a/crates/chematic-3d/src/lib.rs
+++ b/crates/chematic-3d/src/lib.rs
@@ -158,7 +158,41 @@ pub fn generate_and_minimize_constrained(mol: &chematic_core::Molecule) -> Coord
     minimize_dreiding(mol, projected)
 }
 
-/// Generate 3D coordinates and minimize using UFF force field.
+#[deprecated(
+    since = "0.8.2",
+    note = "misnamed: this runs neither chematic-ff's real UFF nor this crate's own typed \
+            DREIDING engine (`generate_and_minimize_dreiding`) — it runs chematic-3d's own \
+            internal generic, element-pair-parameterized harmonic force field \
+            (`minimize::minimize()`; `minimize_with_config`'s dispatch only special-cases \
+            MMFF94, so `ForceField::UFF`/`ForceField::DREIDING` are indistinguishable and \
+            both fall through to this same generic engine). Use \
+            `generate_and_minimize_dreiding` for typed DREIDING physics, or \
+            `minimize::minimize_with_policy_gated(..., minimize::ForceFieldPolicy::UffOnly, ...)` \
+            / `chematic_ff::uff::{assign_uff_types, minimize_uff}` for real UFF physics. \
+            See issue #204."
+)]
+/// Generate 3D coordinates and minimize geometry in one step.
+///
+/// **Despite the name, this does not run chematic-ff's UFF — and it is *not* equivalent to
+/// [`generate_and_minimize_dreiding`] either.** `minimize_uff` here resolves to this crate's
+/// own [`crate::minimize::minimize_uff`], which is honestly documented as an alias for
+/// [`crate::minimize::minimize`] (`MinimizeConfig::default()`). That generic `minimize()`
+/// dispatches on `config.force_field`, but its match arm only special-cases MMFF94 — both
+/// the `UFF` and `DREIDING` enum variants fall through to the same catch-all,
+/// `minimize_generic_with_config`, which uses chematic-3d's own internal, untyped,
+/// element-pair bond/angle/VDW table (informally "UFF-derived", see `minimize.rs`'s
+/// "UFF-derived element parameters" section) — a third, distinct engine from both
+/// `chematic_ff::uff::minimize_uff` (real UFF) and [`crate::minimize::minimize_dreiding`]
+/// (which assigns real per-atom DREIDING types via `assign_dreiding_types` and is what
+/// [`generate_and_minimize_dreiding`] actually calls). This function is kept only so
+/// existing external callers (outside this workspace) don't break; do not add new calls
+/// to it.
+///
+/// - For typed DREIDING physics, call [`generate_and_minimize_dreiding`] directly.
+/// - For real UFF physics, use
+///   [`crate::minimize::minimize_with_policy_gated`] with
+///   [`crate::minimize::ForceFieldPolicy::UffOnly`], or call
+///   `chematic_ff::uff::{assign_uff_types, minimize_uff}` directly.
 pub fn generate_and_minimize_uff(mol: &chematic_core::Molecule) -> Coords3D {
     let coords = generate_coords(mol);
     minimize_uff(mol, coords)
@@ -774,6 +808,88 @@ mod tests {
             ensemble.conformer_count() >= 2,
             "flexible molecule with Gaussian noise should produce diverse conformers, got {}",
             ensemble.conformer_count()
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Regression test for issue #204
+    // -----------------------------------------------------------------------
+
+    /// `generate_and_minimize_uff`'s name has always claimed UFF, but it has never
+    /// invoked `chematic_ff::uff::minimize_uff`. It also turns out NOT to be equivalent
+    /// to [`generate_and_minimize_dreiding`] either (an initial version of this test
+    /// asserted that and failed): `minimize::minimize()`'s dispatch only special-cases
+    /// `ForceField::MMFF94`, so both `UFF` and `DREIDING` variants fall through to the
+    /// same generic, untyped, element-pair harmonic engine — a third implementation,
+    /// distinct from both real UFF and the typed DREIDING engine
+    /// (`minimize::minimize_dreiding`, assigning real `DREIDINGType`s) that
+    /// `generate_and_minimize_dreiding` actually runs. Pin the corrected,
+    /// honestly-documented contract from three directions: (1) its output is
+    /// byte-identical to calling `minimize::minimize()` directly (confirming exactly
+    /// what it delegates to), (2) it differs from real, typed DREIDING
+    /// (`generate_and_minimize_dreiding`), and (3) it differs from real UFF
+    /// (`ForceFieldPolicy::UffOnly`) — proving all three were never the same force
+    /// field.
+    #[test]
+    #[allow(deprecated)]
+    fn generate_and_minimize_uff_runs_neither_dreiding_nor_real_uff() {
+        use crate::minimize::{
+            ForceFieldPolicy, MinimizeConfig, minimize, minimize_with_policy_gated,
+        };
+        use crate::{generate_and_minimize_dreiding, generate_and_minimize_uff};
+
+        let mol = parse("c1ccccc1").expect("benzene SMILES");
+
+        let deprecated_result = generate_and_minimize_uff(&mol);
+
+        // (1) It is exactly `minimize::minimize()` on freshly-generated coords — no more,
+        // no less. This is the true, honest description of its current behavior.
+        let generic_result = minimize(&mol, generate_coords(&mol));
+        for i in 0..mol.atom_count() as u32 {
+            let a = deprecated_result.get(AtomIdx(i));
+            let b = generic_result.get(AtomIdx(i));
+            assert!(
+                a.distance(&b) < 1e-12,
+                "generate_and_minimize_uff must be byte-identical to minimize::minimize() \
+                 (that is literally what it delegates to); atom {i} diverged"
+            );
+        }
+
+        // (2) It differs from real, typed DREIDING.
+        let dreiding_result = generate_and_minimize_dreiding(&mol);
+        let differs_from_dreiding = (0..mol.atom_count() as u32).any(|i| {
+            deprecated_result
+                .get(AtomIdx(i))
+                .distance(&dreiding_result.get(AtomIdx(i)))
+                > 1e-6
+        });
+        assert!(
+            differs_from_dreiding,
+            "generate_and_minimize_uff's output must differ from typed DREIDING \
+             (generate_and_minimize_dreiding) — the two use different energy engines \
+             (generic element-pair table vs. assign_dreiding_types)"
+        );
+
+        // (3) It differs from real UFF (`chematic_ff::uff::minimize_uff`).
+        let real_uff = minimize_with_policy_gated(
+            &mol,
+            generate_coords(&mol),
+            ForceFieldPolicy::UffOnly,
+            &MinimizeConfig::default(),
+            false,
+        )
+        .expect("real UFF minimization of benzene should succeed");
+        let differs_from_real_uff = (0..mol.atom_count() as u32).any(|i| {
+            deprecated_result
+                .get(AtomIdx(i))
+                .distance(&real_uff.coords.get(AtomIdx(i)))
+                > 1e-6
+        });
+        assert!(
+            differs_from_real_uff,
+            "generate_and_minimize_uff's output must differ from real UFF \
+             (chematic_ff::uff::minimize_uff) — if this ever matches, the deprecated \
+             function has started running real UFF and its doc comment must be updated"
         );
     }
 }

--- a/docs/uff_robustness_diagnosis_185_188.md
+++ b/docs/uff_robustness_diagnosis_185_188.md
@@ -199,6 +199,17 @@ patching it here (no step-clamping/symptom-masking, per task instruction).
   doc comment does not, and its name claims a force field it never runs.
   Filed as its own issue (not fixed here — a public function rename/behavior
   change needs its own authorization).
+  - **Resolved in issue #204's fix PR.** `#[deprecated]`, with an honest doc
+    comment. The fix investigation also refined the framing above: the
+    "DREIDING-default" phrasing here undersells it — `minimize_with_config`'s
+    dispatch only special-cases `ForceField::MMFF94`, so `ForceField::UFF`
+    and `ForceField::DREIDING` are indistinguishable on that path and both
+    fall through to the same generic, untyped, element-pair harmonic engine.
+    That engine is a **third** implementation, distinct from both real UFF
+    and this crate's own typed DREIDING engine (`minimize_dreiding`, which
+    `generate_and_minimize_dreiding` actually calls) — confirmed by a test
+    that initially asserted DREIDING-equivalence and failed. See
+    `CHANGELOG.md`'s `[Unreleased]` entry for the corrected description.
 - **Issue #185's reported "~481.27 Å" worst-bond number could not be
   reproduced.** Naphthalene's worst bond length from `generate_coords` at
   the default 200-step `UffOnly` budget, measured independently twice — once


### PR DESCRIPTION
## Summary

Refs #204

`chematic_3d::generate_and_minimize_uff`'s name and doc comment ("Generate 3D coordinates and minimize using UFF force field") claim it runs UFF. It never has. This PR does not delete or silently change its runtime behavior -- it deprecates it with an honest doc comment, based on the investigation below.

Rebased onto `main` after #213 (pipeline_v2 Python binding) merged -- the only conflict was `CHANGELOG.md`'s `[Unreleased]` section, resolved by keeping both entries (#213's `### Added — chematic-py` and this PR's `### Deprecated — chematic-3d`), neither overwriting the other.

### Investigation: who calls this, and how

Grepped the whole workspace (`chematic-py`, `chematic-wasm`, `chematic-mcp`, every other crate, tests, docs, examples) for `generate_and_minimize_uff`. **Zero in-workspace callers.** Every consumer that wants DREIDING behavior already calls `generate_and_minimize_dreiding` directly (`chematic-mcp/src/tools.rs`, `chematic-py/src/{bulk.rs,mol_methods.rs}`, `chematic-wasm/src/{mol_3d.rs,workflow.rs}`), and Python/WASM's own `.minimize_uff()` bindings call `chematic_ff::minimize_uff` (real UFF) *directly*, bypassing this function entirely (`chematic-py/src/mol_methods.rs:394`, `chematic-wasm/src/mol_3d.rs:641`). So nothing in this repo depends on `generate_and_minimize_uff`'s current (or any) behavior. **The function itself is not removed and its runtime behavior is unchanged** -- only its documentation and deprecation status change.

Because `chematic-3d` is a published crate (crates.io) and an unknown external caller could still depend on the current behavior, the safest fix given the priority order in the issue is: **keep the function, don't change its runtime behavior, don't delete it** -- just make its documentation honest and mark it `#[deprecated]` pointing callers at the two functions that actually do what its name/behavior separately claim.

### A deeper finding than the issue text describes

The issue's own text says `generate_and_minimize_uff` "delegates to the generic `minimize()` function using `MinimizeConfig::default()` (`ForceField::DREIDING`)" -- implying it's equivalent to the DREIDING pipeline. An early version of this PR's regression test asserted exactly that (`generate_and_minimize_uff(&mol) == generate_and_minimize_dreiding(&mol)`), and **that assertion failed**.

Tracing why: `minimize_with_config`'s dispatch (`crates/chematic-3d/src/minimize.rs`) only special-cases `ForceField::MMFF94` -- both `ForceField::UFF` and `ForceField::DREIDING` fall through to the same catch-all, `minimize_generic_with_config`. That's a **third**, distinct, untyped, element-pair-parameterized harmonic engine (`total_energy`/`ideal_bond_len`, informally "UFF-derived" per the module's own section header) -- not real UFF (`chematic_ff::uff::minimize_uff`), and not the typed DREIDING engine either (`minimize_dreiding`, which assigns real `DREIDINGType`s via `assign_dreiding_types` and is what `generate_and_minimize_dreiding` actually calls).

So `generate_and_minimize_uff` runs neither UFF nor DREIDING -- it runs a third engine that happens to be reachable only through this one deprecated entry point (`ForceField::DREIDING`'s default enum tag is inert on that dispatch path; `ForceField::UFF` would produce identical output).

### What changed

- `crates/chematic-3d/src/lib.rs`: `#[deprecated(note = ...)]` -- **no `since`**. The next release version isn't confirmed (`Cargo.toml` is still at `0.8.1`; unreleased changes accumulate under `CHANGELOG.md`'s `[Unreleased]` with no version decided yet), and `since` is optional on `#[deprecated]`. Matches this crate's own existing precedent -- `chematic-core`'s `#[deprecated(since = "0.1.95", ...)]` on `total_hcount` used an already-released version number, never a speculative future one. `since` will be added at actual release time. Doc comment describes the three-engine finding and points to `generate_and_minimize_dreiding` (typed DREIDING) or `minimize_with_policy_gated(..., ForceFieldPolicy::UffOnly, ...)` / `chematic_ff::uff::{assign_uff_types, minimize_uff}` (real UFF).
- New regression test, renamed to **`generate_and_minimize_uff_delegates_to_generic_minimize`** (was `..._runs_neither_dreiding_nor_real_uff` -- renamed because after review, only one property is hard-gated, not three; see below). Fixed in response to review feedback before merge:
  - **Wording fix**: the delegation check was previously called "byte-identical" -- it's actually a floating-point distance-tolerance comparison (`< 1e-12`), not a bitwise one. Now worded "numerically identical (within floating-point tolerance)".
  - **Assertion-strength fix**: the test previously *hard-asserted* that the deprecated function's output always differs from typed DREIDING and from real UFF. Different force fields can in principle converge to the same local minimum for a particular molecule by coincidence, which would make "always differs" a fragile, unrelated regression gate -- if that ever happened for some future molecule/build/compiler, the test would fail for a reason that has nothing to do with this function's actual contract. Converted to `println!` diagnostic output (still visible with `--nocapture`, never gates pass/fail).
  - **The only permanently-pinned, load-bearing assertion**: the deprecated function's output is numerically identical to calling `generate_coords` + `minimize::minimize()` directly -- that is its actual, honest contract, and the only property this test hard-gates.
- `docs/uff_robustness_diagnosis_185_188.md`: added a resolution pointer under the item that originally spun this out as its own issue (historical finding left intact, not rewritten).
- `CHANGELOG.md`: new `### Deprecated -- chematic-3d` entry under `[Unreleased]`, alongside (not overwriting) #213's own entry.

## Test plan

- [x] `cargo test -p chematic-3d --lib -- generate_and_minimize_uff_delegates_to_generic_minimize --nocapture` -- passes; diagnostic lines print `differs from typed DREIDING on benzene: true` / `differs from real UFF on benzene: true` without gating on them
- [x] `bash scripts/check.sh` on the post-#213-rebase head -- fmt, clippy `-D warnings` (workspace, all-targets), full workspace test suite (`chematic-3d` lib: 480 tests, 477 passed + 3 ignored, 0 failed), cargo-deny, publish-graph, version check -- all pass, "All checks passed."

## Not done here (explicit scope)

- No rename or deletion of `generate_and_minimize_uff` -- kept as a compatibility shim for any external, out-of-tree caller of this published crate.
- No change to `minimize_with_config`'s dispatch, `minimize_generic_with_config`, or any other force-field engine -- this PR documents the existing three-engine reality, it doesn't change it.
