### PR TITLE
fix(3d): fix two generate_coords atom-coincidence bugs

### DIFF
--- a/crates/chematic-3d/src/dg.rs
+++ b/crates/chematic-3d/src/dg.rs
@@ -248,12 +248,57 @@ fn place_component(
 // Ring placement
 // ---------------------------------------------------------------------------
 
+/// Order `rings` (each a slice of `AtomIdx`) into fusion-consistent visiting
+/// order via BFS on the ring-adjacency graph (two rings are adjacent iff they
+/// share at least one atom). Returns each ring paired with whether it starts
+/// a new "island" (shares no atom with any ring already visited).
+///
+/// SSSR's own enumeration order does **not** guarantee that every ring after
+/// the first shares an atom with some already-visited ring -- confirmed on a
+/// 3-linearly-fused system (anthracene): SSSR can return `[terminal ring A,
+/// terminal ring C, middle ring B]`, where ring C shares zero atoms with ring
+/// A (only with the not-yet-visited ring B). Iterating SSSR's raw order and
+/// falling back to "keep the previous ring's center" whenever zero shared
+/// atoms are found (this function's caller used to do exactly that) silently
+/// superimposes two entire, unrelated rings on the same coordinates. BFS on
+/// the adjacency graph guarantees each ring is visited only after a ring it
+/// actually shares atoms with, whenever such a ring exists in the same
+/// component.
+fn order_rings_by_fusion_adjacency<'a>(
+    rings: &[&'a Vec<AtomIdx>],
+) -> Vec<(&'a Vec<AtomIdx>, bool)> {
+    let n = rings.len();
+    let mut visited = vec![false; n];
+    let mut result = Vec::with_capacity(n);
+    for start in 0..n {
+        if visited[start] {
+            continue;
+        }
+        visited[start] = true;
+        result.push((rings[start], true)); // starts a new island
+        let mut queue: VecDeque<usize> = VecDeque::new();
+        queue.push_back(start);
+        while let Some(i) = queue.pop_front() {
+            for j in 0..n {
+                if !visited[j] && rings[i].iter().any(|a| rings[j].contains(a)) {
+                    visited[j] = true;
+                    result.push((rings[j], false)); // fused to an already-visited ring
+                    queue.push_back(j);
+                }
+            }
+        }
+    }
+    result
+}
+
 /// Place ring atoms from SSSR onto regular polygon templates.
 ///
 /// Each ring that contains atoms from `component` is laid out in the XY plane.
-/// The first ring is centred at (`x_offset` + ring_radius, 0, 0).
-/// Subsequent rings within the same component are fused to the previous ring
-/// (sharing a bond edge) or offset if not fused.
+/// The first ring (and the first ring of each subsequent, fusion-disconnected
+/// "island" of rings within the same component, e.g. biphenyl's two separate
+/// phenyl rings) is centred at a fresh anchor beyond any already-placed atom.
+/// Every other ring fuses to a previously-placed ring atom (sharing a bond
+/// edge) via [`order_rings_by_fusion_adjacency`]'s visiting order.
 fn place_rings(
     mol: &Molecule,
     component: &[AtomIdx],
@@ -264,20 +309,22 @@ fn place_rings(
 ) {
     let component_set: std::collections::HashSet<AtomIdx> = component.iter().copied().collect();
 
+    let relevant_rings: Vec<&Vec<AtomIdx>> = ring_set
+        .rings()
+        .iter()
+        .filter(|ring| !ring.is_empty() && ring.iter().all(|a| component_set.contains(a)))
+        .collect();
+    if relevant_rings.is_empty() {
+        return;
+    }
+    let ordered_rings = order_rings_by_fusion_adjacency(&relevant_rings);
+
     let mut ring_cx = x_offset;
     let mut ring_cy = 0.0_f64;
-    let mut first_ring = true;
+    let mut any_placed_yet = false;
 
-    for ring in ring_set.rings() {
-        // Only process rings whose atoms all belong to this component.
-        if !ring.iter().all(|a| component_set.contains(a)) {
-            continue;
-        }
-
+    for (ring, is_new_island) in ordered_rings {
         let ring_size = ring.len();
-        if ring_size == 0 {
-            continue;
-        }
 
         // Use bond length between consecutive ring atoms for the polygon side.
         let bond_len = {
@@ -289,13 +336,25 @@ fn place_rings(
         // Circumradius of a regular polygon: r = bond_len / (2 * sin(PI / n)).
         let r = bond_len / (2.0 * (PI / ring_size as f64).sin());
 
-        if first_ring {
-            ring_cx = x_offset + r;
+        if is_new_island {
+            // Anchor beyond any atom already placed in this component, so a
+            // second (fusion-disconnected) ring island never collides with
+            // the first -- x_offset itself only for the very first ring.
+            let anchor_x = if any_placed_yet {
+                component
+                    .iter()
+                    .filter(|a| placed[a.0 as usize])
+                    .map(|&a| coords.get(a).x)
+                    .fold(f64::NEG_INFINITY, f64::max)
+                    + 5.0
+            } else {
+                x_offset
+            };
+            ring_cx = anchor_x + r;
             ring_cy = 0.0;
-            first_ring = false;
         } else {
-            // Try to fuse to a previously-placed ring atom. If two atoms of
-            // this ring are already placed, shift the centre to be consistent.
+            // Fuse to a previously-placed ring atom. If two atoms of this
+            // ring are already placed, shift the centre to be consistent.
             let already_placed: Vec<AtomIdx> = ring
                 .iter()
                 .copied()
@@ -313,7 +372,9 @@ fn place_rings(
                 ring_cx = p0.x + r;
                 ring_cy = p0.y;
             }
-            // else keep ring_cx/ring_cy (floating ring, shouldn't happen in SSSR)
+            // else: unreachable given `order_rings_by_fusion_adjacency`
+            // only marks a ring `is_new_island = false` when it shares an
+            // atom with some already-visited ring.
         }
 
         // Choose a ring conformation based on size and chemical environment.
@@ -395,6 +456,7 @@ fn place_rings(
             coords.set(atom_idx, Point3::new(x, y, z));
             placed[atom_idx.0 as usize] = true;
         }
+        any_placed_yet = true;
     }
 }
 
@@ -622,6 +684,55 @@ mod tests {
         let mol = parse("CC(C)Cc1ccc(cc1)C(C)C(=O)O").unwrap();
         let n = mol.atom_count();
         assert_eq!(n, 15, "ibuprofen has 15 heavy atoms");
+        let coords = generate_coords(&mol);
+        let min_d = min_pairwise_distance(&coords, n);
+        assert!(
+            min_d > 0.3,
+            "no two atoms should be nearly coincident, got min pairwise distance {min_d}"
+        );
+    }
+
+    #[test]
+    fn generate_coords_anthracene_terminal_rings_not_superimposed() {
+        // Regression test: `place_rings` used to iterate SSSR's raw ring
+        // order and fuse each ring to whichever ring was placed immediately
+        // before it. SSSR does NOT guarantee that order matches fusion
+        // adjacency: for anthracene, SSSR returns [terminal ring A, terminal
+        // ring C, middle ring B] -- ring C shares ZERO atoms with ring A
+        // (only with the not-yet-placed ring B), so the old code's "0
+        // already-placed atoms" branch silently reused ring A's exact
+        // center for ring C, superimposing two entire terminal rings (6
+        // atoms) on the same coordinates. This was independently discovered
+        // while investigating issue #185 (chematic-ff's UFF minimizer
+        // blowing up on naphthalene but reportedly not anthracene) --
+        // anthracene's apparent "safety" turned out to be this collision
+        // bug accidentally producing a degenerate-but-not-catastrophic
+        // starting point, not genuine minimizer robustness: after this fix,
+        // anthracene's `generate_coords` output blows up under
+        // `chematic_ff::minimize_uff` too, same as naphthalene (see
+        // `minimize.rs`'s `chematic_ff_own_uff_minimizer_blows_up_*` tests).
+        let mol = parse("c1ccc2cc3ccccc3cc2c1").unwrap();
+        let n = mol.atom_count();
+        assert_eq!(n, 14, "anthracene has 14 heavy atoms");
+        let coords = generate_coords(&mol);
+        let min_d = min_pairwise_distance(&coords, n);
+        assert!(
+            min_d > 0.3,
+            "no two atoms should be nearly coincident, got min pairwise distance {min_d}"
+        );
+    }
+
+    #[test]
+    fn generate_coords_biphenyl_disconnected_ring_islands_not_superimposed() {
+        // Regression test: two rings connected only via a non-ring bond
+        // (biphenyl) share zero atoms and are never fusion-adjacent -- a
+        // genuine "new island" case, not a fusion-order bug. Before this
+        // fix, a ring island beyond the very first reused whatever
+        // `ring_cx`/`ring_cy` the previous, unrelated ring left behind
+        // instead of anchoring fresh beyond it.
+        let mol = parse("c1ccc(cc1)-c1ccccc1").unwrap();
+        let n = mol.atom_count();
+        assert_eq!(n, 12, "biphenyl has 12 heavy atoms");
         let coords = generate_coords(&mol);
         let min_d = min_pairwise_distance(&coords, n);
         assert!(

--- a/crates/chematic-3d/src/dg.rs
+++ b/crates/chematic-3d/src/dg.rs
@@ -208,15 +208,40 @@ fn place_component(
     // First, lay out ring atoms onto polygon templates.
     place_rings(mol, component, ring_set, x_offset, coords, &mut placed);
 
-    // Then extend non-ring atoms via DFS from the component root.
-    let root = component[0];
-    if !placed[root.0 as usize] {
-        // No ring in this component — place root at x_offset.
+    // If no ring placed anything in this component, anchor the first atom at
+    // x_offset so there is at least one placed atom to extend from below.
+    //
+    // Placing this anchor unconditionally (rather than only when no ring
+    // exists) was the root cause of a real bug: `place_rings` centres its
+    // first ring at `x_offset + ring_radius`, which puts one ring vertex at
+    // x = x_offset too (the vertex diametrically opposite the k=0 vertex,
+    // since `ring_cx - ring_radius == x_offset`) -- so an unconditional
+    // anchor at `(x_offset, 0, 0)` collided with (or landed a
+    // floating-point epsilon from) that ring vertex on ANY molecule where
+    // `component[0]` is a non-ring atom directly bonded to that ring (e.g.
+    // plain toluene: the methyl carbon and the ring's ipso carbon ended up
+    // at the same point). Anchoring only when the ring layout placed
+    // nothing avoids ever competing with a ring-computed position.
+    if !component.iter().any(|&a| placed[a.0 as usize]) {
+        let root = component[0];
         coords.set(root, Point3::new(x_offset, 0.0, 0.0));
         placed[root.0 as usize] = true;
     }
 
-    dfs_place(mol, root, &mut placed, coords);
+    // Extend outward via DFS from every atom already placed (every ring
+    // atom, and/or the anchor above) -- not just a single root. `dfs_place`
+    // is a no-op for atoms whose neighbours are all already placed, so this
+    // is safe and cheap to call per seed; it is what makes a substituent
+    // attached to a *different* ring atom than the one nearest `component[0]`
+    // actually get walked and placed, rather than being left at
+    // `Coords3D::new_zeroed`'s (0, 0, 0) default forever (e.g. the second
+    // methyl on p-xylene, or ibuprofen's isobutyl/carboxyl tail hanging off
+    // a ring atom the original single-seed DFS never reached).
+    for &atom in component {
+        if placed[atom.0 as usize] {
+            dfs_place(mol, atom, &mut placed, coords);
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -531,6 +556,77 @@ mod tests {
         assert!(
             has_nonzero,
             "at least some atoms should be placed away from origin"
+        );
+    }
+
+    fn min_pairwise_distance(coords: &Coords3D, n: usize) -> f64 {
+        let mut min_d = f64::MAX;
+        for i in 0..n {
+            for j in (i + 1)..n {
+                let d = coords
+                    .get(AtomIdx(i as u32))
+                    .distance(&coords.get(AtomIdx(j as u32)));
+                min_d = min_d.min(d);
+            }
+        }
+        min_d
+    }
+
+    #[test]
+    fn generate_coords_toluene_methyl_and_ipso_carbon_not_coincident() {
+        // Regression test: `place_component` used to place a non-ring root
+        // atom directly bonded to a ring at the fixed anchor (x_offset, 0, 0)
+        // UNCONDITIONALLY, even when a ring had already been placed with its
+        // own atom landing at that exact point (`place_rings` centres its
+        // first ring at x_offset + ring_radius, putting the vertex
+        // diametrically opposite k=0 at x = x_offset too). On plain toluene
+        // this collided the methyl carbon with the ring's ipso carbon --
+        // two chemically bonded atoms at (approximately) the same 3D point.
+        let mol = parse("Cc1ccccc1").unwrap();
+        let n = mol.atom_count();
+        assert_eq!(n, 7, "toluene has 7 heavy atoms");
+        let coords = generate_coords(&mol);
+        let min_d = min_pairwise_distance(&coords, n);
+        assert!(
+            min_d > 0.5,
+            "no two atoms should be within 0.5 \u{c5} of each other, got {min_d}"
+        );
+    }
+
+    #[test]
+    fn generate_coords_para_disubstituted_ring_both_substituents_placed() {
+        // Regression test: `dfs_place` used to be seeded only once, from the
+        // component root -- once it reached an already-ring-placed atom it
+        // stopped, so a substituent hanging off a *different* ring atom
+        // than the one nearest the root was never visited and stayed at
+        // `Coords3D::new_zeroed`'s (0, 0, 0) default. p-xylene has two
+        // methyls on opposite ring atoms: only one was ever placed before
+        // the fix.
+        let mol = parse("Cc1ccc(C)cc1").unwrap();
+        let n = mol.atom_count();
+        assert_eq!(n, 8, "p-xylene has 8 heavy atoms");
+        let coords = generate_coords(&mol);
+        let min_d = min_pairwise_distance(&coords, n);
+        assert!(
+            min_d > 0.5,
+            "no two atoms should be within 0.5 \u{c5} of each other, got {min_d}"
+        );
+    }
+
+    #[test]
+    fn generate_coords_ring_with_tail_substituent_all_atoms_placed() {
+        // Regression test, ibuprofen-shaped: a multi-atom substituent chain
+        // (isopropyl + carboxyl) hanging off a ring atom that the initial
+        // single-seed DFS never reached used to be left entirely at the
+        // (0, 0, 0) default -- 5 atoms all exactly coincident.
+        let mol = parse("CC(C)Cc1ccc(cc1)C(C)C(=O)O").unwrap();
+        let n = mol.atom_count();
+        assert_eq!(n, 15, "ibuprofen has 15 heavy atoms");
+        let coords = generate_coords(&mol);
+        let min_d = min_pairwise_distance(&coords, n);
+        assert!(
+            min_d > 0.3,
+            "no two atoms should be nearly coincident, got min pairwise distance {min_d}"
         );
     }
 

--- a/crates/chematic-3d/src/dg.rs
+++ b/crates/chematic-3d/src/dg.rs
@@ -248,26 +248,50 @@ fn place_component(
 // Ring placement
 // ---------------------------------------------------------------------------
 
-/// Order `rings` (each a slice of `AtomIdx`) into fusion-consistent visiting
-/// order via BFS on the ring-adjacency graph (two rings are adjacent iff they
-/// share at least one atom). Returns each ring paired with whether it starts
-/// a new "island" (shares no atom with any ring already visited).
+/// Order `rings` into a visiting order via BFS on the ring-adjacency graph,
+/// where two rings are adjacent iff they share an atom (fused, e.g.
+/// naphthalene) OR have a direct bond between some atom in one and some
+/// atom in the other (e.g. biphenyl's two phenyls, bonded but sharing no
+/// atom). Whether a *specific* ring shares an atom with whatever is
+/// already placed by the time [`place_rings`] gets to it is re-checked
+/// there against live placement state, not decided here -- this function's
+/// only job is visiting order.
 ///
-/// SSSR's own enumeration order does **not** guarantee that every ring after
-/// the first shares an atom with some already-visited ring -- confirmed on a
-/// 3-linearly-fused system (anthracene): SSSR can return `[terminal ring A,
-/// terminal ring C, middle ring B]`, where ring C shares zero atoms with ring
-/// A (only with the not-yet-visited ring B). Iterating SSSR's raw order and
-/// falling back to "keep the previous ring's center" whenever zero shared
-/// atoms are found (this function's caller used to do exactly that) silently
-/// superimposes two entire, unrelated rings on the same coordinates. BFS on
-/// the adjacency graph guarantees each ring is visited only after a ring it
-/// actually shares atoms with, whenever such a ring exists in the same
-/// component.
+/// Neither adjacency alone is enough, and SSSR's own enumeration order
+/// guarantees neither kind of ordering on its own:
+/// - Atom-sharing only: confirmed on a 3-linearly-fused system (anthracene)
+///   -- SSSR can return `[terminal ring A, terminal ring C, middle ring
+///   B]`, where ring C shares zero atoms with ring A (only with the
+///   not-yet-visited ring B). Falling back to "keep the previous ring's
+///   center" whenever zero shared atoms are found (an earlier version of
+///   this function's caller did exactly that) silently superimposes two
+///   entire, unrelated rings on the same coordinates.
+/// - Bond adjacency also needed: confirmed on a 3-ring direct-bond chain
+///   (terphenyl, rings connected by single bonds, sharing no atoms at
+///   all) -- SSSR returned `[ring1, ring3, ring2]`, i.e. the ring bonded
+///   to NEITHER already-placed ring (ring3, only bonded to ring2) ahead of
+///   the ring that actually connects the chain together (ring2).
+///   Visiting ring3 before ring2 forces it onto an anchor with no relation
+///   to ring2's real position; when ring2 is later placed and (correctly)
+///   anchored via its real bond to ring3, its OTHER real bond (to ring1)
+///   comes out wrong (measured: 0.66 Å, vs. an ideal ~1.5 Å single bond)
+///   -- one real constraint satisfied while an earlier, arbitrarily placed
+///   ring made the other unsatisfiable.
+///
+/// BFS over the combined adjacency guarantees each ring is visited only
+/// after some ring it can be positioned relative to (by either means),
+/// whenever such a ring exists in the same component.
 fn order_rings_by_fusion_adjacency<'a>(
+    mol: &Molecule,
     rings: &[&'a Vec<AtomIdx>],
-) -> Vec<(&'a Vec<AtomIdx>, bool)> {
+) -> Vec<&'a Vec<AtomIdx>> {
     let n = rings.len();
+    let adjacent = |i: usize, j: usize| -> bool {
+        rings[i].iter().any(|a| rings[j].contains(a))
+            || rings[i]
+                .iter()
+                .any(|&a| mol.neighbors(a).any(|(nb, _)| rings[j].contains(&nb)))
+    };
     let mut visited = vec![false; n];
     let mut result = Vec::with_capacity(n);
     for start in 0..n {
@@ -275,14 +299,14 @@ fn order_rings_by_fusion_adjacency<'a>(
             continue;
         }
         visited[start] = true;
-        result.push((rings[start], true)); // starts a new island
+        result.push(rings[start]);
         let mut queue: VecDeque<usize> = VecDeque::new();
         queue.push_back(start);
         while let Some(i) = queue.pop_front() {
             for j in 0..n {
-                if !visited[j] && rings[i].iter().any(|a| rings[j].contains(a)) {
+                if !visited[j] && adjacent(i, j) {
                     visited[j] = true;
-                    result.push((rings[j], false)); // fused to an already-visited ring
+                    result.push(rings[j]);
                     queue.push_back(j);
                 }
             }
@@ -293,12 +317,17 @@ fn order_rings_by_fusion_adjacency<'a>(
 
 /// Place ring atoms from SSSR onto regular polygon templates.
 ///
-/// Each ring that contains atoms from `component` is laid out in the XY plane.
-/// The first ring (and the first ring of each subsequent, fusion-disconnected
-/// "island" of rings within the same component, e.g. biphenyl's two separate
-/// phenyl rings) is centred at a fresh anchor beyond any already-placed atom.
-/// Every other ring fuses to a previously-placed ring atom (sharing a bond
-/// edge) via [`order_rings_by_fusion_adjacency`]'s visiting order.
+/// Each ring that contains atoms from `component` is laid out in the XY
+/// plane, visited in [`order_rings_by_fusion_adjacency`]'s order. For each
+/// ring, in live placement order: if it shares an atom with something
+/// already placed, fuse to that shared atom (or the midpoint of two, if
+/// two are already placed). Otherwise, if it has a direct bond to an
+/// already-placed atom (e.g. biphenyl's two phenyls, connected but sharing
+/// no atom), anchor via that bond's real length, extending away from the
+/// connected atom's own ring. Otherwise (the very first ring in the
+/// component, or a ring reachable only through not-yet-placed chain atoms
+/// -- see the "no direct bond" branch below), anchor at a fresh position
+/// beyond any already-placed atom in the component.
 fn place_rings(
     mol: &Molecule,
     component: &[AtomIdx],
@@ -317,14 +346,15 @@ fn place_rings(
     if relevant_rings.is_empty() {
         return;
     }
-    let ordered_rings = order_rings_by_fusion_adjacency(&relevant_rings);
+    let ordered_rings = order_rings_by_fusion_adjacency(mol, &relevant_rings);
 
-    let mut ring_cx = x_offset;
-    let mut ring_cy = 0.0_f64;
     let mut any_placed_yet = false;
 
-    for (ring, is_new_island) in ordered_rings {
+    for ring in ordered_rings {
         let ring_size = ring.len();
+        // Always assigned in every branch below before being read.
+        let ring_cx: f64;
+        let ring_cy: f64;
 
         // Use bond length between consecutive ring atoms for the polygon side.
         let bond_len = {
@@ -336,45 +366,126 @@ fn place_rings(
         // Circumradius of a regular polygon: r = bond_len / (2 * sin(PI / n)).
         let r = bond_len / (2.0 * (PI / ring_size as f64).sin());
 
-        if is_new_island {
-            // Anchor beyond any atom already placed in this component, so a
-            // second (fusion-disconnected) ring island never collides with
-            // the first -- x_offset itself only for the very first ring.
-            let anchor_x = if any_placed_yet {
-                component
-                    .iter()
-                    .filter(|a| placed[a.0 as usize])
-                    .map(|&a| coords.get(a).x)
-                    .fold(f64::NEG_INFINITY, f64::max)
-                    + 5.0
-            } else {
-                x_offset
-            };
-            ring_cx = anchor_x + r;
-            ring_cy = 0.0;
-        } else {
-            // Fuse to a previously-placed ring atom. If two atoms of this
-            // ring are already placed, shift the centre to be consistent.
-            let already_placed: Vec<AtomIdx> = ring
-                .iter()
-                .copied()
-                .filter(|a| placed[a.0 as usize])
-                .collect();
+        // Placement strategy is decided from LIVE `placed` state here, not
+        // from `order_rings_by_fusion_adjacency`'s visiting order: that
+        // function only orders rings so that *some* already-placed
+        // neighbour (by either adjacency kind) exists by the time a ring
+        // is reached -- it does not, and should not, commit to which kind
+        // applies, since that can only be known once earlier rings in the
+        // same BFS traversal have actually been placed.
+        let shared_atoms: Vec<AtomIdx> = ring
+            .iter()
+            .copied()
+            .filter(|a| placed[a.0 as usize])
+            .collect();
 
-            if already_placed.len() >= 2 {
+        if shared_atoms.is_empty() {
+            // No shared ring atom -- may still have a real bond straight to
+            // an already-placed atom -- biphenyl's two phenyl rings share
+            // zero atoms but ARE directly bonded to each other. Anchoring
+            // blindly at a fixed offset ignored that bond entirely and
+            // left it stretched to whatever the offset was (measured:
+            // exactly 5.0 Å for biphenyl, vs. an ideal ~1.4 Å aromatic C-C
+            // single bond) -- both ring endpoints were already marked
+            // `placed`, so `dfs_place`'s chain walk (which only visits
+            // *unplaced* neighbours) never got a chance to correct it.
+            // Look for such a bond first and, if found, anchor via its
+            // real ideal length instead.
+            let direct_bond = ring.iter().find_map(|&ring_atom| {
+                mol.neighbors(ring_atom)
+                    .map(|(nb, _)| nb)
+                    .find(|nb| placed[nb.0 as usize])
+                    .map(|anchor_atom| (ring_atom, anchor_atom))
+            });
+
+            if let Some((ring_atom, anchor_atom)) = direct_bond {
+                let anchor_pos = coords.get(anchor_atom);
+                // Extend away from the centroid of `anchor_atom`'s OWN
+                // already-placed ring specifically, not blindly along +X
+                // and not the whole component's centroid either: +X only
+                // happens to work when the connecting atom sits on the
+                // "outer" side of its own ring (biphenyl's own para-like
+                // case), and a whole-component centroid still misleads a
+                // 3+-ring chain (terphenyl) once an earlier ring has
+                // already skewed the average away from the specific ring
+                // being extended from. `place_rings` runs before any
+                // `dfs_place` chain walk, so every already-placed atom here
+                // is necessarily a ring atom -- `anchor_atom` always
+                // belongs to exactly one prior entry in `relevant_rings`.
+                // Measured without this: 3-phenylpyridine collapsed to
+                // 0.14 Å min pairwise distance (whole-component-centroid
+                // version), terphenyl's third ring still did too even with
+                // it (component-wide average, not this ring's own centroid).
+                let centroid_xy = relevant_rings
+                    .iter()
+                    .find(|other_ring| other_ring.contains(&anchor_atom))
+                    .map(|other_ring| {
+                        let (sx, sy, n) =
+                            other_ring
+                                .iter()
+                                .fold((0.0, 0.0, 0.0_f64), |(sx, sy, n), &a| {
+                                    let p = coords.get(a);
+                                    (sx + p.x, sy + p.y, n + 1.0)
+                                });
+                        (sx / n, sy / n)
+                    })
+                    .unwrap_or((anchor_pos.x, anchor_pos.y));
+                let dx = anchor_pos.x - centroid_xy.0;
+                let dy = anchor_pos.y - centroid_xy.1;
+                let dist = (dx * dx + dy * dy).sqrt();
+                let (ux, uy) = if dist > 1e-6 {
+                    (dx / dist, dy / dist)
+                } else {
+                    (1.0, 0.0)
+                };
+                let bond_len_to_ring = ideal_bond_len(mol, ring_atom, anchor_atom);
+                let ring_atom_x = anchor_pos.x + ux * bond_len_to_ring;
+                let ring_atom_y = anchor_pos.y + uy * bond_len_to_ring;
+                let k = ring.iter().position(|&a| a == ring_atom).unwrap();
+                let angle = 2.0 * PI * k as f64 / ring_size as f64;
+                ring_cx = ring_atom_x - r * angle.cos();
+                ring_cy = ring_atom_y - r * angle.sin();
+            } else {
+                // No direct bond to any already-placed atom -- this ring is
+                // reachable, if at all within this component, only through
+                // atoms `place_rings` hasn't placed yet (chain-bridged ring
+                // islands, e.g. two phenyls linked by a -CH2CH2- bridge;
+                // `place_rings` places every ring before any chain atom is
+                // walked, so that bridge's own length can't be known here).
+                // Known limitation, not fixed by this anchor: the fixed
+                // +5 Å offset below only guarantees no collision, not a
+                // correct bond length at the eventual chain-to-ring
+                // junction.
+                let anchor_x = if any_placed_yet {
+                    component
+                        .iter()
+                        .filter(|a| placed[a.0 as usize])
+                        .map(|&a| coords.get(a).x)
+                        .fold(f64::NEG_INFINITY, f64::max)
+                        + 5.0
+                } else {
+                    x_offset
+                };
+                ring_cx = anchor_x + r;
+                ring_cy = 0.0;
+            }
+        } else {
+            // Fuse to a previously-placed ring atom (shares >=1 atom with
+            // something already placed). If two atoms of this ring are
+            // already placed, shift the centre to be consistent.
+            if shared_atoms.len() >= 2 {
                 // Use the midpoint of the two most recently placed ring atoms.
-                let p0 = coords.get(already_placed[0]);
-                let p1 = coords.get(already_placed[1]);
+                let p0 = coords.get(shared_atoms[0]);
+                let p1 = coords.get(shared_atoms[1]);
                 ring_cx = (p0.x + p1.x) / 2.0;
                 ring_cy = (p0.y + p1.y) / 2.0 + r;
-            } else if already_placed.len() == 1 {
-                let p0 = coords.get(already_placed[0]);
+            } else {
+                // shared_atoms.len() == 1, guaranteed nonempty by the
+                // `else` branch of `if shared_atoms.is_empty()` above.
+                let p0 = coords.get(shared_atoms[0]);
                 ring_cx = p0.x + r;
                 ring_cy = p0.y;
             }
-            // else: unreachable given `order_rings_by_fusion_adjacency`
-            // only marks a ring `is_new_island = false` when it shares an
-            // atom with some already-visited ring.
         }
 
         // Choose a ring conformation based on size and chemical environment.
@@ -634,6 +745,29 @@ mod tests {
         min_d
     }
 
+    /// Asserts every BONDED pair in `mol` is finite and within
+    /// `[min_len, max_len]` Å. Deliberately distinct from
+    /// `min_pairwise_distance`, which only checks the single closest pair
+    /// over ALL atoms (bonded or not) -- it can miss a specific bonded
+    /// pair landing too far apart (a stretch only ever *increases*
+    /// distances, so it can't move the global minimum) while some
+    /// unrelated, non-bonded pair happens to be close. Panics with the
+    /// offending atom indices and distance so a failure is directly
+    /// actionable.
+    fn assert_bonded_pairs_sane(mol: &Molecule, coords: &Coords3D, min_len: f64, max_len: f64) {
+        for (_, b) in mol.bonds() {
+            let p1 = coords.get(b.atom1);
+            let p2 = coords.get(b.atom2);
+            let d = p1.distance(&p2);
+            assert!(
+                d.is_finite() && d >= min_len && d <= max_len,
+                "bond {}-{} has length {d:.4} \u{c5}, expected finite and within [{min_len}, {max_len}] \u{c5}",
+                b.atom1.0,
+                b.atom2.0
+            );
+        }
+    }
+
     #[test]
     fn generate_coords_toluene_methyl_and_ipso_carbon_not_coincident() {
         // Regression test: `place_component` used to place a non-ring root
@@ -720,6 +854,23 @@ mod tests {
             min_d > 0.3,
             "no two atoms should be nearly coincident, got min pairwise distance {min_d}"
         );
+        // NOT extended with `assert_bonded_pairs_sane` like the
+        // biphenyl/terphenyl/meta-linked tests below: doing so here (during
+        // this PR's review) surfaced FOUR distorted bonds at this molecule's
+        // ring-fusion seams -- 0.8675 Å, 1.3163 Å, 2.0365 Å, 2.2644 Å,
+        // not just the single 2.2644 Å this file's own commit history
+        // previously (incorrectly) described as the only imperfection.
+        // Confirmed by direct comparison (temporarily disabling this PR's
+        // new bond-adjacency ordering edge and re-running) that these come
+        // from the PRE-EXISTING `shared_atoms.len() >= 2` fuse branch above
+        // -- its `ring_cy = (p0.y + p1.y) / 2.0 + r` always extends the new
+        // ring in +y from the fusion bond's midpoint, regardless of which
+        // direction is actually away from the rest of the structure. This
+        // predates this PR entirely (shipped in `d45f91b`, this test's own
+        // prior form never checked bond lengths, only
+        // `min_pairwise_distance`) and is a different code path from the
+        // "new island" direct-bond anchor this PR's biphenyl/terphenyl fix
+        // touches -- not fixed here, flagged for a separate decision.
     }
 
     #[test]
@@ -730,6 +881,19 @@ mod tests {
         // fix, a ring island beyond the very first reused whatever
         // `ring_cx`/`ring_cy` the previous, unrelated ring left behind
         // instead of anchoring fresh beyond it.
+        //
+        // The FIRST fix for this (anchor the new island at a fixed offset
+        // beyond the rest of the component) traded that collision for a
+        // different bug: it ignored the real single bond directly
+        // connecting biphenyl's two rings entirely, stretching it to
+        // exactly that fixed offset (measured: 5.0 Å, vs. an ideal ~1.5 Å
+        // single bond) -- both endpoints were already `placed`, so
+        // `dfs_place`'s chain walk (unplaced-neighbours only) never got a
+        // chance to correct it. `min_pairwise_distance` alone could not
+        // have caught this: a stretch only increases distances, so it
+        // never becomes the global minimum. Fixed by detecting a direct
+        // bond to an already-placed atom before falling back to the
+        // fixed-offset anchor.
         let mol = parse("c1ccc(cc1)-c1ccccc1").unwrap();
         let n = mol.atom_count();
         assert_eq!(n, 12, "biphenyl has 12 heavy atoms");
@@ -738,6 +902,109 @@ mod tests {
         assert!(
             min_d > 0.3,
             "no two atoms should be nearly coincident, got min pairwise distance {min_d}"
+        );
+        assert_bonded_pairs_sane(&mol, &coords, 1.0, 1.8);
+    }
+
+    #[test]
+    fn generate_coords_terphenyl_chain_of_new_island_rings_bond_lengths_sane() {
+        // Regression test: a chain of 3+ rings, each directly bonded to the
+        // next with zero shared atoms (so every ring after the first is a
+        // "new island" per `order_rings_by_fusion_adjacency`), needs each
+        // new-island anchor to extend away from the SPECIFIC ring it is
+        // bonding to, not from the whole component's running centroid.
+        // Using the whole-component centroid still collapsed the third
+        // ring here (measured: 0.14 \u{c5} min pairwise distance) even after
+        // fixing biphenyl's simpler 2-ring case, because by the time the
+        // third ring is placed the average of rings 1+2 no longer points
+        // "outward" from ring 2's own extent. Fixed by finding the
+        // specific already-placed ring containing the connecting atom and
+        // using only its own centroid.
+        let mol = parse("c1ccc(cc1)-c1ccc(cc1)-c1ccccc1").unwrap();
+        let n = mol.atom_count();
+        assert_eq!(n, 18, "terphenyl has 18 heavy atoms");
+        let coords = generate_coords(&mol);
+        let min_d = min_pairwise_distance(&coords, n);
+        assert!(
+            min_d > 0.3,
+            "no two atoms should be nearly coincident, got min pairwise distance {min_d}"
+        );
+        assert_bonded_pairs_sane(&mol, &coords, 1.0, 1.8);
+    }
+
+    #[test]
+    fn generate_coords_meta_linked_biaryl_bond_lengths_sane() {
+        // Regression test: when the connecting ring atom sits on the side
+        // of its ring FACING the already-placed structure (meta-linked,
+        // unlike biphenyl's own para-like case), a fixed +X extension
+        // direction points the new ring straight back into what's already
+        // placed. Measured without the centroid-outward fix: 0.14 \u{c5}
+        // min pairwise distance on this exact molecule.
+        let mol = parse("c1ccc(cc1)-c1cccnc1").unwrap();
+        let n = mol.atom_count();
+        assert_eq!(n, 12, "3-phenylpyridine has 12 heavy atoms");
+        let coords = generate_coords(&mol);
+        let min_d = min_pairwise_distance(&coords, n);
+        assert!(
+            min_d > 0.3,
+            "no two atoms should be nearly coincident, got min pairwise distance {min_d}"
+        );
+        assert_bonded_pairs_sane(&mol, &coords, 1.0, 1.8);
+    }
+
+    #[test]
+    fn generate_coords_spiro_ring_adjacency_unaffected() {
+        // Positive control for the two fixes above: spiro rings share
+        // EXACTLY ONE atom, so `order_rings_by_fusion_adjacency` correctly
+        // marks the second ring `is_new_island = false` (fused, via the
+        // existing shared-atom branch this PR does not touch) -- confirms
+        // the new "new island direct-bond" logic never fires for spiro
+        // systems and doesn't regress them.
+        let mol = parse("C1CCC2(CC1)CCCCC2").unwrap();
+        let n = mol.atom_count();
+        assert_eq!(n, 11, "spiro[5.5]undecane has 11 heavy atoms");
+        let coords = generate_coords(&mol);
+        let min_d = min_pairwise_distance(&coords, n);
+        assert!(
+            min_d > 0.3,
+            "no two atoms should be nearly coincident, got min pairwise distance {min_d}"
+        );
+        assert_bonded_pairs_sane(&mol, &coords, 1.0, 1.8);
+    }
+
+    #[test]
+    fn generate_coords_bibenzyl_chain_bridged_ring_islands_known_broken() {
+        // NOT a regression test for a fix -- pins a KNOWN, still-open
+        // limitation. `place_rings` places every ring in a component
+        // before `dfs_place` walks any chain atom, so a ring reachable
+        // from an already-placed ring only through a non-ring bridge (here
+        // the -CH2CH2- of bibenzyl, PhCH2CH2Ph) has no already-placed atom
+        // for the direct-bond anchor added in this PR to find -- it falls
+        // through to the fixed +5 \u{c5}-offset anchor, which guarantees no
+        // collision but not a correct bond length at the eventual
+        // chain-to-ring junction. Fixing this needs `place_component`
+        // restructured to interleave ring placement and chain DFS in true
+        // graph order, not a targeted fix within `place_rings` alone --
+        // out of scope here. This test exists so that future restructuring
+        // has a ready-made regression fixture: it currently pins the
+        // broken value so a fix is provable (this assertion should FAIL
+        // once the underlying limitation is actually fixed, at which point
+        // replace it with a `assert_bonded_pairs_sane` call instead of
+        // deleting it).
+        let mol = parse("c1ccccc1CCc1ccccc1").unwrap();
+        let n = mol.atom_count();
+        assert_eq!(n, 14, "bibenzyl has 14 heavy atoms");
+        let coords = generate_coords(&mol);
+        let worst = mol
+            .bonds()
+            .map(|(_, b)| coords.get(b.atom1).distance(&coords.get(b.atom2)))
+            .fold(0.0_f64, f64::max);
+        assert!(
+            worst > 5.0,
+            "expected this known-broken chain-bridged case to still have a grossly \
+             stretched bond (last measured 8.7358 \u{c5}); got worst bond {worst:.4} \u{c5} -- \
+             if this now passes, the chain-bridged ring-island limitation documented above \
+             was fixed and this test should be replaced with a sane-bond-length assertion"
         );
     }
 

--- a/crates/chematic-3d/src/minimize.rs
+++ b/crates/chematic-3d/src/minimize.rs
@@ -2007,8 +2007,12 @@ fn run_uff_bridge(
 /// The rescue itself: `original_failure` is `coords`' own (already-computed)
 /// failure. Raw starting energy alone cannot decide in advance whether a
 /// given start needs this — measured (`docs/uff_robustness_diagnosis_185_188.md`):
-/// anthracene's raw `generate_coords` energy is ~5 orders of magnitude worse
-/// than naphthalene's, yet anthracene never needs this path — so the
+/// naphthalene and anthracene start from virtually identical raw
+/// `generate_coords` UFF energies (~1.256e5 vs ~1.267e5 kcal/mol) and
+/// worst starting bonds (2.26 Å, identical), yet naphthalene's raw UFF
+/// minimization reaches a sound geometry (worst bond 2.19 Å) while
+/// anthracene's plateaus permanently unsound (worst bond 3.39 Å, still
+/// above `MAX_SANE_BOND_LENGTH` even at 200,000 steps) — so the
 /// decision is made from the ACTUAL post-minimization outcome, never a
 /// pre-minimization heuristic guess.
 ///
@@ -3134,10 +3138,15 @@ mod policy_bridge_tests {
     /// unproven: `minimize_uff`'s naive steepest-descent-with-step-halving
     /// line search on a larger, more constrained fused-ring system) — not
     /// something this PR fixes (chematic-ff is out of this PR's
-    /// file-ownership scope) or definitively diagnoses. Non-monotonic in
-    /// ring count: anthracene (3 fused rings) does NOT blow up under the
-    /// same fallback path while naphthalene (2 fused rings) does, so "more
-    /// fused rings" is not itself the mechanism.
+    /// file-ownership scope) or definitively diagnoses. Not specific to
+    /// ring count either way: anthracene (3 fused rings) blows up under the
+    /// same isolated path too, and worse than naphthalene (2 fused
+    /// rings) — it never recovers a sound geometry even at 200,000 steps,
+    /// vs. naphthalene's ~10,000 (see issue #185's investigation notes; an
+    /// earlier reading of anthracene as "immune" was itself an artifact of
+    /// a since-fixed `dg::generate_coords` ring-placement bug that
+    /// silently superimposed two of its rings, corrupting that
+    /// measurement).
     #[test]
     fn chematic_ff_own_uff_minimizer_blows_up_naphthalene_independent_of_this_bridge() {
         let mol = parse("c1ccc2ccccc2c1").expect("naphthalene");
@@ -3419,23 +3428,33 @@ mod policy_bridge_tests {
     // the full write-up and measured numbers this pins.
     //
     // Measured finding (not assumed): `generate_coords` produces starting
-    // geometries with enormous UFF energies (naphthalene ~1.3e5, hexane
-    // ~1.5e7, anthracene ~2.7e10 kcal/mol -- dominated by unrelieved vdW
+    // geometries with enormous UFF energies (naphthalene ~1.3e5, anthracene
+    // ~1.3e5, hexane ~1.5e7 kcal/mol -- dominated by unrelieved vdW
     // overlap, not bond stretch) for essentially every molecule, not just
     // the ones that end up blowing up. `minimize_uff`'s plain fixed-step
     // steepest descent (no conjugate-gradient/quasi-Newton acceleration)
-    // *does* eventually relieve this and reach a sound, low-energy geometry
-    // for every molecule checked here -- given enough iterations. Whether a
-    // molecule's specific clash-relief trajectory happens to land inside
-    // `MinimizeConfig::default().max_steps` (200) is not predicted by worst
-    // starting bond length or starting energy: anthracene starts from a
-    // ~5-order-of-magnitude worse energy than naphthalene yet fully
-    // converges within budget, while naphthalene (needs ~4,500 steps) and
-    // hexane (needs >20,000, still not fully converged at 100,000) do not.
-    // This is a shared iteration-budget-vs-starting-energy mechanism across
-    // both issues, not two independent root causes -- and not a `dg.rs`
-    // ring-placement defect specific to fused aromatics (naphthalene's raw
-    // worst bond, 2.26 Å, is *better* than anthracene's, 3.73 Å).
+    // eventually relieves this and reaches a sound, low-energy geometry for
+    // *most* molecules checked here, given enough iterations -- but not
+    // all: naphthalene needs ~10,000 steps and hexane needs >20,000 (still
+    // not fully converged at 100,000), while anthracene never reaches a
+    // sound geometry at all, plateauing at worst bond 3.39 Å (still above
+    // `MAX_SANE_BOND_LENGTH`) from 10,000 steps all the way through
+    // 200,000, with `minimize_uff`'s own RMS-gradient convergence check
+    // reporting `converged: true` on that unsound plateau -- a real,
+    // distinct trapped-local-minimum failure mode, not just an
+    // under-provisioned iteration budget. Whether a molecule's specific
+    // clash-relief trajectory succeeds at all is not predicted by starting
+    // energy or worst starting bond length: naphthalene and anthracene
+    // start from virtually identical raw energy (~1.3e5 kcal/mol either
+    // way) and identical worst starting bond (2.26 Å) yet only one
+    // recovers. (An earlier version of this comment cited anthracene's raw
+    // worst bond as 3.73 Å and its energy as ~5 orders of magnitude worse
+    // than naphthalene's, concluding anthracene was *immune* to this
+    // failure class and using that as evidence against a `dg.rs`
+    // ring-placement explanation -- both the numbers and that conclusion
+    // were an artifact of a since-fixed `dg::generate_coords` bug that
+    // silently superimposed two of anthracene's three rings on identical
+    // coordinates, corrupting the measurement; see issue #185.)
     //
     // Not fixed by the diagnostic pass itself: per that phase's scope, it was
     // regression-fixture only. Fixed by a follow-up PR (`run_uff_bridge`'s

--- a/crates/chematic-3d/tests/g1_regression_byte_identical.rs
+++ b/crates/chematic-3d/tests/g1_regression_byte_identical.rs
@@ -30,6 +30,21 @@
 //! multi-ring fusion-order logic never applies) -- this file's pinned
 //! values are unchanged by it, verified by running this test unmodified
 //! both before and after that second fix.
+//!
+//! A third fix (same PR, review round 2) taught `place_rings` to anchor a
+//! fusion-disconnected ring island via a real bond to already-placed
+//! structure when one exists (biphenyl, terphenyl), rather than an
+//! arbitrary fixed offset that silently stretched that bond. Also
+//! confirmed NOT to affect aspirin (still just the one ring) -- unchanged
+//! before/after, same as the second fix.
+//!
+//! Two of this file's pinned values (`plane_of_best_fit`,
+//! `descriptors_3d_outputs_unchanged`'s `rdf[0]`) are asserted via
+//! `assert_close_ulp` rather than `to_bits()` equality: CI (x86_64) and
+//! local development (aarch64) compute them a few ULP apart --
+//! FMA/vectorization differences in their summation order, not a
+//! correctness regression (the other 17 values in this file match
+//! bit-for-bit across both targets).
 
 use chematic_3d::dg::generate_coords;
 use chematic_3d::{
@@ -42,6 +57,25 @@ fn aspirin_coords() -> (chematic_core::Molecule, chematic_3d::Coords3D) {
     let mol = parse("CC(=O)Oc1ccccc1C(=O)O").unwrap();
     let coords = generate_coords(&mol);
     (mol, coords)
+}
+
+/// Asserts `actual` is finite, positive, and within `max_ulp` of
+/// `expected_bits` (an `f64::to_bits()` snapshot) -- an ULP-scale
+/// tolerance rather than a magnitude-scaled absolute epsilon, so it stays
+/// exactly as tight regardless of the value's own magnitude. `to_bits()`
+/// is monotonic with value for same-signed floats, so a plain bit-pattern
+/// `abs_diff` is a correct ULP distance here (both callers below are
+/// positive).
+fn assert_close_ulp(actual: f64, expected_bits: u64, max_ulp: u64, label: &str) {
+    assert!(actual.is_finite(), "{label}: expected finite, got {actual}");
+    assert!(actual > 0.0, "{label}: expected positive, got {actual}");
+    let actual_bits = actual.to_bits();
+    let ulp_diff = actual_bits.abs_diff(expected_bits);
+    assert!(
+        ulp_diff <= max_ulp,
+        "{label}: {ulp_diff} ULP from expected (bits {actual_bits} vs {expected_bits}), \
+         allowed {max_ulp}"
+    );
 }
 
 #[test]
@@ -63,10 +97,17 @@ fn shape_descriptors_outputs_unchanged() {
     assert_eq!(eccentricity(&mol, &coords).to_bits(), 4605136510549718693);
     // Not bit-pinned like the rest: this value's summation order makes it
     // sensitive to FMA/vectorization differences between the aarch64
-    // (local) and x86_64 (CI) targets -- observed 1-ULP drift across the
-    // two, confirmed via a real CI run, not assumed. An epsilon check still
-    // catches any real regression at far coarser precision than 1 ULP.
-    assert!((plane_of_best_fit(&mol, &coords) - 0.7890321356743597).abs() < 1e-9);
+    // (local) and x86_64 (CI) targets -- observed exactly 1-ULP drift
+    // across the two (CI bits 4605282189209689201 vs local
+    // 4605282189209689202), confirmed via a real CI run, not assumed.
+    // 2 ULP gives slack above the observed 1 ULP without loosening this
+    // into a magnitude-blind absolute epsilon.
+    assert_close_ulp(
+        plane_of_best_fit(&mol, &coords),
+        4605282189209689201,
+        2,
+        "plane_of_best_fit",
+    );
 }
 
 #[test]
@@ -84,9 +125,13 @@ fn descriptors_3d_outputs_unchanged() {
     let rdf = rdf_descriptors(&mol, &coords);
     assert_eq!(rdf.len(), 20);
     // Same aarch64/x86_64 FMA/summation-order drift as plane_of_best_fit
-    // above -- see that comment. Epsilon scaled to this value's own
-    // ~1e-20 magnitude rather than a flat tolerance.
-    assert!((rdf[0] - 1.1758914601851493e-20).abs() < 1e-27);
+    // above -- see that comment (CI bits 4308752783383236313 vs local
+    // 4308752783383236201, a 112-ULP gap despite this value's tiny ~1e-20
+    // magnitude, which is exactly why a magnitude-scaled ULP check is used
+    // instead of a magnitude-scaled absolute epsilon: at this scale an
+    // absolute epsilon tight enough to mean anything is easy to get wrong
+    // in either direction).
+    assert_close_ulp(rdf[0], 4308752783383236313, 150, "rdf[0]");
 
     let ac = autocorr_3d(&mol, &coords);
     assert_eq!(ac.len(), 8);

--- a/crates/chematic-3d/tests/g1_regression_byte_identical.rs
+++ b/crates/chematic-3d/tests/g1_regression_byte_identical.rs
@@ -22,6 +22,14 @@
 //! substituent -- these were byte-identical snapshots of a genuinely wrong
 //! geometry, not a neutral baseline. Re-verified sane post-fix (minimum
 //! pairwise interatomic distance 1.22 \u{c5}, no collisions) before repinning.
+//!
+//! A second, independent `dg::generate_coords` fix landed in the same PR
+//! (`place_rings`'s ring visiting order didn't match ring-fusion adjacency,
+//! silently superimposing unrelated rings in some multi-ring-fused systems
+//! -- see issue #185). Confirmed NOT to affect aspirin (single ring, so the
+//! multi-ring fusion-order logic never applies) -- this file's pinned
+//! values are unchanged by it, verified by running this test unmodified
+//! both before and after that second fix.
 
 use chematic_3d::dg::generate_coords;
 use chematic_3d::{
@@ -53,10 +61,12 @@ fn shape_descriptors_outputs_unchanged() {
     );
     assert_eq!(asphericity(&mol, &coords).to_bits(), 4643472035674254761);
     assert_eq!(eccentricity(&mol, &coords).to_bits(), 4605136510549718693);
-    assert_eq!(
-        plane_of_best_fit(&mol, &coords).to_bits(),
-        4605282189209689202
-    );
+    // Not bit-pinned like the rest: this value's summation order makes it
+    // sensitive to FMA/vectorization differences between the aarch64
+    // (local) and x86_64 (CI) targets -- observed 1-ULP drift across the
+    // two, confirmed via a real CI run, not assumed. An epsilon check still
+    // catches any real regression at far coarser precision than 1 ULP.
+    assert!((plane_of_best_fit(&mol, &coords) - 0.7890321356743597).abs() < 1e-9);
 }
 
 #[test]
@@ -73,7 +83,10 @@ fn descriptors_3d_outputs_unchanged() {
 
     let rdf = rdf_descriptors(&mol, &coords);
     assert_eq!(rdf.len(), 20);
-    assert_eq!(rdf[0].to_bits(), 4308752783383236201);
+    // Same aarch64/x86_64 FMA/summation-order drift as plane_of_best_fit
+    // above -- see that comment. Epsilon scaled to this value's own
+    // ~1e-20 magnitude rather than a flat tolerance.
+    assert!((rdf[0] - 1.1758914601851493e-20).abs() < 1e-27);
 
     let ac = autocorr_3d(&mol, &coords);
     assert_eq!(ac.len(), 8);

--- a/crates/chematic-3d/tests/g1_regression_byte_identical.rs
+++ b/crates/chematic-3d/tests/g1_regression_byte_identical.rs
@@ -10,6 +10,18 @@
 //! below is a snapshot of this crate's pre-existing behavior on aspirin's
 //! rule-based conformer, captured by running this same test with these
 //! source files unmodified (only new files added elsewhere in the crate).
+//!
+//! **Re-pinned (issue #252 follow-up) after a real `dg::generate_coords` bug
+//! fix**: `place_component` used to place a non-ring root atom unconditionally
+//! at `(x_offset, 0, 0)`, which collided with a ring vertex `place_rings`
+//! independently computed at that same point, AND only ever seeded
+//! `dfs_place` from a single root, silently leaving any substituent on a
+//! *different* ring atom at the `Coords3D::new_zeroed` (0, 0, 0) default.
+//! Aspirin has two substituents on different ring atoms (the acetoxy group
+//! and the carboxylic acid), so its pre-fix conformer had a collapsed
+//! substituent -- these were byte-identical snapshots of a genuinely wrong
+//! geometry, not a neutral baseline. Re-verified sane post-fix (minimum
+//! pairwise interatomic distance 1.22 \u{c5}, no collisions) before repinning.
 
 use chematic_3d::dg::generate_coords;
 use chematic_3d::{
@@ -29,21 +41,21 @@ fn shape_descriptors_outputs_unchanged() {
     let (mol, coords) = aspirin_coords();
 
     let (p1, p2, p3) = pmi(&mol, &coords);
-    assert_eq!(p1.to_bits(), 4641030930311365385);
-    assert_eq!(p2.to_bits(), 4642440373202006155);
-    assert_eq!(p3.to_bits(), 4643411699880215071);
+    assert_eq!(p1.to_bits(), 4644029000416014720);
+    assert_eq!(p2.to_bits(), 4649000708028099279);
+    assert_eq!(p3.to_bits(), 4649818517720963228);
 
-    assert_eq!(npr1(&mol, &coords).to_bits(), 4604711176012659252);
-    assert_eq!(npr2(&mol, &coords).to_bits(), 4606060549641463300);
+    assert_eq!(npr1(&mol, &coords).to_bits(), 4600925831808218358);
+    assert_eq!(npr2(&mol, &coords).to_bits(), 4606067565117627831);
     assert_eq!(
         radius_of_gyration(&mol, &coords).to_bits(),
-        4609080816536283578
+        4612204248550002610
     );
-    assert_eq!(asphericity(&mol, &coords).to_bits(), 4632702946048551376);
-    assert_eq!(eccentricity(&mol, &coords).to_bits(), 4602893161489872220);
+    assert_eq!(asphericity(&mol, &coords).to_bits(), 4643472035674254761);
+    assert_eq!(eccentricity(&mol, &coords).to_bits(), 4605136510549718693);
     assert_eq!(
         plane_of_best_fit(&mol, &coords).to_bits(),
-        4604408828436051570
+        4605282189209689202
     );
 }
 
@@ -53,17 +65,17 @@ fn descriptors_3d_outputs_unchanged() {
 
     let whim = whim_descriptors(&mol, &coords);
     assert_eq!(whim.len(), 22);
-    assert_eq!(whim[0].to_bits(), 4606306289098307689);
+    assert_eq!(whim[0].to_bits(), 4613856678274617005);
 
     let getaway = getaway_descriptors(&mol, &coords);
     assert_eq!(getaway.len(), 19);
-    assert_eq!(getaway[0].to_bits(), 4613348228423443963);
+    assert_eq!(getaway[0].to_bits(), 4612638039418707655);
 
     let rdf = rdf_descriptors(&mol, &coords);
     assert_eq!(rdf.len(), 20);
-    assert_eq!(rdf[0].to_bits(), 4493306176433625389);
+    assert_eq!(rdf[0].to_bits(), 4308752783383236201);
 
     let ac = autocorr_3d(&mol, &coords);
     assert_eq!(ac.len(), 8);
-    assert_eq!(ac[0].to_bits(), 4655804895277587578);
+    assert_eq!(ac[0].to_bits(), 0);
 }

--- a/docs/uff_robustness_diagnosis_185_188.md
+++ b/docs/uff_robustness_diagnosis_185_188.md
@@ -5,6 +5,59 @@ fixtures pinning the measurements below live in
 `crates/chematic-3d/src/minimize.rs`'s `mod tests` (search for "Issues #185 /
 #188 diagnosis").
 
+## Correction (2026-08-07): anthracene's numbers below were measured on a
+## collided geometry
+
+Every anthracene number in Findings 1–3 and the Conclusion below was
+measured against a `dg::generate_coords` output that silently superimposed
+two of anthracene's three rings on identical coordinates — a real,
+independent `dg.rs` bug (`place_rings` assumed SSSR's raw ring enumeration
+order always matches ring-fusion adjacency order; false for anthracene's
+`[terminal, terminal, middle]` SSSR order), fixed in PR #253. **Finding
+1's own metric could not see this**: it measures the worst *bonded*-pair
+distance, and anthracene's two superimposed terminal rings are not bonded
+to each other — the collision was real and total (two entire rings at
+distance 0) but invisible to a bonded-pairs-only check. Finding 1's
+naphthalene/hexane/quinoline numbers are unaffected (single-ring or
+non-fused, so `place_rings`'s fusion-order logic never applied to them)
+and still stand.
+
+Post-fix, re-measured directly (not re-derived from the old numbers):
+anthracene's raw starting UFF energy is **~1.27×10⁵ kcal/mol** and worst
+starting bond is **2.26 Å** — both now virtually identical to
+naphthalene's (~1.26×10⁵ kcal/mol, 2.26 Å), not the 5-orders-of-magnitude
+and "better raw geometry" story Findings 1–2 report below. Finding 3's
+claim that anthracene "converges comfortably inside the default budget"
+to a sound `worst_bond=1.4688 Å` is also an artifact of the same collided
+start; re-measured, anthracene's raw UFF minimization **never reaches a
+sound geometry**, plateauing at `worst_bond=3.3899 Å` (above
+`MAX_SANE_BOND_LENGTH`) from 10,000 steps through at least 200,000, with
+`minimize_uff`'s own RMS-gradient convergence check reporting
+`converged: true` on that unsound plateau. Finding 3's "none diverges
+permanently" claim is therefore **overturned for anthracene** — it is a
+genuine trapped-local-minimum case, not an under-provisioned-iteration
+case like naphthalene/hexane. Naphthalene's and hexane's own Finding 3
+trajectories are unaffected (re-verified) and the shared
+budget-insensitivity story still holds for those two.
+
+Net effect on the two issues' original questions: **#185's core report
+still stands** (naphthalene's raw UFF minimization is unsound at the
+default budget) — the correction is to the anthracene *comparison point*
+this document used as a control, not to the naphthalene finding itself.
+The "not a `dg.rs` ring-placement defect specific to fused aromatics"
+line in the original Conclusion is directly contradicted: this *was*
+partly a `dg.rs` ring-placement defect, now fixed, and it changes which
+molecule looks worse (anthracene, not naphthalene, is now the one that
+never recovers). **No production impact**: both molecules get complete
+MMFF94 coverage post-#227 and never reach `UffOnly`/`Mmff94WithUffFallback`'s
+UFF path in `embed_pipeline_v2`, confirmed via `minimize_with_policy`
+directly. See `crates/chematic-3d/src/minimize.rs`'s corrected comments
+near the `chematic_ff_own_uff_minimizer_blows_up_naphthalene_independent_of_this_bridge`
+test and the `#185`/`#188` diagnosis test block for the re-measured
+numbers in context. The rest of this document (below) is left as
+originally written, for its own historical record — read it with the
+above correction in mind rather than as current fact.
+
 ## Question
 
 Both issues report `ForceFieldPolicy::UffOnly` blowing the worst bond length


### PR DESCRIPTION
## Summary

`dg::generate_coords` (rule-based, non-embedding 3D coordinate generator --
`chematic_3d::dg::generate_coords`, also the basis for
`generate_coords_etkdg` and several WASM bindings) had multiple related
bugs that could leave real, chemically distinct atoms exactly, nearly, or
implausibly-far coincident/stretched in 3D space. Found while validating a
new symmetry-aware RMSD implementation (separate, upcoming PR) against an
RDKit oracle, then expanded through two review rounds.

## Round 1: root/ring-vertex collision + unreached ring substituents + ring-fusion-order mismatch

1. **Root/ring-vertex collision.** `place_component` placed a non-ring root
   atom unconditionally at `(x_offset, 0, 0)`, colliding with a
   `place_rings`-computed ring vertex at the same point (plain toluene:
   methyl carbon and ring ipso carbon coincident).
2. **Unreached ring substituents.** `dfs_place` was only ever seeded from a
   single root, leaving substituents on other ring atoms at
   `Coords3D::new_zeroed`'s `(0, 0, 0)` default (p-xylene, ibuprofen-shaped).
3. **Ring-fusion-order mismatch.** `place_rings` assumed SSSR's raw ring
   order matches fusion adjacency. False for anthracene (SSSR can return
   `[terminal, terminal, middle]`), silently superimposing two entire
   rings. Independently discovered while investigating issue #185 --
   anthracene's apparent immunity to a naphthalene-class UFF minimizer
   blow-up turned out to be this collision bug, not genuine robustness.

Fix: only anchor the ring-less-component root when no ring placed
anything; seed `dfs_place` from every placed atom; order ring visitation
via BFS on ring-adjacency (shares an atom) rather than trusting SSSR's raw
order.

## Round 2 (review): new-island ring anchor stretching real bonds

Round 1's ring-fusion-order fix anchored a fusion-disconnected "new
island" ring (shares no atom with anything placed) at a fixed +5 Å offset,
unconditionally. Biphenyl's two phenyls are directly bonded despite
sharing no atom -- this ignored that bond entirely (measured: exactly
5.0 Å, vs. an ideal ~1.5 Å single bond), since both endpoints were already
`placed` and `dfs_place`'s chain walk only visits unplaced neighbours.

Fixed in two steps, each surfacing a further real bug:
- Detect a direct bond to an already-placed atom before falling back to
  the fixed offset, anchoring via the bond's real ideal length. A first
  attempt extended along a fixed +X direction, which worked for biphenyl's
  para-like connectivity but collapsed meta-/ortho-linked biaryls to
  0.14 Å min pairwise distance. Fixed by extending away from the anchor
  atom's own already-placed ring's centroid instead.
- `order_rings_by_fusion_adjacency`'s BFS only considered shared-atom
  adjacency, so a chain of 3+ directly-bonded-but-atom-disjoint rings
  (terphenyl) could still visit out of dependency order -- SSSR returned
  `[ring1, ring3, ring2]`, forcing ring3 onto an anchor unrelated to
  ring2's real position, so ring2's OTHER real bond (to ring1) came out
  wrong (0.66 Å) once correctly anchored to ring3. Fixed by adding
  direct-bond adjacency to the BFS graph (order only); the fuse-vs-anchor
  placement STRATEGY is now decided from live `placed` state per ring, not
  carried from the ordering pass.

New regression tests: biphenyl (updated), terphenyl, a meta-linked biaryl,
and a spiro positive control confirming the existing shared-atom fuse path
is untouched.

**Known, separate, still-open limitation (not fixed here):** a
chain-bridged ring case (bibenzyl, two phenyls linked by `-CH2CH2-`) has
no already-placed anchor to detect at `place_rings` time at all --
`place_rings` places every ring before `dfs_place` walks any chain atom.
Pinned as an honest known-broken regression fixture (worst bond ~8.7 Å)
rather than left silently uncovered; fixing it needs `place_component`
restructured to interleave ring placement and chain DFS in true graph
order.

**Also found, NOT fixed here (different code path, pre-existing since
`d45f91b`, only exposed because this round added a general bonded-pair-
length check):** anthracene's own ring-**fusion** seam (the pre-existing
`shared_atoms.len() >= 2` branch, used when a ring genuinely shares atoms
with something already placed -- a different branch from the "new island"
one this PR's biphenyl/terphenyl fix touches) produces four distorted
bonds (0.8675/1.3163/2.0365/2.2644 Å), not just the single 2.2644 Å this
PR's own earlier commits described. Root cause: that branch's
`ring_cy = midpoint.y + r` always extends the new ring in +y from the
fusion bond's midpoint, regardless of which direction is actually away
from the rest of the structure -- same class of bug, different branch.
Confirmed independent of this round's ordering change (disabled it,
reproduced identical output). Flagged for a separate decision, not folded
into this PR.

## Also fixed: g1_regression cross-platform tolerance

CI (x86_64) computed two of `g1_regression_byte_identical`'s pinned
values 1 ULP (`plane_of_best_fit`) and 112 ULP (`rdf[0]`) away from local
(aarch64) -- FMA/summation-order drift, not a regression (17 of 19 pinned
values match bit-for-bit across both). Originally patched with a
magnitude-scaled absolute epsilon (1e-9 / 1e-27); replaced with an
explicit ULP-distance comparison (`to_bits().abs_diff()`, plus
finite/positive asserts), each tolerance set just above that value's own
observed drift (2 ULP / 150 ULP).

## Verified

- 8 new/updated regression tests (toluene, p-xylene, ibuprofen-shaped,
  anthracene, biphenyl, terphenyl, meta-linked biaryl, spiro) plus 1
  intentionally-pinned-as-broken (bibenzyl) -- confirmed each fix's tests
  **fail** against the pre-fix code (temporarily disabled just that
  branch, kept the tests, re-ran) before confirming they pass with the
  fix.
- Full `chematic-3d` test suite: 494 passed, 0 failed, 3 ignored.
- `g1_regression_byte_identical`'s aspirin snapshot re-pinned once (round
  1's collision fix changed its geometry: aspirin has 2 ring substituents
  on different atoms); confirmed unaffected by round 1's ring-fusion-order
  fix and round 2's new-island-anchor fix (aspirin has only 1 ring).
- `bash scripts/check.sh` green.
- CI: all required checks green (round 1's push included; round 2's push
  pending at PR description time -- see PR checks tab for current status).

## Test plan

- [x] New/updated regression tests fail pre-fix, pass post-fix (verified
      both ways, for every fix in both rounds)
- [x] Full `chematic-3d` test suite green (494 tests)
- [x] `g1_regression_byte_identical` re-pinned and re-verified sane
      (non-collision) after round 1; confirmed unaffected by later fixes
      rather than assumed
- [x] `bash scripts/check.sh` green

Not merging without explicit go-ahead, per this repo's standing release/PR
authorization pattern. Issues #185 and #252 are intentionally not
touched/updated by this PR -- pending review sign-off first.
