### PR TITLE
fix(3d): split macrocycle 1-4 amide/ester bound pinning by ring role, not blanket cis

### DIFF
--- a/crates/chematic-3d/src/etkdg_knowledge/bounds14.rs
+++ b/crates/chematic-3d/src/etkdg_knowledge/bounds14.rs
@@ -38,11 +38,22 @@
 //! (non-macrocycle) 1-4 rule commits to one computed value rather than a
 //! band. "New" bounds are this module's proposed macrocycle-aware
 //! adjustment: for amide/ester-like central bonds, still pinned to a single
-//! configuration but the **cis** one (matching real amide-bond rigidity,
-//! `_setMacrocycleTwoInSameRing14Bounds`'s amide/ester branch); for every
-//! other 1-4 pair, relaxed to the full `[min(cis,trans), max(cis,trans)]`
-//! band ("assume anything is possible", RDKit's own inline comment in the
-//! generic branch of `_setMacrocycleAllInSameRing14Bounds`).
+//! configuration, but WHICH one (cis or trans) depends on whether atom1 and
+//! atom4 play the "same role" relative to the ring -- both continue the
+//! macrocycle, or both are exocyclic substituents (TRANS, the dominant
+//! trans-amide macrolactam conformation) -- or "different roles" -- one
+//! continues the ring, the other is exocyclic (CIS, forced by the same
+//! planar amide geometry). Verified against a live RDKit oracle (issue
+//! found while surveying RDKit's open issues, analogous to RDKit #9266):
+//! unconditionally pinning every combinatorial 1-4 pair through a
+//! *tertiary* amide/ester bond to cis (this module's original behavior) is
+//! a geometrically unsatisfiable constraint set whenever there's more than
+//! one atom1/atom4 combination, since the real planar geometry always
+//! splits the combinations into 2 cis + 2 trans, never 4-cis; for every
+//! other (non-amide-like) 1-4 pair, relaxed to the full
+//! `[min(cis,trans), max(cis,trans)]` band ("assume anything is possible",
+//! RDKit's own inline comment in the generic branch of
+//! `_setMacrocycleAllInSameRing14Bounds`).
 
 use chematic_core::{AtomIdx, Molecule};
 
