### PR TITLE
fix(rxn): make SMIRKS product chirality assignment parity-aware

### DIFF
--- a/crates/chematic-rxn/src/transform.rs
+++ b/crates/chematic-rxn/src/transform.rs
@@ -704,6 +704,215 @@ fn clear_orphaned_stereo_bonds(mol: Molecule) -> Molecule {
     result
 }
 
+// ---------------------------------------------------------------------------
+// Product-side chirality correction (parity-aware)
+// ---------------------------------------------------------------------------
+//
+// `build_product`'s Step 1 leaves every mapped core atom's chirality as
+// whatever `src_atom.clone()` produced -- the reactant's own flag, if any.
+// Two things can make that flag wrong or meaningless by the time the
+// product molecule's bonds are fully built (Steps 3-4):
+//
+//   - An EXPLICIT product-template flag (`[C@:1]`/`[C@@:1]`) describes an
+//     absolute configuration relative to the TEMPLATE's own neighbour
+//     write-order, not the reactant's. Naively copying the symbol without
+//     accounting for a reordered template ignores exactly the kind of
+//     reorder that inverts configuration (mirroring the parity math
+//     `smirks_chirality_ok`/`permutation_parity` already does for
+//     REACTANT-side match validation, just never applied to the product).
+//   - An INHERITED flag (no explicit template chirality) can survive on an
+//     atom whose real bonding topology changed within the reaction's own
+//     mapped/core region (e.g. a ring bond broken by the reaction) --
+//     `build_product`'s old invalidation heuristic only ever compared
+//     *unmapped* substituent element sets, never mapped-neighbour identity.
+//
+// Both are handled here, in a single post-build pass (run after all of
+// `build_product`'s bonds exist, since validating either case requires the
+// atom's REAL final neighbour set): an explicit template flag is
+// transcribed together with its own neighbour order (validated against the
+// atom's real adjacency, not re-derived); an inherited flag is kept only if
+// both an order exists to trust it by and the core neighbourhood provably
+// didn't change, and cleared otherwise. Two mechanisms, not one unified
+// permutation-parity re-expression, because an unmapped/template-literal
+// substituent has no reactant identity to map an order back to at all.
+
+/// Map a template-space stereo order into product-index space via
+/// `template_idx_to_new`. [`STEREO_H_SENTINEL`] passes through unchanged.
+/// `None` if any real (non-sentinel) template atom didn't make it into the
+/// product (shouldn't happen for a well-formed template, but fails closed).
+fn map_stereo_order(order: &[u32], template_idx_to_new: &[Option<AtomIdx>]) -> Option<Vec<u32>> {
+    order
+        .iter()
+        .map(|&t| {
+            if t == STEREO_H_SENTINEL {
+                Some(STEREO_H_SENTINEL)
+            } else {
+                template_idx_to_new
+                    .get(t as usize)
+                    .copied()
+                    .flatten()
+                    .map(|a| a.0)
+            }
+        })
+        .collect()
+}
+
+/// True when `order` (already in product-index space) matches `new_idx`'s
+/// REAL final neighbour set in `product`: at most one H-sentinel, no
+/// duplicate real entries, right length, and the real entries are exactly
+/// `new_idx`'s actual adjacency. Deliberately a set/degree check, not a
+/// permutation-parity one -- `order` is stored verbatim once validated;
+/// `corrected_chirality` (the SMILES writer) and `chematic-cip` already do
+/// the write-order-independent parity math whenever they consume it.
+fn order_matches_final_topology(product: &Molecule, new_idx: AtomIdx, order: &[u32]) -> bool {
+    let sentinels = order.iter().filter(|&&x| x == STEREO_H_SENTINEL).count();
+    if sentinels > 1 {
+        return false;
+    }
+    let real: Vec<u32> = order
+        .iter()
+        .copied()
+        .filter(|&x| x != STEREO_H_SENTINEL)
+        .collect();
+    let real_set: FxHashSet<u32> = real.iter().copied().collect();
+    if real.len() != real_set.len() {
+        return false; // Duplicate entry -- malformed order.
+    }
+    if order.len() != product.degree(new_idx) + sentinels {
+        return false;
+    }
+    let actual: FxHashSet<u32> = product.neighbors(new_idx).map(|(nb, _)| nb.0).collect();
+    real_set == actual
+}
+
+/// Bug-B validity gate for an atom that inherited its chirality flag from
+/// the reactant (no explicit product-template chirality): the original
+/// unmapped-substituent element-multiset comparison, PLUS a symmetric
+/// mapped-neighbour atom-map-number-set comparison -- closing the gap where
+/// a core/mapped neighbour's topology changes (e.g. a ring bond broken by
+/// the reaction) invisibly to the element-multiset-only check.
+fn bug_b_topology_unchanged(
+    product_template: &Molecule,
+    ti: AtomIdx,
+    reactant: &Molecule,
+    src_idx: AtomIdx,
+    all_template_atoms: &FxHashSet<(usize, AtomIdx)>,
+    mol_idx: usize,
+    atom_to_map: &FxHashMap<(usize, AtomIdx), u16>,
+) -> bool {
+    let mut prod_elems: FxHashMap<u8, usize> = FxHashMap::default();
+    let mut prod_mapped: FxHashSet<u16> = FxHashSet::default();
+    for (nb, _) in product_template.neighbors(ti) {
+        match product_template.atom(nb).atom_map {
+            None => {
+                *prod_elems
+                    .entry(product_template.atom(nb).element.atomic_number())
+                    .or_insert(0) += 1;
+            }
+            Some(am) => {
+                prod_mapped.insert(am);
+            }
+        }
+    }
+
+    let mut rxn_elems: FxHashMap<u8, usize> = FxHashMap::default();
+    let mut rxn_mapped: FxHashSet<u16> = FxHashSet::default();
+    for (nb, _) in reactant.neighbors(src_idx) {
+        if !all_template_atoms.contains(&(mol_idx, nb)) {
+            continue;
+        }
+        match atom_to_map.get(&(mol_idx, nb)) {
+            Some(&am) => {
+                rxn_mapped.insert(am);
+            }
+            None => {
+                *rxn_elems
+                    .entry(reactant.atom(nb).element.atomic_number())
+                    .or_insert(0) += 1;
+            }
+        }
+    }
+
+    (prod_elems.is_empty() || prod_elems == rxn_elems) && prod_mapped == rxn_mapped
+}
+
+/// Post-build chirality correction. Must run after `build_product`'s Steps
+/// 3-4 (all bonds added), since validation needs each atom's real final
+/// degree/neighbour set. See the module-level doc above for why this is two
+/// mechanisms (transcribe-and-validate for an explicit template flag,
+/// gate-and-preserve-or-clear for an inherited one), not one.
+fn correct_product_stereo(
+    mut product: Molecule,
+    product_template: &Molecule,
+    template_idx_to_new: &[Option<AtomIdx>],
+    global_map: &FxHashMap<u16, (usize, AtomIdx)>,
+    all_template_atoms: &FxHashSet<(usize, AtomIdx)>,
+    input_mols: &[&Molecule],
+) -> Molecule {
+    let atom_to_map: FxHashMap<(usize, AtomIdx), u16> =
+        global_map.iter().map(|(&am, &k)| (k, am)).collect();
+
+    for i in 0..product_template.atom_count() {
+        let ti = AtomIdx(i as u32);
+        let Some(new_idx) = template_idx_to_new[i] else {
+            continue;
+        };
+        let tmpl_atom = product_template.atom(ti);
+
+        if tmpl_atom.chirality != Chirality::None {
+            // Explicit product-template chirality: the template is the sole
+            // source of truth here regardless of whether this atom is a
+            // matched core atom, an unmatched map number, or fully new --
+            // no global_map lookup needed on this branch.
+            let resolved = product_template
+                .stereo_neighbor_order(ti)
+                .and_then(|order| map_stereo_order(order, template_idx_to_new))
+                .filter(|order| order_matches_final_topology(&product, new_idx, order));
+            match resolved {
+                Some(order) => {
+                    product.set_chirality(new_idx, tmpl_atom.chirality);
+                    product.set_stereo_neighbor_order(new_idx, order);
+                }
+                None => product.set_chirality(new_idx, Chirality::None),
+            }
+        } else if let Some(am) = tmpl_atom.atom_map
+            && let Some(&(mol_idx, src_idx)) = global_map.get(&am)
+        {
+            // Matched core atom, no explicit template chirality: keep the
+            // flag `src_atom.clone()` gave it in Step 1 only if it's
+            // actually usable and provably still valid.
+            let src_atom = input_mols[mol_idx].atom(src_idx);
+            if src_atom.chirality != Chirality::None {
+                let keep = input_mols[mol_idx].stereo_neighbor_order(src_idx).is_some()
+                    && bug_b_topology_unchanged(
+                        product_template,
+                        ti,
+                        input_mols[mol_idx],
+                        src_idx,
+                        all_template_atoms,
+                        mol_idx,
+                        &atom_to_map,
+                    );
+                if !keep {
+                    product.set_chirality(new_idx, Chirality::None);
+                }
+                // else: leave the inherited flag as-is. stereo_neighbor_order
+                // stays unset -- there is no derivable per-neighbour
+                // reactant<->product correspondence for template-literal
+                // substituents, so "trust the flag, no order" is the most
+                // honest achievable answer (matching what downstream
+                // consumers already do for any atom with no recorded
+                // order).
+            }
+        }
+        // else: no template chirality, and not a matched core atom --
+        // new_atom.chirality is already Chirality::None from Step 1's clone
+        // of a template-literal atom.
+    }
+
+    product
+}
+
 /// Build one product molecule applying full SMIRKS semantics.
 ///
 /// 1. Atom-mapped product atoms: copy source atom + override aromatic/charge/H from template.
