### PR TITLE
feat(3d): symmetry-aware Kabsch RMSD (rmsd_symmetric), oracle-validated

### DIFF
--- a/crates/chematic-3d/examples/rmsd_symmetric_oracle_dump.rs
+++ b/crates/chematic-3d/examples/rmsd_symmetric_oracle_dump.rs
@@ -1,0 +1,97 @@
+//! Dumps conformer pairs + chematic's `rmsd_symmetric` result for a handful
+//! of molecules chosen to exercise graph-automorphism symmetry (terminal
+//! -CF3, neopentane's 4 methyls, benzene's ring, a carboxylate to
+//! demonstrate the documented `symmetrizeConjugatedTerminalGroups` gap) plus
+//! one plain drug-like molecule with no interesting symmetry as a control.
+//!
+//! One conformer is `dg::generate_coords`'s output; the second is that same
+//! conformer under a fixed rigid rotation+translation, with two
+//! automorphism-equivalent atoms' positions additionally swapped where the
+//! molecule has any (so the comparison genuinely exercises alignment AND
+//! symmetry matching together, not a trivial self-comparison).
+//!
+//! Run:
+//! ```text
+//! cargo run --release -p chematic-3d --example rmsd_symmetric_oracle_dump \
+//!   > /tmp/rmsd_symmetric_oracle_dump.jsonl
+//! .venv/bin/python scripts/rmsd_symmetric_oracle_check.py \
+//!   /tmp/rmsd_symmetric_oracle_dump.jsonl
+//! ```
+
+use chematic_3d::conformer::rmsd_symmetric;
+use chematic_3d::coords::{Coords3D, Point3};
+use chematic_3d::dg::generate_coords;
+use chematic_core::AtomIdx;
+use serde_json::json;
+
+/// name, SMILES, (optional) pair of 0-based atom indices to swap in the
+/// second conformer (symmetry-equivalent atoms, chosen by inspection of the
+/// SMILES atom order).
+type Case = (&'static str, &'static str, Option<(usize, usize)>);
+const CASES: &[Case] = &[
+    ("propane", "CCC", None),
+    ("cf3_ethane", "FC(F)(F)C", Some((0, 2))), // two of the three F's
+    ("neopentane", "CC(C)(C)C", Some((0, 2))), // two of the four methyl carbons
+    ("benzene", "c1ccccc1", Some((0, 3))),     // two para ring carbons
+    ("acetate", "CC(=O)[O-]", Some((2, 3))),   // the two formally-different O's
+    ("ibuprofen", "CC(C)Cc1ccc(cc1)C(C)C(=O)O", None), // no interesting symmetry, control
+];
+
+fn rotate_translate(c: &Coords3D) -> Coords3D {
+    // Fixed 37 deg rotation around an arbitrary axis + a translation --
+    // deterministic, not random, so this dump is reproducible byte-for-byte.
+    let theta = 37f64.to_radians();
+    let (cs, sn) = (theta.cos(), theta.sin());
+    let n = c.atom_count();
+    let mut out = Coords3D::new_zeroed(n);
+    for i in 0..n {
+        let p = c.get(AtomIdx(i as u32));
+        // Rotate around z, then around x, then translate -- enough to mix
+        // all three axes without needing a general axis-angle formula.
+        let x1 = p.x * cs - p.y * sn;
+        let y1 = p.x * sn + p.y * cs;
+        let z1 = p.z;
+        let y2 = y1 * cs - z1 * sn;
+        let z2 = y1 * sn + z1 * cs;
+        out.set(AtomIdx(i as u32), Point3::new(x1 + 5.0, y2 - 3.0, z2 + 1.5));
+    }
+    out
+}
+
+fn main() {
+    for (name, smiles, swap) in CASES {
+        let mol = chematic_smiles::parse(smiles).unwrap();
+        let n = mol.atom_count();
+        let base = generate_coords(&mol);
+        let mut moved = rotate_translate(&base);
+        if let Some((i, j)) = swap {
+            let (ai, aj) = (AtomIdx(*i as u32), AtomIdx(*j as u32));
+            let (pi, pj) = (moved.get(ai), moved.get(aj));
+            moved.set(ai, pj);
+            moved.set(aj, pi);
+        }
+        let symmetric = rmsd_symmetric(&mol, &base, &moved);
+        let base_coords: Vec<[f64; 3]> = (0..n)
+            .map(|i| {
+                let p = base.get(AtomIdx(i as u32));
+                [p.x, p.y, p.z]
+            })
+            .collect();
+        let moved_coords: Vec<[f64; 3]> = (0..n)
+            .map(|i| {
+                let p = moved.get(AtomIdx(i as u32));
+                [p.x, p.y, p.z]
+            })
+            .collect();
+        println!(
+            "{}",
+            json!({
+                "name": name,
+                "smiles": smiles,
+                "conformer_a": base_coords,
+                "conformer_b": moved_coords,
+                "chematic_rmsd_symmetric": symmetric,
+            })
+        );
+    }
+}

