### PR TITLE
fix(3d): WASM-portable monotonic clock for pipeline_v2/distance_geometry_v2 (Refs #219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     honest name, or `minimize::minimize_with_policy_gated(..., ForceFieldPolicy::UffOnly, ...)`
     / `chematic_ff::uff::{assign_uff_types, minimize_uff}` for real UFF physics.
 
+### Fixed — `chematic-3d`
+
+- **`embed_pipeline_v2`/`distance_geometry_v2` panicked unconditionally under real
+  `wasm32-unknown-unknown`.** `std::time::Instant::now()` has no host time source on
+  that target and traps with `"time not implemented on this platform"` — hit at all
+  13 call sites used for timeout enforcement and per-stage timing (12 in
+  `pipeline_v2.rs`, 1 in `distance_geometry_v2.rs`). This was latent (no previously
+  shipped WASM export reached these modules) until PR #220's not-yet-merged
+  `embed_pipeline_v2_json` binding exercised it end-to-end and filed it as issue #219.
+  Fixed via a small crate-internal `clock` module: `web_time::Instant` (backed by
+  `Performance.now()`) on `wasm32-unknown-unknown`, `std::time::Instant` everywhere
+  else (via `web-time`'s own re-export) — a pure clock-source swap, no change to
+  timeout contracts, stage-timing field names/units, or any chemistry/geometry/torsion/
+  force-field logic. Verified end-to-end (both `wasm-pack --target nodejs` and
+  `--target web` artifacts, real success + typed-timeout paths, no partial-coords-as-
+  success) via a local, unpushed integration of PR #220's head, since #220 itself
+  isn't merged yet. A related but distinct conditional trap in `chematic-smarts`'s MCS
+  timeout path (already reachable from the shipped `mcs_smiles_json_with_ring_config`
+  export) was found during the call-site audit and filed separately as issue #221
+  rather than folded into this fix (different crate, different root cause).
+
 _Nothing else yet — everything below `[0.8.1]` has shipped._
 
 ## [0.8.1] — 2026-07-30

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -23,6 +23,12 @@ chematic-chem       = { path = "../chematic-chem",       version = "0.8.1" }
 chematic-fp         = { path = "../chematic-fp",         version = "0.8.1" }
 chematic-smarts     = { path = "../chematic-smarts",     version = "0.8.1" }
 
+# std::time::Instant panics on wasm32-unknown-unknown (issue #219); web-time
+# is a drop-in Instant replacement backed by Performance.now() there, and
+# re-exports std::time::Instant everywhere else -- see src/clock.rs.
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+web-time = "1"
+
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies
 # comment -- a version-pinned dev-dependency must resolve against the

--- a/crates/chematic-3d/src/clock.rs
+++ b/crates/chematic-3d/src/clock.rs
@@ -1,0 +1,13 @@
+//! Monotonic clock, portable across native and `wasm32-unknown-unknown`.
+//!
+//! `std::time::Instant::now()` panics with "time not implemented on this
+//! platform" under real `wasm32-unknown-unknown` (no host time source) --
+//! see <https://github.com/kent-tokyo/chematic/issues/219>. `web_time::Instant`
+//! is API-compatible and backed by `Performance.now()` there, while
+//! transparently re-exporting `std::time::Instant` everywhere else.
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) use web_time::Instant;
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+pub(crate) use std::time::Instant;

--- a/crates/chematic-3d/src/distance_geometry_v2.rs
+++ b/crates/chematic-3d/src/distance_geometry_v2.rs
@@ -41,7 +41,8 @@
 //! are all separately merged.
 
 use std::collections::HashMap;
-use std::time::Instant;
+
+use crate::clock::Instant;
 
 use chematic_core::{AtomIdx, BondOrder, Chirality, Molecule};
 

--- a/crates/chematic-3d/src/lib.rs
+++ b/crates/chematic-3d/src/lib.rs
@@ -11,6 +11,7 @@
 #![allow(clippy::needless_range_loop)]
 
 pub mod align;
+pub(crate) mod clock;
 pub mod conformer;
 pub mod constraints;
 pub mod coords;

--- a/crates/chematic-3d/src/pipeline_v2.rs
+++ b/crates/chematic-3d/src/pipeline_v2.rs
@@ -115,10 +115,9 @@
 //!   standing convention that heuristic-projection residuals are visible, not assumed
 //!   away (`distance_geometry_v2::bounds_conformance`'s own doc comment).
 
-use std::time::Instant;
-
 use chematic_core::{AtomIdx, Molecule};
 
+use crate::clock::Instant;
 use crate::coords::Coords3D;
 use crate::dg_fft::ideal_bond_length;
 use crate::distance_geometry_v2::{


### PR DESCRIPTION
Refs #219

## Root cause

`std::time::Instant::now()` panics with `"time not implemented on this platform"`
under real `wasm32-unknown-unknown` (no host time source). It was called
unconditionally at 13 confirmed call sites in `chematic-3d` (re-audited fresh
against current `main` at `ebe0832`, not assumed from the issue's own count):

- `crates/chematic-3d/src/distance_geometry_v2.rs:409` (1 site — embedding retry
  loop's `timeout_ms` enforcement)
- `crates/chematic-3d/src/pipeline_v2.rs:544,590,599,635,672,737,768,777,813,832,861,889`
  (12 sites — `StageTimings` per-stage measurement)

This is why PR #220's not-yet-merged `embed_pipeline_v2_json` WASM binding traps
on every real-pipeline call under Node/browser, even though it passes all native
tests.

## Fix

A small crate-internal clock abstraction (`crates/chematic-3d/src/clock.rs`):

```rust
#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
pub(crate) use web_time::Instant;

#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
pub(crate) use std::time::Instant;
```

`web-time = "1"` (latest stable, MSRV 1.60, well under this workspace's 1.85) is
added as a `[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]`
entry in `chematic-3d/Cargo.toml` — a normal-cost native build never sees it.
`web-time` itself re-exports `std::time::Instant` verbatim on every non-wasm32
target, so native behavior is structurally unchanged, not just tested-to-match.

Both files' `use std::time::Instant;` were swapped to `use crate::clock::Instant;`.
No chemistry/geometry/torsion/force-field logic touched; no public API added;
no timeout-contract, stage-timing field name, or unit changed.

## Call-site audit (repo-wide, fresh count)

Searched all of `crates/` for `Instant`/`elapsed()`/`duration_since()`:

- **13/13 confirmed** in `chematic-3d` (matches the issue's count, independently
  re-derived rather than trusted).
- All other hits are in `examples/*.rs` binaries (never compiled into the
  `cdylib` wasm-pack builds — not reachable from any WASM export) or inside
  native-only `#[test]` functions in `chematic-chem` (not part of the shipped
  wasm32 artifact either).
- One related-but-out-of-scope finding: `chematic-smarts/src/mcs.rs` has 4
  *conditional* `Instant::now()` calls (only invoked when `McsConfig::timeout_ms`
  is set), already reachable today via chematic-wasm's shipped
  `mcs_smiles_json_with_ring_config`. Different crate (chematic-3d depends on
  chematic-smarts, not vice versa), different root cause location, so filed
  separately as **#221** rather than folded into this PR.

## Native regression gate

`cargo test -p chematic-3d --lib`: **477 passed, 0 failed, 3 ignored** (all 3
ignored are pre-existing, unrelated to this change — 2 in `minimize.rs`, 1 in
`o3a.rs`). Includes the existing deterministic-seed reproducibility tests
(`distance_geometry_v2::same_seed_reproducible`,
`pipeline_v2::same_seed_same_config_reproduces_identical_result`), which pin
exact non-timing output for a fixed seed — both pass unchanged. Since
`web-time` re-exports `std::time::Instant` byte-for-byte on native targets,
this is a structural guarantee, not just an empirical one.

## Real WASM runtime verification

`embed_pipeline_v2_json` (PR #220) doesn't exist on this branch yet, so
verification used a **local-only, unpushed** worktree merging this branch's
commit with PR #220's head (`5ea662a`) — the merge commit and worktree were
discarded after verification; this PR's own commits contain only the clock fix.

- `wasm-pack build crates/chematic-wasm --target nodejs --out-dir pkg-node --release`:
  builds clean. Real pipeline calls that previously trapped
  (`RuntimeError: unreachable`) now return real success/typed-failure envelopes:
  decane success (10 atoms, all-finite coords), ring-torsion fail-closed typed
  failure (`stage: "torsion_optimization"`, `cause.kind:
  "ring_torsion_application_unsupported"`), all 4 finite/count/order fixtures,
  all 8 cross-binding parity fixtures (structural fields — coords length, stereo
  counts, force-field actual/fallback, `finalValidation.sound` — matched;
  timing excluded).
- `wasm-pack build crates/chematic-wasm --target web --out-dir pkg-web --release`,
  loaded via `initSync` over the raw `.wasm` bytes in Node (bypassing
  `fetch`/browser): same success path works identically — this is the exact
  target both `publish-npm.yml` and `pages.yml` build.
- Timeout behavior: `embedTimeoutMs`/`totalTimeoutMs: null` succeed; a present
  large timeout (60000ms) succeeds; `totalTimeoutMs: 0` fails closed with a typed
  `cause.kind: "timeout"` and **no** `result` key (no partial coords as success)
  — on both targets.
- Malformed-config / oversized-input rejection (already unaffected by #219,
  since it's rejected before any `Instant::now()` call) reconfirmed unaffected.

## Local gate

- `cargo fmt --all -- --check`: clean
- `cargo clippy -p chematic-3d --all-targets -- -D warnings`: clean
- `cargo check -p chematic-3d --target wasm32-unknown-unknown`: clean
- `bash scripts/check.sh`: **All checks passed.** (pre-existing, unrelated
  `zune-core`/`zune-jpeg` duplicate-dependency warnings only, same as every
  other recent PR)

## Known residual

- Issue **#221** (chematic-smarts MCS conditional trap) — filed, not fixed here.
- This PR alone changes nothing user-visible: `embed_pipeline_v2_json` isn't on
  `main` yet (still PR #220). The practical unblock only lands once #220 rebases
  onto this fix and flips its Node test assertions from trap-expecting to
  real-success-expecting (Phase 1, separate PR, not started here).

## Merge recommendation

Ready to merge on its own — self-contained, zero behavior change to anything
currently shipped in `chematic-3d` except making a previously-impossible WASM
code path actually work. Once merged, PR #220 should rebase onto the resulting
`main` (`--force-with-lease` against its current head `5ea662a`, not plain
`--force`) to pick this up.