### PR TITLE
fix(smarts): WASM-portable monotonic clock for MCS timeout path (Refs #221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,10 +113,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   force-field logic. Verified end-to-end (both `wasm-pack --target nodejs` and
   `--target web` artifacts, real success + typed-timeout paths, no partial-coords-as-
   success) via a local, unpushed integration of PR #220's head, since #220 itself
-  isn't merged yet. A related but distinct conditional trap in `chematic-smarts`'s MCS
-  timeout path (already reachable from the shipped `mcs_smiles_json_with_ring_config`
-  export) was found during the call-site audit and filed separately as issue #221
-  rather than folded into this fix (different crate, different root cause).
+  wasn't merged yet at the time. A related but distinct conditional trap in
+  `chematic-smarts`'s MCS timeout path was found during the call-site audit and
+  filed separately as issue #221 rather than folded into this fix (different
+  crate, different root cause) — see below.
+
+### Fixed — `chematic-smarts`
+
+- **`find_mcs_with_config`'s timeout path traps under real `wasm32-unknown-unknown`**
+  (issue #221, same underlying mechanism as #219 above, independently fixed here
+  since `chematic-3d` depends on `chematic-smarts`, not the other way around).
+  4 conditional `Instant::now()` calls in `mcs.rs`'s deadline check — only
+  reached when `McsConfig::timeout_ms` is `Some`. Correction to #219's own
+  changelog entry above: at the time that entry was written, no WASM export
+  actually plumbed a `timeout_ms` through to JS (`mcs_smiles_json_with_ring_config`
+  always used `McsConfig::default()`, i.e. `timeout_ms: None`) — so this trap was
+  latent, not already reachable in production, same as #219 was before PR #220's
+  binding shipped. Fixed via the identical `crate::clock` pattern (own module,
+  own `web-time` target-specific dependency — `chematic-smarts` can't reuse
+  `chematic-3d`'s module directly, the dependency direction runs the other way).
+  No algorithm change; `test_timeout_does_not_panic` (native, `timeout_ms: Some(1)`)
+  continues to pass unchanged.
 
 _Nothing else yet — everything below `[0.8.1]` has shipped._
 

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -20,6 +20,12 @@ chematic-core = { path = "../chematic-core", version = "0.8.1" }
 chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
 rustc-hash = "2"
 
+# std::time::Instant panics on wasm32-unknown-unknown (issue #221); web-time
+# is a drop-in Instant replacement backed by Performance.now() there, and
+# re-exports std::time::Instant everywhere else -- see src/clock.rs.
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+web-time = "1"
+
 [dev-dependencies]
 chematic-smiles = { path = "../chematic-smiles" }
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-smarts/src/clock.rs
+++ b/crates/chematic-smarts/src/clock.rs
@@ -1,0 +1,16 @@
+//! Monotonic clock, portable across native and `wasm32-unknown-unknown`.
+//!
+//! `std::time::Instant::now()` panics with "time not implemented on this
+//! platform" under real `wasm32-unknown-unknown` (no host time source) --
+//! see <https://github.com/kent-tokyo/chematic/issues/221> (same underlying
+//! trap as chematic-3d's <https://github.com/kent-tokyo/chematic/issues/219>,
+//! independently fixed here since chematic-3d depends on this crate, not the
+//! other way around). `web_time::Instant` is API-compatible and backed by
+//! `Performance.now()` there, while transparently re-exporting
+//! `std::time::Instant` everywhere else.
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub(crate) use web_time::Instant;
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+pub(crate) use std::time::Instant;

--- a/crates/chematic-smarts/src/lib.rs
+++ b/crates/chematic-smarts/src/lib.rs
@@ -8,6 +8,7 @@
 #![forbid(unsafe_code)]
 
 pub mod cache;
+pub(crate) mod clock;
 pub mod cx;
 pub mod match_vf2;
 pub mod mcs;

--- a/crates/chematic-smarts/src/mcs.rs
+++ b/crates/chematic-smarts/src/mcs.rs
@@ -7,11 +7,11 @@
 //! bound on reachable size is no better than the current best.
 
 use std::collections::HashMap;
-use std::time::Instant;
 
 use chematic_core::{AtomIdx, BondOrder, Molecule};
 use chematic_perception::{RingSet, find_sssr};
 
+use crate::clock::Instant;
 use crate::query::{AtomPrimitive, AtomQuery, BondPrimitive, BondQuery, QueryMolecule};
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs #221

## Root cause

`chematic-smarts/src/mcs.rs`'s `find_mcs_with_config` computes a deadline (`Instant::now() + Duration::from_millis(timeout_ms)`) and checks it at 3 further points during search — 4 `Instant::now()` calls total, all conditional on `McsConfig::timeout_ms` being `Some`. `std::time::Instant::now()` panics under real `wasm32-unknown-unknown` (no host time source), same underlying mechanism as issue #219 (chematic-3d, fixed in #222).

**Correction to #219's own CHANGELOG entry**: while auditing this during #219/#222, I stated this was "already reachable from the shipped `mcs_smiles_json_with_ring_config` export." That was wrong — checked again while writing this PR: that function always constructs `McsConfig { ring_matches_ring_only, complete_rings_only, ..McsConfig::default() }`, and `McsConfig::default()` sets `timeout_ms: None`. **No WASM export today threads a caller-supplied `timeout_ms` through to `find_mcs`/`find_mcs_with_config` at all.** So this trap is latent — the same "nothing has ever exercised this path yet" situation #219 was in before PR #220 shipped a binding that could reach it — not an active production bug. I've corrected the #219 CHANGELOG entry's wording in this PR (see below) since it's factually wrong as written on `main`.

## Fix

Same pattern as #219/#222, in its own module since `chematic-3d` depends on `chematic-smarts` (not the reverse — the two crates can't share one `clock` module):

```rust
// crates/chematic-smarts/src/clock.rs
#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
pub(crate) use web_time::Instant;

#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
pub(crate) use std::time::Instant;
```

`web-time = "1"` added as a `[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]` entry in `chematic-smarts/Cargo.toml` (zero cost to native builds). `mcs.rs`'s `use std::time::Instant;` swapped to `use crate::clock::Instant;`. No algorithm change.

## Verification

- `cargo test -p chematic-smarts --lib --quiet`: **169 passed, 0 failed, 0 ignored**. Includes the existing `test_timeout_does_not_panic` (`timeout_ms: Some(1)`), which already exercises the exact deadline-check code path this fix touches on native — passes unchanged (`web-time` re-exports `std::time::Instant` verbatim on native, so this is structural, not just empirical).
- `cargo check -p chematic-smarts --target wasm32-unknown-unknown`: clean.
- `cargo clippy -p chematic-smarts --all-targets -- -D warnings`, `cargo fmt --all --check`: clean.
- `bash scripts/check.sh`: all checks passed.
- No new WASM-level regression test added: since no public WASM export can reach this code path with a timeout set today (see correction above), there is nothing to exercise at the binding layer without adding new API surface, which is out of scope for a clock-only fix. If/when a future WASM export exposes MCS `timeout_ms`, it inherits this fix automatically.

## Changed files

- `crates/chematic-smarts/src/clock.rs` (new)
- `crates/chematic-smarts/src/lib.rs`: register the module
- `crates/chematic-smarts/src/mcs.rs`: swap the `Instant` import
- `crates/chematic-smarts/Cargo.toml`: target-specific `web-time` dependency
- `CHANGELOG.md`: new `### Fixed — chematic-smarts` entry; corrects the inaccurate "already reachable" claim in #219's own entry

## Known residuals

None — this closes out the full call-site audit from #219/#222 (the only other non-`chematic-3d` hit found repo-wide).

## Merge recommendation

Ready to merge — self-contained, zero behavior change, corrects a factual error already on `main`.