@@ -754,44 +963,12 @@ fn build_product(
                 // means "unspecified" in a product context — clear it so implicit
                 // valence rules determine H count (fixes issue #18).
                 new_atom.hydrogen_count = tmpl_atom.hydrogen_count.filter(|&h| h > 0);
-                // Apply product-template chirality when explicitly specified (@/@@).
-                // When the template has Chirality::None:
-                //   • If the non-mapped substituents written into the product template
-                //     have a DIFFERENT element composition from what the reactant
-                //     template matched (substituent replacement, e.g. Br→I), the
-                //     neighbour topology changes and the source stereo is invalid.
-                //   • If the substituent element sets are identical (pass-through,
-                //     e.g. [C:1](F)(Cl)Br >> [C:1](F)(Cl)Br)) preserve the source
-                //     chirality — the common case for remote-reaction SMIRKS.
-                if tmpl_atom.chirality != Chirality::None {
-                    new_atom.chirality = tmpl_atom.chirality;
-                } else {
-                    // Element multiset of non-mapped atoms in the product template
-                    // adjacent to this core atom.
-                    let mut prod_elems: FxHashMap<u8, usize> = FxHashMap::default();
-                    for (nb, _) in product_template.neighbors(AtomIdx(i as u32)) {
-                        if product_template.atom(nb).atom_map.is_none() {
-                            *prod_elems
-                                .entry(product_template.atom(nb).element.atomic_number())
-                                .or_insert(0) += 1;
-                        }
-                    }
-                    if !prod_elems.is_empty() {
-                        // Element multiset of this core atom's neighbours that were
-                        // matched by the reactant template (heavy atoms only).
-                        let mut rxn_elems: FxHashMap<u8, usize> = FxHashMap::default();
-                        for (nb, _) in input_mols[mol_idx].neighbors(src_idx) {
-                            if all_template_atoms.contains(&(mol_idx, nb)) {
-                                *rxn_elems
-                                    .entry(input_mols[mol_idx].atom(nb).element.atomic_number())
-                                    .or_insert(0) += 1;
-                            }
-                        }
-                        if prod_elems != rxn_elems {
-                            new_atom.chirality = Chirality::None;
-                        }
-                    }
-                }
+                // Chirality is intentionally left as whatever src_atom.clone()
+                // produced above (i.e. the reactant's own flag, if any) --
+                // correct_product_stereo, run after all bonds are added
+                // below, is the sole authority on the final chirality/order
+                // for every atom, whether it inherits from the reactant or
+                // carries an explicit product-template @/@@.
                 new_atom.atom_map = None;
                 let idx = builder.add_atom(new_atom);
                 src_to_new.insert((mol_idx, src_idx), idx);
@@ -877,9 +1054,21 @@ fn build_product(
         }
     }
 
+    // Parity-aware atom chirality correction (see the doc above
+    // correct_product_stereo) -- must run after all bonds above are added,
+    // since it validates against each atom's real final neighbour set.
+    let product = correct_product_stereo(
+        builder.build(),
+        product_template,
+        &template_idx_to_new,
+        global_map,
+        all_template_atoms,
+        input_mols,
+    );
+
     // Clear any Up/Down stereo markers left on bonds that are no longer adjacent
     // to a double bond (e.g. after C=C → C=O conversion via SMIRKS).
-    clear_orphaned_stereo_bonds(builder.build())
+    clear_orphaned_stereo_bonds(product)
 }
 
 /// Standard Cartesian product: given `sets[0], sets[1], …`, return all
