### PR TITLE
chore(release): v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-08-09
+
+Two independent fixes from the ongoing issue #227 program: a production
+MMFF94 stretch-bend coverage fix (**breaking**, see migration notes below)
+and a `chematic-3d` starting-geometry correctness fix for fused/multi-ring
+molecules.
+
 ### Fixed — `chematic-ff` (MMFF94 stretch-bend accuracy, issue #227 Priority 2B)
 
 - `chematic_ff::mmff94_stbn` now falls back to RDKit's own periodic-table-row
@@ -124,6 +131,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   boundary has no equivalent to "the struct literal already names every
   field," so silently defaulting an *omitted* field here doesn't compromise
   the `deny_unknown_fields` fail-closed guarantee for *unrecognized* fields.
+
+### Fixed — `chematic-3d` (unsound starting geometry for fused/multi-ring molecules, issue #185/#252)
+
+- **`dg::generate_coords`'s rule-based ring placement (`place_rings`) no
+  longer produces atom-coincident or wildly-stretched starting geometries**
+  for several distinct multi-ring topologies. Issue #185 originally blamed
+  the UFF minimizer itself (reported as spuriously "converged" on unsound
+  anthracene-class geometry); re-diagnosis found the minimizer was doing
+  its job correctly on a bad *input* — three independent bugs in
+  `generate_coords`, not the minimizer:
+  - A non-ring root atom was placed unconditionally at a fixed
+    `(x_offset, 0, 0)`, colliding with a ring vertex `place_rings`
+    independently computed at that same point; `dfs_place` also only ever
+    seeded from a single root, silently leaving any substituent on a
+    *different* ring atom at the zeroed-coordinate default (e.g. aspirin's
+    two substituents on different ring atoms).
+  - Ring-visiting order could mismatch true ring-fusion adjacency (checked
+    only shared atoms, not direct bonds between rings), silently
+    superimposing unrelated rings in some multi-ring systems connected
+    purely by bonds (e.g. terphenyl).
+  - A fusion-disconnected "new island" ring (e.g. biphenyl's second ring)
+    was anchored via an arbitrary fixed offset rather than the real bond
+    connecting it to already-placed structure, stretching that bond up to
+    ~5 Å.
+  - Verified via a new bonded-pair-length test helper
+    (`assert_bonded_pairs_sane`, catches stretched bonds that a
+    closest-pair-only distance check structurally cannot) plus new
+    regression fixtures (terphenyl, a meta-linked biaryl, a spiro positive
+    control, and a bibenzyl fixture that pins a still-open limitation, see
+    below).
+  - Measured on the 265-molecule Wave 1 corpus: all 28
+    `MinimizationFailed` cases (19 `CatastrophicBondBlowup` + 9
+    `ExcessiveResidualForce`) now resolve to `Ok`, 0 regressions,
+    confirmed deterministic (byte-identical across repeated runs).
+  - Issue #185 has been retitled and corrected to reflect this root cause
+    (kept open, not closed — the minimizer's false-convergence *reporting*
+    on unsound geometry is a real, separate concern that remains
+    unaddressed); issue #252 (the 265-corpus population this fix resolves)
+    is closed as completed.
+  - **Known, NOT fixed here, tracked separately:** a fused-ring seam
+    orientation bug for genuine ring fusions (anthracene-class, distorted
+    bonds at the fusion seam — issue #255) and a chain-bridged ring-island
+    placement gap (bibenzyl-class, `place_rings` runs entirely before any
+    chain-atom DFS walk — issue #256). Neither is part of the resolved
+    28-molecule population above (verified: none of the 28 contain a fused
+    polycyclic aromatic ring system).
 
 ## [0.11.0] — 2026-08-04
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,5 +23,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.11.0
+version: 0.12.0
 date-released: "2026-07-29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.11.0
+# chematic v0.12.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-07-17, v0.4.29 vs RDKit 2026.03.3 --
@@ -419,6 +419,11 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +1
 
 ## Recent Development
 
+**v0.12.0** (2026-08-09): **MMFF94 stretch-bend production fix (breaking), 3D starting-geometry fix for fused/multi-ring molecules**
+- `chematic-ff`: `mmff94_stbn` now falls back to RDKit's real 29-row periodic-table-row stretch-bend defaults when the specific/generic MMFF-type table has no row — unconditional production behavior for every MMFF94 policy, not behind an opt-in flag. Missing stretch-bend instances on the 265-molecule Wave 1 corpus: 2,107 → 0. **Breaking**: `mmff94_stbn` gained 3 required `atomic_num_{i,j,k}: u8` parameters (prior type-only behavior kept as new `mmff94_stbn_type_only`); Python's raw `PipelineV2Config(...)` constructor gained a new required `gate_mmff94_stretch_bend` argument (`.safe(...)` unaffected)
+- `chematic-3d`: `dg::generate_coords` no longer produces atom-coincident or wildly-stretched starting geometry for several multi-ring topologies (issue #185/#252) — root/ring-vertex collision, ring-fusion-order mismatch, and fixed-offset ring-island anchoring were all independent bugs, not a UFF minimizer defect as issue #185 originally suspected. All 28 `MinimizationFailed` cases on the 265-molecule corpus now resolve to `Ok`, 0 regressions. Two known, separately-tracked residual limitations remain unfixed: fused-ring seam orientation (issue #255) and chain-bridged ring islands (issue #256)
+- Full details in `CHANGELOG.md`'s `[0.12.0]` section
+
 **v0.11.0** (2026-08-04): **MMFF94 O2CM typing coverage, SMIRKS/CDXML stereo correctness, 2D/3D layout fixes**
 - `chematic-ff`: closed the O2CM terminal-oxygen typing gap (issue #227 Priority 1A-3) — atom-type parity 98.82% → 99.37% on the 265-molecule Wave 1 corpus, oxygen-element parity 95.88% → 100%, strict-gate minimization success 123 → 130/265, 0 cross-element mismatches (unchanged). Issue #227 stays open
 - `chematic-rxn`: SMIRKS product chirality assignment made parity-aware — a reordered mapped template neighbor order now correctly inverts/validates the product's `@`/`@@` flag instead of copying it verbatim; inherited (non-template) chirality now fails closed to `Chirality::None` when its neighbor order or mapped topology can't be validated
@@ -509,7 +514,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v0.11.0)
+├── Cargo.toml                    workspace root (v0.12.0)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)
@@ -562,7 +567,7 @@ If you use chematic in academic or research work, please cite:
   author    = {kent-tokyo},
   title     = {chematic: A pure-Rust cheminformatics toolkit},
   url       = {https://github.com/kent-tokyo/chematic},
-  version   = {0.11.0},
+  version   = {0.12.0},
   year      = {2026},
 }
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -106,7 +106,7 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.11.0
+# chematic v0.12.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-06, v0.4.22 vs RDKit 2026.03.3 --
@@ -282,6 +282,19 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi      
 ---
 
 ## 最近の開発
+
+**v0.12.0**（2026-08-09）: **MMFF94 stretch-bend本番修正（breaking）、fused/multi-ring分子の3D初期構造修正**
+- `chematic-ff`: `mmff94_stbn`がRDKit実装の29行周期表行stretch-bendデフォルトへfallbackするように — 265分子コーパスでstretch-bend欠落2,107→0。**Breaking**: `mmff94_stbn`に`atomic_num_{i,j,k}: u8`が必須引数として追加（旧動作は`mmff94_stbn_type_only`として維持）、Python生`PipelineV2Config(...)`コンストラクタに`gate_mmff94_stretch_bend`が新規必須引数として追加（`.safe(...)`は無変更）
+- `chematic-3d`: `dg::generate_coords`がfused/multi-ring分子で原子座標衝突・結合stretchを起こさなくなった（issue #185/#252）— UFF minimizer自体のバグではなく、生成された初期構造自体の問題と判明。265分子コーパスで`MinimizationFailed` 28件全てが解消、regression 0件。fused-ring seam方向（issue #255）とchain-bridged ring island配置（issue #256）は既知の未修正課題として別issue化
+- 詳細は`CHANGELOG.md`の`[0.12.0]`セクション参照
+
+**v0.11.0**（2026-08-04）: **MMFF94 O2CM typing coverage、SMIRKS/CDXMLステレオ正当性、2D/3Dレイアウト修正**
+- `chematic-ff`: O2CM末端酸素typing gapを解消（issue #227 Priority 1A-3）— 265分子Wave 1コーパスでatom-type一致率98.82%→99.37%、strict-gate最小化成功123→130/265
+- `chematic-rxn`: SMIRKS product chirality割り当てをparity-aware化 — reorderされたmapped neighbor順序に応じて`@`/`@@`flagを正しく反転/検証
+- `chematic-mol`: CDXMLリーダーがdirectional wedgeからtetrahedral stereoを認識するように（RDKit issue #9359）
+- `chematic-depict`: 独立した(非fused)環系が2D上で同一座標に衝突しなくなった
+- `chematic-3d`: ETKDG macrocyclic amideの1-4距離boundを真のcis/trans役割で分割
+- 詳細は`CHANGELOG.md`の`[0.11.0]`セクション参照
 
 **v0.10.1**（2026-08-02）: **MMFF94数値atom typing修正（正当性ホットフィックス）**
 - `chematic-ff`: MMFF94が誤ったelementのparameter行へ衝突し、その結果の物理的に誤ったenergyを成功として返し得るバグ（issue #227「furan collision」）を修正 — 芳香族atom typerがRDKit実装の5員環/6員環alpha/beta-heteroatom分類を実装していなかったのが根本原因。pinしたRDKitソースから移植し、provenance付きnumeric-typeレジストリと、このバグの再発を構造的に不可能にするconstruction-time semantic-compatibility invariant（不整合はfail closed = `NumericTypeError`）を追加。このinvariantが同種のバグをさらに2件検出: protonated amine Nとanionic Oが互いのelementのparameter行として誤typeされていた。265分子コーパス（本番API）で測定: MMFF94最小化成功 44 → 102、pin済みRDKitオラクル比較で6693原子中cross-element型不一致 0件（91.83%完全一致）

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.11.0 | Yes | Current release — active support |
+| v0.12.0 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.11.0) receives all security updates.  
+**Active Support**: Latest release (v0.12.0) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -16,12 +16,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.11.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.11.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.11.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.11.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.11.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.12.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.12.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.12.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.12.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.12.0" }
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #219); web-time
 # is a drop-in Instant replacement backed by Performance.now() there, and

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -16,14 +16,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.11.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.12.0" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.11.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.11.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.11.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.11.0" }
-chematic-cip        = { path = "../chematic-cip",        version = "0.11.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.12.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.12.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.12.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.12.0" }
+chematic-cip        = { path = "../chematic-cip",        version = "0.12.0" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.11.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.12.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -22,10 +22,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.11.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.11.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.11.0" }
+chematic-core = { path = "../chematic-core", version = "0.12.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.12.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.12.0" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.11.0" }
+chematic-core = { path = "../chematic-core", version = "0.12.0" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.11.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.12.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -22,13 +22,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.11.0" }
+chematic-core = { path = "../chematic-core", version = "0.12.0" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.11.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.11.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.11.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.12.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.12.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.12.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -18,10 +18,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.11.0", path = "../chematic-core" }
-chematic-smiles = { version = "0.11.0", path = "../chematic-smiles" }
-chematic-chem = { version = "0.11.0", path = "../chematic-chem" }
-chematic-rxn = { version = "0.11.0", path = "../chematic-rxn" }
+chematic-core = { version = "0.12.0", path = "../chematic-core" }
+chematic-smiles = { version = "0.12.0", path = "../chematic-smiles" }
+chematic-chem = { version = "0.12.0", path = "../chematic-chem" }
+chematic-rxn = { version = "0.12.0", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.11.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.12.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -17,15 +17,15 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.11.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.11.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.11.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.11.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.11.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.11.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.11.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.11.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.12.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.12.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.12.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.12.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.12.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.12.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.12.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.12.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
 
 [dev-dependencies]
 # Real JSON Schema 2020-12 validator, used only in tests to independently

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -16,10 +16,10 @@ documentation = "https://docs.rs/chematic-mol"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.11.0" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.11.0" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.11.0" }
-chematic-smiles      = { path = "../chematic-smiles",      version = "0.11.0" }
+chematic-core        = { path = "../chematic-core",        version = "0.12.0" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.12.0" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.12.0" }
+chematic-smiles      = { path = "../chematic-smiles",      version = "0.12.0" }
 serde_json           = "1.0"
 
 [dev-dependencies]

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.11.0" }
+chematic-core = { path = "../chematic-core", version = "0.12.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,16 +25,16 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.11.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.11.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.11.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.11.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.11.0", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.11.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.11.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.11.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.11.0" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.11.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.11.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.11.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.12.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.12.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.12.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.12.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.12.0", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.12.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.12.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.12.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.12.0" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.12.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.12.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.12.0" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -22,9 +22,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 perf-instrumentation = []
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.11.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.11.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.11.0" }
+chematic-core   = { path = "../chematic-core",   version = "0.12.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.12.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.12.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.11.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
+chematic-core = { path = "../chematic-core", version = "0.12.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
 rustc-hash = "2"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #221); web-time

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.11.0" }
+chematic-core = { path = "../chematic-core", version = "0.12.0" }
 
 [features]
 # Feature-gated internal work counters for the orbit-pruning canonical

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -26,16 +26,16 @@ wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["console"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.11.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.11.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.11.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.11.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.11.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.11.0", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.11.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.11.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.11.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.11.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.11.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.11.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.11.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.12.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.12.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.12.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.12.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.12.0", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.12.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.12.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.12.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.12.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.12.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.12.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.12.0" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -33,15 +33,15 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.11.0", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.11.0", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.11.0", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.11.0", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.11.0", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.11.0", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.11.0", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.11.0", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.11.0", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.11.0", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.11.0", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.11.0", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.12.0", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.12.0", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.12.0", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.12.0", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.12.0", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.12.0", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.12.0", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.12.0", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.12.0", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.12.0", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.12.0", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.12.0", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Bumps to v0.12.0, per `scripts/bump_version.py` (Cargo.toml workspace version + README/README_ja/CITATION.cff/SECURITY.md/demo package.json sync).

Two independent fixes since v0.11.0, both from the ongoing issue #227 program:

- `chematic-ff`: MMFF94 stretch-bend Dfsb periodic-row production fallback (PR #250) — **breaking** (`mmff94_stbn` gained required `atomic_num_{i,j,k}` params; Python's raw `PipelineV2Config(...)` gained a required `gate_mmff94_stretch_bend` arg). This is why v0.12.0 is a minor bump, not a patch — confirmed during PR #250's own review.
- `chematic-3d`: `dg::generate_coords` ring-placement fixes for fused/multi-ring starting geometry (PR #253, issue #185/#252) — non-breaking correctness fix.

Full changelog: `CHANGELOG.md`'s new `[0.12.0]` section (renamed from `[Unreleased]`, with a new empty `[Unreleased]` added above it). README/README_ja `Recent Development` sections also updated (README_ja was missing its v0.11.0 entry entirely — added alongside v0.12.0 to close that pre-existing gap).

**Not included:** PR #257 (symmetric RMSD, Priority 4 groundwork) — still open/unmerged, deferred to a future release per explicit scope decision.

## Test plan

- [x] `bash scripts/check.sh` green (fmt, clippy `-D warnings`, full workspace test suite, cargo-deny, publish graph, version consistency — including the README freshness check, which flagged and was fixed)
- [ ] CI green on this PR

Merging this PR, tagging `v0.12.0`, and pushing the tag (which auto-triggers `release.yml`/`publish-npm.yml`/`publish-pypi.yml`) are all explicitly authorized for this release.
