### PR TITLE
chore(release): v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,98 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — everything below `[0.10.1]` has shipped._
+_Nothing yet — everything below `[0.11.0]` has shipped._
+
+## [0.11.0] — 2026-08-04
+
+Four independent fixes surfaced while surveying RDKit's open GitHub issues
+for applicability to chematic, plus one MMFF94 typing-coverage fix from the
+ongoing issue #227 program. No breaking API changes.
+
+### Fixed — `chematic-ff` (MMFF94 correctness and coverage)
+
+- **O2CM terminal-oxygen typing gap closed** (issue #227 Priority 1A-3,
+  PR #241). RDKit's `AtomTyper.cpp` `case 8` (aliphatic oxygen) terminal-atom
+  branch resolves a much broader set of conditions than the numeric-type
+  registry's "O2CM / OXYGEN, CARBOXYLATE ANION" name suggests; chematic's
+  typer only covered a subset, so any terminal oxygen outside it fell
+  through to the wrong row. Ported the real union of conditions from a
+  pinned RDKit source, cross-checked against a live RDKit oracle across 19
+  distinct molecules. Wrong-element parameter selection remains
+  structurally prohibited by the construction-time semantic-compatibility
+  invariant introduced in 0.10.1 — this fix closes a *coverage* gap, not a
+  cross-element-mismatch regression (that count stays 0).
+  - Measured on the 265-molecule Wave 1 corpus (6693 comparable atoms):
+    exact atom-type parity 98.82% → **99.37%** (6614 → 6651/6693);
+    oxygen-element parity 95.88% → **100.00%** (861 → 898/898); production
+    `minimize_with_policy(Mmff94BondAngleStrict)` success 123 → **130/265**;
+    cross-element mismatch 0 → 0 (unchanged); unclassified 0 → 0
+    (unchanged). All 42 remaining real mismatches are fully classified by
+    bucket, none unexplained. Issue #227 stays open — MMFF94 coverage is
+    measurably better, this release does not claim it is complete.
+
+### Fixed — `chematic-rxn`, `chematic-mol` (stereo and format correctness)
+
+- **SMIRKS product chirality made parity-aware** (PR #243). Reaction
+  templates that reorder mapped substituents (e.g.
+  `[C@@H:1](F)(Cl)Br >> [C@@H:1](Cl)(F)Br`) previously copied the template's
+  `@`/`@@` flag onto the product verbatim, ignoring that a reordered
+  neighbor-write-order changes the real configuration the flag encodes —
+  producing a silently un-inverted product. A product atom with an explicit
+  template chirality now has its mapped neighbor order validated against
+  the atom's real final topology before the flag is kept. A product atom
+  that only *inherits* a reactant's chirality (no explicit template flag)
+  is now kept only when a defined `stereo_neighbor_order` exists on the
+  reactant side and neither the unmapped-neighbor element set nor the
+  mapped-neighbor atom-map-number set changed across the template — closing
+  a gap where a stale flag from a topology change inside the mapped core
+  could survive. Both branches fail closed to `Chirality::None` on any
+  unresolvable case, matching this project's standing no-silent-wrong
+  policy.
+- **CDXML reader perceives tetrahedral stereo from directional wedges**
+  (RDKit issue #9359, PR #244). `parse_cdxml`/`parse_cdxml_all` previously
+  never ran tetrahedral-parity perception at all — `Atom.chirality` stayed
+  `Chirality::None` regardless of how a molecule was drawn. Wired into the
+  same shared `apply_local_parity_from_wedges` mechanism MOL V2000/V3000
+  and MRV already use. Non-directional displays (`Bold`/`Hash`/`Dash`, which
+  ChemDraw sometimes draws for plain visual emphasis rather than stereo
+  intent, and which have no Begin/End reference convention) are perceived
+  only opt-in, via the new `CdxmlParseOptions { infer_nondirectional_stereo:
+  bool }` (default `false`) and `parse_cdxml_with_options`/
+  `parse_cdxml_all_with_options`; directional wedges
+  (`WedgeBegin`/`WedgeEnd`/`WedgedHashBegin`/`WedgedHashEnd`) are always
+  perceived. When non-directional inference is enabled, the result is now
+  independent of which atom a `<b>` element happens to list first (`B` vs
+  `E`) — a bond-order-flip normalization (new `Molecule::set_bond_order`,
+  chematic-core) replaces an earlier endpoint-swap approach that was found
+  to silently perturb `neighbors()` iteration order and corrupt the very
+  parity calculation it fed. `bond.order` (`Up`/`Down`) is recorded
+  faithfully for any wedge display regardless of the flag; only chirality
+  *perception* is gated.
+
+### Fixed — `chematic-depict`, `chematic-3d` (2D/3D correctness)
+
+- **2D depiction no longer collides independent ring systems** (PR #242).
+  Ring systems with no shared/fused atoms (separate substituents on a
+  chain, or a spiro junction) were placed via a coordinate-blind
+  `place_regular_ring` fallback that always centers at the literal origin —
+  two unrelated same-sized rings could land at bit-for-bit identical
+  coordinates. Replaced the old two-phase "place all rings blind, then
+  place chains" layout with a single connectivity-driven growth pass that
+  anchors every newly-placed ring, including single-atom (spiro) junctions,
+  relative to already-placed geometry.
+- **ETKDG macrocyclic amide 1-4 distance bounds now split by true
+  cis/trans ring role** (PR #245). `macrocycle_14_bound_adjustments`
+  previously pinned all four combinatorial 1-4 atom pairs across a
+  tertiary/secondary amide bond to the same tight *cis* distance band — a
+  geometrically unsatisfiable constraint set (a planar amide's four
+  combinatorial pairs actually split 2 cis + 2 trans) whose least-bad
+  embedding compromise was an unphysical ~90-130° dihedral twist instead of
+  planar. Now computed from real ring-continuation role instead of a
+  blanket assumption. When a central amide bond belongs to two or more
+  eligible macrocycles at once (a theta-graph topology, where the correct
+  role assignment is genuinely ambiguous), the embedder abstains to a
+  relaxed band rather than guessing.
 
 ## [0.10.1] — 2026-08-02
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,5 +23,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.10.1
+version: 0.11.0
 date-released: "2026-07-29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.10.1"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.10.1
+# chematic v0.11.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-07-17, v0.4.29 vs RDKit 2026.03.3 --
@@ -419,6 +419,14 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +1
 
 ## Recent Development
 
+**v0.11.0** (2026-08-04): **MMFF94 O2CM typing coverage, SMIRKS/CDXML stereo correctness, 2D/3D layout fixes**
+- `chematic-ff`: closed the O2CM terminal-oxygen typing gap (issue #227 Priority 1A-3) — atom-type parity 98.82% → 99.37% on the 265-molecule Wave 1 corpus, oxygen-element parity 95.88% → 100%, strict-gate minimization success 123 → 130/265, 0 cross-element mismatches (unchanged). Issue #227 stays open
+- `chematic-rxn`: SMIRKS product chirality assignment made parity-aware — a reordered mapped template neighbor order now correctly inverts/validates the product's `@`/`@@` flag instead of copying it verbatim; inherited (non-template) chirality now fails closed to `Chirality::None` when its neighbor order or mapped topology can't be validated
+- `chematic-mol`: CDXML reader now perceives tetrahedral stereo from directional wedges (RDKit issue #9359), wired into the same shared mechanism MOL/MRV already use; non-directional `Bold`/`Hash`/`Dash` displays are opt-in via `CdxmlParseOptions` and, when enabled, invariant to CDXML's B/E bond-atom ordering
+- `chematic-depict`: independent (non-fused) ring systems no longer collide at identical/near-identical 2D coordinates
+- `chematic-3d`: ETKDG macrocyclic amide 1-4 distance bounds now split by true cis/trans ring-continuation role instead of blanket-pinning all four combinatorial pairs to cis; abstains to a relaxed band when a central amide bond is shared by multiple eligible macrocycles at once
+- Full details in `CHANGELOG.md`'s `[0.11.0]` section
+
 **v0.10.1** (2026-08-02): **MMFF94 numeric-typing correctness hotfix**
 - `chematic-ff`: fixed a class of bug where MMFF94 could silently resolve an atom against a parameter row belonging to a different element and report the resulting physically-wrong energy as success (issue #227's "furan collision") — the aromatic atom typer never implemented RDKit's real 5-/6-ring alpha/beta-heteroatom classification. Ported from a pinned RDKit source with a new provenance-cited numeric-type registry, plus a construction-time semantic-compatibility invariant that makes this bug class fail closed (`NumericTypeError`) instead of silently wrong, going forward. That invariant caught two more instances of the identical bug: a protonated amine N and an anionic O were each being typed as the *other* element's parameter row. Measured on the 265-molecule Wave 1 corpus (production API): 44 → 102 successful MMFF94 minimizations, 0 cross-element type mismatches across 6693 comparable atoms vs. a pinned RDKit oracle (91.83% exact match)
 - This is a correctness hotfix, not a coverage-completion release — issue #227 stays open (140 `MissingParameters` and 22 `MinimizationFailed` cases remain, stretch-bend is not yet gated, no full-corpus energy/gradient parity harness exists yet). See Migration notes in `CHANGELOG.md`'s `[0.10.1]` section if you cache MMFF94 results
@@ -501,7 +509,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v0.10.1)
+├── Cargo.toml                    workspace root (v0.11.0)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)
@@ -554,7 +562,7 @@ If you use chematic in academic or research work, please cite:
   author    = {kent-tokyo},
   title     = {chematic: A pure-Rust cheminformatics toolkit},
   url       = {https://github.com/kent-tokyo/chematic},
-  version   = {0.10.1},
+  version   = {0.11.0},
   year      = {2026},
 }
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -106,7 +106,7 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.10.1
+# chematic v0.11.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-06, v0.4.22 vs RDKit 2026.03.3 --

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.10.1 | Yes | Current release — active support |
+| v0.11.0 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.10.1) receives all security updates.  
+**Active Support**: Latest release (v0.11.0) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -16,12 +16,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.10.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.10.1" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.10.1" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.10.1" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.10.1" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.10.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.11.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.11.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.11.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.11.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.11.0" }
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #219); web-time
 # is a drop-in Instant replacement backed by Performance.now() there, and

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -16,14 +16,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.10.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.11.0" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.10.1" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.10.1" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.10.1" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.10.1" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.10.1" }
-chematic-cip        = { path = "../chematic-cip",        version = "0.10.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.11.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.11.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.11.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.11.0" }
+chematic-cip        = { path = "../chematic-cip",        version = "0.11.0" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.10.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.10.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.11.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -22,10 +22,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.10.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.10.1" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.10.1" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.10.1" }
+chematic-core = { path = "../chematic-core", version = "0.11.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.11.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.11.0" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.10.1" }
+chematic-core = { path = "../chematic-core", version = "0.11.0" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.10.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.10.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.11.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -22,13 +22,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.10.1" }
+chematic-core = { path = "../chematic-core", version = "0.11.0" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.10.1" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.10.1" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.10.1" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.10.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.11.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.11.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.11.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -18,10 +18,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.10.1", path = "../chematic-core" }
-chematic-smiles = { version = "0.10.1", path = "../chematic-smiles" }
-chematic-chem = { version = "0.10.1", path = "../chematic-chem" }
-chematic-rxn = { version = "0.10.1", path = "../chematic-rxn" }
+chematic-core = { version = "0.11.0", path = "../chematic-core" }
+chematic-smiles = { version = "0.11.0", path = "../chematic-smiles" }
+chematic-chem = { version = "0.11.0", path = "../chematic-chem" }
+chematic-rxn = { version = "0.11.0", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.10.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.10.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.11.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -17,15 +17,15 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.10.1" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.10.1" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.10.1", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.10.1" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.10.1" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.10.1" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.10.1" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.10.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.10.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.11.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.11.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.11.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.11.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.11.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.11.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.11.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.11.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
 
 [dev-dependencies]
 # Real JSON Schema 2020-12 validator, used only in tests to independently

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -16,10 +16,10 @@ documentation = "https://docs.rs/chematic-mol"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.10.1" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.10.1" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.10.1" }
-chematic-smiles      = { path = "../chematic-smiles",      version = "0.10.1" }
+chematic-core        = { path = "../chematic-core",        version = "0.11.0" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.11.0" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.11.0" }
+chematic-smiles      = { path = "../chematic-smiles",      version = "0.11.0" }
 serde_json           = "1.0"
 
 [dev-dependencies]

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.10.1" }
+chematic-core = { path = "../chematic-core", version = "0.11.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,16 +25,16 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.10.1" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.10.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.10.1" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.10.1" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.10.1" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.10.1", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.10.1" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.10.1" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.10.1" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.10.1" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.10.1" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.10.1" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.10.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.11.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.11.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.11.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.11.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.11.0", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.11.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.11.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.11.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.11.0" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.11.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.11.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.11.0" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -22,9 +22,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 perf-instrumentation = []
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.10.1" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.10.1" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.10.1" }
+chematic-core   = { path = "../chematic-core",   version = "0.11.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.11.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.11.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.10.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.10.1" }
+chematic-core = { path = "../chematic-core", version = "0.11.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
 rustc-hash = "2"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #221); web-time

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.10.1" }
+chematic-core = { path = "../chematic-core", version = "0.11.0" }
 
 [features]
 # Feature-gated internal work counters for the orbit-pruning canonical

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -26,16 +26,16 @@ wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["console"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.10.1" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.10.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.10.1" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.10.1", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.10.1" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.10.1", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.10.1" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.10.1" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.10.1" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.10.1" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.10.1" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.10.1" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.10.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.11.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.11.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.11.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.11.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.11.0", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.11.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.11.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.11.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.11.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.11.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.11.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.11.0" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -33,15 +33,15 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.10.1", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.10.1", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.10.1", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.10.1", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.10.1", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.10.1", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.10.1", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.10.1", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.10.1", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.10.1", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.10.1", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.10.1", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.11.0", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.11.0", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.11.0", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.11.0", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.11.0", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.11.0", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.11.0", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.11.0", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.11.0", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.11.0", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.11.0", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.11.0", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

v0.11.0 — minor release. Bundles four fixes from the RDKit-open-issues survey
(PR #242, merged earlier, plus #243/#244/#245 merged this session) and one
MMFF94 typing-coverage fix from the ongoing issue #227 program (PR #241,
merged this session). No breaking API changes.

### MMFF94 correctness and coverage (PR #241)

O2CM terminal-oxygen typing gap closed (issue #227 Priority 1A-3). On the
265-molecule Wave 1 corpus (6693 comparable atoms):

| | before | after |
|---|---|---|
| Exact atom-type parity | 98.82% (6614/6693) | **99.37% (6651/6693)** |
| Oxygen-element parity | 95.88% (861/898) | **100.00% (898/898)** |
| Strict-gate success | 123/265 | **130/265** |
| Cross-element mismatch | 0 | 0 (unchanged) |
| Unclassified | 0 | 0 (unchanged) |

Wrong-element parameter selection stays structurally prohibited by the
0.10.1 construction-time semantic-compatibility invariant — this is a
coverage fix, not a regression in that guarantee. All 42 remaining real
mismatches are fully classified by bucket. Issue #227 stays open.

### Stereo and format correctness (PR #243, #244)

- SMIRKS product chirality assignment is now parity-aware: a reordered
  mapped template neighbor order correctly inverts/validates the product's
  `@`/`@@` flag instead of copying it verbatim; inherited (non-template)
  chirality fails closed to `Chirality::None` when its neighbor order or
  mapped topology can't be validated.
- CDXML reader now perceives tetrahedral stereo from directional wedges
  (RDKit issue #9359), via the same shared mechanism MOL/MRV already use.
  Non-directional `Bold`/`Hash`/`Dash` are opt-in
  (`CdxmlParseOptions::infer_nondirectional_stereo`, default `false`) and,
  when enabled, invariant to CDXML's B/E bond-atom ordering.

### 2D/3D correctness (PR #242, #245)

- 2D depiction no longer places independent (non-fused) ring systems at
  identical/near-identical coordinates.
- ETKDG macrocyclic amide 1-4 distance bounds now split by true cis/trans
  ring-continuation role instead of blanket-pinning all four combinatorial
  pairs to cis. When a central amide bond is shared by two or more eligible
  macrocycles at once (a theta-graph topology), the embedder abstains to a
  relaxed band rather than guessing. (The N-cyclohexyl case considered
  during this work was a negative control and did not reproduce a bug —
  the real closed issue is the theta-graph ambiguity.)

Full per-fix detail in `CHANGELOG.md`'s `[0.11.0]` section.

## Verification

- `bash scripts/check.sh` — full green (fmt, clippy, workspace lib+integration
  tests, pytest, cargo-audit, cargo-deny, publish graph, version consistency)
  on this branch, run twice (once before, once after a README
  "Recent Development" addition prompted by `check.sh`'s own warning).
- `cargo publish --dry-run -p chematic-core` — packages and verifies cleanly
  (185.7KiB / 43.9KiB compressed, 14 files, no unexpected contents via
  `cargo package --list`).
- `cargo publish --dry-run -p chematic-ff` fails to resolve
  `chematic-core = "^0.11.0"` against the live crates.io index — expected:
  chematic-core 0.11.0 isn't published yet, so a downstream crate's dry-run
  can't resolve until crates are published in the documented safe order
  (`chematic-core` first, then `chematic-perception`, `chematic-cip`, ...
  per `bash scripts/check.sh`'s publish-graph output). Not a blocker.
- #241 and #244 (this session's two outstanding PRs from the prior review
  round) both merged into `main` with fresh, full-green CI (including the
  Rust Criterion / Python bench regression gates) before this branch was cut.

## Not done here

Tagging `v0.11.0` and the actual `cargo publish` run (in the safe
dependency order above) are intentionally not done as part of this PR —
gated on a separate explicit go-ahead per standing project policy on
irreversible/registry-visible actions.