@@ -905,6 +1094,10 @@ fn cartesian_product<T: Clone>(sets: &[Vec<T>]) -> Vec<Vec<T>> {
 mod tests {
     use super::*;
     use chematic_smiles::parse;
+
+    fn canonical(mol: &Molecule) -> String {
+        chematic_smiles::canonical_smiles(mol)
+    }
 
     #[test]
     fn identity_single_atom() {
@@ -1143,6 +1336,148 @@ mod tests {
             core_chirality,
             Chirality::CounterClockwise,
             "product template @ must override source @@ → CounterClockwise"
+        );
+    }
+
+    #[test]
+    fn stereo_identity_template_order_preserves_configuration() {
+        // Product template repeats the exact same neighbour order as the
+        // reactant template (F, Cl, Br) with an explicit @@ -- the simplest
+        // "nothing changed" case for the parity-aware correction.
+        let mol = parse("[C@@H](F)(Cl)Br").unwrap();
+        let results = run_reactants("[C@@H:1](F)(Cl)Br>>[C@@H:1](F)(Cl)Br", &[&mol]).unwrap();
+        let prod = &results[0][0];
+        let smi = canonical(prod);
+        let input_smi = canonical(&mol);
+        assert_eq!(
+            smi, input_smi,
+            "identity template order should reproduce the input unchanged"
+        );
+    }
+
+    #[test]
+    fn stereo_reordered_template_inverts_absolute_configuration() {
+        // Issue found while surveying RDKit's open issues (analogous to
+        // RDKit #9257): reordering two substituents in the product template
+        // while keeping the SAME @@ symbol must invert the absolute
+        // configuration -- the symbol describes an order-relative sense,
+        // not an absolute one. Cross-checked against a live RDKit oracle
+        // (`rdkit.Chem.rdChemReactions`): RDKit's `reordered` output equals
+        // its own `inverted` output, both differing from `identity`.
+        let mol = parse("[C@@H](F)(Cl)Br").unwrap();
+        let identity = canonical(
+            &run_reactants("[C@@H:1](F)(Cl)Br>>[C@@H:1](F)(Cl)Br", &[&mol]).unwrap()[0][0],
+        );
+        let reordered = canonical(
+            &run_reactants("[C@@H:1](F)(Cl)Br>>[C@@H:1](Cl)(F)Br", &[&mol]).unwrap()[0][0],
+        );
+        let explicit_invert = canonical(
+            &run_reactants("[C@@H:1](F)(Cl)Br>>[C@H:1](F)(Cl)Br", &[&mol]).unwrap()[0][0],
+        );
+        assert_ne!(
+            reordered, identity,
+            "reordering two substituents under the same @@ symbol must change \
+             the absolute configuration"
+        );
+        assert_eq!(
+            reordered, explicit_invert,
+            "reordering two substituents under @@ must match the explicit-@ \
+             (same order, opposite symbol) result -- both express the same \
+             inverted configuration"
+        );
+    }
+
+    #[test]
+    fn stereo_substituent_replacement_clears_chirality() {
+        // Neighbour SET changes (Br -> I): the old flag can no longer mean
+        // anything -- must clear to Chirality::None, not carry a stale @@
+        // onto a differently-substituted center. Pre-existing behavior,
+        // now driven by correct_product_stereo's Bug-B gate instead of the
+        // deleted ad hoc heuristic; must not regress.
+        let mol = parse("[C@@H](F)(Cl)Br").unwrap();
+        let results = run_reactants("[C@@H:1](F)(Cl)Br>>[C:1](F)(Cl)I", &[&mol]).unwrap();
+        let prod = &results[0][0];
+        let core_chirality = prod.atom(AtomIdx(0)).chirality;
+        assert_eq!(
+            core_chirality,
+            Chirality::None,
+            "substituent replacement (Br->I) must clear chirality, not preserve a stale flag"
+        );
+    }
+
+    #[test]
+    fn stereo_lost_mapped_neighbor_clears_spurious_chirality() {
+        // Issue found while surveying RDKit's open issues: a mapped/core
+        // neighbour (N) is dropped by the product template, while the
+        // template's own C:1 atom carries no explicit chirality. The old
+        // invalidation heuristic only ever compared *unmapped* substituent
+        // element sets (both empty here, since every neighbour of C:1 is
+        // mapped) and missed this case entirely, producing a spurious
+        // chirality tag on a carbon with 3 identical implicit hydrogens.
+        let mol = parse("[C@H](N)(O)Cl").unwrap();
+        let results = run_reactants("[C@H:1]([N:2])([O:3])Cl>>[C:1][O:3]", &[&mol]).unwrap();
+        let prod = &results[0][0];
+        let smi = canonical(prod);
+        assert!(
+            !smi.contains('@'),
+            "carbon losing its N neighbour is no longer a stereocenter (3 identical \
+             implicit H's) -- product must carry no chirality symbol, got {smi}"
+        );
+    }
+
+    #[test]
+    fn stereo_polyol_ring_contraction_no_spurious_ch2oh_chirality() {
+        // The originally reported repro (analogous to RDKit #9257), minimized
+        // versions of which are the two tests directly above. A pyranose ->
+        // furanose ring contraction where one ring carbon (mapped :2) loses
+        // its own explicit chirality in the product template and becomes a
+        // plain CH2OH (degree 2, bonded to a degree-1 O) -- pre-fix this
+        // atom kept a spurious inherited chirality tag ([C@H2], a carbon
+        // with 3 identical implicit hydrogens). Does NOT assert a specific
+        // sign at the two atoms whose absolute configuration this fix does
+        // not by itself resolve either way (mapped :11, unchanged reactant->
+        // product template and therefore architecturally untouched by this
+        // fix; and :15, the debated center in the original RDKit report) --
+        // only that the reaction produces exactly 4 real stereocenters, not
+        // 5, and that the correct atom (the one that structurally lost its
+        // stereocenter) is the one that lost its tag.
+        let smirks = "[O:1][C@H:2]1[O:3][C@H:4]([C:5][C:6])[C@@H:11]([O:12])[C@H:13]([O:14])\
+                       [C@H:15]1[O:16]>>[O:1][C:2][C@:15]([O:16])1[O:3][C@H:4]([C:5][C:6])\
+                       [C@@H:11]([O:12])[C@H:13]1[O:14]";
+        let mol = parse("CC[C@H]1O[C@H](O)[C@H](O)[C@@H](O)[C@@H]1O").unwrap();
+        let results = run_reactants(smirks, &[&mol]).unwrap();
+        let prod = &results[0][0];
+
+        let n = prod.atom_count();
+        let chiral_atoms: Vec<AtomIdx> = (0..n)
+            .map(|i| AtomIdx(i as u32))
+            .filter(|&a| prod.atom(a).chirality != Chirality::None)
+            .collect();
+        assert_eq!(
+            chiral_atoms.len(),
+            4,
+            "expected exactly 4 real stereocenters in the product, got {}: {:?}",
+            chiral_atoms.len(),
+            chiral_atoms
+        );
+
+        // Structurally identify the CH2OH carbon: degree 2, bonded to a
+        // degree-1 oxygen -- not by a hardcoded index, since atom order
+        // depends on build_product's own construction order.
+        let ch2oh = (0..n).map(|i| AtomIdx(i as u32)).find(|&a| {
+            let atom = prod.atom(a);
+            atom.element == chematic_core::Element::C
+                && prod.degree(a) == 2
+                && prod.neighbors(a).any(|(nb, _)| {
+                    prod.atom(nb).element == chematic_core::Element::O && prod.degree(nb) == 1
+                })
+        });
+        let ch2oh = ch2oh.expect("product must contain a CH2OH carbon");
+        assert_eq!(
+            prod.atom(ch2oh).chirality,
+            Chirality::None,
+            "the CH2OH carbon (lost its own chirality in the product template, degree 2, \
+             no longer has 4 distinct substituents) must not carry a stereo tag"
         );
     }
 

--- a/crates/chematic-rxn/src/transform.rs
+++ b/crates/chematic-rxn/src/transform.rs
@@ -833,7 +833,41 @@ fn bug_b_topology_unchanged(
         }
     }
 
-    (prod_elems.is_empty() || prod_elems == rxn_elems) && prod_mapped == rxn_mapped
+    // NOTE: `prod_elems.is_empty()` is deliberately NOT special-cased here.
+    // An empty `prod_elems` legitimately means "product-template atom has no
+    // unmapped neighbours" -- which is also true when the reactant's
+    // template-matched unmapped substituents (F/Cl/Br etc., matched by the
+    // reactant SMARTS itself, not carried-through remote substituents --
+    // those never enter `rxn_elems` at all, since `rxn_elems` only counts
+    // neighbours inside `all_template_atoms`) were silently DELETED by the
+    // product template. `prod_elems == rxn_elems` alone correctly requires
+    // both to be empty together, or both to hold the same multiset --
+    // exactly what "unchanged" means; special-casing empty-on-one-side
+    // would let a genuine deletion through undetected.
+    prod_elems == rxn_elems && prod_mapped == rxn_mapped
+}
+
+/// Map a REACTANT-space stereo order (atom indices into
+/// `input_mols[mol_idx]`) into product-index space via `src_to_new`.
+/// [`STEREO_H_SENTINEL`] passes through unchanged. `None` if any real
+/// (non-sentinel) reactant neighbour never made it into the product (e.g. it
+/// was part of a leaving group the reaction consumed) -- the correspondence
+/// is not derivable, so the caller must fail closed rather than guess.
+fn remap_reactant_stereo_order(
+    order: &[u32],
+    mol_idx: usize,
+    src_to_new: &FxHashMap<(usize, AtomIdx), AtomIdx>,
+) -> Option<Vec<u32>> {
+    order
+        .iter()
+        .map(|&t| {
+            if t == STEREO_H_SENTINEL {
+                Some(STEREO_H_SENTINEL)
+            } else {
+                src_to_new.get(&(mol_idx, AtomIdx(t))).map(|a| a.0)
+            }
+        })
+        .collect()
 }
 
 /// Post-build chirality correction. Must run after `build_product`'s Steps