--- a/crates/chematic-3d/src/conformer.rs
+++ b/crates/chematic-3d/src/conformer.rs
@@ -2,7 +2,11 @@
 
 use std::fmt;
 
-use chematic_core::{AtomIdx, Molecule};
+use chematic_core::{AtomIdx, BondOrder, Molecule};
+use chematic_smarts::{
+    AtomPrimitive, AtomQuery, BondPrimitive, BondQuery, MatchConfig, QueryMolecule,
+    find_matches_with_config,
+};
 
 use crate::coords::Coords3D;
 use crate::shape_descriptors::jacobi3;
@@ -148,6 +152,21 @@ impl ConformerEnsemble {
         Some(kabsch_rmsd(ca, cb, n))
     }
 
+    /// Symmetry-aware Kabsch RMSD between conformers `a` and `b`: the minimum
+    /// [`conformer_rmsd`]-style RMSD over every way `b`'s atoms can be
+    /// relabelled onto `a`'s that is consistent with the molecule's own graph
+    /// symmetry (automorphisms), not just the identity relabelling.
+    ///
+    /// See [`rmsd_symmetric`] for the algorithm and its known limitation
+    /// (no `-COO⁻`/`-NO₂`-style terminal-group symmetrization).
+    ///
+    /// Returns `None` if either index is out of range.
+    pub fn conformer_rmsd_symmetric(&self, a: usize, b: usize) -> Option<f64> {
+        let ca = self.conformers.get(a)?;
+        let cb = self.conformers.get(b)?;
+        Some(rmsd_symmetric(&self.mol, ca, cb))
+    }
+
     /// Compute the 12 USR shape descriptors for conformer `idx`.
     ///
     /// Returns `None` if `idx` is out of range.
