### PR TITLE
chore(release): v0.9.0 — pipeline v2 (Python/WASM) + WASM clock portability fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet — everything below `[0.9.0]` has shipped._
+
+## [0.9.0] — 2026-08-01
+
 ### Added — `chematic-py`
 
 - **`Mol.embed_pipeline_v2(config)`**: Python binding for the Rust-only
@@ -134,6 +138,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `chematic-3d`'s module directly, the dependency direction runs the other way).
   No algorithm change; `test_timeout_does_not_panic` (native, `timeout_ms: Some(1)`)
   continues to pass unchanged.
+
+### Migration notes
+
+- **`generate_and_minimize_uff()` is `#[deprecated]` but not removed and not
+  behavior-changed** — it still resolves to the same generic, untyped
+  element-pair-parameterized minimizer it always has. Nothing breaks; the
+  deprecation warning is a nudge toward `generate_and_minimize_dreiding()`
+  (same behavior, honest name) or `chematic_ff::uff::{assign_uff_types,
+  minimize_uff}` (real UFF), not a behavior change to migrate away from.
+- **`Mol.embed_pipeline_v2()` (Python) and `embed_pipeline_v2_json()` (WASM)
+  are new, additive, opt-in APIs.** No existing default 3D API
+  (`generate_coords`, `etkdg`, `generate_and_minimize_dreiding`, the existing
+  WASM 3D exports, etc.) changed behavior in this release. Pipeline v2 is not
+  a default and does not need to be adopted.
+- **Partial coordinates on pipeline v2 failure are diagnostic-only, never a
+  usable result.** `PipelineV2Error.diagnostics["last_known_coords"]`
+  (Python) / `error.lastKnownCoords` (WASM) are explicitly flagged
+  (`coords_are_diagnostic_only` / `coordsAreDiagnosticOnly: true`) and must
+  not be treated as a successful embedding.
+  - Same JSON envelope: check `ok`/ the exception type before touching
+    `result`, never assume a `coords` field is present on failure.
+- **The `chematic-3d`/`chematic-smarts` clock-portability fixes (#219, #221)
+  change only the *source* of monotonic timestamps** (`web_time::Instant` on
+  `wasm32-unknown-unknown`, `std::time::Instant` — identical to before —
+  everywhere else). No timeout threshold, stage-timing field name/unit, or
+  chemistry/geometry/torsion/force-field calculation changed. Native builds
+  are unaffected structurally, not just by measurement (`web-time`
+  re-exports `std::time::Instant` verbatim off-wasm).
+- **No change to CIP, E/Z, ECFP4, or the RDKit benchmark** in this release —
+  those remain exactly as measured in `[0.8.1]` and earlier.
+- The `canonical_smiles()` explicit/implicit-hydrogen migration note from
+  `[0.8.1]` below still applies as written; it is not superseded by anything
+  in this release.
 
 _Nothing else yet — everything below `[0.8.1]` has shipped._
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,5 +23,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.8.1
+version: 0.9.0
 date-released: "2026-07-29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.8.1
+# chematic v0.9.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-07-17, v0.4.29 vs RDKit 2026.03.3 --
@@ -409,13 +409,20 @@ See the [full WASM API reference](https://kent-tokyo.github.io/chematic/) for al
 | `chematic`            | Umbrella crate with feature flags (all sub-crates, incl. `iupac`, `inchi`)                              | 1     |
 
 ```
-cargo test --workspace --lib --quiet                                          # 2,812 tests, all passing (2026-07-27)
+cargo test --workspace --lib --quiet                                          # 3,207 tests, all passing (2026-08-01)
 cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +16 IUPAC-exact InChI tests
 ```
 
 ---
 
 ## Recent Development
+
+**v0.9.0** (2026-08-01): **Opt-in 3D embedding pipeline v2 in Python + WASM, WASM-portable monotonic clock**
+- `chematic-py`: `Mol.embed_pipeline_v2(config)` — Python binding for the Rust-only `pipeline_v2::embed_pipeline_v2` (torsion-knowledge-aware distance geometry + stereo verification/repair + policy-gated force field), returning full per-stage evidence (never just final coordinates) and a typed `PipelineV2Error` with structured, diagnostic-only partial evidence on failure. Applies directly to the caller's own atom order — no canonicalize/reparse. Additive; no existing default 3D API changed
+- `chematic-wasm`: `embed_pipeline_v2_json(mol, configJson)` — WASM mirror of the above, same config/evidence shape as a tagged-union JSON envelope. New CI job builds both `wasm-pack` targets (`nodejs`/`web`) and runs the Node integration suite on every push/PR — this repo had zero WASM-runtime CI coverage before this
+- `chematic-3d`/`chematic-smarts`: fixed `std::time::Instant::now()` panicking unconditionally under real `wasm32-unknown-unknown` (issues #219, #221) — the pipeline v2 binding's own first real-runtime run is what surfaced this pre-existing gap. Fixed via a small crate-internal `clock` module (`web_time::Instant` on wasm32, `std::time::Instant` elsewhere) in each affected crate; no chemistry/geometry/torsion/force-field or timeout-contract change
+- `chematic-3d`: `generate_and_minimize_uff()` deprecated (issue #204) — it never ran chematic-ff's real UFF despite its name; kept, not removed, not behavior-changed
+- Full details in `CHANGELOG.md`'s `[0.9.0]` section
 
 **v0.8.1** (2026-07-30): **`canonical_smiles()` explicit/implicit hydrogen-count correctness fix**
 - `chematic-smiles`/`chematic-core`: two representations of the same molecule that differ only in whether an atom's H count came from bracket notation (`[Cl]`) or organic-subset notation (`Cl`) — when the explicit value merely repeats what valence inference gives anyway — now canonicalize identically; `initial_invariant`'s Morgan-rank seed and the canonical writer's bracket-necessity check previously read the raw `hydrogen_count` field directly instead of the crate's own `implicit_hcount()` unifier. Isotope, charge, real stereochemistry, and any genuinely disambiguating explicit H count remain fully distinguishing — only the redundant case is unified. Found via [kent-tokyo/renkin PR #65](https://github.com/kent-tokyo/renkin/pull/65) (a `run_reactants` product from a bracket-notation SMIRKS template diverging from a directly user-typed SMILES of the identical compound). Some canonical SMILES output strings for existing inputs will change as a direct, intended consequence — see `CHANGELOG.md`'s `[0.8.1]` Migration notes if you depend on exact string stability across versions
@@ -593,7 +600,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v0.8.1)
+├── Cargo.toml                    workspace root (v0.9.0)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)
@@ -646,7 +653,7 @@ If you use chematic in academic or research work, please cite:
   author    = {kent-tokyo},
   title     = {chematic: A pure-Rust cheminformatics toolkit},
   url       = {https://github.com/kent-tokyo/chematic},
-  version   = {0.8.1},
+  version   = {0.9.0},
   year      = {2026},
 }
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -106,7 +106,7 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.8.1
+# chematic v0.9.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-06, v0.4.22 vs RDKit 2026.03.3 --

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.8.1 | Yes | Current release — active support |
+| v0.9.0 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.8.1) receives all security updates.  
+**Active Support**: Latest release (v0.9.0) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -16,12 +16,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.8.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.8.1" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.8.1" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.8.1" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.8.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.9.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.9.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.9.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.9.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.9.0" }
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #219); web-time
 # is a drop-in Instant replacement backed by Performance.now() there, and

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -16,14 +16,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.8.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.9.0" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.8.1" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.8.1" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.8.1" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.8.1" }
-chematic-cip        = { path = "../chematic-cip",        version = "0.8.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.9.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.9.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.9.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.9.0" }
+chematic-cip        = { path = "../chematic-cip",        version = "0.9.0" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.8.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.9.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -22,10 +22,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.8.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.8.1" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.8.1" }
+chematic-core = { path = "../chematic-core", version = "0.9.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.9.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.9.0" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.8.1" }
+chematic-core = { path = "../chematic-core", version = "0.9.0" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.8.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.9.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -22,13 +22,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.8.1" }
+chematic-core = { path = "../chematic-core", version = "0.9.0" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.8.1" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.8.1" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.8.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.9.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.9.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.9.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -18,10 +18,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.8.1", path = "../chematic-core" }
-chematic-smiles = { version = "0.8.1", path = "../chematic-smiles" }
-chematic-chem = { version = "0.8.1", path = "../chematic-chem" }
-chematic-rxn = { version = "0.8.1", path = "../chematic-rxn" }
+chematic-core = { version = "0.9.0", path = "../chematic-core" }
+chematic-smiles = { version = "0.9.0", path = "../chematic-smiles" }
+chematic-chem = { version = "0.9.0", path = "../chematic-chem" }
+chematic-rxn = { version = "0.9.0", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.8.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.9.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -17,15 +17,15 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.8.1" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.8.1" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.8.1", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.8.1" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.8.1" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.8.1" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.8.1" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.8.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.9.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.9.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.9.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.9.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.9.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.9.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.9.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.9.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
 
 [dev-dependencies]
 # Real JSON Schema 2020-12 validator, used only in tests to independently

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -16,10 +16,10 @@ documentation = "https://docs.rs/chematic-mol"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.8.1" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.8.1" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.8.1" }
-chematic-smiles      = { path = "../chematic-smiles",      version = "0.8.1" }
+chematic-core        = { path = "../chematic-core",        version = "0.9.0" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.9.0" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.9.0" }
+chematic-smiles      = { path = "../chematic-smiles",      version = "0.9.0" }
 serde_json           = "1.0"
 
 [dev-dependencies]

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.8.1" }
+chematic-core = { path = "../chematic-core", version = "0.9.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,16 +25,16 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.8.1" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.8.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.8.1" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.8.1" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.8.1", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.8.1" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.8.1" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.8.1" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.8.1" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.8.1" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.8.1" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.8.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.9.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.9.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.9.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.9.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.9.0", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.9.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.9.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.9.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.9.0" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.9.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.9.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.9.0" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -22,9 +22,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 perf-instrumentation = []
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.8.1" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.8.1" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.8.1" }
+chematic-core   = { path = "../chematic-core",   version = "0.9.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.9.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.9.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.8.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
+chematic-core = { path = "../chematic-core", version = "0.9.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
 rustc-hash = "2"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #221); web-time

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.8.1" }
+chematic-core = { path = "../chematic-core", version = "0.9.0" }
 
 [features]
 # Feature-gated internal work counters for the orbit-pruning canonical

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -26,16 +26,16 @@ wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["console"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.8.1" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.8.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.8.1" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.8.1", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.8.1" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.8.1", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.8.1" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.8.1" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.8.1" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.8.1" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.8.1" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.8.1" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.8.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.9.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.9.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.9.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.9.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.9.0", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.9.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.9.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.9.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.9.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.9.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.9.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.9.0" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -33,15 +33,15 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.8.1", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.8.1", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.8.1", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.8.1", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.8.1", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.8.1", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.8.1", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.8.1", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.8.1", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.8.1", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.8.1", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.8.1", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.9.0", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.9.0", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.9.0", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.9.0", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.9.0", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.9.0", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.9.0", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.9.0", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.9.0", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.9.0", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.9.0", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.9.0", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Minor feature release: 0.8.1 → 0.9.0. Bundles PR #213/#214/#215/#217/#218 (already on `main`) plus the three PRs merged in this program's most recent phase: #222 (issue #219 fix), #220 (WASM `embed_pipeline_v2_json` binding), #223 (issue #221 fix). No ETKDGv3 benchmark, E/Z, CIP-default, or ECFP4-API-unification work is included — those proceed against this release as a frozen baseline, per plan.

## Headline changes

- **`chematic-py`**: `Mol.embed_pipeline_v2(config)` + `PipelineV2Config` + structured `PipelineV2Error.diagnostics` — opt-in torsion-knowledge-aware 3D embedding pipeline, full per-stage evidence, diagnostic-only partial coordinates on failure.
- **`chematic-wasm`**: `embed_pipeline_v2_json(mol, configJson)` — WASM mirror of the above (tagged-union JSON envelope). Verified end-to-end under both `wasm-pack --target nodejs` and `--target web` (the latter is what `publish-npm.yml`/`pages.yml` actually ship). New `test-wasm` CI job — this repo had zero WASM-runtime CI coverage before it.
- **`chematic-3d`/`chematic-smarts`**: WASM-portable monotonic clock (issues #219, #221) — `std::time::Instant::now()` panicked unconditionally under real `wasm32-unknown-unknown`; fixed via a small crate-internal `clock` module in each affected crate (`web_time::Instant` on wasm32, `std::time::Instant` elsewhere). No chemistry/geometry/torsion/force-field or timeout-contract change.
- **`chematic-3d`**: `generate_and_minimize_uff()` deprecated (issue #204) — never ran real UFF despite its name; kept, not removed, not behavior-changed.
- Parallel-worktree `git stash` ban documented in `AGENTS.md` (#218, docs-only).

**Not claimed**: RDKit ETKDGv3 parity/superiority, fully-portable WASM API surface, cross-target bit-exact coordinates, or pipeline v2 becoming a default. Pipeline v2 is explicit opt-in everywhere (Rust/Python/WASM).

## Version changes

- `Cargo.toml` `workspace.package.version`: `0.8.1` → `0.9.0`
- `scripts/bump_version.py --old 0.8.1` propagated to: `README.md`, `README_ja.md`, `CITATION.cff`, `SECURITY.md`, `demo/pkg/package.json`, and all 18 crates' intra-workspace path-dependency version pins in their `Cargo.toml`s.
- **Full repo-wide audit** of every remaining `0.8.1` string post-bump: 4 hits, all in `README.md`/`CHANGELOG.md`'s own historical `[0.8.1]` entries (describing what that release actually shipped — correctly left untouched, not a stale "current version" claim). No gaps found.
- `Cargo.lock` is gitignored in this repo (library workspace convention) — not applicable.
- Test count in `README.md` refreshed: 2,812 → **3,207** tests, all passing (fresh measurement on this branch, not carried over).
- **Known pre-existing residual, not fixed here** (out of scope for a version-bump PR): `README.md`'s crate-summary table still says `chematic-wasm` is "published `0.7.0`" on npm — checked against the actual registry (`npm view @kent-tokyo/chematic version` → `0.8.1`), so that claim was already stale before this release. Left as-is; the real "published X" values should be corrected as part of the actual publish step for this release, not pre-emptively bumped to `0.9.0` here before publishing has happened. Also noted: `README_ja.md`'s own "Recent Development" section lags 3 versions behind the English `README.md` (last per-version entry is v0.7.1) — pre-existing translation-maintenance backlog, not touched in this PR (would be a large, separate task).

## CHANGELOG summary

- `[Unreleased]` → `[0.9.0] — 2026-08-01`; fresh empty `[Unreleased]` added on top.
- New `### Migration notes` section under `[0.9.0]`: `generate_and_minimize_uff` deprecation is non-breaking; Python/WASM pipeline v2 are additive-only; no default 3D API changed; partial coordinates on failure are diagnostic-only; the clock-portability fixes change only the timestamp *source*, not chemistry/geometry/timeout contracts; no change to CIP/E-Z/ECFP4/RDKit-benchmark numbers; the `[0.8.1]` canonical-SMILES migration note still applies unmodified.

## Publish order (unchanged from `scripts/check.sh`'s dependency-graph derivation)

```
chematic-core → chematic-perception → chematic-cip → chematic-smarts → chematic-smiles →
chematic-rxn → chematic-fp → chematic-iupac → chematic-chem → chematic-ff → chematic-3d →
chematic-depict → chematic-inchi → chematic-mol → chematic → chematic-ewald → chematic-mcp →
chematic-wasm
```
(18 publishable crates.)

## Rust dry-run result

- `cargo publish --dry-run -p chematic-core --allow-dirty`: **succeeds** (no workspace deps to resolve against the registry).
- All 17 downstream crates' dry-runs **fail** with `failed to select a version for the requirement "chematic-core = ^0.9.0"` — **expected**, not a real problem: `cargo publish --dry-run` resolves path-dependencies against the *live* registry, which doesn't have `0.9.0` yet for any crate. This is inherent to batch-dry-running an interdependent workspace before any real publish (every past release, e.g. v0.8.0/v0.8.1, would show the identical pattern) — the actual verification for local correctness is `cargo check --workspace`/`cargo test --workspace` (path-based, both clean — see below), and `cargo package --list -p <crate>` for packaging sanity (also clean, see below). Real sequential publishing (each crate really goes live before the next dry-run/publish) is how this resolves in practice, same as documented for the v0.8.0 release.
- `cargo package --list` for all 18 crates: **no stray fixtures/build artifacts** in any package (checked for `pkg-node`/`pkg-web`/`target/`/`*.wasm`/`validation/results`/scratch paths — none found).

## Python wheel result

- Clean venv (fresh `python3 -m venv`), `maturin build --release -m crates/chematic-py/Cargo.toml` → `chematic-0.9.0-cp313-cp313-macosx_11_0_arm64.whl`.
- `pip install` into the clean venv → `chematic.__version__` == `0.9.0`.
- `pytest crates/chematic-py/tests/ -q` against the installed wheel: **500 passed, 72 skipped, 0 failed**.
- Explicit `Mol.embed_pipeline_v2()` smoke: decane success (10 finite coords) + ring-torsion fail-closed typed `PipelineV2Error` — both confirmed against the release wheel.

## WASM package result

- `wasm-pack build --target nodejs --out-dir pkg-node --release`: clean; generated `package.json` version == `0.9.0`.
- All 5 `crates/chematic-wasm/tests/*.test.mjs` (excluding the web-target-specific one) run clean against the fresh nodejs build.
- `wasm-pack build --target web --out-dir pkg-web --release`: clean; generated `package.json` version == `0.9.0`.
- `pipeline_v2_web_target.test.mjs` (loads the raw `--target web` artifact via `initSync`): decane success + typed timeout, both real, no trap.
- `embed_pipeline_v2_json` confirmed present in generated `pkg-node/chematic_wasm.d.ts`.
- MCS timeout smoke: no new WASM-level test added — confirmed during #221's own PR that no shipped WASM export threads `timeout_ms` through to `find_mcs`/`find_mcs_with_config` today (`mcs_smiles_json_with_ring_config` always uses `McsConfig::default()`), so there's no existing binding-level path to exercise; native `test_timeout_does_not_panic` covers the fixed code path directly.

## Version consistency result

- `bash scripts/check.sh` → **"Version consistent: 0.9.0"**, publish graph OK, advisories/bans/licenses/sources OK.
- Rust workspace version, Python wheel version (`chematic.__version__`), and both WASM package.json versions (`nodejs`/`web`) all independently confirmed as `0.9.0`.

## Local gate

- `cargo fmt --all -- --check`: clean.
- `cargo check --workspace`: clean (note: plain `cargo build --workspace` fails to *link* `chematic-py` — pre-existing, expected PyO3-without-`libpython`-linkage behavior on this build, unrelated to this change; `cargo check`/`maturin build` are the crate's actual supported build paths, per `CLAUDE.md`).
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo test --workspace --lib --quiet`: **3,207 passed, 0 failed** (7 pre-existing `#[ignore]`d tests not counted, unrelated to this release).
- `bash scripts/check.sh`: all checks passed.

## CI status

Triggered on push; not yet independently re-confirmed green at time of writing (Rust Criterion regression gate in particular takes ~20-25 min based on the last three PRs in this program — will need a follow-up check before merge).

## Known residuals

- Stale npm-published-version claim in `README.md`'s crate table (`0.7.0` vs. actual live `0.8.1`) — pre-existing, not fixed here; correct as part of the real publish step.
- `README_ja.md`'s Recent Development section lags 3 versions behind — pre-existing translation backlog, not fixed here.
- Issues #219 and #221 need manual `gh issue close`/comment — this environment denies `gh issue comment`/`gh issue close` for me (same restriction as issues #200/#204 earlier in this program); `gh pr` operations are unaffected.
- ETKDGv3 benchmark, E/Z abstain audit, CIP-default decision, ECFP4 API unification: **not started**, per plan — this release is meant to be their frozen baseline.

## Public API impact

Additive only: `Mol.embed_pipeline_v2()`/`PipelineV2Config`/`PipelineV2Error` (Python), `embed_pipeline_v2_json` (WASM), one new `#[deprecated]` attribute (`generate_and_minimize_uff`, still callable, unchanged behavior). No existing default API's behavior changed.

## Release operations

This PR is opened **Ready, not merged**. Per instructions: I will not merge, tag, or publish. Once this PR is approved and merged, the next step is to resolve `main`'s exact merge commit SHA and create the annotated `v0.9.0` tag against **that commit only** (this repo's `vX.Y.Z` tag push triggers the GitHub Release workflow that generates release notes and creates the GitHub Release — tagging before merge or against a different commit would misfire that automation).