@@ -848,6 +882,7 @@ fn correct_product_stereo(
     global_map: &FxHashMap<u16, (usize, AtomIdx)>,
     all_template_atoms: &FxHashSet<(usize, AtomIdx)>,
     input_mols: &[&Molecule],
+    src_to_new: &FxHashMap<(usize, AtomIdx), AtomIdx>,
 ) -> Molecule {
     let atom_to_map: FxHashMap<(usize, AtomIdx), u16> =
         global_map.iter().map(|(&am, &k)| (k, am)).collect();
@@ -880,29 +915,47 @@ fn correct_product_stereo(
         {
             // Matched core atom, no explicit template chirality: keep the
             // flag `src_atom.clone()` gave it in Step 1 only if it's
-            // actually usable and provably still valid.
+            // actually usable and provably still valid. Three-way rule,
+            // all conditions required:
+            //   1. bug_b_topology_unchanged: the TEMPLATE-level neighbour
+            //      composition (unmapped element multiset + mapped atom-map
+            //      set) is unchanged reactant-template -> product-template.
+            //   2. remap_reactant_stereo_order succeeds: every atom the
+            //      reactant's own recorded order references is uniquely
+            //      identifiable in the product (via src_to_new) -- fails
+            //      closed (None) for a leaving-group neighbour the reaction
+            //      consumed, where no correspondence is derivable at all.
+            //   3. order_matches_final_topology: the remapped order's real
+            //      entries are EXACTLY this atom's real final adjacency in
+            //      the built product molecule -- catches a neighbour that
+            //      survived into the product (so (2) succeeds) but whose
+            //      specific BOND to this atom did not (e.g. reattached
+            //      elsewhere by the reaction), which a template-level
+            //      heuristic alone cannot see.
+            // Never keep a raw flag without a validated order alongside it.
             let src_atom = input_mols[mol_idx].atom(src_idx);
             if src_atom.chirality != Chirality::None {
-                let keep = input_mols[mol_idx].stereo_neighbor_order(src_idx).is_some()
-                    && bug_b_topology_unchanged(
-                        product_template,
-                        ti,
-                        input_mols[mol_idx],
-                        src_idx,
-                        all_template_atoms,
-                        mol_idx,
-                        &atom_to_map,
-                    );
-                if !keep {
-                    product.set_chirality(new_idx, Chirality::None);
+                let topology_unchanged = bug_b_topology_unchanged(
+                    product_template,
+                    ti,
+                    input_mols[mol_idx],
+                    src_idx,
+                    all_template_atoms,
+                    mol_idx,
+                    &atom_to_map,
+                );
+                let remapped_order = topology_unchanged
+                    .then(|| input_mols[mol_idx].stereo_neighbor_order(src_idx))
+                    .flatten()
+                    .and_then(|order| remap_reactant_stereo_order(order, mol_idx, src_to_new))
+                    .filter(|order| order_matches_final_topology(&product, new_idx, order));
+                match remapped_order {
+                    Some(order) => {
+                        product.set_chirality(new_idx, src_atom.chirality);
+                        product.set_stereo_neighbor_order(new_idx, order);
+                    }
+                    None => product.set_chirality(new_idx, Chirality::None),
                 }
-                // else: leave the inherited flag as-is. stereo_neighbor_order
-                // stays unset -- there is no derivable per-neighbour
-                // reactant<->product correspondence for template-literal
-                // substituents, so "trust the flag, no order" is the most
-                // honest achievable answer (matching what downstream
-                // consumers already do for any atom with no recorded
-                // order).
             }
         }
         // else: no template chirality, and not a matched core atom --
@@ -1064,6 +1117,7 @@ fn build_product(
         global_map,
         all_template_atoms,
         input_mols,
+        &src_to_new,
     );
 
     // Clear any Up/Down stereo markers left on bonds that are no longer adjacent
@@ -1308,20 +1362,240 @@ mod tests {
     // ── Stereo SMIRKS tests ───────────────────────────────────────────────────
 
     #[test]
-    fn stereo_preserved_when_template_has_no_spec() {
-        // Product template [C:1] has no chirality → source @@ is preserved via clone.
+    fn stereo_cleared_when_all_neighbors_are_unmapped_template_literals() {
+        // Product template [C:1] has no chirality, and all three substituents
+        // (F, Cl, Br) are unmapped literal atoms in BOTH templates -- SMIRKS
+        // gives no per-atom reactant<->product correspondence for an unmapped
+        // atom (only `:n` atom-map numbers establish identity), so there is no
+        // derivable stereo_neighbor_order to carry the inherited flag with.
+        // Fail-closed: clear rather than keep a flag with an undefined order
+        // (chematic-cip already treats order-less chirality as unassigned, so
+        // keeping the raw flag here was never actually meaningful downstream).
         let mol = parse("[C@@H](F)(Cl)Br").unwrap();
         let results = run_reactants("[C@@H:1](F)(Cl)Br>>[C:1](F)(Cl)Br", &[&mol]).unwrap();
         assert!(!results.is_empty(), "should match and produce a product");
         let prod = &results[0][0];
         // The core C atom is first in the builder (index 0).
         let core_chirality = prod.atom(AtomIdx(0)).chirality;
-        // Template has None → source Clockwise (@@ in SMILES = Clockwise) is preserved.
+        assert_eq!(
+            core_chirality,
+            Chirality::None,
+            "no derivable stereo_neighbor_order for an all-unmapped-substituent \
+             inherited flag must clear chirality, not keep an order-less flag"
+        );
+    }
+
+    #[test]
+    fn stereo_preserved_when_all_neighbors_are_mapped_and_remappable() {
+        // Every substituent around the stereocenter is atom-mapped, so each
+        // has a real, unique reactant->product correspondence via src_to_new.
+        // This is the case the remap mechanism *can* and must handle: keep
+        // both the flag and a validated, remapped stereo_neighbor_order.
+        let mol = parse("[C@@H](F)(Cl)Br").unwrap();
+        let results = run_reactants(
+            "[C@@H:1]([F:2])([Cl:3])[Br:4]>>[C:1]([F:2])([Cl:3])[Br:4]",
+            &[&mol],
+        )
+        .unwrap();
+        assert!(!results.is_empty(), "should match and produce a product");
+        let prod = &results[0][0];
+        let core_chirality = prod.atom(AtomIdx(0)).chirality;
         assert_eq!(
             core_chirality,
             Chirality::Clockwise,
-            "source @@ chirality must be preserved when template has no stereo spec"
+            "source @@ chirality must be preserved when every neighbor is \
+             mapped and remappable, with an identity-order template"
         );
+        assert!(
+            prod.stereo_neighbor_order(AtomIdx(0)).is_some(),
+            "a kept inherited flag must always carry a validated stereo_neighbor_order"
+        );
+    }
+
+    #[test]
+    fn stereo_unmapped_leaving_groups_fully_removed_clears_chirality() {
+        // Blocker #1 from review: the reactant's literal unmapped
+        // substituents (F, Cl, Br) are removed entirely by the product
+        // template (bare [C:1], zero neighbours) -- bug_b_topology_unchanged
+        // must not special-case an empty product-side unmapped set as
+        // "unchanged" when the reactant side was non-empty. In the current
+        // architecture this is enforced twice over: the topology gate itself
+        // (fixed here) AND independently by remap_reactant_stereo_order,
+        // since a literal/unmapped reactant-template neighbour never has a
+        // src_to_new entry regardless of what the product does with it. The
+        // observable behavior this test pins is the one the reviewer asked
+        // for either way: chirality must clear, not survive.
+        let mol = parse("[C@@H](F)(Cl)Br").unwrap();
+        let results = run_reactants("[C@@H:1](F)(Cl)Br>>[C:1]", &[&mol]).unwrap();
+        assert!(!results.is_empty(), "should match and produce a product");
+        let prod = &results[0][0];
+        assert_eq!(
+            prod.atom(AtomIdx(0)).chirality,
+            Chirality::None,
+            "deleting all of the stereocenter's unmapped substituents must clear chirality"
+        );
+    }
+
+    #[test]
+    fn stereo_remote_reaction_preserves_stereocenter() {
+        // The bond change (Br leaving, N arriving) happens two bonds away
+        // from the stereocenter, through a mapped, unchanged carrier chain
+        // (F, Cl, C4 all keep the same atom-map numbers and the same
+        // relative template order on both sides) -- the stereocenter's own
+        // immediate neighbor set and order are completely untouched by the
+        // remote reaction. Configuration must survive.
+        let mol = parse("[C@@H](F)(Cl)CCBr").unwrap();
+        let amine = parse("N").unwrap();
+        let results = run_reactants(
+            "[C@@H:1]([F:2])([Cl:3])[C:4][C:5][Br:6].[N:7]\
+             >>[C:1]([F:2])([Cl:3])[C:4][C:5][N:7]",
+            &[&mol, &amine],
+        )
+        .unwrap();
+        assert!(!results.is_empty(), "should match and produce a product");
+        let prod = &results[0][0];
+        assert_eq!(
+            prod.atom(AtomIdx(0)).chirality,
+            Chirality::Clockwise,
+            "a remote bond change 2 bonds away must not disturb the \
+             stereocenter's own unchanged, fully-mapped neighbor set"
+        );
+        assert!(
+            prod.stereo_neighbor_order(AtomIdx(0)).is_some(),
+            "preserved chirality must carry a validated stereo_neighbor_order"
+        );
+    }
+
+    #[test]
+    fn stereo_survives_16_plus_atom_map_relabelings_smiles_and_cip_invariant() {
+        // The chemistry must not depend on which integers a SMIRKS author
+        // picks for `:n` map numbers -- only the correspondence they encode.
+        // Re-run the same reaction with 20 distinct map-number assignments
+        // (same template text shape and order each time, only the four
+        // integers change) and assert canonical SMILES and accurate CIP
+        // agree with the first run every time.
+        let mol = parse("[C@@H](F)(Cl)Br").unwrap();
+        // Central atom is fixed at map `:1`; offset the other three ranges
+        // so none of them ever collides with it or each other.
+        let labelings: Vec<[u32; 3]> = (2..=21).map(|i| [i, i + 100, i + 200]).collect();
+        assert!(labelings.len() >= 16, "need at least 16 relabelings");
+
+        let mut baseline_smiles: Option<String> = None;
+        let mut baseline_cip: Option<Option<chematic_core::CipCode>> = None;
+        for [b, c, d] in labelings {
+            let smirks =
+                format!("[C@@H:1]([F:{b}])([Cl:{c}])[Br:{d}]>>[C:1]([F:{b}])([Cl:{c}])[Br:{d}]");
+            let results = run_reactants(&smirks, &[&mol]).unwrap();
+            assert!(!results.is_empty(), "labeling {b},{c},{d} must still match");
+            let prod = &results[0][0];
+            let smi = canonical(prod);
+            let cip = chematic_chem::assign_cip_with_mode(prod, chematic_chem::CipMode::Accurate)
+                .unwrap()
+                .get(AtomIdx(0));
+
+            match (&baseline_smiles, &baseline_cip) {
+                (None, None) => {
+                    baseline_smiles = Some(smi);
+                    baseline_cip = Some(cip);
+                }
+                (Some(base_smi), Some(base_cip)) => {
+                    assert_eq!(
+                        &smi, base_smi,
+                        "canonical SMILES must be invariant to atom-map relabeling \
+                         (labeling {b},{c},{d})"
+                    );
+                    assert_eq!(
+                        &cip, base_cip,
+                        "accurate CIP code must be invariant to atom-map relabeling \
+                         (labeling {b},{c},{d})"
+                    );
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    #[test]
+    fn stereo_chirality_implies_valid_stereo_neighbor_order_invariant() {
+        // Cross-cutting invariant the reviewer required: whenever an atom
+        // carries a non-None chirality flag, it must always have a valid
+        // stereo_neighbor_order alongside it -- never a raw flag with no
+        // order (which chematic-cip and the SMILES writer cannot interpret
+        // meaningfully). Checked across every atom of a representative
+        // spread of already-covered product-generating scenarios.
+        let assert_invariant_holds = |mol: &Molecule, label: &str| {
+            for i in 0..mol.atom_count() {
+                let idx = AtomIdx(i as u32);
+                if mol.atom(idx).chirality != Chirality::None {
+                    assert!(
+                        mol.stereo_neighbor_order(idx).is_some(),
+                        "{label}: atom {i} has chirality {:?} but no stereo_neighbor_order",
+                        mol.atom(idx).chirality
+                    );
+                }
+            }
+        };
+
+        let mol = parse("[C@@H](F)(Cl)Br").unwrap();
+        let chain_mol = parse("[C@@H](F)(Cl)CCBr").unwrap();
+        let amine = parse("N").unwrap();
+
+        let scenarios: Vec<(&str, Vec<Molecule>)> = vec![
+            (
+                "identity template order",
+                vec![
+                    run_reactants("[C@@H:1](F)(Cl)Br>>[C@@H:1](F)(Cl)Br", &[&mol]).unwrap()[0][0]
+                        .clone(),
+                ],
+            ),
+            (
+                "reordered template inverts",
+                vec![
+                    run_reactants("[C@@H:1](F)(Cl)Br>>[C@@H:1](Cl)(F)Br", &[&mol]).unwrap()[0][0]
+                        .clone(),
+                ],
+            ),
+            (
+                "all neighbors mapped and remappable",
+                vec![
+                    run_reactants(
+                        "[C@@H:1]([F:2])([Cl:3])[Br:4]>>[C:1]([F:2])([Cl:3])[Br:4]",
+                        &[&mol],
+                    )
+                    .unwrap()[0][0]
+                        .clone(),
+                ],
+            ),
+            (
+                "all unmapped substituents deleted",
+                vec![run_reactants("[C@@H:1](F)(Cl)Br>>[C:1]", &[&mol]).unwrap()[0][0].clone()],
+            ),
+            (
+                "substituent replacement",
+                vec![
+                    run_reactants("[C@@H:1](F)(Cl)Br>>[C:1](F)(Cl)I", &[&mol]).unwrap()[0][0]
+                        .clone(),
+                ],
+            ),
+            (
+                "remote reaction",
+                vec![
+                    run_reactants(
+                        "[C@@H:1]([F:2])([Cl:3])[C:4][C:5][Br:6].[N:7]\
+                         >>[C:1]([F:2])([Cl:3])[C:4][C:5][N:7]",
+                        &[&chain_mol, &amine],
+                    )
+                    .unwrap()[0][0]
+                        .clone(),
+                ],
+            ),
+        ];
+
+        for (label, products) in &scenarios {
+            for prod in products {
+                assert_invariant_holds(prod, label);
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix 2 of the "bugs surfaced by surveying RDKit's open issues" program (see the approved plan for the other 3 fixes and the 29-issue triage). Found while investigating whether RDKit issue #9257 ("Incorrect stereo in product from RunReactants") applies to chematic. It surfaced two distinct, independently-diagnosed, chematic-specific stereo-assignment bugs in `build_product` -- not simply "does RDKit's bug reproduce here."

**Updated after review**: the reviewer found two real gaps in the first version of this PR (see "Review round 2" below) -- both are now fixed, and fixing the second one changes observable behavior for one class of input (see "Behavior change" below, read this before merging).

## Symptoms (both minimized and cross-checked against a live RDKit oracle, not just the original bug report's giant polyol)

**Bug A -- wrong absolute configuration when a template reorders substituents:**
```
[C@@H:1](F)(Cl)Br>>[C@@H:1](F)(Cl)Br   (identity)   on [C@@H](F)(Cl)Br  -> Cl[C@@H](F)Br
[C@@H:1](F)(Cl)Br>>[C@@H:1](Cl)(F)Br   (reordered)  on [C@@H](F)(Cl)Br  -> Cl[C@@H](F)Br  (pre-fix, WRONG)
[C@@H:1](F)(Cl)Br>>[C@H:1](F)(Cl)Br    (explicit invert) on same       -> Cl[C@H](F)Br
```
`rdkit.Chem.rdChemReactions` on the analogous case correctly inverts when substituents are reordered under the same `@@` symbol (`reordered` == `explicit_invert`, both differ from `identity`). Pre-fix, chematic ignored the reorder entirely (`reordered` == `identity`).

**Bug B -- spurious chirality tag on a non-stereocenter:**
```
[C@H:1]([N:2])([O:3])Cl>>[C:1][O:3]   on [C@H](N)(O)Cl   -> O[C@H2]   (pre-fix, WRONG)
```
A stereo tag on a carbon with 3 identical implicit hydrogens.

## Root cause

1. `build_product` (Step 1) copied an explicit product-template chirality flag (`[C@:1]`/`[C@@:1]`) onto the new atom **verbatim**, with no account for whether the template's own neighbor-write-order matched the real neighbor order the product atom ends up with once bonds are added later in the same function. This is architecturally inconsistent with the file's own REACTANT-side matching logic (`smirks_chirality_ok`/`permutation_parity`), which already does exactly this kind of order-vs-order parity check -- just never applied to the product side.
2. When the template had no explicit chirality, `new_atom` started as `src_atom.clone()` (inheriting the reactant's flag by default), and the existing invalidation heuristic only compared the element multiset of **unmapped** neighbors between reactant-match and product-template. It was blind to a **mapped** (core, in-template) neighbor's topology changing -- e.g. a ring bond broken by the reaction -- so a stale, now-meaningless tag could survive.
3. A deeper, previously-unflagged structural gap found while designing the fix: `build_product` never populated `Molecule::stereo_neighbor_order` on any atom it created. Even a numerically-correct flag was only correct by coincidence downstream (the SMILES writer and CIP engine both need this order to correctly interpret a `@`/`@@` flag).

## Fix

A single post-build pass, `correct_product_stereo`, run after all of `build_product`'s bonds exist (both bug classes need each atom's real final neighbor set to validate against). Two distinct mechanisms, not one unified re-expression -- an explicit template flag carries a complete, self-describing `(order, flag)` pair; an inherited flag has no template order to transcribe and can only be validated as a pass/fail gate:

- **Explicit template chirality** (`map_stereo_order` + `order_matches_final_topology`): map the template's own `stereo_neighbor_order` into product-index space via `template_idx_to_new`, validate it against the atom's real final degree/adjacency (right length, no duplicates, at most one H-sentinel, real-entry set == actual neighbors), and if valid, store both the flag and the validated order verbatim (`set_chirality` + `set_stereo_neighbor_order`). If invalid (a malformed/stale template order), fail closed to `Chirality::None`.
- **Inherited flag from an unspecified template** (`bug_b_topology_unchanged` + `remap_reactant_stereo_order` + `order_matches_final_topology`): keep the flag, with a full remapped order, only if **all** of the following hold:
  1. the template-level neighbour composition is unchanged (unmapped element multiset + mapped atom-map-number set, both directions);
  2. the reactant's own recorded `stereo_neighbor_order` remaps completely into product-index space via `src_to_new` -- every real (non-sentinel) entry must resolve to an actual product atom;
  3. the remapped order's real entries exactly equal the atom's real final adjacency in the built product.

  If any step fails, chirality is cleared to `Chirality::None`. Never keep a raw flag without a validated order.

Both branches fail closed to `Chirality::None` when the required order/validation data isn't available.

`build_product`'s Step 1 no longer touches chirality at all (deleted the old copy/heuristic block); `new_atom.chirality` is left as whatever `src_atom.clone()` produced, and `correct_product_stereo` is the sole authority on the final value.

## Review round 2: two blockers fixed

The reviewer read the diff (not just this summary) and found two real gaps in the first version:

**Blocker 1 -- `bug_b_topology_unchanged` had a silent-deletion hole.** The original condition was `(prod_elems.is_empty() || prod_elems == rxn_elems) && prod_mapped == rxn_mapped`. The `prod_elems.is_empty()` short-circuit let a case through undetected: if the product template deletes *all* of the reactant's unmapped substituents (F/Cl/Br etc.), `prod_elems` is trivially empty and the check passed regardless of what `rxn_elems` held. Fixed to `prod_elems == rxn_elems` (no special case) -- both must be empty together, or hold the identical multiset.

  Honest note on this fix's actual bite today: with blocker 2's stricter remap gate now in place (see below), this specific hole is independently closed a second, stronger way -- a literal/unmapped reactant-template neighbour (the only kind `rxn_elems` counts) never has a `src_to_new` entry regardless of what the product template does with it, so `remap_reactant_stereo_order` already fails closed for exactly the cases this bug would have let through. Verified empirically: reintroducing the `is_empty()` bug alone (keeping the new remap gate) does **not** make `stereo_unmapped_leaving_groups_fully_removed_clears_chirality` fail. Kept the fix anyway -- it's what was asked for, it's correct in its own right, and it's cheap insurance if the remap gate is ever relaxed later.

**Blocker 2 -- an inherited flag could be kept with no `stereo_neighbor_order` at all.** The original design (matching the approved plan) deliberately left `stereo_neighbor_order` unset in the "keep" case, reasoning that there's no derivable per-neighbour correspondence for template-literal substituents. The reviewer rejected that: a flag with no order is exactly the "raw flag, no order" shape the SMILES writer and CIP engine can't interpret meaningfully -- explicitly forbidden. Required fix: remap the reactant's `stereo_neighbor_order` into product-index space using `src_to_new` and the full match mapping; if every neighbour remaps uniquely, keep flag + order; if correspondence is ambiguous or undeliverable, clear chirality; never keep the flag alone. Implemented as `remap_reactant_stereo_order` (new), wired into `correct_product_stereo`'s inherited-flag branch exactly as described in "Fix" above.

## Behavior change -- read before merging

Fixing blocker 2 changes observable output for one class of input, contradicting what the original PR (and the approved plan) said would happen:

> `stereo_neighbor_order` is deliberately left unset in the kept case ... "trust the flag, no order" is the most honest achievable answer

That design is gone. **A SMIRKS whose reactant template writes a stereocenter's substituents as literal, unmapped atoms (`F`, `Cl`, `Br`, ... -- not `[F:2]`, `[Cl:3]`, ...) and whose product template has no explicit chirality on that atom now clears chirality instead of preserving it**, because none of those literal substituents have a derivable reactant->product correspondence (SMIRKS only tracks identity through `:n` map numbers).

Concretely: `[C@@H:1](F)(Cl)Br>>[C:1](F)(Cl)Br` on `[C@@H](F)(Cl)Br` now produces `Chirality::None`, where the pre-review version of this PR (and current `main`) produces `Clockwise`. This is pinned by the renamed test `stereo_cleared_when_all_neighbors_are_unmapped_template_literals` (was `stereo_preserved_when_template_has_no_spec`).

**Migration path**: atom-map the substituents that need to carry through with tracked identity -- `[C@@H:1]([F:2])([Cl:3])[Br:4]>>[C:1]([F:2])([Cl:3])[Br:4]` still correctly preserves `Clockwise` with a validated order, demonstrated by the new `stereo_preserved_when_all_neighbors_are_mapped_and_remappable` test.

**Why this is the right tradeoff, not just the stricter one**: `chematic-cip` and the SMILES writer already treat a chirality flag with no `stereo_neighbor_order` as meaningless/unassigned, so the old "preserved" flag was never actually load-bearing downstream -- it was a `@@` symbol nobody could correctly interpret. Losing stereo you can't justify beats keeping stereo whose meaning is undefined.

**Blast-radius check** (no other in-repo caller relies on the old behavior):
- `crates/chematic-rxn/src/retro.rs` (`DEFAULT_TEMPLATES`, the only built-in template library in the repo): zero `@`/`@@` in any template -- unaffected, confirmed by grep.
- `chematic-py`'s `run_smirks` docstring example (`[N:1][C@@H:2](C)C(=O)O>>[N:1].[C@@H:2](C)C(=O)O`) writes explicit `@@` chirality on **both** sides of the map-number-2 atom -- this goes through the unrelated, unaffected explicit-template-chirality branch (Bug A path above), not the inherited-flag branch this change touches. Verified empirically (ran the exact docstring example): product still carries `Clockwise` with a valid `stereo_neighbor_order`.
- Repo-wide grep for `@` combined with `>>` (reaction-template shape) outside `chematic-rxn/src/transform.rs` and the docstring above: no other hits, in Rust, Python, or WASM sources, docs, or `validation/`/`scripts/` fixtures.

## Existing-test impact

Both pre-existing chirality tests were hand-traced before implementing: `stereo_inverted_by_template` is unaffected (Bug A path, unchanged). `stereo_preserved_when_template_has_no_spec` is the one behavior change described above -- renamed to `stereo_cleared_when_all_neighbors_are_unmapped_template_literals` and its assertion inverted to match the new, reviewer-required fail-closed behavior.

## Regression tests (10 new/renamed total across both review rounds, run against real `run_reactants` output; several independently cross-checked against `rdkit.Chem.rdChemReactions`)

| Test | Fixture | Asserts |
|---|---|---|
| `stereo_identity_template_order_preserves_configuration` | identity-order template | product SMILES equals input unchanged |
| `stereo_reordered_template_inverts_absolute_configuration` | the Bug-A minimized repro | `reordered != identity` AND `reordered == explicit_invert` |
| `stereo_substituent_replacement_clears_chirality` | existing `Br->I` behavior | still clears to `Chirality::None` (must not regress) |
| `stereo_lost_mapped_neighbor_clears_spurious_chirality` | the Bug-B minimized repro | product SMILES contains no `@` |
| `stereo_polyol_ring_contraction_no_spurious_ch2oh_chirality` | the original reported SMIRKS/reactant | exactly 4 real stereocenters (not 5); the structurally-identified CH2OH carbon has `Chirality::None` |
| `stereo_cleared_when_all_neighbors_are_unmapped_template_literals` (renamed, inverted) | literal unmapped F/Cl/Br, product template deletes them | `Chirality::None` -- see "Behavior change" |
| `stereo_preserved_when_all_neighbors_are_mapped_and_remappable` (new) | same fixture, substituents atom-mapped instead | `Clockwise` **and** a validated `stereo_neighbor_order` present -- the migration path for the behavior change |
| `stereo_unmapped_leaving_groups_fully_removed_clears_chirality` (new) | reviewer's blocker-1 scenario, unmapped substituents fully deleted | `Chirality::None`; positive-controlled to fail under true pre-review code, confirmed *not* discriminating for the `is_empty()` bug alone now that the remap gate independently covers it (see "Review round 2" honesty note) |
| `stereo_remote_reaction_preserves_stereocenter` (new) | bond change 2 bonds away from a fully-mapped, unchanged stereocenter | configuration preserved with a valid order; positive-controlled to fail (specifically on the order-presence assertion) against the pre-review "keep flag, no order" design |
| `stereo_survives_16_plus_atom_map_relabelings_smiles_and_cip_invariant` (new) | 20 distinct atom-map-number assignments, same template shape | canonical SMILES and accurate CIP (`chematic_chem::assign_cip_with_mode(.., CipMode::Accurate)`) both invariant across every relabeling |
| `stereo_chirality_implies_valid_stereo_neighbor_order_invariant` (new) | sweep across 6 of the scenarios above | cross-cutting invariant: every atom with `chirality != None` has `stereo_neighbor_order.is_some()` |

Every new/changed test in this round was positive-control verified: patched to simulate the pre-review behavior (topology-heuristic-only, no remap; or the `is_empty()` bug alone), confirmed the relevant test fails, then restored and confirmed the full suite is green again.

## Verification

- `cargo test -p chematic-rxn --lib --quiet` -- 159/159 pass.
- `cargo test --workspace --lib --quiet` -- full green, 0 failures.
- `cargo clippy --workspace --all-targets -- -D warnings` -- clean.
- `cargo fmt --all -- --check` -- clean.
- `bash scripts/check.sh` -- full green (fmt, clippy, lib+integration tests, pytest, cargo-deny, publish graph, version consistency).

## Public API impact

None on function signatures. `correct_product_stereo`, `remap_reactant_stereo_order`, `order_matches_final_topology`, and `bug_b_topology_unchanged` are private functions internal to `transform.rs`. `build_product`'s own signature, and every public `run_reactants*` entry point, is unchanged. See "Behavior change" above for the one output-shape change this round introduces.

## Performance impact

Negligible. The remap adds one more bounded pass over the stereocenter's own neighbour order (already O(degree), same order of work as the validation it composes with).

## Not done here / next steps

Per the approved plan, this is Fix 2 of 4 independent fixes found via the RDKit-issue survey (Fix 1, 2D depict layout ring coincidence, merged as PR #242, `6b64ce8`). The remaining 2 (CDXML "Bold" bond stereo -- PR #244, currently back in Draft pending a real chirality-perception implementation; ETKDG macrocycle amide 1-4 bounds -- PR #245, pending a ring-identity fix) are separate, independent PRs.

**Do not merge without explicit go-ahead.**
