### PR TITLE
fix(mol): read CDXML "Bold" bond display as wedge-up stereo

### DIFF
--- a/crates/chematic-core/src/molecule.rs
+++ b/crates/chematic-core/src/molecule.rs
@@ -753,6 +753,17 @@ impl Molecule {
         self.atoms[idx.0 as usize].chirality = chirality;
     }
 
+    /// Set the bond order of bond `idx` in-place. Endpoints (`atom1`/
+    /// `atom2`) and adjacency are untouched -- order alone doesn't affect
+    /// connectivity, so unlike [`Self::remove_bond`] + [`Self::add_bond`],
+    /// this never perturbs any atom's `neighbors()` iteration order (some
+    /// callers, e.g. 2D-wedge tetrahedral-parity perception, rely on that
+    /// order to pick an "apex" neighbor -- a remove+re-add would silently
+    /// change which neighbor that is).
+    pub fn set_bond_order(&mut self, idx: BondIdx, order: BondOrder) {
+        self.bonds[idx.0 as usize].order = order;
+    }
+
     /// Return the enhanced stereo groups attached to this molecule.
     pub fn stereo_groups(&self) -> &[StereoGroup] {
         &self.stereo_groups

--- a/crates/chematic-mol/src/cdxml.rs
+++ b/crates/chematic-mol/src/cdxml.rs
@@ -151,9 +151,15 @@ pub fn parse_cdxml_with_options(
 /// `"Hash"` / `"Dash"` / `"WedgeEnd"` / `"WedgedHashEnd"` → [`BondOrder::Down`].
 /// `"Bold"` is ChemDraw's simplified, non-directional "coming toward viewer"
 /// convention (a plain thick line, used by some chemists in place of a real
-/// wedge) -- it carries no begin/end distinction of its own, so it's
-/// interpreted the same bond-direction-from-B-to-E way `"Hash"`/`"Dash"`
-/// already are, not via a new direction-inference mechanism.
+/// wedge), mapped to the same `BondOrder` bucket as `"WedgeBegin"` for
+/// round-trip/structural purposes. `"Bold"`/`"Hash"`/`"Dash"` have no
+/// Begin/End reference convention, unlike `"WedgeBegin"`/`"WedgeEnd"`.
+/// When non-directional stereo inference is enabled
+/// ([`CdxmlParseOptions::infer_nondirectional_stereo`]), the parser
+/// identifies a unique stereocenter-candidate endpoint and normalizes a
+/// temporary perception view so the result is invariant to CDXML B/E
+/// ordering; if the reference endpoint is ambiguous (or there isn't one),
+/// chirality perception abstains rather than guessing.
 ///
 /// These wedge bonds, combined with 2D coordinates, are what actually
 /// perceives `Atom.chirality` (see the module-level doc for the full

--- a/crates/chematic-mol/src/cdxml.rs
+++ b/crates/chematic-mol/src/cdxml.rs
@@ -94,8 +94,13 @@ pub fn parse_cdxml(input: &str) -> Result<(Molecule, Vec<(f64, f64)>), CdxmlErro
 /// # Stereochemistry
 ///
 /// Wedge bonds are derived from the `Display` attribute of `<b>` elements:
-/// `"WedgeBegin"` / `"WedgedHashBegin"` → [`BondOrder::Up`];
+/// `"WedgeBegin"` / `"WedgedHashBegin"` / `"Bold"` → [`BondOrder::Up`];
 /// `"Hash"` / `"Dash"` / `"WedgeEnd"` / `"WedgedHashEnd"` → [`BondOrder::Down`].
+/// `"Bold"` is ChemDraw's simplified, non-directional "coming toward viewer"
+/// convention (a plain thick line, used by some chemists in place of a real
+/// wedge) -- it carries no begin/end distinction of its own, so it's
+/// interpreted the same bond-direction-from-B-to-E way `"Hash"`/`"Dash"`
+/// already are, not via a new direction-inference mechanism.
 /// Accumulator for a single CDXML `<fragment>` being parsed.
 #[derive(Default)]
 struct FragAccum {
@@ -259,7 +264,7 @@ pub fn parse_cdxml_all(input: &str) -> Result<Vec<(Molecule, Vec<(f64, f64)>)>, 
             };
             let order = if base == BondOrder::Single {
                 match attrs.get("Display").map(String::as_str) {
-                    Some("WedgeBegin") | Some("WedgedHashBegin") => BondOrder::Up,
+                    Some("WedgeBegin") | Some("WedgedHashBegin") | Some("Bold") => BondOrder::Up,
                     Some("Hash") | Some("Dash") | Some("WedgeEnd") | Some("WedgedHashEnd") => {
                         BondOrder::Down
                     }
@@ -618,6 +623,92 @@ mod tests {
         let (mol2, _) = parse_cdxml(&written).unwrap();
         let bond2 = mol2.bond(chematic_core::BondIdx(0));
         assert_eq!(bond2.order, BondOrder::Up);
+    }
+
+    /// Issue found while surveying RDKit's open issues (analogous to RDKit
+    /// #9359, "CDXML reading doesn't use Bold or undirectional hash bonds
+    /// for stereochemistry"): ChemDraw's simplified non-directional "Bold"
+    /// bond display (a plain thick line, used by some chemists in place of
+    /// a real wedge) must be interpreted as stereo, same as this reader
+    /// already does for bare "Hash".
+    #[test]
+    fn parse_cdxml_bold_bond_is_wedge_up() {
+        let cdxml = r#"<CDXML><fragment>
+<n id="1" Element="6" p="0 0"/>
+<n id="2" Element="6" p="10 0"/>
+<b B="1" E="2" Order="1" Display="Bold"/>
+</fragment></CDXML>"#;
+        let (mol, _) = parse_cdxml(cdxml).unwrap();
+        let bond = mol.bond(chematic_core::BondIdx(0));
+        assert_eq!(
+            bond.order,
+            BondOrder::Up,
+            "Display=\"Bold\" must be read as a wedge-up stereo bond, not silently \
+             dropped to a plain single bond"
+        );
+    }
+
+    /// "Bold" and "WedgeBegin" both encode the same "coming toward viewer"
+    /// stereo relative to a bond's B->E atom order -- for identical
+    /// connectivity/geometry, both display attributes must parse to the
+    /// same BondOrder.
+    #[test]
+    fn parse_cdxml_bold_bond_matches_wedge_begin() {
+        let bold = r#"<CDXML><fragment>
+<n id="1" Element="6" p="0 0"/>
+<n id="2" Element="6" p="10 0"/>
+<b B="1" E="2" Order="1" Display="Bold"/>
+</fragment></CDXML>"#;
+        let wedge = r#"<CDXML><fragment>
+<n id="1" Element="6" p="0 0"/>
+<n id="2" Element="6" p="10 0"/>
+<b B="1" E="2" Order="1" Display="WedgeBegin"/>
+</fragment></CDXML>"#;
+        let (mol_bold, _) = parse_cdxml(bold).unwrap();
+        let (mol_wedge, _) = parse_cdxml(wedge).unwrap();
+        assert_eq!(
+            mol_bold.bond(chematic_core::BondIdx(0)).order,
+            mol_wedge.bond(chematic_core::BondIdx(0)).order,
+        );
+    }
+
+    /// Negative control: bare "Hash"/"Dash" (already-handled non-directional
+    /// stereo) and a plain undecorated bond must be unaffected by adding
+    /// the "Bold" arm -- confirms no accidental widening of the match.
+    #[test]
+    fn parse_cdxml_bold_addition_does_not_change_other_display_values() {
+        for (display, expected) in [
+            ("Hash", BondOrder::Down),
+            ("Dash", BondOrder::Down),
+            ("WedgeEnd", BondOrder::Down),
+            ("WedgedHashEnd", BondOrder::Down),
+            ("WedgedHashBegin", BondOrder::Up),
+        ] {
+            let cdxml = format!(
+                r#"<CDXML><fragment>
+<n id="1" Element="6" p="0 0"/>
+<n id="2" Element="6" p="10 0"/>
+<b B="1" E="2" Order="1" Display="{display}"/>
+</fragment></CDXML>"#
+            );
+            let (mol, _) = parse_cdxml(&cdxml).unwrap();
+            assert_eq!(
+                mol.bond(chematic_core::BondIdx(0)).order,
+                expected,
+                "Display=\"{display}\" regressed"
+            );
+        }
+        let plain = r#"<CDXML><fragment>
+<n id="1" Element="6" p="0 0"/>
+<n id="2" Element="6" p="10 0"/>
+<b B="1" E="2" Order="1"/>
+</fragment></CDXML>"#;
+        let (mol, _) = parse_cdxml(plain).unwrap();
+        assert_eq!(
+            mol.bond(chematic_core::BondIdx(0)).order,
+            BondOrder::Single,
+            "a bond with no Display attribute at all must stay plain Single"
+        );
     }
 
     #[test]

--- a/crates/chematic-mol/src/cdxml.rs
+++ b/crates/chematic-mol/src/cdxml.rs
@@ -21,14 +21,29 @@
 //!   can read what this writer produces), not full ChemDraw-application
 //!   compatibility — CDXML is a proprietary format and writing files
 //!   ChemDraw itself will accept requires undocumented attributes.
-//! - Wedge/hash bond stereo (tetrahedral) is derived from `Display` attribute.
+//! - Tetrahedral chirality (`Atom.chirality`) is perceived from wedge/hash
+//!   `Display` bonds plus 2D coordinates via
+//!   [`chematic_perception::apply_local_parity_from_wedges`] -- the same
+//!   CIP-independent mechanism the MOL/MRV readers use, so it abstains
+//!   (leaves `Chirality::None`) rather than guessing on contradictory
+//!   wedges, missing coordinates, or degenerate/coplanar geometry. A
+//!   non-directional `Display` (`Bold`/`Hash`/`Dash`, which has no
+//!   narrow/wide end telling you which atom it actually describes) is
+//!   additionally downgraded to a plain single bond before perception runs
+//!   if BOTH of its endpoints independently qualify as stereocenter
+//!   candidates -- one such bond cannot mean "toward the viewer" from both
+//!   ends of the same bond at once, so both abstain rather than each
+//!   guessing from contradictory height assignments. A directional wedge
+//!   (`WedgeBegin`/`WedgeEnd`) between two such candidates is NOT ambiguous
+//!   (the Begin atom is the reference by CDXML's own convention) and is
+//!   unaffected by this check.
 //! - E/Z double-bond stereo is derived from 2D coordinates via `assign_ez_from_2d`.
 //! - Presentation-only nodes (text boxes, arrows, etc.) are silently skipped.
 
 use std::collections::HashMap;
 
 use chematic_core::{Atom, AtomIdx, BondOrder, Element, Molecule, MoleculeBuilder};
-use chematic_perception::assign_ez_from_2d;
+use chematic_perception::{apply_local_parity_from_wedges, assign_ez_from_2d};
 
 use crate::cml::parse_xml_attrs;
 
@@ -101,6 +116,10 @@ pub fn parse_cdxml(input: &str) -> Result<(Molecule, Vec<(f64, f64)>), CdxmlErro
 /// wedge) -- it carries no begin/end distinction of its own, so it's
 /// interpreted the same bond-direction-from-B-to-E way `"Hash"`/`"Dash"`
 /// already are, not via a new direction-inference mechanism.
+///
+/// These wedge bonds, combined with 2D coordinates, are what actually
+/// perceives `Atom.chirality` (see the module-level doc for the full
+/// abstain-on-ambiguity behavior).
 /// Accumulator for a single CDXML `<fragment>` being parsed.
 #[derive(Default)]
 struct FragAccum {
@@ -114,6 +133,13 @@ struct FragAccum {
     bond_bs: Vec<String>,
     bond_es: Vec<String>,
     bond_ords: Vec<BondOrder>,
+    /// Raw `Display` attribute value per bond, `None` if absent. Needed
+    /// alongside `bond_ords` because `BondOrder::Up`/`Down` alone can't
+    /// distinguish a directional wedge (`WedgeBegin`/`WedgeEnd`, which has
+    /// an inherent narrow-end convention) from a non-directional one
+    /// (`Bold`/`Hash`/`Dash`, which doesn't) -- see the ambiguity check in
+    /// `flush()`.
+    bond_display: Vec<Option<String>>,
 }
 
 impl FragAccum {
@@ -131,6 +157,49 @@ impl FragAccum {
             id_to_pos.insert(id.as_str(), i);
         }
 
+        // Resolve every bond's endpoints to atom positions up front, both to
+        // validate atom refs early and so degree (needed by the ambiguity
+        // check below) can be computed before any bond is added.
+        let mut bond_pos: Vec<(usize, usize)> = Vec::with_capacity(self.bond_bs.len());
+        let mut degree: Vec<usize> = vec![0; self.atom_ids.len()];
+        for k in 0..self.bond_bs.len() {
+            let pos_b = *id_to_pos
+                .get(self.bond_bs[k].as_str())
+                .ok_or_else(|| CdxmlError::UnknownAtomRef(self.bond_bs[k].clone()))?;
+            let pos_e = *id_to_pos
+                .get(self.bond_es[k].as_str())
+                .ok_or_else(|| CdxmlError::UnknownAtomRef(self.bond_es[k].clone()))?;
+            degree[pos_b] += 1;
+            degree[pos_e] += 1;
+            bond_pos.push((pos_b, pos_e));
+        }
+
+        // Non-directional wedge displays (a plain thick/dashed line, no
+        // narrow/wide end) carry no convention for which endpoint is "the"
+        // stereocenter -- unlike WedgeBegin/WedgeEnd, whose Begin atom is
+        // the narrow end by CDXML's own drawing convention. If BOTH
+        // endpoints independently qualify as stereocenter candidates (3-4
+        // neighbours, [`chematic_perception`]'s own gate), a single such
+        // bond cannot mean "toward the viewer" from both ends at once --
+        // downgrade it to a plain single bond before parity perception runs
+        // so neither endpoint gets a chirality assignment it can't justify.
+        // A directional wedge between two such candidates is NOT ambiguous
+        // (the Begin atom is unambiguously the reference) and must keep
+        // working, so only the non-directional set is checked here.
+        for (k, &(pos_b, pos_e)) in bond_pos.iter().enumerate() {
+            let is_nondirectional_wedge = matches!(
+                self.bond_display[k].as_deref(),
+                Some("Bold") | Some("Hash") | Some("Dash")
+            );
+            if !is_nondirectional_wedge {
+                continue;
+            }
+            let eligible = |d: usize| (3..=4).contains(&d);
+            if eligible(degree[pos_b]) && eligible(degree[pos_e]) {
+                self.bond_ords[k] = BondOrder::Single;
+            }
+        }
+
         let mut builder = MoleculeBuilder::new();
         let mut idx_map: HashMap<usize, AtomIdx> = HashMap::new();
         let mut coords: Vec<(f64, f64)> = Vec::new();
@@ -145,13 +214,7 @@ impl FragAccum {
             coords.push((self.atom_xs[i], self.atom_ys[i]));
         }
 
-        for k in 0..self.bond_bs.len() {
-            let pos_b = *id_to_pos
-                .get(self.bond_bs[k].as_str())
-                .ok_or_else(|| CdxmlError::UnknownAtomRef(self.bond_bs[k].clone()))?;
-            let pos_e = *id_to_pos
-                .get(self.bond_es[k].as_str())
-                .ok_or_else(|| CdxmlError::UnknownAtomRef(self.bond_es[k].clone()))?;
+        for (k, &(pos_b, pos_e)) in bond_pos.iter().enumerate() {
             let a1 = idx_map[&pos_b];
             let a2 = idx_map[&pos_e];
             builder.add_bond(a1, a2, self.bond_ords[k]).map_err(|_| {
@@ -160,6 +223,19 @@ impl FragAccum {
         }
 
         let mut mol = builder.build();
+        // Tetrahedral parity first (raw wedge/hash still fully intact on
+        // bond.order), THEN E/Z direction -- same ordering rationale as
+        // mol2000.rs/mol3000.rs/mrv.rs: E/Z writes to a separate side
+        // channel (cip_code here) and never touches bond.order, so it can't
+        // disturb the wedge/hash data parity perception just consumed.
+        // RDKit issue #9359: CDXML reading never perceived tetrahedral
+        // chirality from wedge/hash bonds at all, for ANY Display value
+        // (WedgeBegin included) -- this closes that gap using the same
+        // shared, CIP-independent local-parity mechanism the MOL/MRV
+        // readers already use, so CDXML gets the same abstain-don't-guess
+        // guarantees (contradictory wedges, missing coordinates,
+        // degenerate/coplanar geometry) for free.
+        apply_local_parity_from_wedges(&mut mol, &coords);
         // Derive E/Z stereo from 2D atom positions (RDKit issue #9356: CDXML loses E/Z).
         assign_ez_from_2d(&mut mol, &coords);
         results.push((mol, coords));
@@ -276,6 +352,7 @@ pub fn parse_cdxml_all(input: &str) -> Result<Vec<(Molecule, Vec<(f64, f64)>)>, 
             acc.bond_bs.push(b);
             acc.bond_es.push(e);
             acc.bond_ords.push(order);
+            acc.bond_display.push(attrs.get("Display").cloned());
         }
     }
 
@@ -369,6 +446,7 @@ pub fn write_cdxml(mol: &Molecule, coords: &[(f64, f64)]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chematic_core::Chirality;
 
     // Minimal hand-crafted CDXML for ethanol (C-C-O) with 2 bonds.
     const ETHANOL_CDXML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -708,6 +786,306 @@ mod tests {
             mol.bond(chematic_core::BondIdx(0)).order,
             BondOrder::Single,
             "a bond with no Display attribute at all must stay plain Single"
+        );
+    }
+
+    // ── RDKit issue #9359: actual tetrahedral chirality perception ────────
+    //
+    // The tests above only ever checked `bond.order` -- they confirm the
+    // *bond* survives as a wedge, not that a *chirality* was ever perceived
+    // from it. Before this fix, `flush()` never called any wedge-to-parity
+    // mechanism at all, for ANY Display value including plain WedgeBegin --
+    // so `Atom.chirality` was always `Chirality::None` for every CDXML
+    // molecule, no matter how it was drawn. These tests assert the actual
+    // RDKit #9359 expectation (`center_atom(mol).GetChiralTag() !=
+    // CHI_UNSPECIFIED`, i.e. `Atom.chirality != Chirality::None` here), and
+    // then go further to check *meaning*, not just non-None.
+
+    /// RDKit #9359's exact repro fixture (`BOLD_BASE_CDXML`, atom/bond ids
+    /// preserved), parameterised on the `Display` of the C1-F2 bond (`101`)
+    /// so the no-wedge/Bold/Hash/WedgeBegin cases share one source of
+    /// truth. Atom 1 (implicit Carbon, the default when `Element` is
+    /// omitted) is the only degree-4 atom -- F(2), the ring-continuation
+    /// C(3)->C(4), Cl(7), and CH3(6) -- matching RDKit's own
+    /// `center_atom` (`atomic_number==6 and degree==4`) selector.
+    fn rdkit_9359_cdxml(display: Option<&str>) -> String {
+        let bond101 = match display {
+            Some(d) => format!(r#"<b id="101" B="1" E="2" Display="{d}"/>"#),
+            None => r#"<b id="101" B="1" E="2"/>"#.to_string(),
+        };
+        format!(
+            r#"<CDXML>
+<page>
+<fragment>
+<n id="1" p="270.73 355.40"/>
+<n id="2" p="263.44 367.76" Element="9"/>
+<n id="3" p="283.22 348.33"/>
+<n id="4" p="295.58 355.62"/>
+<n id="6" p="258.37 348.11"/>
+<n id="7" p="277.79 367.89" Element="17" NumHydrogens="0"><t><s>Cl</s></t></n>
+{bond101}
+<b id="102" B="1" E="3"/>
+<b id="103" B="1" E="7"/>
+<b id="104" B="1" E="6"/>
+<b id="105" B="3" E="4"/>
+</fragment>
+</page>
+</CDXML>"#
+        )
+    }
+
+    const RDKIT_9359_CENTER: chematic_core::AtomIdx = chematic_core::AtomIdx(0);
+
+    #[test]
+    fn rdkit_9359_no_display_has_no_chirality() {
+        // Flat drawing, no wedge at all -- must NOT invent stereo.
+        let (mol, _) = parse_cdxml(&rdkit_9359_cdxml(None)).unwrap();
+        assert_eq!(mol.atom(RDKIT_9359_CENTER).chirality, Chirality::None);
+    }
+
+    #[test]
+    fn rdkit_9359_bold_perceives_chirality() {
+        let (mol, _) = parse_cdxml(&rdkit_9359_cdxml(Some("Bold"))).unwrap();
+        assert_ne!(
+            mol.atom(RDKIT_9359_CENTER).chirality,
+            Chirality::None,
+            "RDKit #9359: Display=\"Bold\" must perceive a real chirality, \
+             matching center_atom(mol).GetChiralTag() != CHI_UNSPECIFIED"
+        );
+        assert!(mol.stereo_neighbor_order(RDKIT_9359_CENTER).is_some());
+    }
+
+    #[test]
+    fn rdkit_9359_hash_perceives_chirality() {
+        let (mol, _) = parse_cdxml(&rdkit_9359_cdxml(Some("Hash"))).unwrap();
+        assert_ne!(
+            mol.atom(RDKIT_9359_CENTER).chirality,
+            Chirality::None,
+            "RDKit #9359: Display=\"Hash\" (undirectional) must also perceive chirality"
+        );
+    }
+
+    /// The meaning check the reviewer required, not just non-None: Bold
+    /// ("coming toward viewer") and Hash ("going away from viewer") are
+    /// chemically OPPOSITE for the exact same 2D layout -- if perception
+    /// were just guessing, there'd be no reason for these to differ let
+    /// alone invert consistently.
+    #[test]
+    fn rdkit_9359_bold_and_hash_are_opposite_configurations() {
+        let (mol_bold, _) = parse_cdxml(&rdkit_9359_cdxml(Some("Bold"))).unwrap();
+        let (mol_hash, _) = parse_cdxml(&rdkit_9359_cdxml(Some("Hash"))).unwrap();
+        let bold_chirality = mol_bold.atom(RDKIT_9359_CENTER).chirality;
+        let hash_chirality = mol_hash.atom(RDKIT_9359_CENTER).chirality;
+        assert_ne!(bold_chirality, Chirality::None);
+        assert_ne!(hash_chirality, Chirality::None);
+        assert_ne!(
+            bold_chirality, hash_chirality,
+            "Bold (toward viewer) and Hash (away from viewer) on the identical \
+             2D layout must give opposite configurations, not the same one"
+        );
+
+        // Independent oracle cross-check: accurate CIP assignment must
+        // agree that these two are opposite, not just chematic's own raw
+        // Chirality enum by coincidence.
+        let cip_bold = chematic_chem::assign_cip(&mol_bold).get(RDKIT_9359_CENTER);
+        let cip_hash = chematic_chem::assign_cip(&mol_hash).get(RDKIT_9359_CENTER);
+        assert!(
+            cip_bold.is_some() && cip_hash.is_some(),
+            "{cip_bold:?} {cip_hash:?}"
+        );
+        assert_ne!(
+            cip_bold, cip_hash,
+            "independent CIP oracle must also see Bold/Hash as opposite R/S"
+        );
+    }
+
+    /// "Bold" and "WedgeBegin" both encode the same "coming toward viewer"
+    /// convention -- for the identical layout they must produce the SAME
+    /// chirality, not just both-non-None independently.
+    #[test]
+    fn rdkit_9359_bold_matches_wedge_begin_configuration() {
+        let (mol_bold, _) = parse_cdxml(&rdkit_9359_cdxml(Some("Bold"))).unwrap();
+        let (mol_wedge, _) = parse_cdxml(&rdkit_9359_cdxml(Some("WedgeBegin"))).unwrap();
+        assert_eq!(
+            mol_bold.atom(RDKIT_9359_CENTER).chirality,
+            mol_wedge.atom(RDKIT_9359_CENTER).chirality,
+        );
+    }
+
+    /// B/E-reversed variant (required by review): swapping which atom is
+    /// stored as B vs E for the SAME Display value must invert the
+    /// perceived configuration -- the wedge-direction convention is
+    /// anchored to the bond's own B->E order, not to "whichever atom turns
+    /// out to be the real stereocenter."
+    #[test]
+    fn rdkit_9359_bold_be_reversed_inverts_configuration() {
+        let (mol_forward, _) = parse_cdxml(&rdkit_9359_cdxml(Some("Bold"))).unwrap();
+        let reversed = rdkit_9359_cdxml(Some("Bold")).replace(
+            r#"<b id="101" B="1" E="2" Display="Bold"/>"#,
+            r#"<b id="101" B="2" E="1" Display="Bold"/>"#,
+        );
+        let (mol_reversed, _) = parse_cdxml(&reversed).unwrap();
+        let forward = mol_forward.atom(RDKIT_9359_CENTER).chirality;
+        let rev = mol_reversed.atom(RDKIT_9359_CENTER).chirality;
+        assert_ne!(forward, Chirality::None);
+        assert_ne!(rev, Chirality::None);
+        assert_ne!(
+            forward, rev,
+            "reversing B/E for the same Display must invert the perceived configuration"
+        );
+    }
+
+    /// Reflection (negate all Y coordinates) must invert the perceived
+    /// configuration; rotation + translation must leave it unchanged.
+    #[test]
+    fn rdkit_9359_bold_reflection_inverts_rotation_translation_preserves() {
+        let base = rdkit_9359_cdxml(Some("Bold"));
+        let (mol_base, coords_base) = parse_cdxml(&base).unwrap();
+        let base_chirality = mol_base.atom(RDKIT_9359_CENTER).chirality;
+        assert_ne!(base_chirality, Chirality::None);
+
+        // Reflection: negate Y for every atom's `p` attribute.
+        let reflect_re = regex_lite_reflect_y(&base);
+        let (mol_reflected, _) = parse_cdxml(&reflect_re).unwrap();
+        assert_eq!(
+            mol_reflected.atom(RDKIT_9359_CENTER).chirality,
+            invert(base_chirality),
+            "mirroring the 2D layout (negate Y) must invert the configuration"
+        );
+
+        // Rotation (37 degrees) + translation (+1000, -500): must be a
+        // no-op for chirality -- recompute coords directly (not via the
+        // CDXML string) since only chematic_perception's own math needs
+        // exercising here, not the parser's coordinate formatting.
+        let theta: f64 = 37.0_f64.to_radians();
+        let (sin_t, cos_t) = theta.sin_cos();
+        let rotated_translated: Vec<(f64, f64)> = coords_base
+            .iter()
+            .map(|&(x, y)| {
+                let (rx, ry) = (x * cos_t - y * sin_t, x * sin_t + y * cos_t);
+                (rx + 1000.0, ry - 500.0)
+            })
+            .collect();
+        let mut mol_rt = mol_base.clone();
+        chematic_perception::apply_local_parity_from_wedges(&mut mol_rt, &rotated_translated);
+        assert_eq!(
+            mol_rt.atom(RDKIT_9359_CENTER).chirality,
+            base_chirality,
+            "rotation + translation must not change the perceived configuration"
+        );
+    }
+
+    fn invert(c: Chirality) -> Chirality {
+        match c {
+            Chirality::Clockwise => Chirality::CounterClockwise,
+            Chirality::CounterClockwise => Chirality::Clockwise,
+            Chirality::None => Chirality::None,
+        }
+    }
+
+    /// Negates the Y coordinate of every atom's `p="x y"` attribute in a
+    /// CDXML fragment string -- test-only helper, not a general XML editor.
+    fn regex_lite_reflect_y(cdxml: &str) -> String {
+        let mut out = String::with_capacity(cdxml.len());
+        let mut rest = cdxml;
+        while let Some(start) = rest.find("p=\"") {
+            out.push_str(&rest[..start + 3]);
+            rest = &rest[start + 3..];
+            let end = rest.find('"').expect("unterminated p attribute");
+            let coord = &rest[..end];
+            let mut parts = coord.split_whitespace();
+            let x: f64 = parts.next().unwrap().parse().unwrap();
+            let y: f64 = parts.next().unwrap().parse().unwrap();
+            out.push_str(&format!("{x} {}", -y));
+            rest = &rest[end..];
+        }
+        out.push_str(rest);
+        out
+    }
+
+    // ── Ambiguity: non-directional wedge between two stereocenters ────────
+
+    /// Both endpoints of a single "Bold" bond independently qualify as
+    /// stereocenter candidates (degree 4 each) -- a non-directional wedge
+    /// has no narrow/wide-end convention to say which one it actually
+    /// describes, so BOTH must abstain (fail closed) rather than each
+    /// independently claiming a configuration derived from contradictory
+    /// height assignments of the same bond.
+    #[test]
+    fn bold_bond_between_two_stereocenters_abstains_both_sides() {
+        let cdxml = r#"<CDXML><fragment>
+<n id="1" p="0 0"/>
+<n id="2" p="10 0"/>
+<n id="3" p="0 10" Element="9"/>
+<n id="4" p="-10 0" Element="17"/>
+<n id="5" p="0 -10" Element="35"/>
+<n id="6" p="20 10" Element="9"/>
+<n id="7" p="20 -10" Element="17"/>
+<n id="8" p="10 -20" Element="35"/>
+<b B="1" E="2" Display="Bold"/>
+<b B="1" E="3"/>
+<b B="1" E="4"/>
+<b B="1" E="5"/>
+<b B="2" E="6"/>
+<b B="2" E="7"/>
+<b B="2" E="8"/>
+</fragment></CDXML>"#;
+        let (mol, _) = parse_cdxml(cdxml).unwrap();
+        let a1 = chematic_core::AtomIdx(0);
+        let a2 = chematic_core::AtomIdx(1);
+        assert_eq!(mol.neighbors(a1).count(), 4);
+        assert_eq!(mol.neighbors(a2).count(), 4);
+        assert_eq!(
+            mol.atom(a1).chirality,
+            Chirality::None,
+            "ambiguous non-directional wedge between two stereocenters must abstain"
+        );
+        assert_eq!(mol.atom(a2).chirality, Chirality::None);
+        assert_eq!(
+            mol.bond(chematic_core::BondIdx(0)).order,
+            BondOrder::Single,
+            "the ambiguous bond itself must be downgraded before perception runs"
+        );
+    }
+
+    /// Negative control: the exact same connectivity/geometry, but with a
+    /// real directional "WedgeBegin" instead of "Bold" -- the Begin atom is
+    /// unambiguously the reference by CDXML's own convention, so this is
+    /// NOT ambiguous and must keep perceiving chirality normally (proves
+    /// the downgrade in the test above is specific to non-directional
+    /// displays, not a blanket "shared bond between two stereocenters"
+    /// suppression that would also break the common, unambiguous case).
+    #[test]
+    fn wedge_begin_between_two_stereocenters_is_not_ambiguous() {
+        let cdxml = r#"<CDXML><fragment>
+<n id="1" p="0 0"/>
+<n id="2" p="10 0"/>
+<n id="3" p="0 10" Element="9"/>
+<n id="4" p="-10 0" Element="17"/>
+<n id="5" p="0 -10" Element="35"/>
+<n id="6" p="20 10" Element="9"/>
+<n id="7" p="20 -10" Element="17"/>
+<n id="8" p="10 -20" Element="35"/>
+<b B="1" E="2" Display="WedgeBegin"/>
+<b B="1" E="3"/>
+<b B="1" E="4"/>
+<b B="1" E="5"/>
+<b B="2" E="6"/>
+<b B="2" E="7"/>
+<b B="2" E="8"/>
+</fragment></CDXML>"#;
+        let (mol, _) = parse_cdxml(cdxml).unwrap();
+        let a1 = chematic_core::AtomIdx(0);
+        assert_ne!(
+            mol.atom(a1).chirality,
+            Chirality::None,
+            "a directional WedgeBegin between two stereocenters is not ambiguous \
+             and must still perceive chirality"
+        );
+        assert_eq!(
+            mol.bond(chematic_core::BondIdx(0)).order,
+            BondOrder::Up,
+            "a directional wedge must never be downgraded by the ambiguity check"
         );
     }
 

--- a/crates/chematic-mol/src/cdxml.rs
+++ b/crates/chematic-mol/src/cdxml.rs
@@ -26,17 +26,20 @@
 //!   [`chematic_perception::apply_local_parity_from_wedges`] -- the same
 //!   CIP-independent mechanism the MOL/MRV readers use, so it abstains
 //!   (leaves `Chirality::None`) rather than guessing on contradictory
-//!   wedges, missing coordinates, or degenerate/coplanar geometry. A
-//!   non-directional `Display` (`Bold`/`Hash`/`Dash`, which has no
-//!   narrow/wide end telling you which atom it actually describes) is
-//!   additionally downgraded to a plain single bond before perception runs
-//!   if BOTH of its endpoints independently qualify as stereocenter
-//!   candidates -- one such bond cannot mean "toward the viewer" from both
-//!   ends of the same bond at once, so both abstain rather than each
-//!   guessing from contradictory height assignments. A directional wedge
-//!   (`WedgeBegin`/`WedgeEnd`) between two such candidates is NOT ambiguous
+//!   wedges, missing coordinates, or degenerate/coplanar geometry.
+//!   Directional wedges (`WedgeBegin`/`WedgeEnd`/`WedgedHashBegin`/
+//!   `WedgedHashEnd`) are always perceived. Non-directional ones
+//!   (`Bold`/`Hash`/`Dash` -- a plain thick or dashed line, no narrow/wide
+//!   end) are perceived only when [`CdxmlParseOptions::infer_nondirectional_stereo`]
+//!   is explicitly opted in (`parse_cdxml_with_options`/
+//!   `parse_cdxml_all_with_options`), since `Bold` in particular is
+//!   sometimes drawn for visual emphasis rather than stereo intent. When
+//!   opted in, a non-directional bond whose BOTH endpoints independently
+//!   qualify as stereocenter candidates (3-4 neighbours) still abstains --
+//!   one such bond cannot mean "toward the viewer" from both ends at once
+//!   -- while a directional wedge in the same situation is not ambiguous
 //!   (the Begin atom is the reference by CDXML's own convention) and is
-//!   unaffected by this check.
+//!   unaffected either way.
 //! - E/Z double-bond stereo is derived from 2D coordinates via `assign_ez_from_2d`.
 //! - Presentation-only nodes (text boxes, arrows, etc.) are silently skipped.
 
@@ -84,23 +87,58 @@ impl std::error::Error for CdxmlError {}
 // Parser
 // ---------------------------------------------------------------------------
 
+/// Options controlling optional/heuristic CDXML parsing behavior.
+///
+/// Currently just the one knob (kept as a struct, not a bare `bool`
+/// parameter, so a future option doesn't force every call site to change
+/// signature again).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CdxmlParseOptions {
+    /// When `true`, also perceive tetrahedral chirality from
+    /// **non-directional** wedge displays (`Bold`/`Hash`/`Dash` -- a plain
+    /// thick or dashed line, no narrow/wide end). Default **`false`**:
+    /// `Bold` in particular is sometimes used by chemists as a plain thick
+    /// line for visual emphasis, not stereo intent, so treating it as
+    /// stereo unconditionally would manufacture false positives (RDKit
+    /// issue #9359's own discussion leans the same way -- inferring stereo
+    /// from these should be opt-in, not silently default).
+    ///
+    /// This flag has no effect on **directional** wedges
+    /// (`WedgeBegin`/`WedgeEnd`/`WedgedHashBegin`/`WedgedHashEnd`), which
+    /// are unambiguous stereo intent and are always perceived regardless.
+    pub infer_nondirectional_stereo: bool,
+}
+
 /// Parse a CDXML document and return the first molecular fragment.
 ///
-/// Convenience wrapper around [`parse_cdxml_all`].
-/// Parse a ChemDraw CDXML string into a molecule and 2D coordinates.
+/// Convenience wrapper around [`parse_cdxml_all`], using
+/// [`CdxmlParseOptions::default`]. Use [`parse_cdxml_with_options`] to
+/// perceive chirality from non-directional (`Bold`/`Hash`/`Dash`) wedges
+/// too.
 ///
 /// **Coordinate system:** The returned `coords` use **ChemDraw Y-down convention**
 /// (Y increases downward, matching screen/SVG pixel space). No Y-axis conversion is required
 /// for SVG rendering; coordinates can be used directly in [`crate::svg::render_svg`] or similar.
 pub fn parse_cdxml(input: &str) -> Result<(Molecule, Vec<(f64, f64)>), CdxmlError> {
-    let mut all = parse_cdxml_all(input)?;
+    parse_cdxml_with_options(input, &CdxmlParseOptions::default())
+}
+
+/// Same as [`parse_cdxml`], with explicit [`CdxmlParseOptions`].
+pub fn parse_cdxml_with_options(
+    input: &str,
+    options: &CdxmlParseOptions,
+) -> Result<(Molecule, Vec<(f64, f64)>), CdxmlError> {
+    let mut all = parse_cdxml_all_with_options(input, options)?;
     if all.is_empty() {
         return Ok((MoleculeBuilder::new().build(), vec![]));
     }
     Ok(all.remove(0))
 }
 
-/// Parse all molecular fragments from a CDXML document.
+/// Parse all molecular fragments from a CDXML document, using
+/// [`CdxmlParseOptions::default`]. Use [`parse_cdxml_all_with_options`] to
+/// perceive chirality from non-directional (`Bold`/`Hash`/`Dash`) wedges
+/// too.
 ///
 /// Each `<fragment>` element in the document is parsed as a separate
 /// molecule.  Returns a `Vec` of `(Molecule, 2D-coords)` pairs in document
@@ -119,7 +157,13 @@ pub fn parse_cdxml(input: &str) -> Result<(Molecule, Vec<(f64, f64)>), CdxmlErro
 ///
 /// These wedge bonds, combined with 2D coordinates, are what actually
 /// perceives `Atom.chirality` (see the module-level doc for the full
-/// abstain-on-ambiguity behavior).
+/// abstain-on-ambiguity behavior, and [`CdxmlParseOptions`] for the
+/// non-directional opt-in).
+#[allow(clippy::type_complexity)]
+pub fn parse_cdxml_all(input: &str) -> Result<Vec<(Molecule, Vec<(f64, f64)>)>, CdxmlError> {
+    parse_cdxml_all_with_options(input, &CdxmlParseOptions::default())
+}
+
 /// Accumulator for a single CDXML `<fragment>` being parsed.
 #[derive(Default)]
 struct FragAccum {
@@ -147,7 +191,11 @@ impl FragAccum {
         self.atom_ids.is_empty() && self.bond_bs.is_empty()
     }
 
-    fn flush(&mut self, results: &mut Vec<(Molecule, Vec<(f64, f64)>)>) -> Result<(), CdxmlError> {
+    fn flush(
+        &mut self,
+        results: &mut Vec<(Molecule, Vec<(f64, f64)>)>,
+        options: &CdxmlParseOptions,
+    ) -> Result<(), CdxmlError> {
         if self.is_empty() {
             return Ok(());
         }
@@ -174,32 +222,6 @@ impl FragAccum {
             bond_pos.push((pos_b, pos_e));
         }
 
-        // Non-directional wedge displays (a plain thick/dashed line, no
-        // narrow/wide end) carry no convention for which endpoint is "the"
-        // stereocenter -- unlike WedgeBegin/WedgeEnd, whose Begin atom is
-        // the narrow end by CDXML's own drawing convention. If BOTH
-        // endpoints independently qualify as stereocenter candidates (3-4
-        // neighbours, [`chematic_perception`]'s own gate), a single such
-        // bond cannot mean "toward the viewer" from both ends at once --
-        // downgrade it to a plain single bond before parity perception runs
-        // so neither endpoint gets a chirality assignment it can't justify.
-        // A directional wedge between two such candidates is NOT ambiguous
-        // (the Begin atom is unambiguously the reference) and must keep
-        // working, so only the non-directional set is checked here.
-        for (k, &(pos_b, pos_e)) in bond_pos.iter().enumerate() {
-            let is_nondirectional_wedge = matches!(
-                self.bond_display[k].as_deref(),
-                Some("Bold") | Some("Hash") | Some("Dash")
-            );
-            if !is_nondirectional_wedge {
-                continue;
-            }
-            let eligible = |d: usize| (3..=4).contains(&d);
-            if eligible(degree[pos_b]) && eligible(degree[pos_e]) {
-                self.bond_ords[k] = BondOrder::Single;
-            }
-        }
-
         let mut builder = MoleculeBuilder::new();
         let mut idx_map: HashMap<usize, AtomIdx> = HashMap::new();
         let mut coords: Vec<(f64, f64)> = Vec::new();
@@ -214,6 +236,11 @@ impl FragAccum {
             coords.push((self.atom_xs[i], self.atom_ys[i]));
         }
 
+        // The REAL molecule keeps every wedge bond's Display-derived
+        // BondOrder::Up/Down and its original B/E atom order exactly as
+        // parsed, for ANY Display value -- structural/round-trip fidelity
+        // is unconditional, independent of whether that bond ends up
+        // feeding chirality perception below.
         for (k, &(pos_b, pos_e)) in bond_pos.iter().enumerate() {
             let a1 = idx_map[&pos_b];
             let a2 = idx_map[&pos_e];
@@ -223,19 +250,115 @@ impl FragAccum {
         }
 
         let mut mol = builder.build();
-        // Tetrahedral parity first (raw wedge/hash still fully intact on
-        // bond.order), THEN E/Z direction -- same ordering rationale as
-        // mol2000.rs/mol3000.rs/mrv.rs: E/Z writes to a separate side
-        // channel (cip_code here) and never touches bond.order, so it can't
-        // disturb the wedge/hash data parity perception just consumed.
-        // RDKit issue #9359: CDXML reading never perceived tetrahedral
-        // chirality from wedge/hash bonds at all, for ANY Display value
-        // (WedgeBegin included) -- this closes that gap using the same
-        // shared, CIP-independent local-parity mechanism the MOL/MRV
-        // readers already use, so CDXML gets the same abstain-don't-guess
-        // guarantees (contradictory wedges, missing coordinates,
-        // degenerate/coplanar geometry) for free.
-        apply_local_parity_from_wedges(&mut mol, &coords);
+
+        // Non-directional wedge displays (`Bold`/`Hash`/`Dash` -- a plain
+        // thick or dashed line, no narrow/wide end) carry NO Begin/End
+        // convention at all in the CDXML spec, unlike `WedgeBegin`/
+        // `WedgeEnd`/`WedgedHashBegin`/`WedgedHashEnd`. Which atom a `<b>`
+        // element happens to list first as `B` is an arbitrary artifact of
+        // however the file was written -- it is not a "narrow end" signal,
+        // so `chematic_perception::wedge_z`'s `bond.atom1` == the tip/
+        // reference-atom convention (correct for a directional wedge, whose
+        // Begin atom genuinely IS the tip) must not be applied naively to
+        // these using the raw B/E order. Concretely: swapping which atom a
+        // CDXML author lists as B vs E for the identical drawing must NOT
+        // change the perceived configuration for `Bold`/`Hash`/`Dash`,
+        // while it correctly DOES for a real `WedgeBegin`/`WedgeEnd` pair
+        // (the Begin atom is genuinely a different physical reference).
+        //
+        // Resolved by perceiving parity on a throwaway VIEW of the
+        // molecule, not the real one -- so the real molecule's own bond
+        // orders/atom order are never touched by any of this -- with each
+        // non-directional bond's contribution to that view decided as:
+        //   - `options.infer_nondirectional_stereo` is `false` (the
+        //     default): downgraded to `Single` in the view unconditionally.
+        //     `Bold` in particular is sometimes drawn for visual emphasis,
+        //     not stereo intent, so this reader does not manufacture
+        //     stereo from it unless explicitly asked to.
+        //   - `true`, exactly one endpoint qualifies as a stereocenter
+        //     candidate (3-4 neighbours, matching
+        //     [`chematic_perception`]'s own gate): reordered in the view so
+        //     that endpoint is atom1 -- then `wedge_z`'s existing
+        //     atom1-is-the-reference convention becomes correct by
+        //     construction, independent of the original B/E order.
+        //   - `true`, both endpoints qualify: one non-directional bond
+        //     cannot mean "toward the viewer" from both ends of the same
+        //     bond at once -- downgraded to `Single` in the view so neither
+        //     gets a chirality it can't justify (a directional wedge in the
+        //     same situation is NOT ambiguous, since the Begin atom is
+        //     unambiguously the reference, and is never altered here).
+        //   - `true`, neither qualifies: no-op (the shared perception gate
+        //     already skips both regardless).
+        // Directional wedges are never altered in the view either way.
+        let any_nondirectional_wedge = self
+            .bond_display
+            .iter()
+            .any(|d| matches!(d.as_deref(), Some("Bold") | Some("Hash") | Some("Dash")));
+        if !any_nondirectional_wedge {
+            apply_local_parity_from_wedges(&mut mol, &coords);
+        } else {
+            let mut view = mol.clone();
+            for (k, &(pos_b, pos_e)) in bond_pos.iter().enumerate() {
+                let is_nondirectional_wedge = matches!(
+                    self.bond_display[k].as_deref(),
+                    Some("Bold") | Some("Hash") | Some("Dash")
+                );
+                if !is_nondirectional_wedge {
+                    continue;
+                }
+                let (a1, a2) = (idx_map[&pos_b], idx_map[&pos_e]);
+                let Some((bond_idx, _)) = view.bond_between(a1, a2) else {
+                    continue;
+                };
+                if !options.infer_nondirectional_stereo {
+                    view.set_bond_order(bond_idx, BondOrder::Single);
+                    continue;
+                }
+                let eligible = |d: usize| (3..=4).contains(&d);
+                let (b_elig, e_elig) = (eligible(degree[pos_b]), eligible(degree[pos_e]));
+                if b_elig && e_elig {
+                    view.set_bond_order(bond_idx, BondOrder::Single);
+                } else if e_elig && !b_elig {
+                    // The candidate (stereocenter) is E, not B. `wedge_z`
+                    // reads `bond.atom1` as the reference atom -- flip
+                    // Up<->Down (equivalent to "as seen from E instead of
+                    // B") rather than swapping atom1/atom2 in place: a
+                    // swap would require remove_bond+add_bond, which
+                    // perturbs `neighbors()` iteration order for BOTH
+                    // endpoints (adjacency is rebuilt from the bond list's
+                    // new order), silently changing which neighbor
+                    // `chematic_perception` picks as tetrahedral apex --
+                    // confirmed empirically: an earlier swap-based version
+                    // of this fix produced a real, non-obvious B/E-order
+                    // dependence via exactly this side channel. Flipping
+                    // just the order field has no such effect (checked in
+                    // `set_bond_order`'s own doc).
+                    let flipped = match view.bond(bond_idx).order {
+                        BondOrder::Up => BondOrder::Down,
+                        BondOrder::Down => BondOrder::Up,
+                        other => other,
+                    };
+                    view.set_bond_order(bond_idx, flipped);
+                }
+            }
+            apply_local_parity_from_wedges(&mut view, &coords);
+            for i in 0..self.atom_ids.len() {
+                let idx = idx_map[&i];
+                let chirality = view.atom(idx).chirality;
+                if chirality != chematic_core::Chirality::None {
+                    mol.set_chirality(idx, chirality);
+                    if let Some(order) = view.stereo_neighbor_order(idx) {
+                        mol.set_stereo_neighbor_order(idx, order.to_vec());
+                    }
+                }
+            }
+        }
+
+        // Tetrahedral parity (above) runs before E/Z direction (below) --
+        // same ordering rationale as mol2000.rs/mol3000.rs/mrv.rs: E/Z
+        // writes to a separate side channel (cip_code here) and never
+        // touches bond.order, so it can't disturb the wedge/hash data
+        // parity perception just consumed.
         // Derive E/Z stereo from 2D atom positions (RDKit issue #9356: CDXML loses E/Z).
         assign_ez_from_2d(&mut mol, &coords);
         results.push((mol, coords));
@@ -247,8 +370,12 @@ impl FragAccum {
 /// Maximum atoms allowed in a single CDXML fragment (DoS guard).
 pub const CDXML_MAX_ATOMS: usize = 10_000;
 
+/// Same as [`parse_cdxml_all`], with explicit [`CdxmlParseOptions`].
 #[allow(clippy::type_complexity)]
-pub fn parse_cdxml_all(input: &str) -> Result<Vec<(Molecule, Vec<(f64, f64)>)>, CdxmlError> {
+pub fn parse_cdxml_all_with_options(
+    input: &str,
+    options: &CdxmlParseOptions,
+) -> Result<Vec<(Molecule, Vec<(f64, f64)>)>, CdxmlError> {
     let mut acc = FragAccum::default();
     let mut results: Vec<(Molecule, Vec<(f64, f64)>)> = Vec::new();
 
@@ -264,7 +391,7 @@ pub fn parse_cdxml_all(input: &str) -> Result<Vec<(Molecule, Vec<(f64, f64)>)>, 
         }
 
         if line.starts_with("</fragment>") {
-            acc.flush(&mut results)?;
+            acc.flush(&mut results, options)?;
             continue;
         }
 
@@ -357,7 +484,7 @@ pub fn parse_cdxml_all(input: &str) -> Result<Vec<(Molecule, Vec<(f64, f64)>)>, 
     }
 
     // Handle documents without explicit </fragment> closing tags.
-    acc.flush(&mut results)?;
+    acc.flush(&mut results, options)?;
 
     Ok(results)
 }
@@ -836,32 +963,105 @@ mod tests {
 
     const RDKIT_9359_CENTER: chematic_core::AtomIdx = chematic_core::AtomIdx(0);
 
-    #[test]
-    fn rdkit_9359_no_display_has_no_chirality() {
-        // Flat drawing, no wedge at all -- must NOT invent stereo.
-        let (mol, _) = parse_cdxml(&rdkit_9359_cdxml(None)).unwrap();
-        assert_eq!(mol.atom(RDKIT_9359_CENTER).chirality, Chirality::None);
+    /// Parses with [`CdxmlParseOptions::infer_nondirectional_stereo`] on --
+    /// the opt-in path, used by tests specifically exercising Bold/Hash
+    /// chirality perception (which is off by default, see the
+    /// default-behavior tests below).
+    fn parse_infer(cdxml: &str) -> (Molecule, Vec<(f64, f64)>) {
+        parse_cdxml_with_options(
+            cdxml,
+            &CdxmlParseOptions {
+                infer_nondirectional_stereo: true,
+            },
+        )
+        .unwrap()
     }
 
     #[test]
-    fn rdkit_9359_bold_perceives_chirality() {
+    fn rdkit_9359_no_display_has_no_chirality() {
+        // Flat drawing, no wedge at all -- must NOT invent stereo, with or
+        // without the opt-in (nothing to infer from either way).
+        let (mol, _) = parse_cdxml(&rdkit_9359_cdxml(None)).unwrap();
+        assert_eq!(mol.atom(RDKIT_9359_CENTER).chirality, Chirality::None);
+        let (mol, _) = parse_infer(&rdkit_9359_cdxml(None));
+        assert_eq!(mol.atom(RDKIT_9359_CENTER).chirality, Chirality::None);
+    }
+
+    // ── Default behavior: Bold/Hash do NOT perceive chirality unopted ─────
+    //
+    // `Bold` in particular is sometimes drawn by chemists as a plain thick
+    // line for visual emphasis, not stereo intent (RDKit #9359's own
+    // discussion leans toward this being opt-in, not silently default) --
+    // so `parse_cdxml`/`parse_cdxml_all` (no explicit options) must NOT
+    // manufacture a chirality from it. `bond.order` still faithfully
+    // records `BondOrder::Up`/`Down` either way (structural fidelity is
+    // unconditional) -- only chirality PERCEPTION is gated.
+
+    #[test]
+    fn rdkit_9359_bold_default_does_not_perceive_chirality() {
         let (mol, _) = parse_cdxml(&rdkit_9359_cdxml(Some("Bold"))).unwrap();
+        assert_eq!(
+            mol.atom(RDKIT_9359_CENTER).chirality,
+            Chirality::None,
+            "Bold must NOT perceive chirality by default (opt-in required)"
+        );
+        assert_eq!(
+            mol.bond(chematic_core::BondIdx(0)).order,
+            BondOrder::Up,
+            "the bond's own order must still faithfully record Up regardless \
+             of whether chirality perception is opted in"
+        );
+    }
+
+    #[test]
+    fn rdkit_9359_hash_default_does_not_perceive_chirality() {
+        let (mol, _) = parse_cdxml(&rdkit_9359_cdxml(Some("Hash"))).unwrap();
+        assert_eq!(
+            mol.atom(RDKIT_9359_CENTER).chirality,
+            Chirality::None,
+            "Hash must NOT perceive chirality by default (opt-in required)"
+        );
+        assert_eq!(mol.bond(chematic_core::BondIdx(0)).order, BondOrder::Down);
+    }
+
+    /// Directional wedges are NOT gated by the opt-in -- they're
+    /// unambiguous stereo intent (a real tapered wedge), so the default
+    /// (no options) already perceives chirality from them, matching the
+    /// RDKit #9359 expectation (`center_atom(mol).GetChiralTag() !=
+    /// CHI_UNSPECIFIED`) out of the box.
+    #[test]
+    fn rdkit_9359_wedge_begin_default_perceives_chirality() {
+        let (mol, _) = parse_cdxml(&rdkit_9359_cdxml(Some("WedgeBegin"))).unwrap();
         assert_ne!(
             mol.atom(RDKIT_9359_CENTER).chirality,
             Chirality::None,
-            "RDKit #9359: Display=\"Bold\" must perceive a real chirality, \
-             matching center_atom(mol).GetChiralTag() != CHI_UNSPECIFIED"
+            "a real directional wedge must perceive chirality without any opt-in"
+        );
+        assert!(mol.stereo_neighbor_order(RDKIT_9359_CENTER).is_some());
+    }
+
+    // ── Opt-in behavior (`infer_nondirectional_stereo: true`) ─────────────
+
+    #[test]
+    fn rdkit_9359_bold_perceives_chirality_when_opted_in() {
+        let (mol, _) = parse_infer(&rdkit_9359_cdxml(Some("Bold")));
+        assert_ne!(
+            mol.atom(RDKIT_9359_CENTER).chirality,
+            Chirality::None,
+            "RDKit #9359: Display=\"Bold\" must perceive a real chirality when \
+             opted in, matching center_atom(mol).GetChiralTag() != CHI_UNSPECIFIED"
         );
         assert!(mol.stereo_neighbor_order(RDKIT_9359_CENTER).is_some());
     }
 
     #[test]
-    fn rdkit_9359_hash_perceives_chirality() {
-        let (mol, _) = parse_cdxml(&rdkit_9359_cdxml(Some("Hash"))).unwrap();
+    fn rdkit_9359_hash_perceives_chirality_when_opted_in() {
+        let (mol, _) = parse_infer(&rdkit_9359_cdxml(Some("Hash")));
         assert_ne!(
             mol.atom(RDKIT_9359_CENTER).chirality,
             Chirality::None,
-            "RDKit #9359: Display=\"Hash\" (undirectional) must also perceive chirality"
+            "RDKit #9359: Display=\"Hash\" (undirectional) must also perceive \
+             chirality when opted in"
         );
     }
 
@@ -872,8 +1072,8 @@ mod tests {
     /// alone invert consistently.
     #[test]
     fn rdkit_9359_bold_and_hash_are_opposite_configurations() {
-        let (mol_bold, _) = parse_cdxml(&rdkit_9359_cdxml(Some("Bold"))).unwrap();
-        let (mol_hash, _) = parse_cdxml(&rdkit_9359_cdxml(Some("Hash"))).unwrap();
+        let (mol_bold, _) = parse_infer(&rdkit_9359_cdxml(Some("Bold")));
+        let (mol_hash, _) = parse_infer(&rdkit_9359_cdxml(Some("Hash")));
         let bold_chirality = mol_bold.atom(RDKIT_9359_CENTER).chirality;
         let hash_chirality = mol_hash.atom(RDKIT_9359_CENTER).chirality;
         assert_ne!(bold_chirality, Chirality::None);
@@ -904,7 +1104,7 @@ mod tests {
     /// chirality, not just both-non-None independently.
     #[test]
     fn rdkit_9359_bold_matches_wedge_begin_configuration() {
-        let (mol_bold, _) = parse_cdxml(&rdkit_9359_cdxml(Some("Bold"))).unwrap();
+        let (mol_bold, _) = parse_infer(&rdkit_9359_cdxml(Some("Bold")));
         let (mol_wedge, _) = parse_cdxml(&rdkit_9359_cdxml(Some("WedgeBegin"))).unwrap();
         assert_eq!(
             mol_bold.atom(RDKIT_9359_CENTER).chirality,
@@ -912,26 +1112,73 @@ mod tests {
         );
     }
 
-    /// B/E-reversed variant (required by review): swapping which atom is
-    /// stored as B vs E for the SAME Display value must invert the
-    /// perceived configuration -- the wedge-direction convention is
-    /// anchored to the bond's own B->E order, not to "whichever atom turns
-    /// out to be the real stereocenter."
+    /// B/E-reversed variant, non-directional (required by review, and the
+    /// review's own required *expected value* corrected from an earlier,
+    /// wrong assumption): `Bold`/`Hash`/`Dash` have NO Begin/End
+    /// convention in the CDXML spec at all -- unlike `WedgeBegin`/
+    /// `WedgeEnd`, whose Begin atom is a real, drawn narrow end. Which
+    /// atom a `<b>` element happens to list first as `B` for a `Bold`
+    /// bond is an arbitrary artifact of how the file was written, not a
+    /// stereo-relevant signal -- so swapping B/E for the SAME `Bold`
+    /// drawing must PRESERVE the perceived configuration, not invert it.
     #[test]
-    fn rdkit_9359_bold_be_reversed_inverts_configuration() {
-        let (mol_forward, _) = parse_cdxml(&rdkit_9359_cdxml(Some("Bold"))).unwrap();
+    fn rdkit_9359_bold_be_reversed_preserves_configuration() {
+        let (mol_forward, _) = parse_infer(&rdkit_9359_cdxml(Some("Bold")));
         let reversed = rdkit_9359_cdxml(Some("Bold")).replace(
             r#"<b id="101" B="1" E="2" Display="Bold"/>"#,
             r#"<b id="101" B="2" E="1" Display="Bold"/>"#,
         );
-        let (mol_reversed, _) = parse_cdxml(&reversed).unwrap();
+        let (mol_reversed, _) = parse_infer(&reversed);
         let forward = mol_forward.atom(RDKIT_9359_CENTER).chirality;
         let rev = mol_reversed.atom(RDKIT_9359_CENTER).chirality;
         assert_ne!(forward, Chirality::None);
-        assert_ne!(rev, Chirality::None);
-        assert_ne!(
+        assert_eq!(
             forward, rev,
-            "reversing B/E for the same Display must invert the perceived configuration"
+            "Bold has no Begin/End convention -- reversing B/E for the identical \
+             drawing must NOT change the perceived configuration"
+        );
+    }
+
+    /// Same B/E-reversal check for `Hash` (the other non-directional
+    /// display), independently -- not inferred from the Bold case alone.
+    #[test]
+    fn rdkit_9359_hash_be_reversed_preserves_configuration() {
+        let (mol_forward, _) = parse_infer(&rdkit_9359_cdxml(Some("Hash")));
+        let reversed = rdkit_9359_cdxml(Some("Hash")).replace(
+            r#"<b id="101" B="1" E="2" Display="Hash"/>"#,
+            r#"<b id="101" B="2" E="1" Display="Hash"/>"#,
+        );
+        let (mol_reversed, _) = parse_infer(&reversed);
+        let forward = mol_forward.atom(RDKIT_9359_CENTER).chirality;
+        let rev = mol_reversed.atom(RDKIT_9359_CENTER).chirality;
+        assert_ne!(forward, Chirality::None);
+        assert_eq!(
+            forward, rev,
+            "Hash has no Begin/End convention -- reversing B/E for the identical \
+             drawing must NOT change the perceived configuration"
+        );
+    }
+
+    /// Negative control, directional: `WedgeBegin` DOES have a real
+    /// Begin/End convention (the Begin atom is the drawn narrow end), so
+    /// switching to `WedgeEnd` for the SAME B/E atom order must genuinely
+    /// invert the configuration (the reference atom flips) -- proves the
+    /// preserve-under-swap behavior above is specific to the
+    /// non-directional set, not a blanket "wedges don't encode direction"
+    /// regression. Uses the default parser (no opt-in needed, directional
+    /// wedges are unaffected by the flag either way).
+    #[test]
+    fn rdkit_9359_wedge_begin_vs_wedge_end_inverts_configuration() {
+        let (mol_begin, _) = parse_cdxml(&rdkit_9359_cdxml(Some("WedgeBegin"))).unwrap();
+        let (mol_end, _) = parse_cdxml(&rdkit_9359_cdxml(Some("WedgeEnd"))).unwrap();
+        let begin = mol_begin.atom(RDKIT_9359_CENTER).chirality;
+        let end = mol_end.atom(RDKIT_9359_CENTER).chirality;
+        assert_ne!(begin, Chirality::None);
+        assert_ne!(end, Chirality::None);
+        assert_ne!(
+            begin, end,
+            "WedgeBegin vs WedgeEnd (same B/E order) must invert -- the Begin \
+             atom is a real, drawn reference, unlike Bold/Hash"
         );
     }
 
@@ -940,13 +1187,13 @@ mod tests {
     #[test]
     fn rdkit_9359_bold_reflection_inverts_rotation_translation_preserves() {
         let base = rdkit_9359_cdxml(Some("Bold"));
-        let (mol_base, coords_base) = parse_cdxml(&base).unwrap();
+        let (mol_base, coords_base) = parse_infer(&base);
         let base_chirality = mol_base.atom(RDKIT_9359_CENTER).chirality;
         assert_ne!(base_chirality, Chirality::None);
 
         // Reflection: negate Y for every atom's `p` attribute.
         let reflect_re = regex_lite_reflect_y(&base);
-        let (mol_reflected, _) = parse_cdxml(&reflect_re).unwrap();
+        let (mol_reflected, _) = parse_infer(&reflect_re);
         assert_eq!(
             mol_reflected.atom(RDKIT_9359_CENTER).chirality,
             invert(base_chirality),
@@ -1030,7 +1277,7 @@ mod tests {
 <b B="2" E="7"/>
 <b B="2" E="8"/>
 </fragment></CDXML>"#;
-        let (mol, _) = parse_cdxml(cdxml).unwrap();
+        let (mol, _) = parse_infer(cdxml);
         let a1 = chematic_core::AtomIdx(0);
         let a2 = chematic_core::AtomIdx(1);
         assert_eq!(mol.neighbors(a1).count(), 4);
@@ -1043,8 +1290,9 @@ mod tests {
         assert_eq!(mol.atom(a2).chirality, Chirality::None);
         assert_eq!(
             mol.bond(chematic_core::BondIdx(0)).order,
-            BondOrder::Single,
-            "the ambiguous bond itself must be downgraded before perception runs"
+            BondOrder::Up,
+            "the bond's own order still faithfully records Bold -> Up; only \
+             chirality PERCEPTION abstains, structural fidelity is unconditional"
         );
     }
 

--- a/crates/chematic-mol/src/lib.rs
+++ b/crates/chematic-mol/src/lib.rs
@@ -38,7 +38,10 @@ pub mod tdt;
 // Convenient re-exports at crate root.
 pub use error::MolParseError;
 // Re-export MolParseError under the alias MolError as specified by the public API.
-pub use cdxml::{CdxmlError, parse_cdxml, parse_cdxml_all, write_cdxml};
+pub use cdxml::{
+    CdxmlError, CdxmlParseOptions, parse_cdxml, parse_cdxml_all, parse_cdxml_all_with_options,
+    parse_cdxml_with_options, write_cdxml,
+};
 pub use cif::{CifError, CifResult, UnitCell, parse_cif, write_cif};
 pub use cjson::{CjsonError, parse_cjson, write_cjson};
 pub use cml::{CmlError, parse_cml, write_cml};


### PR DESCRIPTION
## Summary

Fix 3 of 4 in the "bugs surfaced by surveying RDKit's open issues" program (see the approved plan; Fix 1 = PR #242, Fix 2 = PR #243, Fix 4 = PR #245). Addresses RDKit issue #9359 ("CDXML reading doesn't use \"bold\" or \"undirectional\" hash bonds for stereochemistry").

**Updated after a second review round.** The first version of this PR (Ready) only mapped `Display="Bold"` to `BondOrder::Up` and was moved to Draft: it never perceived any chirality at all. That was fixed in a second commit, which was then reviewed again and found to have a real semantic bug in the B/E-reversal handling, plus a design gap (Bold/Hash should not silently generate stereo by default). Both are fixed here. Full history below.

## Round 1 (original PR): what was wrong

`flush()`'s only stereo-related call was `assign_ez_from_2d` (E/Z double-bond stereo) -- no tetrahedral-parity step existed at all, for any `Display` value including plain `WedgeBegin`. `Atom.chirality` was `Chirality::None` for every CDXML molecule ever parsed, regardless of how it was drawn.

## Round 2: actual chirality perception

`FragAccum::flush()` now calls `chematic_perception::apply_local_parity_from_wedges`, the same shared, CIP-independent mechanism `mol2000.rs`/`mol3000.rs`/`mrv.rs` already use, right after `builder.build()`. CDXML's existing `Display`-to-`BondOrder::Up`/`Down` mapping and its `B`/`E`-to-`atom1`/`atom2` bond storage were already in exactly the shape this shared function expects.

This round also found and fixed a real ambiguity: `Bold`/`Hash`/`Dash` are non-directional, so if both endpoints of one such bond independently qualify as stereocenter candidates, the (necessarily symmetric) shared perception function would assign both endpoints a chirality derived from contradictory height assignments of the same bond. Such bonds are downgraded before perception when both endpoints are 3-4-neighbor candidates.

## Round 3 (this update): two things the reviewer caught, both real

### 1. B/E-reversal was backwards for non-directional displays

My round-2 test asserted that swapping which atom is `B` vs `E` for a `Bold` bond **inverts** the perceived configuration. The reviewer correctly identified this as wrong: per the CDXML spec, only `WedgeBegin`/`WedgeEnd`/`WedgedHashBegin`/`WedgedHashEnd` have a Begin/End (narrow-end) convention. `Bold`/`Hash`/`Dash` have none -- which atom a `<b>` element lists first as `B` is an arbitrary artifact of how the file was written, not a stereo-relevant signal. Reversing B/E for the identical `Bold` drawing must **preserve** the configuration, not invert it. Confirmed against the real CDXML spec semantics and fixed.

**A second, deeper bug surfaced while fixing the first one.** My initial fix normalized non-directional bonds by removing and re-adding them with swapped `atom1`/`atom2` (`Molecule::remove_bond` + `add_bond`). This *looked* right in isolation, but `remove_bond` rebuilds `Molecule` adjacency from the post-removal bond list, and `add_bond` always appends at the end -- so a "swapped" bond ends up in a different position in both endpoints' `neighbors()` iteration order than before. `chematic_perception`'s tetrahedral-parity code picks its "apex" neighbor from `neighbors()`'s first entry, so this silently changed which neighbor was treated as apex, corrupting the very calculation I was trying to fix. Caught by re-running the B/E-reversal test after the "fix" and finding it *still* failed, for a different, non-obvious reason.

Resolved properly: added `Molecule::set_bond_order` (`chematic-core`, in-place mutation of just the `order` field, never touches `atom1`/`atom2` or adjacency) and switched the non-directional-bond normalization to **flip `BondOrder::Up`/`Down`** instead of swapping endpoints, whenever the stereocenter candidate is `E` rather than `B`. This achieves the identical semantic correction (`wedge_z`'s `bond.atom1`-is-the-reference convention becomes correct regardless of original B/E order) without perturbing adjacency at all. Verified: `neighbors()` iteration order is now provably unaffected, and the B/E-reversal tests pass for the right reason, not by coincidence.

### 2. Bold/Hash should not silently generate stereo by default

The reviewer's concrete concern: `Bold` in particular is sometimes drawn by chemists as a plain thick line for visual emphasis, not stereo intent -- treating it as stereo unconditionally would manufacture false positives. RDKit #9359's own discussion leans the same way (opt-in, not default).

Added `CdxmlParseOptions { infer_nondirectional_stereo: bool }` (default `false`) and `parse_cdxml_with_options`/`parse_cdxml_all_with_options`. `parse_cdxml`/`parse_cdxml_all` (existing, unchanged signatures) now use `CdxmlParseOptions::default()`:
- **Directional** wedges (`WedgeBegin`/`WedgeEnd`/...) are **always** perceived, opt-in or not -- they're unambiguous stereo intent.
- **Non-directional** wedges (`Bold`/`Hash`/`Dash`) are perceived **only** when `infer_nondirectional_stereo: true` is explicitly passed.
- `bond.order` (`BondOrder::Up`/`Down`) is recorded faithfully for **any** wedge `Display` value regardless of the flag -- structural/round-trip fidelity is unconditional; only chirality *perception* is gated. Implemented via a throwaway perception-view clone (built only when the document actually contains a non-directional wedge, to avoid unnecessary work for the common case) whose results are copied onto the real molecule; the real molecule's own bonds and their order/direction are never touched by this gating.

## Verification against the reviewer's exact requirement list (from the prior round, still holds)

1. **Wired into the same mechanism V2000/V3000/MRV use** -- yes.
2. **RDKit #9359's exact full CDXML text as a fixture** -- fetched the live issue (`gh issue view 9359 --repo rdkit/rdkit`), used its exact `BOLD_BASE_CDXML` fixture verbatim.
3. **Assert `Atom.chirality != None`** -- yes, for both the opt-in and default-off paths (with the default-off path now correctly asserting `None`, see round 3 above).
4. **Verify meaning via CIP or an independent oracle** -- Bold vs. Hash opposite-configuration check, cross-checked against `chematic_chem::assign_cip`.
5. **B/E-reversed bond-endpoint variant** -- now with the *corrected* expected value: preserve for `Bold`/`Hash`, invert for `WedgeBegin`/`WedgeEnd` (both independently tested).
6. **Abstain on ambiguity** -- both-candidates-eligible non-directional bonds abstain; directional wedges in the same topology are unaffected (negative control).
7. **Reflection inverts, rotation/translation preserve** -- tested.

## Regression tests (18 total: 11 from round 2, 7 new/changed in round 3)

New/changed this round:
- `rdkit_9359_bold_default_does_not_perceive_chirality` / `rdkit_9359_hash_default_does_not_perceive_chirality` (new) -- default (`parse_cdxml`, no options) does NOT perceive from Bold/Hash; `bond.order` still faithfully records Up/Down regardless.
- `rdkit_9359_wedge_begin_default_perceives_chirality` (new) -- directional wedges work out of the box, no opt-in needed.
- `rdkit_9359_bold_perceives_chirality_when_opted_in` / `rdkit_9359_hash_perceives_chirality_when_opted_in` (renamed from round 2, now explicit about requiring opt-in via a new `parse_infer` test helper).
- `rdkit_9359_bold_be_reversed_preserves_configuration` / `rdkit_9359_hash_be_reversed_preserves_configuration` (assertion inverted from round 2's wrong expectation: now asserts **preserve**, not invert).
- `rdkit_9359_wedge_begin_vs_wedge_end_inverts_configuration` (new negative control) -- proves the preserve-under-swap behavior is specific to non-directional displays; a real directional Begin/End distinction still correctly inverts.
- `bold_bond_between_two_stereocenters_abstains_both_sides` / `wedge_begin_between_two_stereocenters_is_not_ambiguous` (updated to use the opt-in parser and corrected `bond.order` assertion -- `BondOrder::Up`, not `Single`, since structural fidelity is now unconditional).

Every changed/new assertion was positive-control verified against the specific bug it guards: the B/E-reversal tests were confirmed to fail under the old (swap-based, adjacency-perturbing) implementation; the default-does-not-infer tests were confirmed to fail with the default-gate disabled; the ambiguity-abstain test was confirmed to fail with the eligibility check disabled.

## Existing-test impact

All 3 pre-existing Bold `bond.order` tests (from the original, first-round commit) are unmodified and still pass.

## Verification

- `cargo test -p chematic-mol --lib --quiet` -- 259/259 pass.
- `cargo test -p chematic-core --lib --quiet` -- 105/105 pass.
- `cargo test --workspace --lib --quiet` -- full green, 0 failures.
- `cargo clippy --workspace --all-targets -- -D warnings` -- clean.
- `cargo fmt --all -- --check` -- clean.
- `bash scripts/check.sh` -- full green.

## Public API impact

- `chematic-core`: new `Molecule::set_bond_order(&mut self, idx: BondIdx, order: BondOrder)` -- pure additive setter, same shape as the existing `set_charge`/`set_isotope`/`set_chirality` family; touches only the bond's own `order` field, never adjacency.
- `chematic-mol`: new `CdxmlParseOptions` struct (`Default` derives to `infer_nondirectional_stereo: false`), new `parse_cdxml_with_options`/`parse_cdxml_all_with_options` functions. `parse_cdxml`/`parse_cdxml_all`'s signatures are unchanged. Observable default-behavior change versus the (never-merged) round-2 state of this same PR: `Bold`/`Hash` no longer perceive chirality unless explicitly opted in -- this PR has not been merged in any prior form, so there is no released behavior being changed.

## Not done here / next steps

Per the approved plan, this is Fix 3 of 4 independent fixes found via the RDKit-issue survey (Fix 1, PR #242, merged as `6b64ce8`; Fix 2, PR #243; Fix 4, PR #245, merged as part of PR #245). No further fixes are planned under this program.

**Do not merge without explicit go-ahead.**