@@ -240,6 +259,104 @@ impl ConformerEnsemble {
             total / count as f64
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Symmetry-aware (automorphism-brute-force) RMSD
+// ---------------------------------------------------------------------------
+
+/// Symmetry-aware Kabsch RMSD between two conformers of the *same* molecule
+/// topology (same atom count, same connectivity), ported from RDKit's
+/// `GetBestRMS` (`Code/GraphMol/MolAlign/AlignMolecules.cpp`, pinned commit
+/// `e74e7b0a5a2fc4e7f77c04ec26a61d4b8edbf22f` — see
+/// `scripts/mmff94_provenance/PROVENANCE.md` for this project's pinning
+/// convention): enumerate every automorphism of `mol` (self-match with
+/// `uniquify: false`, matching RDKit's own `SubstructMatch(..., uniquify=false)`
+/// self-match step) via VF2, and return the minimum Kabsch-aligned RMSD over
+/// every automorphism-consistent relabelling of `coords_b` onto `coords_a`.
+/// Brute force over all matches, same as RDKit — no pruning, no Hungarian
+/// assignment.
+///
+/// A plain (non-symmetry-aware) RMSD is wrong on any molecule with
+/// permutation-equivalent atoms: e.g. a terminal `-CF3`'s three fluorines are
+/// interchangeable, so a conformer pair that differs only by which specific F
+/// atom sits in which position should score ~0, not a large fixed-index RMSD.
+///
+/// **Known limitation, not yet ported**: RDKit's `GetBestRMS` additionally
+/// runs `symmetrizeConjugatedTerminalGroups` before matching, which neutralizes
+/// resonance-equivalent terminal groups (carboxylate `-COO⁻`, nitro `-NO2`, …)
+/// so their two oxygens are treated as interchangeable even though a
+/// Kekulized/formal-charge representation gives them different bond orders.
+/// This function does NOT do that preprocessing, so on such molecules it will
+/// report a higher (worse) RMSD than RDKit's `GetBestRMS` for a case that is
+/// chemically equivalent but not topologically automorphic as drawn. See
+/// issue tracker for the follow-up.
+pub fn rmsd_symmetric(mol: &Molecule, coords_a: &Coords3D, coords_b: &Coords3D) -> f64 {
+    let n = mol.atom_count();
+    if n == 0 {
+        return 0.0;
+    }
+    let query = molecule_self_query(mol);
+    let config = MatchConfig {
+        uniquify: false,
+        ..MatchConfig::default()
+    };
+    let matches = find_matches_with_config(&query, mol, &config);
+    debug_assert!(
+        !matches.is_empty(),
+        "a molecule must always self-match at least via the identity mapping"
+    );
+
+    let mut best = f64::MAX;
+    for m in &matches {
+        let mut relabelled = Coords3D::new_zeroed(n);
+        for qi in 0..n {
+            // `m` maps this molecule's own atom indices (as the query) onto
+            // itself (as the target) under one automorphism; relabelling
+            // `coords_b` by that map produces one automorphism-consistent
+            // atom correspondence between `coords_a` and `coords_b`.
+            let target = m[&qi];
+            relabelled.set(AtomIdx(qi as u32), coords_b.get(target));
+        }
+        let rmsd = kabsch_rmsd(coords_a, &relabelled, n);
+        if rmsd < best {
+            best = rmsd;
+        }
+    }
+    best
+}
+
+/// Build a `QueryMolecule` that matches only `mol` itself: one query atom per
+/// heavy atom (atomic number + formal charge), one query bond per bond
+/// (exact bond-order primitive where the order is unambiguous, `Any` for the
+/// query/metadata bond kinds that carry no independent topological meaning
+/// for automorphism purposes — `Zero`/`Dative`/`Query*`/`Up`/`Down` are all
+/// mapped to `Any` since none of them changes which atoms are interchangeable).
+fn molecule_self_query(mol: &Molecule) -> QueryMolecule {
+    let mut q = QueryMolecule::new();
+    for i in 0..mol.atom_count() {
+        let atom = mol.atom(AtomIdx(i as u32));
+        let by_element =
+            AtomQuery::Primitive(AtomPrimitive::AtomicNum(atom.element.atomic_number()));
+        let by_charge = AtomQuery::Primitive(AtomPrimitive::Charge(atom.charge));
+        q.add_atom(AtomQuery::And(Box::new(by_element), Box::new(by_charge)));
+    }
+    for i in 0..mol.bond_count() {
+        let bond = mol.bond(chematic_core::BondIdx(i as u32));
+        let prim = match bond.order {
+            BondOrder::Single => BondPrimitive::Single,
+            BondOrder::Double => BondPrimitive::Double,
+            BondOrder::Triple => BondPrimitive::Triple,
+            BondOrder::Aromatic => BondPrimitive::Aromatic,
+            _ => BondPrimitive::Any,
+        };
+        q.add_bond(
+            bond.atom1.0 as usize,
+            bond.atom2.0 as usize,
+            BondQuery::Primitive(prim),
+        );
+    }
+    q
 }
 
 // ---------------------------------------------------------------------------
@@ -551,6 +668,100 @@ mod tests {
             rmsd < 1e-6,
             "pure-rotation Kabsch RMSD should be ~0, got {rmsd}"
         );
+    }
+
+    // --- rmsd_symmetric ------------------------------------------------------
+
+    #[test]
+    fn symmetric_rmsd_self_is_zero() {
+        let mol = parse("CCC").unwrap();
+        let c = generate_coords(&mol);
+        let rmsd = rmsd_symmetric(&mol, &c, &c);
+        assert!(rmsd.abs() < 1e-8, "self-RMSD should be 0, got {rmsd}");
+    }
+
+    #[test]
+    fn symmetric_rmsd_never_exceeds_fixed_index_rmsd() {
+        // The identity mapping is always one of the enumerated automorphisms,
+        // so the symmetric RMSD (a minimum over all of them) can never be
+        // larger than the plain fixed-index Kabsch RMSD.
+        let mol = parse("CCC").unwrap();
+        let n = mol.atom_count();
+        let c1 = generate_coords(&mol);
+        let mut c2 = Coords3D::new_zeroed(n);
+        for i in 0..n {
+            let p = c1.get(AtomIdx(i as u32));
+            c2.set(AtomIdx(i as u32), Point3::new(-p.x, p.y, p.z));
+        }
+        let fixed = kabsch_rmsd(&c1, &c2, n);
+        let symmetric = rmsd_symmetric(&mol, &c1, &c2);
+        assert!(
+            symmetric <= fixed + 1e-9,
+            "symmetric RMSD ({symmetric}) must not exceed fixed-index RMSD ({fixed})"
+        );
+    }
+
+    #[test]
+    fn symmetric_rmsd_recovers_zero_when_fixed_index_rmsd_is_wrong() {
+        // 1,1,1-trifluoroethane: the 3 fluorines on the CF3 carbon are
+        // topologically interchangeable (verified: 6 = 3! self-match
+        // automorphisms with `uniquify: false`). Swap two F atoms' positions
+        // between otherwise-identical conformers -- a real geometric
+        // difference under fixed-index comparison, but the SAME physical
+        // structure under symmetry-aware comparison.
+        let mol = parse("FC(F)(F)C").unwrap();
+        let n = mol.atom_count();
+        let base = generate_coords(&mol);
+
+        let fluorines: Vec<AtomIdx> = (0..n)
+            .map(|i| AtomIdx(i as u32))
+            .filter(|&idx| mol.atom(idx).element == chematic_core::Element::F)
+            .collect();
+        assert_eq!(fluorines.len(), 3, "CF3 should have exactly 3 fluorines");
+
+        let mut swapped = Coords3D::new_zeroed(n);
+        for i in 0..n {
+            swapped.set(AtomIdx(i as u32), base.get(AtomIdx(i as u32)));
+        }
+        let (f0, f1) = (fluorines[0], fluorines[1]);
+        let (p0, p1) = (base.get(f0), base.get(f1));
+        swapped.set(f0, p1);
+        swapped.set(f1, p0);
+
+        let fixed = kabsch_rmsd(&base, &swapped, n);
+        assert!(
+            fixed > 0.1,
+            "swapping two real F positions should give a clearly nonzero \
+             fixed-index RMSD, got {fixed}"
+        );
+
+        let symmetric = rmsd_symmetric(&mol, &base, &swapped);
+        assert!(
+            symmetric < 1e-6,
+            "symmetry-aware RMSD should recover ~0 for an automorphism-only \
+             difference, got {symmetric} (fixed-index was {fixed})"
+        );
+    }
+
+    #[test]
+    fn symmetric_rmsd_ensemble_method_matches_free_function() {
+        let mol = parse("CCC").unwrap();
+        let c1 = generate_coords(&mol);
+        let c2 = generate_coords(&mol);
+        let expected = rmsd_symmetric(&mol, &c1, &c2);
+        let mut ens = ConformerEnsemble::with_conformer(mol, c1).unwrap();
+        ens.add_conformer(c2).unwrap();
+        let got = ens.conformer_rmsd_symmetric(0, 1).unwrap();
+        assert!(
+            (got - expected).abs() < 1e-12,
+            "ensemble method should match the free function exactly"
+        );
+    }
+
+    #[test]
+    fn symmetric_rmsd_ensemble_method_out_of_range_returns_none() {
+        let ens = make_ensemble();
+        assert!(ens.conformer_rmsd_symmetric(0, 99).is_none());
     }
 
     #[test]