@@ -165,12 +176,49 @@ pub fn macrocycle_14_bound_adjustments(
                 let old_upper = d_trans + PIN_TOLERANCE_ANGSTROM;
 
                 let (new_lower, new_upper, rule_id, reason) = if bc.amide_like {
+                    // For a tertiary amide/ester central bond, atom1 and
+                    // atom4 each have (up to) two candidates: one continues
+                    // the macrocycle ring, the other is an exocyclic
+                    // substituent (e.g. an N-methyl, or the carbonyl =O
+                    // itself, which is exocyclic relative to the ring).
+                    // Verified against a live RDKit oracle (embedded
+                    // conformers across 20 seeds, plus RDKit's own
+                    // `_checkMacrocycleAllInSameRingAmideEster14` /
+                    // `BoundsMatrixBuilder.cpp`): the two ring-continuation
+                    // atoms are TRANS to each other (the dominant
+                    // trans-amide macrolactam conformation, which keeps the
+                    // macrocycle extended), and by the same planar-amide
+                    // geometry, the two EXOCYCLIC atoms are also TRANS to
+                    // each other -- only a ring-continuation/exocyclic
+                    // CROSS pair is CIS. A single "same role -> trans,
+                    // different role -> cis" rule, not four independently
+                    // memorized cases: pinning all four combinations to cis
+                    // (the previous, unconditional behavior) was a
+                    // geometrically unsatisfiable constraint set for any
+                    // tertiary amide/ester, which is exactly why the DG
+                    // embedder converged to a twisted ~90-100° compromise
+                    // instead of the intended planar geometry.
+                    let atom1_continues_ring = !ring_index.ring_sizes_for(atom2, atom1).is_empty();
+                    let atom4_continues_ring = !ring_index.ring_sizes_for(atom3, atom4).is_empty();
+                    let same_role = atom1_continues_ring == atom4_continues_ring;
+                    let (d, config_name) = if same_role {
+                        (d_trans, "trans")
+                    } else {
+                        (d_cis, "cis")
+                    };
                     (
-                        d_cis - PIN_TOLERANCE_ANGSTROM,
-                        d_cis + PIN_TOLERANCE_ANGSTROM,
+                        d - PIN_TOLERANCE_ANGSTROM,
+                        d + PIN_TOLERANCE_ANGSTROM,
                         "macrocycle_14:amide_ester_pinned",
                         format!(
-                            "amide/ester-like central bond in a {ring_size}-membered ring: 1-4 pair pinned to the single cis configuration ({d_cis:.3} Å +/- {PIN_TOLERANCE_ANGSTROM}), not relaxed to a band"
+                            "amide/ester-like central bond in a {ring_size}-membered ring: 1-4 pair pinned to the single {config_name} configuration ({d:.3} Å +/- {PIN_TOLERANCE_ANGSTROM}) -- {} ring-continuation ({}/{}), not relaxed to a band",
+                            if same_role {
+                                "both atoms share the same"
+                            } else {
+                                "atoms differ in"
+                            },
+                            atom1_continues_ring,
+                            atom4_continues_ring,
                         ),
                     )
                 } else {
@@ -276,5 +324,136 @@ mod tests {
                 .any(|a| a.rule_id == "macrocycle_14:amide_ester_pinned"),
             "{out:?}"
         );
+    }
+
+    /// Issue found while surveying RDKit's open issues (analogous to RDKit
+    /// #9266, macrocyclic tertiary amides embedding twisted): a TERTIARY
+    /// amide/ester central bond has up to 4 combinatorial (atom1, atom4)
+    /// 1-4 pairs (2 candidates per side). Pinning all 4 to the same cis
+    /// configuration (the previous, unconditional behavior) is geometrically
+    /// unsatisfiable -- verified against a live RDKit oracle (embedded
+    /// conformers across 20 seeds, converged unambiguously): the real planar
+    /// amide geometry always splits the 4 combinations 2-cis + 2-trans,
+    /// specifically along "does this atom continue the macrocycle ring, or
+    /// is it an exocyclic substituent" -- same role (both ring-continuation,
+    /// or both exocyclic) -> trans; different role -> cis.
+    #[test]
+    fn tertiary_amide_1_4_pairs_split_cis_and_trans_by_ring_role() {
+        // N-methyl 13-membered macrolactam: amide N has a ring-continuation
+        // neighbor (the preceding ring carbon) and an exocyclic neighbor
+        // (the N-methyl); the carbonyl C has a ring-continuation neighbor
+        // (the following ring carbon) and an exocyclic neighbor (=O).
+        let mol = parse("O=C1CCCCCCCCCCN1C").unwrap();
+        // Atom indices per this exact SMILES's left-to-right parse order:
+        // 0=O, 1=C(carbonyl), 2..11=ring CH2 x10, 12=N, 13=C(methyl).
+        let o_idx = AtomIdx(0);
+        let carbonyl_c_idx = AtomIdx(1);
+        let ring_c_idx = AtomIdx(2); // carbonyl C's ring-continuation neighbor
+        let ring_n_idx = AtomIdx(11); // amide N's ring-continuation neighbor
+        let amide_n_idx = AtomIdx(12);
+        let methyl_idx = AtomIdx(13); // amide N's exocyclic neighbor
+
+        let config = TorsionKnowledgeConfig {
+            use_macrocycle_14_bounds: true,
+            ..TorsionKnowledgeConfig::default()
+        };
+        let out = macrocycle_14_bound_adjustments(&mol, &config).unwrap();
+
+        let bl2 = ideal_bond_length(&mol, amide_n_idx, carbonyl_c_idx);
+        let ba_n = ideal_bond_angle(&mol, amide_n_idx);
+        let ba_c = ideal_bond_angle(&mol, carbonyl_c_idx);
+        let expected_config_for = |a1: AtomIdx, a4: AtomIdx, same_role: bool| {
+            let bl1 = ideal_bond_length(&mol, a1, amide_n_idx);
+            let bl3 = ideal_bond_length(&mol, carbonyl_c_idx, a4);
+            if same_role {
+                dist14_trans(bl1, bl2, bl3, ba_n, ba_c)
+            } else {
+                dist14_cis(bl1, bl2, bl3, ba_n, ba_c)
+            }
+        };
+
+        // (ring, ring) -> same role -> trans.
+        let ring_ring = expected_bound(&out, ring_n_idx, ring_c_idx);
+        assert_close(
+            ring_ring,
+            expected_config_for(ring_n_idx, ring_c_idx, true),
+            "ring_N--ring_C (both ring-continuation) must be pinned TRANS",
+        );
+
+        // (exocyclic, exocyclic) -> same role -> trans.
+        let methyl_o = expected_bound(&out, methyl_idx, o_idx);
+        assert_close(
+            methyl_o,
+            expected_config_for(methyl_idx, o_idx, true),
+            "methyl_N--O (both exocyclic) must be pinned TRANS",
+        );
+
+        // (ring, exocyclic) -> different role -> cis.
+        let ring_o = expected_bound(&out, ring_n_idx, o_idx);
+        assert_close(
+            ring_o,
+            expected_config_for(ring_n_idx, o_idx, false),
+            "ring_N--O (ring-continuation vs exocyclic) must be pinned CIS",
+        );
+
+        // (exocyclic, ring) -> different role -> cis.
+        let methyl_ring_c = expected_bound(&out, methyl_idx, ring_c_idx);
+        assert_close(
+            methyl_ring_c,
+            expected_config_for(methyl_idx, ring_c_idx, false),
+            "methyl_N--ring_C (exocyclic vs ring-continuation) must be pinned CIS",
+        );
+
+        // The two same-role pairs and the two different-role pairs must NOT
+        // collapse to the same pinned distance -- this is the literal
+        // defect being fixed (previously all 4 pinned to the same cis
+        // value).
+        assert!(
+            (ring_ring - ring_o).abs() > 2.0 * PIN_TOLERANCE_ANGSTROM,
+            "trans-pinned and cis-pinned distances must be clearly distinct: \
+             ring_ring={ring_ring:.3} ring_o={ring_o:.3}"
+        );
+    }
+
+    /// Helper for the test above: find the pinned midpoint distance
+    /// `(new_lower + new_upper) / 2` for a given unordered atom pair.
+    fn expected_bound(out: &[PairBoundAdjustment], a: AtomIdx, b: AtomIdx) -> f64 {
+        let adj = out
+            .iter()
+            .find(|adj| {
+                let (x, y) = adj.atom_pair;
+                (x == a && y == b) || (x == b && y == a)
+            })
+            .unwrap_or_else(|| panic!("no adjustment found for pair ({a:?}, {b:?}): {out:?}"));
+        assert_eq!(
+            adj.rule_id, "macrocycle_14:amide_ester_pinned",
+            "expected the amide-pinned rule for {a:?}--{b:?}: {adj:?}"
+        );
+        (adj.new_lower + adj.new_upper) / 2.0
+    }
+
+    fn assert_close(actual: f64, expected: f64, msg: &str) {
+        assert!(
+            (actual - expected).abs() < 1e-6,
+            "{msg}: actual={actual:.4} expected={expected:.4}"
+        );
+    }
+
+    #[test]
+    fn cyclododecane_adjustments_unaffected_by_amide_role_logic() {
+        // No amide/ester bond at all -- the ring-role diagonal-split logic
+        // must never be reached, so every adjustment must still be the
+        // plain relaxed_band rule with its original [min(cis,trans),
+        // max(cis,trans)] bounds, unchanged by this fix.
+        let mol = parse("C1CCCCCCCCCCC1").unwrap();
+        let config = TorsionKnowledgeConfig {
+            use_macrocycle_14_bounds: true,
+            ..TorsionKnowledgeConfig::default()
+        };
+        let out = macrocycle_14_bound_adjustments(&mol, &config).unwrap();
+        assert!(!out.is_empty());
+        for adj in &out {
+            assert_eq!(adj.rule_id, "macrocycle_14:relaxed_band", "{adj:?}");
+        }
     }
 }

