### PR TITLE
chore(release): bump version to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet — everything below `[0.10.0]` has shipped._
+
+## [0.10.0] — 2026-08-01
+
 ### Added — `chematic-rxn`
 
 - **`find_reaction_matches`/`apply_reaction_match`** (issue #225): a public
@@ -34,6 +38,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `coords_2d` but never converted into `Atom.chirality` or a bond's
   E/Z direction — `parse_mrv` silently dropped stereochemistry that was
   present in the file.
+
+### Fixed — `chematic-smiles`
+
+- **Shared E/Z carrier bonds: joint component solver** (issue #149) —
+  replaces the old single-end abstain guard in `resolve_ez_markers` with
+  `resolve_component_jointly`, which resolves coupled stereo-alkene ends
+  (two double bonds sharing one marker-carrier bond) together instead of
+  independently. **10 of the 18 issue #149 fixtures become fully
+  permutation-invariant** (idempotent under re-canonicalization, stable
+  under relabeling/reordering, RDKit-verified 0 stereo loss/corruption);
+  the other 8 remain a documented, semantically-safe residual
+  (`EZ_SHARED_CARRIER_RING_CONSTRAINED_RESIDUALS`) — every one of the 8
+  is a coupled component containing an endocyclic double bond in a 5- or
+  6-membered ring, where marker choice has no free degree left; RDKit
+  re-parse confirms every divergent spelling is stereochemically
+  identical, never corrupted. Full-corpus random-relabeling-only Check-2
+  failures: 18 → 8. **Issue #149 stays open** — the ring-constrained
+  residual's root cause (`compute_stereo_alkene_ends` has no ring-size
+  gate) is characterized in a follow-up audit
+  (`docs/ez_ring_constrained_residual_audit.md`) but not yet fixed.
+
+### Migration notes
+
+- **`parse_mrv` (issue #202) now returns stereochemistry it previously
+  silently discarded.** An MRV file that carries wedge/hash bonds or
+  double-bond 2D geometry will parse to a `Molecule` with `Atom.chirality`
+  set and/or E/Z bond direction set where it previously parsed to a flat
+  (stereo-unset) molecule at the same input. If downstream code compares
+  MRV-derived molecules against a cached/precomputed canonical SMILES,
+  InChI, or fingerprint that was computed from the old (stereo-dropped)
+  parse, that comparison can now diverge — the new value is the more
+  correct one. No change to any other reader (`mol2000.rs`/`cdxml.rs`
+  already perceived this).
+- **A small number of `canonical_smiles()` outputs change** as a
+  consequence of the issue #149 joint component solver — measured at
+  exactly 6 changed lines across a 5,000-molecule corpus, all within the
+  18 pinned issue #149 fixtures (10 newly converge; 8 remain the
+  documented residual, unchanged from `[0.9.0]` and earlier). Same class
+  of change as the `[0.8.1]` explicit/implicit-hydrogen migration note
+  below — if you hardcode/cache canonical SMILES strings, a rare input
+  may now produce a different (but RDKit-verified semantically identical)
+  string.
+- No change to CIP, ECFP4, or the RDKit benchmark in this release.
 
 ## [0.9.0] — 2026-08-01
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,5 +23,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.9.0
+version: 0.10.0
 date-released: "2026-07-29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.9.0
+# chematic v0.10.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-07-17, v0.4.29 vs RDKit 2026.03.3 --
@@ -401,7 +401,7 @@ See the [full WASM API reference](https://kent-tokyo.github.io/chematic/) for al
 | `chematic-rxn`        | Reaction SMILES/SMIRKS, `run_reactants`/`run_reactants_strict`; **`retro_disconnect()`** — 60 retro-SMIRKS templates (AmideBond/Ester/Ether/CNBond/CCBond/CSBond) + SA Score ranking; **parity-aware `@`/`@@` SMIRKS stereo filtering**; **E/Z double-bond stereo filtering** in `run_reactants` (`ez_stereo_outward`, `smirks_ez_stereo_ok`) | 137    |
 | `chematic-inchi`      | InChI/InChIKey: pure-Rust approximation (WASM) **+ IUPAC-standard** via `native-inchi` feature (vendored C lib 1.07.5, bit-exact); **parse_inchi** reader; **verified canonical-SMILES dedup** (`dedup::{group_candidates, deduplicate_verified}`, fail-closed on legacy-CIP-unresolved specified tetrahedral stereo); **accurate-CIP dedup preflight** (issue #161) recovering verified-comparison capability on legacy-CIP-unresolved stereocentres; **indexed graph relation API** (`compare_indexed_graph_relation`, orthogonal `GraphStrictness`/`AtomMapPolicy` axes) | 108 (+16*)    |
 | `chematic-cip`        | Opt-in accurate CIP engine (`assign_cip_accurate_experimental`, hierarchical digraph, Rules 1a/1b/2/4b/5, RDKit-compatible MANCUDE fractional atomic numbers) — the default `assign_cip()`/`CipMode::LegacyFast` is unchanged | —     |
-| `chematic-wasm`       | **131+ WASM exports** — npm: `@kent-tokyo/chematic` (published `0.7.0`, in sync with crates.io/PyPI); pKa/ADMET/BBB/Caco-2/hERG/CYP3A4; `smiles_to_pdbqt`, `minimize_uff_json`, **`retro_disconnect_json`** (issue #91) | 223   |
+| `chematic-wasm`       | **131+ WASM exports** — npm: `@kent-tokyo/chematic` (published in lockstep with crates.io/PyPI); pKa/ADMET/BBB/Caco-2/hERG/CYP3A4; `smiles_to_pdbqt`, `minimize_uff_json`, **`retro_disconnect_json`** (issue #91) | 223   |
 | `chematic-iupac`      | Local IUPAC name generation — **25+ compound classes**: alkanes, cycloalkanes, alkenes/alkynes, alcohols, amines, halides, aldehydes, ketones, acids, esters, amides, **piperidine, morpholine, piperazine, naphthalene, sulfides** | 47    |
 | `chematic-mcp`        | **MCP (Model Context Protocol) server** — AI agent integration; **20 tools**: parse_smiles, calc_properties, ecfp4, tanimoto, smarts_match, canonical_smiles, find_mcs, generate_3d, pains_check, brenk_check, sa_score, admet_profile, boiled_egg, lipinski_check, name_to_smiles, retrosynthesis, smiles_to_moljson, moljson_to_smiles, representation_router, **molecule_context_pack**; dual-era protocol (legacy `2024-11-05` + modern `2026-07-28` stateless dialect), `structuredContent`/`outputSchema` on all 20 tools | 82    |
 | `chematic-py`         | PyO3 Python bindings (`pip install chematic`); 300+ API endpoints: `from_smiles()`, `Mol.descriptors()`, `Mol.minimize_dreiding()`, `from_cxsmiles()`, `from_rxn_file()`/`to_rxn_file()`, `parse_sdf_with_coords()`, `Mol.ring_families()`, `tanimoto_matrix()`, `iter_sdf()`, `SimilarityIndex`; **`mol.to_pdf()`/`mol.to_eps()`** (depict); **`from_cjson()`/`mol.to_cjson()`** (ChemicalJSON); **`mol.schultz_mti`, `mol.gutman_mti`, `mol.vabc`, `mol.gravitational_index`**; **`bulk.substructure_match(smarts, mols)`** (parallel VF2 on pre-parsed Mol objects); **`mol.describe()`** (LLM/MCP-ready natural-language summary); **`mol.diff(other)`** (element + descriptor diff); Sprint 18–27 coverage | 300+  |
@@ -409,13 +409,19 @@ See the [full WASM API reference](https://kent-tokyo.github.io/chematic/) for al
 | `chematic`            | Umbrella crate with feature flags (all sub-crates, incl. `iupac`, `inchi`)                              | 1     |
 
 ```
-cargo test --workspace --lib --quiet                                          # 3,207 tests, all passing (2026-08-01)
+cargo test --workspace --lib --quiet                                          # 3,223 tests, all passing (2026-08-01)
 cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +16 IUPAC-exact InChI tests
 ```
 
 ---
 
 ## Recent Development
+
+**v0.10.0** (2026-08-01): **Match-level SMIRKS reaction application, MRV 2D stereo, shared E/Z carrier bond fix**
+- `chematic-rxn`: `find_reaction_matches`/`apply_reaction_match` (issue #225) — a public seam between enumerating a SMIRKS's matches against reactant molecules and applying one of them, for callers that need to accept some matches and reject others (e.g. based on whether the matched bond is a ring bond) without discarding the whole `run_reactants` call. `run_reactants`/`run_reactants_strict` are now implemented in terms of these two functions, unchanged in cost (still one SMIRKS parse + one VF2 match pass per call)
+- `chematic-mol`: MRV reader now perceives 2D wedge/hash tetrahedral and E/Z stereo (issue #202) — `parse_mrv` previously read wedge/dash bonds and 2D coordinates into `coords_2d` but never converted them into `Atom.chirality`/bond E/Z direction, silently dropping stereochemistry present in the file
+- `chematic-smiles`: shared E/Z carrier bonds now resolved via a joint component solver (issue #149) — 10 of 18 previously-abstained fixtures become fully permutation-invariant; the remaining 8 are a documented, RDKit-verified semantically-safe residual (endocyclic double bonds in 5-/6-membered rings, where marker choice has no free degree). Issue #149 stays open pending a scoped fix for the ring-constrained residual
+- Full details in `CHANGELOG.md`'s `[0.10.0]` section
 
 **v0.9.0** (2026-08-01): **Opt-in 3D embedding pipeline v2 in Python + WASM, WASM-portable monotonic clock**
 - `chematic-py`: `Mol.embed_pipeline_v2(config)` — Python binding for the Rust-only `pipeline_v2::embed_pipeline_v2` (torsion-knowledge-aware distance geometry + stereo verification/repair + policy-gated force field), returning full per-stage evidence (never just final coordinates) and a typed `PipelineV2Error` with structured, diagnostic-only partial evidence on failure. Applies directly to the caller's own atom order — no canonicalize/reparse. Additive; no existing default 3D API changed
@@ -600,7 +606,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v0.9.0)
+├── Cargo.toml                    workspace root (v0.10.0)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)
@@ -653,7 +659,7 @@ If you use chematic in academic or research work, please cite:
   author    = {kent-tokyo},
   title     = {chematic: A pure-Rust cheminformatics toolkit},
   url       = {https://github.com/kent-tokyo/chematic},
-  version   = {0.9.0},
+  version   = {0.10.0},
   year      = {2026},
 }
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -106,7 +106,7 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.9.0
+# chematic v0.10.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-06, v0.4.22 vs RDKit 2026.03.3 --

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.9.0 | Yes | Current release — active support |
+| v0.10.0 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.9.0) receives all security updates.  
+**Active Support**: Latest release (v0.10.0) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -16,12 +16,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.9.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.9.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.9.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.9.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.9.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.10.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.10.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.10.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.10.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.10.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.10.0" }
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #219); web-time
 # is a drop-in Instant replacement backed by Performance.now() there, and

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -16,14 +16,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.9.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.10.0" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.9.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.9.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.9.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.9.0" }
-chematic-cip        = { path = "../chematic-cip",        version = "0.9.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.10.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.10.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.10.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.10.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.10.0" }
+chematic-cip        = { path = "../chematic-cip",        version = "0.10.0" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.9.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.10.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.10.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -22,10 +22,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.9.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.9.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.9.0" }
+chematic-core = { path = "../chematic-core", version = "0.10.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.10.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.10.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.10.0" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.9.0" }
+chematic-core = { path = "../chematic-core", version = "0.10.0" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.9.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.10.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.10.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -22,13 +22,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.9.0" }
+chematic-core = { path = "../chematic-core", version = "0.10.0" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.9.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.9.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.9.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.10.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.10.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.10.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.10.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -18,10 +18,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.9.0", path = "../chematic-core" }
-chematic-smiles = { version = "0.9.0", path = "../chematic-smiles" }
-chematic-chem = { version = "0.9.0", path = "../chematic-chem" }
-chematic-rxn = { version = "0.9.0", path = "../chematic-rxn" }
+chematic-core = { version = "0.10.0", path = "../chematic-core" }
+chematic-smiles = { version = "0.10.0", path = "../chematic-smiles" }
+chematic-chem = { version = "0.10.0", path = "../chematic-chem" }
+chematic-rxn = { version = "0.10.0", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.9.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.10.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.10.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -17,15 +17,15 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.9.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.9.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.9.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.9.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.9.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.9.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.9.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.9.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.10.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.10.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.10.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.10.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.10.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.10.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.10.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.10.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.10.0" }
 
 [dev-dependencies]
 # Real JSON Schema 2020-12 validator, used only in tests to independently

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -16,10 +16,10 @@ documentation = "https://docs.rs/chematic-mol"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.9.0" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.9.0" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.9.0" }
-chematic-smiles      = { path = "../chematic-smiles",      version = "0.9.0" }
+chematic-core        = { path = "../chematic-core",        version = "0.10.0" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.10.0" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.10.0" }
+chematic-smiles      = { path = "../chematic-smiles",      version = "0.10.0" }
 serde_json           = "1.0"
 
 [dev-dependencies]

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.9.0" }
+chematic-core = { path = "../chematic-core", version = "0.10.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,16 +25,16 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.9.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.9.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.9.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.9.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.9.0", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.9.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.9.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.9.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.9.0" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.9.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.9.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.9.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.10.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.10.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.10.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.10.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.10.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.10.0", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.10.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.10.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.10.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.10.0" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.10.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.10.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.10.0" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -22,9 +22,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 perf-instrumentation = []
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.9.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.9.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.9.0" }
+chematic-core   = { path = "../chematic-core",   version = "0.10.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.10.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.10.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.9.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
+chematic-core = { path = "../chematic-core", version = "0.10.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.10.0" }
 rustc-hash = "2"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #221); web-time

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.9.0" }
+chematic-core = { path = "../chematic-core", version = "0.10.0" }
 
 [features]
 # Feature-gated internal work counters for the orbit-pruning canonical

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -26,16 +26,16 @@ wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["console"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.9.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.9.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.9.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.9.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.9.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.9.0", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.9.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.9.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.9.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.9.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.9.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.9.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.9.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.10.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.10.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.10.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.10.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.10.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.10.0", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.10.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.10.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.10.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.10.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.10.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.10.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.10.0" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -33,15 +33,15 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.9.0", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.9.0", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.9.0", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.9.0", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.9.0", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.9.0", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.9.0", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.9.0", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.9.0", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.9.0", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.9.0", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.9.0", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.10.0", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.10.0", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.10.0", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.10.0", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.10.0", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.10.0", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.10.0", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.10.0", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.10.0", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.10.0", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.10.0", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.10.0", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Minor feature release: `workspace.package.version` 0.9.0 → 0.10.0.

Refs #225, #202, #149.

## What's shipping

- **`chematic-rxn`** (issue #225): `find_reaction_matches`/`apply_reaction_match`/`ReactionMatch` — a public seam between enumerating a SMIRKS's matches and applying one of them, for callers that need to accept some matches and reject others without discarding a whole `run_reactants` call. `run_reactants`/`run_reactants_strict` are now implemented in terms of these two functions, unchanged in cost (still one SMIRKS parse + one VF2 match pass per call).
- **`chematic-mol`** (issue #202): `parse_mrv` now perceives 2D wedge/hash tetrahedral and E/Z stereo, mirroring `mol2000.rs`/`cdxml.rs`. Previously silently dropped.
- **`chematic-smiles`** (issue #149): joint component solver for shared E/Z carrier bonds. 10/18 pinned fixtures become fully permutation-invariant; the other 8 are a documented, RDKit-verified semantically-safe residual (endocyclic double bonds in 5-/6-membered rings). **Issue #149 stays open** — this release does not close it.

Full details in `CHANGELOG.md`'s `[0.10.0]` section, including a new Migration notes subsection (MRV stereo behavior change, small canonical-SMILES output diff class).

## Release mechanics

- `Cargo.toml`: `workspace.package.version` 0.9.0 → 0.10.0
- `python scripts/bump_version.py`: propagated across README/README_ja/CITATION.cff/SECURITY.md/demo/pkg/package.json/all 18 crates' intra-workspace path-dependency version pins
- `CHANGELOG.md`: `[Unreleased]` promoted to `[0.10.0]` — 2026-08-01, fresh empty `[Unreleased]` on top. Also added a `chematic-smiles` entry for PR #229/issue #149 that had **no CHANGELOG entry at all** pre-release (found during this release prep, not part of #229 itself) — that PR's own diff never touched `CHANGELOG.md`.
- `README.md`: new v0.10.0 Recent Development entry, refreshed test count (3,207 → 3,223 — chematic-py, cdylib-only with 0 Rust `#[test]` functions, excluded from the count both before and after, so this is a like-for-like comparison), fixed a stale npm-version claim ("published `0.7.0`, in sync with crates.io/PyPI" — actually 0.9.0 at commit time, checked live against npm/PyPI/crates.io) to a version-free "published in lockstep with crates.io/PyPI" so it can't silently drift out of sync on a future release again.

Full repo-wide audit of remaining `0.9.0` strings post-bump: only 3 hits left, all in `CHANGELOG.md`/`README.md`'s own `[0.9.0]`/v0.9.0 historical entries (correctly untouched — they describe what that release shipped, not a current-version claim).

## Local gate (fresh)

- `cargo test --workspace --lib --quiet` (excl. `chematic-py`, cdylib-only): 3,223/3,223 passed, 0 failed.
- `bash scripts/check.sh`: all green — fmt/clippy/tests/cargo-deny/publish-graph/version-consistency. (`chematic-py` pytest step was skipped in this worktree specifically — no local `.venv` with the package installed here — CI's dedicated "Test (Python bindings)" job covers it independently and is required below.)
- `scripts/check_publish_graph.py`: confirmed safe publish order for the post-merge `cargo publish` sequence (core → perception → cip → smarts → smiles → rxn → fp → iupac → chem → ff → 3d → depict → inchi → mol → chematic → ewald → mcp → wasm).

## Recommendation

Ready for review. **Not merging in this turn** — merge, tag, and publish (crates.io/npm/PyPI) are separately authorized follow-up steps once this PR's CI is green.