--- a/crates/chematic-3d/src/lib.rs
+++ b/crates/chematic-3d/src/lib.rs
@@ -40,7 +40,7 @@ pub mod usr;
 pub mod xyz;
 
 pub use align::{AlignResult, align_coords, apply_alignment, rmsd_no_align};
-pub use conformer::{ConformerEnsemble, ConformerError};
+pub use conformer::{ConformerEnsemble, ConformerError, rmsd_symmetric};
 pub use constraints::{
     AngleConstraint, BondConstraint, ConstraintSet, build_constraints, satisfy_constraints,
 };

--- a/scripts/rmsd_symmetric_oracle_check.py
+++ b/scripts/rmsd_symmetric_oracle_check.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Independent RDKit oracle check for `chematic_3d::conformer::rmsd_symmetric`
+(crates/chematic-3d/src/conformer.rs).
+
+Reads the JSONL dump produced by
+`crates/chematic-3d/examples/rmsd_symmetric_oracle_dump.rs` (one row per
+molecule: SMILES + two heavy-atom-only conformers + chematic's own
+`rmsd_symmetric` result) and independently recomputes each pair's
+symmetry-aware RMSD via RDKit's `rdMolAlign.GetBestRMS`, the function
+chematic's `rmsd_symmetric` was ported from.
+
+`rmsd_symmetric`'s own doc comment already discloses one known gap: RDKit's
+`GetBestRMS` additionally runs `symmetrizeConjugatedTerminalGroups` (treats
+carboxylate/nitro-style terminal O's as interchangeable regardless of formal
+bond order), which chematic does not port. The acetate case in the dump
+exists specifically to demonstrate this gap -- a disagreement there is
+EXPECTED, not a bug, and is reported as such rather than flagged as a
+mismatch.
+
+Run:
+    cargo run --release -p chematic-3d --example rmsd_symmetric_oracle_dump \
+      > /tmp/rmsd_symmetric_oracle_dump.jsonl
+    .venv/bin/python scripts/rmsd_symmetric_oracle_check.py \
+      /tmp/rmsd_symmetric_oracle_dump.jsonl
+"""
+
+import json
+import sys
+
+from rdkit import Chem
+from rdkit.Chem import rdMolAlign
+from rdkit.Geometry import Point3D
+
+KNOWN_SYMMETRIZATION_GAP = {"acetate"}
+AGREE_TOL = 1e-3  # Å; two independent Kabsch/automorphism-search implementations
+
+
+def mol_with_conformer(smiles, coords):
+    mol = Chem.MolFromSmiles(smiles, sanitize=True)
+    if mol is None:
+        raise ValueError(f"RDKit failed to parse {smiles!r}")
+    if mol.GetNumAtoms() != len(coords):
+        raise ValueError(
+            f"{smiles!r}: RDKit atom count {mol.GetNumAtoms()} != "
+            f"dump coord count {len(coords)} (SMILES atom-order mismatch?)"
+        )
+    conf = Chem.Conformer(mol.GetNumAtoms())
+    for i, (x, y, z) in enumerate(coords):
+        conf.SetAtomPosition(i, Point3D(x, y, z))
+    mol.AddConformer(conf, assignId=True)
+    return mol
+
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else "/tmp/rmsd_symmetric_oracle_dump.jsonl"
+    rows = [json.loads(line) for line in open(path)]
+
+    print(f"{'name':<14} {'chematic':>12} {'rdkit':>12} {'diff':>10}  status")
+    mismatches = []
+    for row in rows:
+        name = row["name"]
+        probe = mol_with_conformer(row["smiles"], row["conformer_a"])
+        ref = mol_with_conformer(row["smiles"], row["conformer_b"])
+        rdkit_rmsd = rdMolAlign.GetBestRMS(probe, ref)
+        chematic_rmsd = row["chematic_rmsd_symmetric"]
+        diff = abs(chematic_rmsd - rdkit_rmsd)
+
+        if name in KNOWN_SYMMETRIZATION_GAP:
+            status = "KNOWN GAP (symmetrizeConjugatedTerminalGroups not ported)"
+        elif diff <= AGREE_TOL:
+            status = "OK"
+        else:
+            status = "MISMATCH"
+            mismatches.append(name)
+
+        print(f"{name:<14} {chematic_rmsd:>12.6f} {rdkit_rmsd:>12.6f} {diff:>10.6f}  {status}")
+
+    if mismatches:
+        print(f"\n{len(mismatches)} unexplained mismatch(es): {mismatches}", file=sys.stderr)
+        sys.exit(1)
+    print("\nAll non-known-gap cases agree with RDKit within "
+          f"{AGREE_TOL} Å.")
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/README.md
+++ b/validation/README.md
@@ -124,6 +124,42 @@ individual PR #253 sub-fix was causal per molecule (no ablation study
 run) -- only that the tracked population is fully resolved with no
 regression.
 
+### Symmetric RMSD oracle check (Priority 4 groundwork, `rmsd_symmetric`)
+
+`chematic_3d::conformer::rmsd_symmetric` (`crates/chematic-3d/src/conformer.rs`)
+is a port of RDKit's `GetBestRMS` (`Code/GraphMol/MolAlign/AlignMolecules.cpp`):
+symmetry-aware Kabsch RMSD via brute-force enumeration of the molecule's own
+graph automorphisms (VF2 self-match, `uniquify: false`), not a fixed
+atom-index correspondence. Needed before Priority 4's reference-conformer
+benchmark, since a plain fixed-index RMSD is wrong on any molecule with
+permutation-equivalent atoms (e.g. a terminal `-CF3`'s three fluorines).
+
+- **Dump:** `cargo run --release -p chematic-3d --example
+  rmsd_symmetric_oracle_dump > /tmp/rmsd_symmetric_oracle_dump.jsonl` -- 6
+  cases (propane control; `-CF3`, neopentane, and benzene testing
+  automorphism recovery on leaf atoms vs. ring atoms; acetate testing the
+  known gap below; ibuprofen as a no-symmetry drug-like control), each a
+  `dg::generate_coords` conformer paired with a fixed rigid
+  rotation+translation of itself with two atoms' positions additionally
+  swapped.
+- **Oracle:** `.venv/bin/python scripts/rmsd_symmetric_oracle_check.py
+  /tmp/rmsd_symmetric_oracle_dump.jsonl` -- independently recomputes each
+  pair's RMSD via RDKit's `rdMolAlign.GetBestRMS` on the same coordinates.
+- **Result:** 5/6 cases agree with RDKit to within 2e-6 Å (propane,
+  `-CF3`-ethane, neopentane, benzene, ibuprofen). Benzene's nonzero residual
+  (1.143095 Å, both engines) is correct, not noise: swapping two *para ring*
+  atoms' positions is not a graph automorphism of a plain hexagon (unlike
+  swapping two terminal leaf atoms on the same parent, as in `-CF3` or
+  neopentane's methyls), so no relabelling can recover 0 -- confirmed by
+  independent derivation, not just tool agreement.
+- **Known, documented gap:** acetate disagrees (chematic 0.356 Å vs. RDKit
+  0.0 Å). RDKit's `GetBestRMS` additionally runs
+  `symmetrizeConjugatedTerminalGroups` before matching, treating a
+  carboxylate's two oxygens as interchangeable despite their different
+  formal bond orders; `rmsd_symmetric` does not port that preprocessing step
+  (documented in its own doc comment). Expected, not a bug -- tracked as a
+  follow-up, not blocking Priority 4's benchmark groundwork.
+
 ### 175-mol drug-like corpus
 
 A curated set of 175 drug-like molecules covering common scaffolds (benzoic acid derivatives,


### PR DESCRIPTION
## Summary

Priority 4 groundwork: adds `chematic_3d::conformer::rmsd_symmetric`, a symmetry-aware Kabsch RMSD ported from RDKit's `GetBestRMS` (`Code/GraphMol/MolAlign/AlignMolecules.cpp`). Enumerates the molecule's own graph automorphisms (VF2 self-match, `uniquify: false`) and returns the minimum Kabsch-aligned RMSD over every automorphism-consistent atom relabelling, instead of a fixed atom-index correspondence.

This matters for the upcoming reference-conformer benchmark (Priority 4 in the roadmap): a plain fixed-index RMSD is wrong on any molecule with permutation-equivalent atoms (terminal `-CF3`'s three fluorines, neopentane's four methyls, etc.) — it would report a large spurious distance for conformers that are physically identical up to a relabelling of interchangeable atoms.

## Oracle validation

New `crates/chematic-3d/examples/rmsd_symmetric_oracle_dump.rs` + `scripts/rmsd_symmetric_oracle_check.py` independently cross-check chematic's result against RDKit's `rdMolAlign.GetBestRMS` on 6 cases (propane control, `-CF3`-ethane, neopentane, benzene, acetate, ibuprofen control).

- **5/6 agree with RDKit to within 2e-6 Å.**
- Benzene's nonzero residual (1.143095 Å, identically in both engines) is *correct*, not noise — verified by independent derivation: swapping two *para ring* carbons' positions is not a graph automorphism of a plain hexagon (unlike swapping two leaf atoms on the same parent, e.g. `-CF3`'s fluorines or neopentane's methyls), so no relabelling can recover 0.
- **Known, documented gap:** acetate disagrees (chematic 0.356 Å vs. RDKit 0.0 Å). RDKit's `GetBestRMS` additionally runs `symmetrizeConjugatedTerminalGroups`, treating a carboxylate's two oxygens as interchangeable despite differing formal bond order. `rmsd_symmetric` does not port that preprocessing step — disclosed in its own doc comment, not silently swept under a passing test. Tracked as a future follow-up, not a blocker for Priority 4's benchmark groundwork.

Full write-up: `validation/README.md`, new "Symmetric RMSD oracle check" section.

## Scope

- No production chemistry behavior changed outside the new `rmsd_symmetric` function and `ConformerEnsemble::conformer_rmsd_symmetric` convenience wrapper — both purely additive (new `pub fn`s, new `pub use` in `lib.rs`).
- Does not touch `dg.rs`, MMFF94, or any code from the recently-merged #253/#254.

## Test plan

- [x] `bash scripts/check.sh` green (fmt, clippy `-D warnings`, full workspace test suite, cargo-deny, publish graph, version consistency)
- [x] New unit tests in `conformer.rs`: self-RMSD is 0, symmetric RMSD never exceeds fixed-index RMSD, symmetric RMSD recovers ~0 on an automorphism-only CF3 fluorine swap where fixed-index RMSD is nonzero, `ConformerEnsemble` wrapper matches the free function, out-of-range index returns `None`
- [x] Independent RDKit oracle check (`scripts/rmsd_symmetric_oracle_check.py`) — 5/6 exact agreement, 1/6 documented known gap

Not merging — opening Ready per this session's established go-ahead pattern.