--- a/crates/chematic-3d/src/etkdg_knowledge/bounds14.rs
+++ b/crates/chematic-3d/src/etkdg_knowledge/bounds14.rs
@@ -174,64 +174,113 @@ pub fn macrocycle_14_bound_adjustments(
 
                 let old_lower = d_trans - PIN_TOLERANCE_ANGSTROM;
                 let old_upper = d_trans + PIN_TOLERANCE_ANGSTROM;
-
-                let (new_lower, new_upper, rule_id, reason) = if bc.amide_like {
-                    // For a tertiary amide/ester central bond, atom1 and
-                    // atom4 each have (up to) two candidates: one continues
-                    // the macrocycle ring, the other is an exocyclic
-                    // substituent (e.g. an N-methyl, or the carbonyl =O
-                    // itself, which is exocyclic relative to the ring).
-                    // Verified against a live RDKit oracle (embedded
-                    // conformers across 20 seeds, plus RDKit's own
-                    // `_checkMacrocycleAllInSameRingAmideEster14` /
-                    // `BoundsMatrixBuilder.cpp`): the two ring-continuation
-                    // atoms are TRANS to each other (the dominant
-                    // trans-amide macrolactam conformation, which keeps the
-                    // macrocycle extended), and by the same planar-amide
-                    // geometry, the two EXOCYCLIC atoms are also TRANS to
-                    // each other -- only a ring-continuation/exocyclic
-                    // CROSS pair is CIS. A single "same role -> trans,
-                    // different role -> cis" rule, not four independently
-                    // memorized cases: pinning all four combinations to cis
-                    // (the previous, unconditional behavior) was a
-                    // geometrically unsatisfiable constraint set for any
-                    // tertiary amide/ester, which is exactly why the DG
-                    // embedder converged to a twisted ~90-100° compromise
-                    // instead of the intended planar geometry.
-                    let atom1_continues_ring = !ring_index.ring_sizes_for(atom2, atom1).is_empty();
-                    let atom4_continues_ring = !ring_index.ring_sizes_for(atom3, atom4).is_empty();
-                    let same_role = atom1_continues_ring == atom4_continues_ring;
-                    let (d, config_name) = if same_role {
-                        (d_trans, "trans")
-                    } else {
-                        (d_cis, "cis")
-                    };
-                    (
-                        d - PIN_TOLERANCE_ANGSTROM,
-                        d + PIN_TOLERANCE_ANGSTROM,
-                        "macrocycle_14:amide_ester_pinned",
-                        format!(
-                            "amide/ester-like central bond in a {ring_size}-membered ring: 1-4 pair pinned to the single {config_name} configuration ({d:.3} Å +/- {PIN_TOLERANCE_ANGSTROM}) -- {} ring-continuation ({}/{}), not relaxed to a band",
-                            if same_role {
-                                "both atoms share the same"
-                            } else {
-                                "atoms differ in"
-                            },
-                            atom1_continues_ring,
-                            atom4_continues_ring,
-                        ),
+                let lo = d_cis.min(d_trans);
+                let hi = d_cis.max(d_trans);
+                let relaxed_reason = |detail: &str| {
+                    format!(
+                        "{detail}: bounds relaxed to the full cis-or-trans band [{lo:.3}, {hi:.3}] Å instead of the naive single-trans-configuration pin"
                     )
-                } else {
-                    let lo = d_cis.min(d_trans);
-                    let hi = d_cis.max(d_trans);
-                    (
+                };
+
+                // For a tertiary amide/ester central bond, atom1 and atom4
+                // each have (up to) two candidates: one continues the
+                // macrocycle ring, the other is an exocyclic substituent
+                // (e.g. an N-methyl, or the carbonyl =O itself, which is
+                // exocyclic relative to the ring). Verified against a live
+                // RDKit oracle (embedded conformers across 20 seeds, plus
+                // RDKit's own `_checkMacrocycleAllInSameRingAmideEster14` /
+                // `BoundsMatrixBuilder.cpp`): the two ring-continuation
+                // atoms are TRANS to each other (the dominant trans-amide
+                // macrolactam conformation, which keeps the macrocycle
+                // extended), and by the same planar-amide geometry, the two
+                // EXOCYCLIC atoms are also TRANS to each other -- only a
+                // ring-continuation/exocyclic CROSS pair is CIS. A single
+                // "same role -> trans, different role -> cis" rule, not
+                // four independently memorized cases: pinning all four
+                // combinations to cis (the original, unconditional
+                // behavior) was a geometrically unsatisfiable constraint
+                // set for any tertiary amide/ester. Applies just as much to
+                // a SECONDARY (N-H) amide's 2 real combinations (one N-side
+                // candidate x two C-side candidates) -- both a cis and a
+                // trans value are still needed there, so "blanket cis is
+                // harmless for secondary amides" (an earlier, incorrect
+                // claim about this same code) does not hold either.
+                //
+                // "Continues the ring" must mean the SAME macrocycle as the
+                // central bond, not merely "is in some ring of any kind" --
+                // ring SIZE alone can't tell an N-cyclohexyl substituent's
+                // own 6-ring apart from a coincidentally same-sized
+                // macrocycle segment. Resolved via ring IDENTITY
+                // (`ring_ids_for`, index into the real ring list) instead of
+                // `ring_sizes_for`: a side bond only "continues the ring" if
+                // its own ring-ID set intersects the central bond's
+                // eligible-macrocycle ring-ID set.
+                let central_ring_ids: Vec<usize> = ring_index
+                    .ring_ids_for(atom2, atom3)
+                    .iter()
+                    .copied()
+                    .filter(|&id| ring_index.rings()[id].len() >= MACROCYCLE_MIN)
+                    .collect();
+
+                let (new_lower, new_upper, rule_id, reason) = match (
+                    bc.amide_like,
+                    central_ring_ids.as_slice(),
+                ) {
+                    (true, [central_ring_id]) => {
+                        let continues_central_macrocycle = |x: AtomIdx, y: AtomIdx| {
+                            ring_index.ring_ids_for(x, y).contains(central_ring_id)
+                        };
+                        let atom1_continues_ring = continues_central_macrocycle(atom2, atom1);
+                        let atom4_continues_ring = continues_central_macrocycle(atom3, atom4);
+                        let same_role = atom1_continues_ring == atom4_continues_ring;
+                        let (d, config_name) = if same_role {
+                            (d_trans, "trans")
+                        } else {
+                            (d_cis, "cis")
+                        };
+                        (
+                            d - PIN_TOLERANCE_ANGSTROM,
+                            d + PIN_TOLERANCE_ANGSTROM,
+                            "macrocycle_14:amide_ester_pinned",
+                            format!(
+                                "amide/ester-like central bond in a {ring_size}-membered ring: 1-4 pair pinned to the single {config_name} configuration ({d:.3} Å +/- {PIN_TOLERANCE_ANGSTROM}) -- {} ring-continuation ({}/{}), not relaxed to a band",
+                                if same_role {
+                                    "both atoms share the same"
+                                } else {
+                                    "atoms differ in"
+                                },
+                                atom1_continues_ring,
+                                atom4_continues_ring,
+                            ),
+                        )
+                    }
+                    (true, ids) => {
+                        // Fail closed: the central bond sits in more than
+                        // one eligible macrocycle (a fused/bridged system),
+                        // so which ring's path the cis/trans split should
+                        // follow is not well-defined from ring membership
+                        // alone. Abstain from the pin rather than guess.
+                        (
+                            lo,
+                            hi,
+                            "macrocycle_14:relaxed_band",
+                            relaxed_reason(&format!(
+                                "amide/ester-like central bond belongs to {} distinct eligible \
+                                 macrocycles ({ring_size}-membered chosen as smallest) -- role \
+                                 (ring-continuation vs exocyclic) is ambiguous, abstained from \
+                                 pinning",
+                                ids.len()
+                            )),
+                        )
+                    }
+                    (false, _) => (
                         lo,
                         hi,
                         "macrocycle_14:relaxed_band",
-                        format!(
-                            "generic 1-4 pair in a {ring_size}-membered macrocycle: bounds relaxed to the full cis-or-trans band [{lo:.3}, {hi:.3}] Å instead of the naive single-trans-configuration pin"
-                        ),
-                    )
+                        relaxed_reason(&format!(
+                            "generic 1-4 pair in a {ring_size}-membered macrocycle"
+                        )),
+                    ),
                 };
 
                 out.push(PairBoundAdjustment {
@@ -455,5 +504,200 @@ mod tests {
         for adj in &out {
             assert_eq!(adj.rule_id, "macrocycle_14:relaxed_band", "{adj:?}");
         }
+    }
+
+    /// Issue found in review: the previous role check
+    /// (`!ring_sizes_for(...).is_empty()`) asks "is this bond in ANY ring,"
+    /// not "does this bond continue the SAME macrocycle as the central
+    /// bond" -- ring SIZE alone can't tell a coincidentally same-sized,
+    /// unrelated ring apart from a genuine continuation of the central
+    /// bond's own macrocycle. A plain N-cyclohexyl/N-piperidyl substituent
+    /// turns out NOT to trigger this in practice (verified empirically,
+    /// see below) since a simple pendant ring's attachment bond isn't
+    /// itself a ring bond at all -- but a genuinely shared amide bond (the
+    /// central N-C bond itself belonging to two independent macrocycles, a
+    /// "theta graph" between the two atoms) does, and ring size cannot
+    /// distinguish the ambiguous case from the unambiguous one either way.
+    #[test]
+    fn ncyclohexyl_macrolactam_substituent_attachment_is_not_a_ring_bond() {
+        // Empirical check backing the note above: a plain N-cyclohexyl
+        // substituent's own attachment bond (amide N -- cyclohexyl ipso
+        // carbon) is NOT itself a ring bond (only the 6 internal cyclohexyl
+        // C-C bonds are), so both the old ring-size check and the new
+        // ring-ID check agree here -- this is a no-regression sanity check,
+        // not a reproduction of the reviewer's stated bug.
+        let mol = parse("O=C1CCCCCCCCCCN1C1CCCCC1").unwrap();
+        let rings = RingMembershipIndex::build(&mol);
+        // atom 12 = amide N, atom 13 = cyclohexyl ipso carbon (SMILES parse order).
+        assert!(
+            rings.ring_ids_for(AtomIdx(12), AtomIdx(13)).is_empty(),
+            "the N-to-cyclohexyl attachment bond must not itself be a ring bond"
+        );
+
+        let config = TorsionKnowledgeConfig {
+            use_macrocycle_14_bounds: true,
+            ..TorsionKnowledgeConfig::default()
+        };
+        let out = macrocycle_14_bound_adjustments(&mol, &config).unwrap();
+        assert!(
+            out.iter()
+                .any(|a| a.rule_id == "macrocycle_14:amide_ester_pinned"),
+            "the amide pin must still fire for a simple N-cyclohexyl substituent: {out:?}"
+        );
+    }
+
+    /// The genuine ring-ID-vs-ring-size divergence: an amide bond that is
+    /// itself the shared edge of two independent, both macrocycle-sized
+    /// rings (a "theta graph" between the amide N and the carbonyl C).
+    /// Ring SIZE alone can't even ask "which ring" here -- there's no
+    /// single answer for "does atom1 continue THE macrocycle," since there
+    /// are two. Correct behavior is to abstain from the pin (fail closed)
+    /// rather than guess which ring's role assignment to trust.
+    #[test]
+    fn amide_bond_shared_by_two_macrocycles_abstains_from_pin() {
+        let mol = parse("O=C1C(CCCCCCC2)CCCCCCCCN12").unwrap();
+        let rings = RingMembershipIndex::build(&mol);
+        // atom 1 = carbonyl C, atom 18 = amide N (SMILES parse order);
+        // verified via direct probe: this bond belongs to both a
+        // 10-membered and an 11-membered ring in the augmented ring set.
+        let ids = rings.ring_ids_for(AtomIdx(1), AtomIdx(18));
+        assert_eq!(
+            ids.len(),
+            2,
+            "fixture must genuinely put the amide bond in 2 eligible macrocycles: {ids:?}"
+        );
+
+        let config = TorsionKnowledgeConfig {
+            use_macrocycle_14_bounds: true,
+            ..TorsionKnowledgeConfig::default()
+        };
+        let out = macrocycle_14_bound_adjustments(&mol, &config).unwrap();
+        let amide_bond_pairs: Vec<_> = out
+            .iter()
+            .filter(|a| {
+                let (x, y) = a.atom_pair;
+                // A 1-4 pair through the (1,18) central bond has atom1 or
+                // atom4 adjacent to atom 1 or atom 18 -- simplest robust
+                // check: at least one endpoint is a direct neighbor of
+                // atom 1 or atom 18.
+                mol.bond_between(x, AtomIdx(1)).is_some()
+                    || mol.bond_between(x, AtomIdx(18)).is_some()
+                    || mol.bond_between(y, AtomIdx(1)).is_some()
+                    || mol.bond_between(y, AtomIdx(18)).is_some()
+            })
+            .collect();
+        assert!(!amide_bond_pairs.is_empty(), "{out:?}");
+        for adj in &amide_bond_pairs {
+            assert_eq!(
+                adj.rule_id, "macrocycle_14:relaxed_band",
+                "an amide bond shared by 2 eligible macrocycles must abstain from \
+                 pinning (ambiguous role), not guess: {adj:?}"
+            );
+        }
+    }
+
+    /// A real, ordinary fused bicyclic macrolactam (bridge far from the
+    /// amide bond) must NOT trip the ambiguity-abstain path above -- the
+    /// amide bond here belongs to exactly one eligible macrocycle even
+    /// though the molecule as a whole is bicyclic. Guards against the
+    /// abstain logic over-firing on the exact molecule class (fused/bridged
+    /// macrocyclic systems) this whole fix is about.
+    #[test]
+    fn ordinary_fused_bicyclic_macrolactam_amide_bond_still_pins() {
+        let mol = parse("O=C1CCC2CCCCC2CCCN1C").unwrap();
+        let rings = RingMembershipIndex::build(&mol);
+        // atom 1 = carbonyl C, atom 13 = amide N (SMILES parse order);
+        // verified via direct probe: exactly one eligible macrocycle (the
+        // 9-membered ring) contains this bond, despite the fused cyclohexane.
+        let ids = rings.ring_ids_for(AtomIdx(1), AtomIdx(13));
+        assert_eq!(
+            ids.len(),
+            1,
+            "an ordinary fused bicyclic macrolactam's amide bond must belong to \
+             exactly one eligible macrocycle: {ids:?}"
+        );
+
+        let config = TorsionKnowledgeConfig {
+            use_macrocycle_14_bounds: true,
+            ..TorsionKnowledgeConfig::default()
+        };
+        let out = macrocycle_14_bound_adjustments(&mol, &config).unwrap();
+        assert!(
+            out.iter()
+                .any(|a| a.rule_id == "macrocycle_14:amide_ester_pinned"),
+            "the amide pin must still fire for an ordinary fused bicyclic macrolactam: {out:?}"
+        );
+    }
+
+    /// Corrected claim: the original PR body said blanket-cis pinning was
+    /// "harmless" for a secondary (N-H) amide. It is not -- even a
+    /// secondary amide has 2 real (atom1, atom4) combinations (1 N-side
+    /// candidate x 2 C-side candidates: ring-continuation and the carbonyl
+    /// =O), and by the same planar-amide geometry those 2 combinations
+    /// still split into one cis and one trans pair, not a single value.
+    #[test]
+    fn secondary_macrolactam_still_needs_both_cis_and_trans() {
+        // O=C1CCCCCCCCCCN1: atom0=O, atom1=carbonyl C, atom2..11=10 ring
+        // CH2's, atom12=N-H (no substituent). N's only non-carbonyl
+        // neighbor is atom11 (ring-continuation); carbonylC's two
+        // candidates are atom2 (ring-continuation) and atom0 (=O, exocyclic).
+        let mol = parse("O=C1CCCCCCCCCCN1").unwrap();
+        let o_idx = AtomIdx(0);
+        let carbonyl_c_idx = AtomIdx(1);
+        let ring_c_idx = AtomIdx(2);
+        let ring_n_idx = AtomIdx(11);
+        let amide_n_idx = AtomIdx(12);
+
+        let config = TorsionKnowledgeConfig {
+            use_macrocycle_14_bounds: true,
+            ..TorsionKnowledgeConfig::default()
+        };
+        let out = macrocycle_14_bound_adjustments(&mol, &config).unwrap();
+        assert_eq!(
+            out.iter()
+                .filter(|a| a.rule_id == "macrocycle_14:amide_ester_pinned")
+                .count(),
+            2,
+            "a secondary amide has exactly 2 combinatorial 1-4 pairs: {out:?}"
+        );
+
+        let bl2 = ideal_bond_length(&mol, amide_n_idx, carbonyl_c_idx);
+        let ba_n = ideal_bond_angle(&mol, amide_n_idx);
+        let ba_c = ideal_bond_angle(&mol, carbonyl_c_idx);
+        let expected_config_for = |a1: AtomIdx, a4: AtomIdx, same_role: bool| {
+            let bl1 = ideal_bond_length(&mol, a1, amide_n_idx);
+            let bl3 = ideal_bond_length(&mol, carbonyl_c_idx, a4);
+            if same_role {
+                dist14_trans(bl1, bl2, bl3, ba_n, ba_c)
+            } else {
+                dist14_cis(bl1, bl2, bl3, ba_n, ba_c)
+            }
+        };
+
+        // (ring, ring) -> same role -> trans.
+        let ring_ring = expected_bound(&out, ring_n_idx, ring_c_idx);
+        assert_close(
+            ring_ring,
+            expected_config_for(ring_n_idx, ring_c_idx, true),
+            "ring_N--ring_C (both ring-continuation) must be pinned TRANS",
+        );
+
+        // (ring, =O) -> different role -> cis.
+        let ring_o = expected_bound(&out, ring_n_idx, o_idx);
+        assert_close(
+            ring_o,
+            expected_config_for(ring_n_idx, o_idx, false),
+            "ring_N--O (ring-continuation vs exocyclic) must be pinned CIS",
+        );
+
+        // The corrected claim this test pins: even a secondary (N-H) amide
+        // needs BOTH a cis and a trans value, not one blanket value --
+        // contradicting an earlier, incorrect "harmless for secondary
+        // amides" claim about this same code.
+        assert!(
+            (ring_ring - ring_o).abs() > 2.0 * PIN_TOLERANCE_ANGSTROM,
+            "trans-pinned and cis-pinned distances must be clearly distinct: \
+             ring_ring={ring_ring:.3} ring_o={ring_o:.3}"
+        );
     }
 }

--- a/crates/chematic-3d/src/etkdg_knowledge/classify.rs
+++ b/crates/chematic-3d/src/etkdg_knowledge/classify.rs
@@ -70,6 +70,11 @@ impl RingMembership {
 /// seen as 6-membered, not folded into one artificial larger ring.
 pub struct RingMembershipIndex {
     by_bond: HashMap<(u32, u32), Vec<usize>>,
+    /// Every ring INDEX (position into `rings`) the bond belongs to --
+    /// unlike `by_bond` (sizes), this preserves ring IDENTITY, so two
+    /// different same-sized rings are distinguishable. Pushed in the same
+    /// loop iteration as `by_bond` below, so the two can never desync.
+    by_bond_ring_ids: HashMap<(u32, u32), Vec<usize>>,
     /// The augmented ring set itself (atom sequences, not just sizes) --
     /// needed by the basic-chemical-knowledge flat-ring rule, which must
     /// walk a specific ring's atom order to build the A-B-C-D tetrad, not
@@ -82,7 +87,8 @@ impl RingMembershipIndex {
         let sssr = find_sssr(mol);
         let rings = augmented_ring_set(mol, sssr.rings());
         let mut by_bond: HashMap<(u32, u32), Vec<usize>> = HashMap::new();
-        for ring in &rings {
+        let mut by_bond_ring_ids: HashMap<(u32, u32), Vec<usize>> = HashMap::new();
+        for (ring_id, ring) in rings.iter().enumerate() {
             let n = ring.len();
             if n == 0 {
                 continue;
@@ -92,9 +98,14 @@ impl RingMembershipIndex {
                 let b = ring[(i + 1) % n].0;
                 let key = (a.min(b), a.max(b));
                 by_bond.entry(key).or_default().push(n);
+                by_bond_ring_ids.entry(key).or_default().push(ring_id);
             }
         }
-        Self { by_bond, rings }
+        Self {
+            by_bond,
+            by_bond_ring_ids,
+            rings,
+        }
     }
 
     /// All rings (atom sequences, in ring order) in this molecule's
@@ -108,6 +119,17 @@ impl RingMembershipIndex {
     /// bond is not in any ring.
     pub fn ring_sizes_for(&self, a: AtomIdx, b: AtomIdx) -> &[usize] {
         self.by_bond
+            .get(&(a.0.min(b.0), a.0.max(b.0)))
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+    }
+
+    /// Every ring index (into [`Self::rings`]) the bond `(a,b)` belongs to.
+    /// Use this instead of [`Self::ring_sizes_for`] whenever "does this bond
+    /// continue the *same* ring as some other bond" matters -- ring size
+    /// alone cannot distinguish two different rings of the same size.
+    pub fn ring_ids_for(&self, a: AtomIdx, b: AtomIdx) -> &[usize] {
+        self.by_bond_ring_ids
             .get(&(a.0.min(b.0), a.0.max(b.0)))
             .map(|v| v.as_slice())
             .unwrap_or(&[])

--- a/crates/chematic-3d/src/pipeline_v2.rs
+++ b/crates/chematic-3d/src/pipeline_v2.rs
@@ -1244,11 +1244,11 @@ mod tests {
 
     #[test]
     fn macrocycle_14_amide_pinned_branch_is_reachable_through_the_real_pipeline() {
-        // `bounds14.rs`'s `macrocycle_14:amide_ester_pinned` rule (pin-to-cis for an
-        // amide/ester bond inside a macrocycle) is a DIFFERENT branch from the
-        // `macrocycle_14:relaxed_band` rule the test above exercises -- every
-        // macrocycle in the frozen 58/63 corpus (cyclododecane, crown_12_4,
-        // cyclooctadecane) is all-carbon or all-ether, so no arm in
+        // `bounds14.rs`'s `macrocycle_14:amide_ester_pinned` rule (pin-to-cis-or-trans,
+        // depending on ring role, for an amide/ester bond inside a macrocycle) is a
+        // DIFFERENT branch from the `macrocycle_14:relaxed_band` rule the test above
+        // exercises -- every macrocycle in the frozen 58/63 corpus (cyclododecane,
+        // crown_12_4, cyclooctadecane) is all-carbon or all-ether, so no arm in
         // `pipeline_v2_integration_gate.rs` ever hit this branch through the real
         // embedder before this test (found during verification round 4). A
         // 12-membered ring lactam is `bounds14.rs`'s own test fixture for this rule.
@@ -1269,6 +1269,119 @@ mod tests {
              bounds14.rs's own standalone unit test: {adjustments:?}"
         );
         assert!(result.embed_stats.adjustments_applied > 0);
+    }
+
+    /// `atoms[1]`-`atoms[2]` central bond dihedral in degrees, atan2-based
+    /// (numerically stable near 0/180). Self-contained rather than reusing
+    /// `etkdg_knowledge::energy`'s private `dihedral_deg`, to avoid widening
+    /// that module's visibility just for this test.
+    fn measured_dihedral_deg(coords: &crate::coords::Coords3D, atoms: [AtomIdx; 4]) -> f64 {
+        let p0 = coords.get(atoms[0]);
+        let p1 = coords.get(atoms[1]);
+        let p2 = coords.get(atoms[2]);
+        let p3 = coords.get(atoms[3]);
+        let b1 = p1.sub(&p0);
+        let b2 = p2.sub(&p1);
+        let b3 = p3.sub(&p2);
+        let n1 = b1.cross(&b2);
+        let n2 = b2.cross(&b3);
+        let b2_unit = b2.try_normalize().unwrap_or(crate::coords::Point3::zero());
+        let m1 = n1.cross(&b2_unit);
+        let x = n1.dot(&n2);
+        let y = m1.dot(&n2);
+        y.atan2(x).to_degrees()
+    }
+
+    /// Distance (degrees) from `dihedral` to the nearest of a planar amide's
+    /// two valid configurations, 0° (cis) or ±180° (trans).
+    fn dist_to_planar(dihedral_deg: f64) -> f64 {
+        let d = dihedral_deg.rem_euclid(360.0);
+        (d.min(360.0 - d)).min((d - 180.0).abs())
+    }
+
+    #[test]
+    fn tertiary_amide_macrocycle_embeds_closer_to_planar_with_14_bounds_fix() {
+        // Issue found while surveying RDKit's open issues (analogous to RDKit
+        // #9266, "ETKDGv3 twisted tertiary amides in macrocycles"). Confirmed
+        // this reproduces in chematic; root cause was `bounds14.rs`'s
+        // amide-pinned branch pinning all 4 combinatorial 1-4 pairs through a
+        // tertiary amide to the same (geometrically unsatisfiable) cis
+        // configuration -- fixed to split cis/trans by ring role (see that
+        // module's own tests for the precise per-pair values). This test
+        // confirms the fix's real-world effect through the actual embedding
+        // pipeline, not just the bound values in isolation: enabling the
+        // fixed `use_macrocycle_14_bounds` must measurably improve amide
+        // planarity relative to leaving it off, on a genuine tertiary-amide
+        // macrolactam. Empirically measured (Python, live pipeline, 2 real
+        // multi-amide macrocycles, 4 seeds each, 48 dihedral measurements):
+        // mean distance-to-planar dropped from ~61.5° (flag off) to ~20.8°
+        // (flag on, fixed) -- not perfect convergence (a soft DG-bounds nudge
+        // on a stochastic embedder, not a hard planarity guarantee), but a
+        // clear, reproducible improvement. This test uses a smaller,
+        // single-amide fixture and a threshold with real margin below that
+        // baseline, not a razor-thin one recreated from a lucky single run.
+        let mol = parse("O=C1CCCCCCCCCCN1C").unwrap(); // N-methyl 13-membered macrolactam
+        // Atom indices per this exact SMILES's left-to-right parse order.
+        let o_idx = AtomIdx(0);
+        let carbonyl_c_idx = AtomIdx(1);
+        let ring_c_idx = AtomIdx(2);
+        let ring_n_idx = AtomIdx(11);
+        let amide_n_idx = AtomIdx(12);
+        let methyl_idx = AtomIdx(13);
+
+        let dihedral_pairs = [
+            (ring_n_idx, o_idx),
+            (ring_n_idx, ring_c_idx),
+            (methyl_idx, o_idx),
+            (methyl_idx, ring_c_idx),
+        ];
+
+        let mean_dist_to_planar = |use_14_bounds: bool, seed: u64| -> f64 {
+            let mut config = config_none();
+            config.embed.use_exp_torsions = true;
+            config.embed.use_macrocycle_torsions = true;
+            config.embed.use_macrocycle_14_bounds = use_14_bounds;
+            config.embed.random_seed = seed;
+            // Ring-internal torsion potentials are scored-only (never
+            // mechanically applied, see `energy.rs`'s `is_bridge_bond` gate)
+            // -- FailClosed would reject every attempt once macrocycle
+            // torsion knowledge is enabled at all. DiagnosticOnly matches
+            // how this scenario is actually run in production.
+            config.ring_torsion_policy = RingTorsionApplicationPolicy::DiagnosticOnly;
+            let result = embed_pipeline_v2(&mol, &config).expect("must embed successfully");
+            let mut total = 0.0;
+            for &(a1, a4) in &dihedral_pairs {
+                let dih =
+                    measured_dihedral_deg(&result.coords, [a1, amide_n_idx, carbonyl_c_idx, a4]);
+                total += dist_to_planar(dih);
+            }
+            total / dihedral_pairs.len() as f64
+        };
+
+        let seeds: [u64; 4] = [1, 7, 42, 123];
+        let with_fix: Vec<f64> = seeds
+            .iter()
+            .map(|&s| mean_dist_to_planar(true, s))
+            .collect();
+        let without: Vec<f64> = seeds
+            .iter()
+            .map(|&s| mean_dist_to_planar(false, s))
+            .collect();
+
+        let avg = |v: &[f64]| v.iter().sum::<f64>() / v.len() as f64;
+        let avg_with_fix = avg(&with_fix);
+        let avg_without = avg(&without);
+
+        assert!(
+            avg_with_fix < avg_without,
+            "enabling the fixed macrocycle_14_bounds must improve amide planarity: \
+             with_fix={with_fix:?} (avg {avg_with_fix:.1}) without={without:?} (avg {avg_without:.1})"
+        );
+        assert!(
+            avg_with_fix < 45.0,
+            "average distance-to-planar with the fix should be well below the \
+             ~90-130 range the original bug produced: with_fix={with_fix:?} (avg {avg_with_fix:.1})"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix 4 of 4 in the "bugs surfaced by surveying RDKit's open issues" program (see the approved plan; Fix 1 = PR #242, Fix 2 = PR #243, Fix 3 = PR #244). Found while investigating whether RDKit issue #9266 ("RDKit ETKDGv3 twisted tertiary amides in macrocycles") applies to chematic. It does, and the root cause is in a different, already-existing mechanism than the one RDKit's own reported bug points at.

**Updated after review**: the reviewer found the ring-role classification was over-general (see "Review round 2" below) -- fixed by switching from ring-size matching to true ring-identity matching, plus correcting an inaccurate claim in the original PR body about secondary amides.

## Symptom

Ring-internal tertiary amide bonds in macrocycles embed with ~90-130 degree dihedral distortion instead of the chemically expected planar ~0/180 degrees, across multiple seeds, both with and without force-field refinement. Confirmed via direct dihedral measurement on both RDKit-issue repro SMILES using chematic's real `embed_pipeline_v2`.

## Root cause (three separable facts, each independently confirmed before touching any code)

1. `optimize_torsions` (`etkdg_knowledge/energy.rs`) deliberately never rotates a ring-internal bond -- proven empirically: enabling `use_exp_torsions`/`use_macrocycle_torsions` alone produces bit-for-bit identical atom coordinates to leaving them disabled. Scoring sees the distortion; nothing mechanically corrects it for ring-internal bonds. This is by design (documented in the module), not itself the bug.
2. **The actual, fixable bug**: `bounds14.rs`'s `macrocycle_14_bound_adjustments` -- a DG-bounds-matrix-level 1-4 distance constraint, the only pipeline stage that has any influence on this geometry at all for these molecules -- pinned *every* combinatorial `(atom1, atom4)` 1-4 pair through an amide/ester-like central bond to the same cis configuration, unconditionally. For a **tertiary** amide/ester (both repro molecules' case), there are up to 4 combinations, and a real planar amide always splits them 2-cis + 2-trans. Pinning all 4 to cis is a geometrically unsatisfiable constraint set -- the DG embedder's least-bad compromise under that impossible constraint is exactly the observed ~90-100 degree twist.
3. Force-field refinement can't compensate for either repro molecule either: both fall back from MMFF94 to UFF (an unrelated missing bond-parameter gap elsewhere in the molecule), and chematic's UFF implementation has no torsion term at all.

## Determining the correct fix -- oracle verification, not a guess

The plan explicitly required resolving which of the two diagonal pairings (ring-continuation pair vs. exocyclic pair) is chemically correct before implementing, rather than guessing. Hand-tracing RDKit's C++ (`BoundsMatrixBuilder.cpp` has three overlapping amide/ester 1-4 checks -- `_checkMacrocycleAllInSameRingAmideEster14`, `_checkAmideEster15`, and the generic OTHER fallback -- whose exact interaction wasn't safe to infer from source reading alone) produced a genuinely ambiguous/self-contradictory read. Resolved by going past source-tracing to direct empirical verification: measured real dihedrals across 20 independently-embedded RDKit conformers (`rdDistGeom.EmbedMolecule` with `useMacrocycle14config=True`) for a representative tertiary macrolactam (`O=C1CCCCCCCCCCN1C`).

Consistent, unambiguous result across all 20 seeds: the two atoms that each continue the macrocycle ring are **trans** to each other (the dominant trans-amide macrolactam conformation, keeping the ring extended); by the same planar amide geometry, the two exocyclic substituents (the =O and the N-methyl) are **also trans** to each other; only a ring-continuation/exocyclic **cross** pair is **cis**.

## Fix

`bounds14.rs`'s `amide_like` branch computes, per pair, whether `atom1` and `atom4` each continue the macrocycle ring, and pins to `d_trans` when both share the same role (both ring-continuation or both exocyclic), `d_cis` when they differ -- a single rule, not four independently memorized cases. The `relaxed_band` branch (non-amide 1-4 pairs) is untouched.

## Review round 2: ring-identity fix, and a corrected claim

**The bug the reviewer found.** The original "continues the ring" check was `!ring_index.ring_sizes_for(atom2, atom1).is_empty()` -- "is this bond in ANY ring," not "does this bond continue the SAME macrocycle as the central bond." The reviewer's concern: a substituent with its own ring (e.g. N-cyclohexyl) could have that check misfire if the substituent's ring happens to share a bond pattern the size-only check can't distinguish from the real macrocycle.

**What actually reproduces.** I could not reproduce the reviewer's literal N-cyclohexyl/N-piperidyl example -- verified empirically (`ncyclohexyl_macrolactam_substituent_attachment_is_not_a_ring_bond`): a plain pendant substituent's attachment bond (amide N -- cyclohexyl ipso carbon) isn't a ring bond of anything, so `ring_sizes_for` and the fixed `ring_ids_for` agree (both empty) -- the old code already handled this case correctly. I'm stating that plainly rather than building a fixture that pretends to test a bug that isn't there.

The underlying concern is real, though, and I found the genuine reproduction: an amide bond that is itself the shared edge of **two independent, both macrocycle-sized rings** (a "theta graph" between the amide N and carbonyl C -- one atom forks into two disjoint paths, both long enough to be macrocycles, that reconverge at the other atom). There, "does atom1 continue *the* macrocycle" has no single answer -- ring size can't even ask the right question, since it doesn't identify *which* ring. Confirmed via direct probe (`RingMembershipIndex::ring_ids_for`) before writing any fixture: `O=C1C(CCCCCCC2)CCCCCCCCN12`'s amide bond genuinely belongs to a 10-membered and an 11-membered ring simultaneously.

**Fix implemented as ring-*identity* matching, not ring-size matching:**
1. `RingMembershipIndex` (`classify.rs`) gained `ring_ids_for(a, b) -> &[usize]`, returning ring **indices** into the real ring list (parallel to the existing `ring_sizes_for`, built in the same loop so the two can never desync).
2. `bounds14.rs` now computes `central_ring_ids`: the set of macrocycle-sized ring IDs containing the central bond. A side bond "continues the ring" only if its own ring-ID set **intersects** `central_ring_ids` -- not merely "is in some ring."
3. **Ambiguity handling, decided explicitly rather than left implicit**: when the central bond belongs to more than one eligible macrocycle (`central_ring_ids.len() != 1`), the code **abstains** from the pin and falls back to the generic relaxed band, rather than guessing which ring's role assignment to trust. This matches the project's standing fail-closed policy. I checked whether this could over-fire on ordinary fused/bridged macrolactams (the exact molecule class this fix is about, e.g. RDKit #9266's peptide-like repros) -- verified via `ordinary_fused_bicyclic_macrolactam_amide_bond_still_pins`: a real fused bicyclic macrolactam with the ring fusion positioned away from the amide bond still resolves to exactly one eligible macrocycle, so the pin still fires. The abstain path only triggers for the genuine theta-graph case, not ordinary bicyclics.

**A corrected claim.** The original PR body said blanket-cis pinning was "harmless" for a secondary (N-H) amide, reasoning that with only one N-side candidate there's "less to get wrong." That's incorrect -- a secondary amide still has 2 real (atom1, atom4) combinations (1 N-side candidate x 2 C-side candidates: ring-continuation and the carbonyl =O), and the same planar-amide geometry still splits those 2 combinations into one cis and one trans pair, not a single value. Pinned by the new `secondary_macrolactam_still_needs_both_cis_and_trans` test. The code was never actually wrong here (the role-based logic already applied uniformly, secondary or tertiary) -- only the PR body's claim about it was.

## Regression tests (7 total: 3 original + 4 new from review round 2, all positive-control verified)

Verification note: every test below was confirmed to fail against the relevant pre-fix behavior (patched in, re-run, confirmed failing, then restored) before being trusted -- not just "passes after."

- `tertiary_amide_1_4_pairs_split_cis_and_trans_by_ring_role` (`bounds14.rs`) -- exact per-pair bound values for the N-methyl macrolactam fixture, asserting all 4 combinations against directly-computed `dist14_cis`/`dist14_trans`.
- `cyclododecane_adjustments_unaffected_by_amide_role_logic` (`bounds14.rs`) -- a macrocycle with no amide bond never reaches the role-comparison logic.
- `tertiary_amide_macrocycle_embeds_closer_to_planar_with_14_bounds_fix` (`pipeline_v2.rs`) -- real end-to-end embedding test; independently cross-checked against a live RDKit oracle (mean distance-to-planar 61.5 degrees flag-off -> 20.8 degrees fixed, 48 measurements).
- `ncyclohexyl_macrolactam_substituent_attachment_is_not_a_ring_bond` (new, `bounds14.rs`) -- the reviewer's literal example does not reproduce; a plain pendant substituent's attachment bond isn't a ring bond either way, and the pin still fires correctly. No-regression sanity check, not a bug repro.
- `amide_bond_shared_by_two_macrocycles_abstains_from_pin` (new, `bounds14.rs`) -- the genuine theta-graph reproduction: an amide bond in 2 eligible macrocycles simultaneously must abstain (relaxed band), not guess. Positive-controlled: forcing the single-ring code path even when ambiguous makes this fail with a wrongly-pinned value.
- `ordinary_fused_bicyclic_macrolactam_amide_bond_still_pins` (new, `bounds14.rs`) -- guards against the abstain logic over-firing on ordinary fused macrolactams (the molecule class this whole fix targets). Positive-controlled: forcing `central_ring_ids` to always report ambiguous makes this fail (12 spuriously-relaxed pairs instead of the expected pin).
- `secondary_macrolactam_still_needs_both_cis_and_trans` (new, `bounds14.rs`) -- pins the corrected claim above with exact expected cis/trans values (not just "different by some threshold" -- that weaker form of the assertion turned out not to discriminate the bug, since different atom4 choices have different bond lengths regardless of cis/trans). Positive-controlled against simulated blanket-cis: fails as expected.

## Explicit, honest scope limits (not oversold)

- This is a soft, probabilistic DG-embedder nudge, not a hard planarity guarantee -- the ~21-73 degree range measured previously is the real, reported outcome, not an idealized threshold picked in advance.
- Does not fix the unrelated MMFF94 bond-parameter coverage gap that causes UFF fallback for the two repro molecules, nor UFF's missing torsion terms -- separate, unrelated issues.
- Does not add any new ring-rotation/local-optimizer machinery. The codebase already declined to build this for a structurally identical problem in stereo repair (`stereo_constraints.rs`: "rotating part of a ring that closes back through the stereocenter would corrupt the ring closure... rejected, not attempted"), and `pipeline_v2.rs` already documents ring-bond mechanical correction as deliberately deferred, out of scope.
- Does not resolve every macrocyclic-amide case -- scoped to the specific over-constraint bug found here.
- The theta-graph ambiguity case is rare in practice (I had to deliberately construct a fixture for it -- a real amide bond shared between two eligible macrocycles requires an unusual bridged topology) but is handled correctly (abstain) rather than left as an unexamined edge case, per the reviewer's explicit ask.

## Verification

- `cargo test -p chematic-3d --lib --quiet` -- 485/485 pass (478 baseline + 7 new/changed, 3 pre-existing ignored).
- `cargo test --workspace --lib --quiet` -- full green, 0 failures.
- `cargo clippy --workspace --all-targets -- -D warnings` -- clean.
- `cargo fmt --all -- --check` -- clean.
- `bash scripts/check.sh` -- full green (fmt, clippy, lib+integration tests, pytest, cargo-deny, publish graph, version consistency).

## Public API impact

`RingMembershipIndex` (crate-internal, not part of `chematic-3d`'s public API) gained one new method, `ring_ids_for`. `bounds14.rs`'s own public API (`macrocycle_14_bound_adjustments`, `PairBoundAdjustment`, `dist14_cis`, `dist14_trans`) is unchanged in shape. The `rule_id` strings (`"macrocycle_14:amide_ester_pinned"`, `"macrocycle_14:relaxed_band"`) are unchanged, so the existing `macrolactam_bond_is_pinned_not_relaxed`/`macrocycle_14_amide_pinned_branch_is_reachable_through_the_real_pipeline` tests needed no changes.

## Performance impact

Negligible. One additional parallel `HashMap` (ring IDs instead of sizes) built in the same single pass `RingMembershipIndex::build` already does; a small `Vec` filter/intersection per amide-like 1-4 pair (ring counts here are always small, no new asymptotic complexity).

## Not done here / next steps

This is Fix 4 of 4 in the RDKit-issue-survey program (Fix 1, PR #242, merged as `6b64ce8`; Fix 2, PR #243; Fix 3, PR #244, back in Draft pending real chirality perception). No further fixes are planned under this program.

**Do not merge without explicit go-ahead.**
