### PR TITLE
spike(fp): reproduce superimposed count-fingerprint coding vs folding baselines

### DIFF
--- a/crates/chematic-fp/examples/superimposed_coding_spike_benchmark.rs
+++ b/crates/chematic-fp/examples/superimposed_coding_spike_benchmark.rs
@@ -19,14 +19,29 @@
 //! unit test) -- the *only* structural knob this spike's design adds over
 //! the RDKit-style baseline is `codeword_weight > 1` (multiple independently
 //! hashed bits per unary count-layer instead of one). The sweep exists to
-//! show, numerically, what that knob alone buys or costs.
+//! show, numerically, what that knob alone buys or costs. See
+//! `superimposed_coding`'s module docs for a short proof that
+//! `codeword_weight` is exactly Tanimoto-neutral in the collision-free
+//! limit, so any effect visible here is collision/saturation noise, never a
+//! genuine improvement.
 //!
-//! A separate pooled section at the end of each `n_bits` block draws
-//! `overlap_frac` uniformly at random per pair (instead of 5 fixed buckets)
-//! so ground truth varies continuously across the sample -- bucketed Pearson
-//! over 80 near-identical ground-truth values per bucket is dominated by
-//! noise, not signal; Pearson only means something once truth has real
-//! spread to correlate against.
+//! Every count/count_sim/superimposed arm clamps count at `max_repeats`, so
+//! their best-case output (even with zero hash collisions) is the exact
+//! Tanimoto of *clamped* counts, not the unclamped ground truth. A
+//! `ceiling(clamp@R)` row -- `exact_count_tanimoto` on both fingerprints'
+//! counts clamped to `max_repeats`, no hashing/folding at all -- is printed
+//! alongside every table so the clamp-bias contribution to each arm's MAE
+//! can be told apart from hashing/collision noise.
+//!
+//! Two regimes are covered per `n_bits`: bucketed fixed-overlap levels (MAE
+//! only -- Pearson over 80 near-identical ground-truth values per bucket is
+//! noise-dominated) and a pooled continuous-overlap sample (`overlap_frac ~
+//! Uniform[0.05, 0.95)` per pair, meaningful Pearson). A final section
+//! re-runs the pooled comparison in a smaller, clamp-free regime
+//! (`n_features=60`, `max_count=max_repeats`) closer to real ECFP4 fill
+//! levels (~5-10% of 2048 bits for drug-like molecules, vs. ~15-45% for the
+//! `n_features=400` headline numbers) to check whether the ordering
+//! observed at high, unrealistic fill survives at realistic fill.
 //!
 //! Usage:
 //! ```text
@@ -73,8 +88,11 @@ impl Rng {
 
 /// Generate a synthetic pair of count fingerprints sharing `overlap_frac` of
 /// a `n_features`-sized universe. Shared features get independent random
-/// counts in `A` and `B`; non-shared features are split evenly between the
-/// two so both fingerprints have private, non-overlapping content too.
+/// counts in `A` and `B` (a simplification: real similar molecules would
+/// have *correlated* counts on shared features, which would push ground
+/// truth higher at high overlap than this generator does); non-shared
+/// features are split evenly between the two so both fingerprints have
+/// private, non-overlapping content too.
 fn gen_pair(
     rng: &mut Rng,
     n_features: usize,
@@ -96,6 +114,13 @@ fn gen_pair(
         }
     }
     (a, b)
+}
+
+/// Clamp every count in `fp` to `cap` -- the best-case (zero-collision)
+/// output shape of any `count_sim`/`superimposed` arm with `max_repeats ==
+/// cap`.
+fn clamp_counts(fp: &[(u64, u32)], cap: u32) -> CountFp {
+    fp.iter().map(|&(f, c)| (f, c.min(cap))).collect()
 }
 
 fn pearson(xs: &[f64], ys: &[f64]) -> f64 {
@@ -229,6 +254,54 @@ struct ArmSample {
     fill: Vec<f64>,
 }
 
+struct BatchResult {
+    exact: Vec<f64>,
+    ceiling: Vec<f64>,
+    per_arm: Vec<ArmSample>,
+}
+
+/// Run `n_pairs` synthetic pairs through every arm plus the clamp-bias
+/// ceiling. `overlap_fn` supplies `overlap_frac` per pair (constant for a
+/// fixed-overlap bucket, random for the pooled sections).
+#[allow(clippy::too_many_arguments)]
+fn run_batch(
+    seed: u64,
+    n_features: usize,
+    max_count: u32,
+    max_repeats: u32,
+    n_bits: usize,
+    n_pairs: usize,
+    arm_defs: &[Arm],
+    mut overlap_fn: impl FnMut(&mut Rng) -> f64,
+) -> BatchResult {
+    let mut rng = Rng::new(seed);
+    let mut exact = Vec::with_capacity(n_pairs);
+    let mut ceiling = Vec::with_capacity(n_pairs);
+    let mut per_arm: Vec<ArmSample> = arm_defs.iter().map(|_| ArmSample::default()).collect();
+
+    for _ in 0..n_pairs {
+        let overlap = overlap_fn(&mut rng);
+        let (a, b) = gen_pair(&mut rng, n_features, overlap, max_count);
+        exact.push(exact_count_tanimoto(&a, &b));
+        ceiling.push(exact_count_tanimoto(
+            &clamp_counts(&a, max_repeats),
+            &clamp_counts(&b, max_repeats),
+        ));
+        for (arm, sample) in arm_defs.iter().zip(per_arm.iter_mut()) {
+            let (fa, fb) = (arm.fold)(&a, &b, n_bits);
+            sample.approx.push(fa.tanimoto(&fb));
+            sample
+                .fill
+                .push((fa.popcount() as f64 + fb.popcount() as f64) / (2.0 * n_bits as f64));
+        }
+    }
+    BatchResult {
+        exact,
+        ceiling,
+        per_arm,
+    }
+}
+
 fn print_header() {
     println!(
         "{:<20} {:>10} {:>10} {:>10} {:>10}",
@@ -236,15 +309,28 @@ fn print_header() {
     );
 }
 
-fn print_row(name: &str, exact: &[f64], sample: &ArmSample) {
+fn print_row(name: &str, exact: &[f64], approx: &[f64], fill: Option<&[f64]>) {
+    let fill_str = match fill {
+        Some(f) => format!("{:>9.1}%", mean(f) * 100.0),
+        None => format!("{:>10}", "n/a"),
+    };
     println!(
-        "{:<20} {:>10} {:>10.4} {:>10.4} {:>9.1}%",
+        "{:<20} {:>10} {:>10.4} {:>10.4} {fill_str}",
         name,
         exact.len(),
-        mae(exact, &sample.approx),
-        pearson(exact, &sample.approx),
-        mean(&sample.fill) * 100.0,
+        mae(exact, approx),
+        pearson(exact, approx),
     );
+}
+
+fn print_batch(label: &str, result: &BatchResult, arm_defs: &[Arm]) {
+    println!("{label}");
+    print_header();
+    print_row("ceiling(clamp@R)", &result.exact, &result.ceiling, None);
+    for (arm, sample) in arm_defs.iter().zip(result.per_arm.iter()) {
+        print_row(arm.name, &result.exact, &sample.approx, Some(&sample.fill));
+    }
+    println!();
 }
 
 fn main() {
@@ -262,65 +348,78 @@ fn main() {
     );
     println!(
         "Primary metric is MAE (mean absolute error vs exact count-Tanimoto). Bucketed-overlap\n\
-         Pearson is included for completeness but is noise-dominated (ground truth barely varies\n\
-         within one fixed overlap level); see the pooled random-overlap section for a meaningful\n\
-         correlation figure.\n"
+         Pearson is noise-dominated (ground truth barely varies within one fixed overlap level);\n\
+         see the pooled random-overlap sections for a meaningful correlation figure. The\n\
+         ceiling(clamp@R) row isolates clamp bias (count clamped to max_repeats, zero hashing)\n\
+         from hashing/collision noise in the arms below it.\n"
     );
 
     for &n_bits in &n_bits_values {
         println!("======================== n_bits = {n_bits} ========================");
-
-        // ---- bucketed overlap levels: MAE + fill per level ----
         let arm_defs = arms(seed_base, max_repeats);
 
         for &overlap in &overlap_levels {
-            let mut rng = Rng::new(seed_base ^ overlap.to_bits() ^ (n_bits as u64));
-            let mut exact = Vec::with_capacity(n_pairs_per_level);
-            let mut per_arm: Vec<ArmSample> =
-                arm_defs.iter().map(|_| ArmSample::default()).collect();
-
-            for _ in 0..n_pairs_per_level {
-                let (a, b) = gen_pair(&mut rng, n_features, overlap, max_count);
-                exact.push(exact_count_tanimoto(&a, &b));
-                for (arm, sample) in arm_defs.iter().zip(per_arm.iter_mut()) {
-                    let (fa, fb) = (arm.fold)(&a, &b, n_bits);
-                    sample.approx.push(fa.tanimoto(&fb));
-                    sample.fill.push(
-                        (fa.popcount() as f64 + fb.popcount() as f64) / (2.0 * n_bits as f64),
-                    );
-                }
-            }
-
-            println!("--- overlap = {overlap:.2} ---");
-            print_header();
-            for (arm, sample) in arm_defs.iter().zip(per_arm.iter()) {
-                print_row(arm.name, &exact, sample);
-            }
-            println!();
+            let result = run_batch(
+                seed_base ^ overlap.to_bits() ^ (n_bits as u64),
+                n_features,
+                max_count,
+                max_repeats,
+                n_bits,
+                n_pairs_per_level,
+                &arm_defs,
+                |_| overlap,
+            );
+            print_batch(
+                &format!("--- overlap = {overlap:.2} ---"),
+                &result,
+                &arm_defs,
+            );
         }
 
-        // ---- pooled continuous-overlap section: meaningful Pearson ----
-        let mut rng = Rng::new(seed_base ^ 0xC0FFEE ^ (n_bits as u64));
-        let mut exact_pooled = Vec::with_capacity(n_pooled_pairs);
-        let mut per_arm_pooled: Vec<ArmSample> =
-            arm_defs.iter().map(|_| ArmSample::default()).collect();
-        for _ in 0..n_pooled_pairs {
-            let overlap = 0.05 + rng.next_f64() * 0.9; // uniform in [0.05, 0.95)
-            let (a, b) = gen_pair(&mut rng, n_features, overlap, max_count);
-            exact_pooled.push(exact_count_tanimoto(&a, &b));
-            for (arm, sample) in arm_defs.iter().zip(per_arm_pooled.iter_mut()) {
-                let (fa, fb) = (arm.fold)(&a, &b, n_bits);
-                sample.approx.push(fa.tanimoto(&fb));
-                sample
-                    .fill
-                    .push((fa.popcount() as f64 + fb.popcount() as f64) / (2.0 * n_bits as f64));
-            }
-        }
-        println!("--- pooled, overlap_frac ~ Uniform[0.05, 0.95) per pair, n={n_pooled_pairs} ---");
-        print_header();
-        for (arm, sample) in arm_defs.iter().zip(per_arm_pooled.iter()) {
-            print_row(arm.name, &exact_pooled, sample);
-        }
-        println!();
+        let pooled = run_batch(
+            seed_base ^ 0xC0FFEE ^ (n_bits as u64),
+            n_features,
+            max_count,
+            max_repeats,
+            n_bits,
+            n_pooled_pairs,
+            &arm_defs,
+            |rng| 0.05 + rng.next_f64() * 0.9,
+        );
+        print_batch(
+            &format!(
+                "--- pooled, overlap_frac ~ Uniform[0.05, 0.95) per pair, n={n_pooled_pairs} ---"
+            ),
+            &pooled,
+            &arm_defs,
+        );
+    }
+
+    // ---- realistic-fill, clamp-free regime ----
+    // n_features=60 puts single-fingerprint popcount in the same ballpark as
+    // real ECFP4 (tens to ~100 active features), and max_count=max_repeats
+    // means no arm clamps, so the ceiling row above should read ~0 MAE here
+    // -- isolating pure hashing/collision effects from clamp bias.
+    println!("======================== realistic-fill, clamp-free regime ========================");
+    println!("n_features=60, max_count=max_repeats={max_repeats} (no clamping), pooled overlap\n");
+    let small_n_features = 60;
+    let matched_max_count = max_repeats;
+    for &n_bits in &n_bits_values {
+        let arm_defs = arms(seed_base, max_repeats);
+        let result = run_batch(
+            seed_base ^ 0xBEEF ^ (n_bits as u64),
+            small_n_features,
+            matched_max_count,
+            max_repeats,
+            n_bits,
+            n_pooled_pairs,
+            &arm_defs,
+            |rng| 0.05 + rng.next_f64() * 0.9,
+        );
+        print_batch(
+            &format!("--- n_bits = {n_bits}, n={n_pooled_pairs} ---"),
+            &result,
+            &arm_defs,
+        );
     }
 }

--- a/crates/chematic-fp/examples/superimposed_coding_spike_benchmark.rs
+++ b/crates/chematic-fp/examples/superimposed_coding_spike_benchmark.rs
@@ -1,0 +1,326 @@
+//! Synthetic benchmark for the `superimposed_coding` SPIKE (see
+//! `crates/chematic-fp/src/superimposed_coding.rs` for module docs, scope,
+//! and the CC BY-NC provenance / COI note -- this benchmark measures our own
+//! synthetic data only, never a claim of reproducing that paper's numbers).
+//!
+//! Generates synthetic `&[(feature_hash, count)]` pairs with a controlled
+//! feature-overlap fraction (using a hand-rolled splitmix64 PRNG -- no new
+//! dependency, this crate doesn't otherwise depend on `rand`), computes the
+//! EXACT count-Tanimoto (ground truth, from `exact_count_tanimoto`) and each
+//! folding strategy's binary Tanimoto on the same pairs, then reports mean
+//! absolute error vs ground truth (primary metric) plus mean bit-vector
+//! fill (`popcount / n_bits`, to explain *why* a strategy over/under-shoots)
+//! per strategy, per `n_bits`, per overlap-level bucket.
+//!
+//! `superimposed_code_counts` is swept over `codeword_weight` ∈ {1,2,3,5}.
+//! `codeword_weight=1` is a deliberate sanity-check arm: at that setting
+//! `superimposed_code_counts` is provably identical to
+//! `count_simulation_fold` (see the `superimposed_with_codeword_weight_one_*`
+//! unit test) -- the *only* structural knob this spike's design adds over
+//! the RDKit-style baseline is `codeword_weight > 1` (multiple independently
+//! hashed bits per unary count-layer instead of one). The sweep exists to
+//! show, numerically, what that knob alone buys or costs.
+//!
+//! A separate pooled section at the end of each `n_bits` block draws
+//! `overlap_frac` uniformly at random per pair (instead of 5 fixed buckets)
+//! so ground truth varies continuously across the sample -- bucketed Pearson
+//! over 80 near-identical ground-truth values per bucket is dominated by
+//! noise, not signal; Pearson only means something once truth has real
+//! spread to correlate against.
+//!
+//! Usage:
+//! ```text
+//! cargo run -p chematic-fp --release --example superimposed_coding_spike_benchmark
+//! ```
+
+use chematic_fp::bitvec::BitVecN;
+use chematic_fp::superimposed_coding::{
+    SuperimposedCodingConfig, count_simulation_fold, exact_count_tanimoto, fold_presence_counts,
+    superimposed_code_counts,
+};
+
+/// A single feature-hash/count fingerprint, as consumed by every folding
+/// strategy under test.
+type CountFp = Vec<(u64, u32)>;
+
+/// splitmix64 -- small, deterministic, dependency-free PRNG for synthetic
+/// data generation only (not used anywhere in the library itself).
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Rng(seed)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+        z ^ (z >> 31)
+    }
+
+    /// Uniform integer in `[lo, hi]` inclusive.
+    fn next_range(&mut self, lo: u32, hi: u32) -> u32 {
+        lo + (self.next_u64() % (hi - lo + 1) as u64) as u32
+    }
+
+    /// Uniform float in `[0, 1)`.
+    fn next_f64(&mut self) -> f64 {
+        (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64
+    }
+}
+
+/// Generate a synthetic pair of count fingerprints sharing `overlap_frac` of
+/// a `n_features`-sized universe. Shared features get independent random
+/// counts in `A` and `B`; non-shared features are split evenly between the
+/// two so both fingerprints have private, non-overlapping content too.
+fn gen_pair(
+    rng: &mut Rng,
+    n_features: usize,
+    overlap_frac: f64,
+    max_count: u32,
+) -> (CountFp, CountFp) {
+    let features: Vec<u64> = (0..n_features).map(|_| rng.next_u64()).collect();
+    let n_shared = (overlap_frac * n_features as f64).round() as usize;
+    let mut a = Vec::new();
+    let mut b = Vec::new();
+    for (i, &f) in features.iter().enumerate() {
+        if i < n_shared {
+            a.push((f, rng.next_range(1, max_count)));
+            b.push((f, rng.next_range(1, max_count)));
+        } else if i % 2 == 0 {
+            a.push((f, rng.next_range(1, max_count)));
+        } else {
+            b.push((f, rng.next_range(1, max_count)));
+        }
+    }
+    (a, b)
+}
+
+fn pearson(xs: &[f64], ys: &[f64]) -> f64 {
+    let n = xs.len() as f64;
+    let mean_x = xs.iter().sum::<f64>() / n;
+    let mean_y = ys.iter().sum::<f64>() / n;
+    let mut cov = 0.0;
+    let mut var_x = 0.0;
+    let mut var_y = 0.0;
+    for (&x, &y) in xs.iter().zip(ys.iter()) {
+        let dx = x - mean_x;
+        let dy = y - mean_y;
+        cov += dx * dy;
+        var_x += dx * dx;
+        var_y += dy * dy;
+    }
+    if var_x == 0.0 || var_y == 0.0 {
+        return f64::NAN;
+    }
+    cov / (var_x.sqrt() * var_y.sqrt())
+}
+
+fn mae(xs: &[f64], ys: &[f64]) -> f64 {
+    xs.iter()
+        .zip(ys.iter())
+        .map(|(&x, &y)| (x - y).abs())
+        .sum::<f64>()
+        / xs.len() as f64
+}
+
+fn mean(xs: &[f64]) -> f64 {
+    xs.iter().sum::<f64>() / xs.len() as f64
+}
+
+/// A folding function: fold a count-fingerprint pair down to two `BitVecN`s
+/// of width `n_bits`.
+type FoldFn = Box<dyn Fn(&[(u64, u32)], &[(u64, u32)], usize) -> (BitVecN, BitVecN)>;
+
+/// A named folding strategy under test.
+struct Arm {
+    name: &'static str,
+    fold: FoldFn,
+}
+
+fn arms(seed: u64, max_repeats: u32) -> Vec<Arm> {
+    vec![
+        Arm {
+            name: "plain",
+            fold: Box::new(move |a, b, n_bits| {
+                (
+                    fold_presence_counts(a, n_bits),
+                    fold_presence_counts(b, n_bits),
+                )
+            }),
+        },
+        Arm {
+            name: "count_sim",
+            fold: Box::new(move |a, b, n_bits| {
+                (
+                    count_simulation_fold(a, n_bits, seed, max_repeats),
+                    count_simulation_fold(b, n_bits, seed, max_repeats),
+                )
+            }),
+        },
+        Arm {
+            name: "superimposed(w=1)",
+            fold: Box::new(move |a, b, n_bits| {
+                let cfg = SuperimposedCodingConfig {
+                    n_bits,
+                    seed,
+                    repetitions: max_repeats,
+                    codeword_weight: 1,
+                };
+                (
+                    superimposed_code_counts(a, &cfg),
+                    superimposed_code_counts(b, &cfg),
+                )
+            }),
+        },
+        Arm {
+            name: "superimposed(w=2)",
+            fold: Box::new(move |a, b, n_bits| {
+                let cfg = SuperimposedCodingConfig {
+                    n_bits,
+                    seed,
+                    repetitions: max_repeats,
+                    codeword_weight: 2,
+                };
+                (
+                    superimposed_code_counts(a, &cfg),
+                    superimposed_code_counts(b, &cfg),
+                )
+            }),
+        },
+        Arm {
+            name: "superimposed(w=3)",
+            fold: Box::new(move |a, b, n_bits| {
+                let cfg = SuperimposedCodingConfig {
+                    n_bits,
+                    seed,
+                    repetitions: max_repeats,
+                    codeword_weight: 3,
+                };
+                (
+                    superimposed_code_counts(a, &cfg),
+                    superimposed_code_counts(b, &cfg),
+                )
+            }),
+        },
+        Arm {
+            name: "superimposed(w=5)",
+            fold: Box::new(move |a, b, n_bits| {
+                let cfg = SuperimposedCodingConfig {
+                    n_bits,
+                    seed,
+                    repetitions: max_repeats,
+                    codeword_weight: 5,
+                };
+                (
+                    superimposed_code_counts(a, &cfg),
+                    superimposed_code_counts(b, &cfg),
+                )
+            }),
+        },
+    ]
+}
+
+#[derive(Default)]
+struct ArmSample {
+    approx: Vec<f64>,
+    fill: Vec<f64>,
+}
+
+fn print_header() {
+    println!(
+        "{:<20} {:>10} {:>10} {:>10} {:>10}",
+        "arm", "n", "MAE", "pearson_r", "mean_fill"
+    );
+}
+
+fn print_row(name: &str, exact: &[f64], sample: &ArmSample) {
+    println!(
+        "{:<20} {:>10} {:>10.4} {:>10.4} {:>9.1}%",
+        name,
+        exact.len(),
+        mae(exact, &sample.approx),
+        pearson(exact, &sample.approx),
+        mean(&sample.fill) * 100.0,
+    );
+}
+
+fn main() {
+    let n_bits_values = [512usize, 1024, 2048];
+    let overlap_levels: [f64; 5] = [0.1, 0.3, 0.5, 0.7, 0.9];
+    let n_pairs_per_level = 80;
+    let n_pooled_pairs = 400;
+    let n_features = 400;
+    let max_count = 12;
+    let seed_base = 20260809u64;
+    let max_repeats = 4u32;
+
+    println!(
+        "superimposed_coding SPIKE synthetic benchmark -- {n_pairs_per_level} pairs/level, {n_features} features, max_count={max_count}, max_repeats={max_repeats}"
+    );
+    println!(
+        "Primary metric is MAE (mean absolute error vs exact count-Tanimoto). Bucketed-overlap\n\
+         Pearson is included for completeness but is noise-dominated (ground truth barely varies\n\
+         within one fixed overlap level); see the pooled random-overlap section for a meaningful\n\
+         correlation figure.\n"
+    );
+
+    for &n_bits in &n_bits_values {
+        println!("======================== n_bits = {n_bits} ========================");
+
+        // ---- bucketed overlap levels: MAE + fill per level ----
+        let arm_defs = arms(seed_base, max_repeats);
+
+        for &overlap in &overlap_levels {
+            let mut rng = Rng::new(seed_base ^ overlap.to_bits() ^ (n_bits as u64));
+            let mut exact = Vec::with_capacity(n_pairs_per_level);
+            let mut per_arm: Vec<ArmSample> =
+                arm_defs.iter().map(|_| ArmSample::default()).collect();
+
+            for _ in 0..n_pairs_per_level {
+                let (a, b) = gen_pair(&mut rng, n_features, overlap, max_count);
+                exact.push(exact_count_tanimoto(&a, &b));
+                for (arm, sample) in arm_defs.iter().zip(per_arm.iter_mut()) {
+                    let (fa, fb) = (arm.fold)(&a, &b, n_bits);
+                    sample.approx.push(fa.tanimoto(&fb));
+                    sample.fill.push(
+                        (fa.popcount() as f64 + fb.popcount() as f64) / (2.0 * n_bits as f64),
+                    );
+                }
+            }
+
+            println!("--- overlap = {overlap:.2} ---");
+            print_header();
+            for (arm, sample) in arm_defs.iter().zip(per_arm.iter()) {
+                print_row(arm.name, &exact, sample);
+            }
+            println!();
+        }
+
+        // ---- pooled continuous-overlap section: meaningful Pearson ----
+        let mut rng = Rng::new(seed_base ^ 0xC0FFEE ^ (n_bits as u64));
+        let mut exact_pooled = Vec::with_capacity(n_pooled_pairs);
+        let mut per_arm_pooled: Vec<ArmSample> =
+            arm_defs.iter().map(|_| ArmSample::default()).collect();
+        for _ in 0..n_pooled_pairs {
+            let overlap = 0.05 + rng.next_f64() * 0.9; // uniform in [0.05, 0.95)
+            let (a, b) = gen_pair(&mut rng, n_features, overlap, max_count);
+            exact_pooled.push(exact_count_tanimoto(&a, &b));
+            for (arm, sample) in arm_defs.iter().zip(per_arm_pooled.iter_mut()) {
+                let (fa, fb) = (arm.fold)(&a, &b, n_bits);
+                sample.approx.push(fa.tanimoto(&fb));
+                sample
+                    .fill
+                    .push((fa.popcount() as f64 + fb.popcount() as f64) / (2.0 * n_bits as f64));
+            }
+        }
+        println!("--- pooled, overlap_frac ~ Uniform[0.05, 0.95) per pair, n={n_pooled_pairs} ---");
+        print_header();
+        for (arm, sample) in arm_defs.iter().zip(per_arm_pooled.iter()) {
+            print_row(arm.name, &exact_pooled, sample);
+        }
+        println!();
+    }
+}

--- a/crates/chematic-fp/src/lib.rs
+++ b/crates/chematic-fp/src/lib.rs
@@ -37,6 +37,13 @@ mod rdkit_morgan_ecfp4;
 mod rdkit_morgan_hash;
 pub mod reaction_fp;
 pub mod search;
+/// Superimposed count-fingerprint coding — a research SPIKE, not a
+/// production fingerprint. Not re-exported at the crate root (unlike the
+/// production fingerprints above); reach it via
+/// `chematic_fp::superimposed_coding::*`. See the module docs for scope,
+/// provenance, and why it is kept structurally separate from `ecfp`/
+/// `rdkit_morgan_ecfp4`.
+pub mod superimposed_coding;
 pub mod topo_path;
 
 pub use atom_pair::{atom_pair_fp, torsion_fp};

--- a/crates/chematic-fp/src/superimposed_coding.rs
+++ b/crates/chematic-fp/src/superimposed_coding.rs
@@ -1,0 +1,417 @@
+//! Superimposed count-fingerprint coding — a bounded reproducibility SPIKE.
+//!
+//! **Status: research spike, not a production fingerprint.** This module is
+//! deliberately standalone: it is not called from [`crate::ecfp`],
+//! [`crate::rdkit_morgan_ecfp4`], or any other production fingerprint path,
+//! and it does not change either engine's output. See `crates/chematic-fp`'s
+//! entry in the repo root `CLAUDE.md` ("Fingerprints: legacy vs.
+//! RDKit-bit-exact") for why those two engines are never blended.
+//!
+//! **Provenance note.** The general idea explored here — approximating
+//! count-aware (multiset) Tanimoto similarity on a fixed-width *binary*
+//! fingerprint by superimposing several independently-hashed codewords per
+//! feature count, rather than folding presence/absence alone — is discussed
+//! in a paper distributed under a CC BY-NC (non-commercial) license, whose
+//! authors disclosed a conflict of interest (a commercial fingerprint
+//! tooling business). No code, pseudocode, or reported numbers from that
+//! paper were used here. Everything below is an independent design over the
+//! general concept (superimposed coding itself is a classical information-
+//! retrieval technique predating that paper by decades — Mooers 1949,
+//! popularized in bit-vector form by Bloom filters), built and verified
+//! against synthetic data generated in this repo, not against any
+//! externally reported figures.
+//!
+//! Three encodings of a *count fingerprint* — `&[(feature_hash, count)]`, the
+//! natural output shape of e.g. [`crate::ecfp::morgan_fp_counts`] — down to a
+//! fixed-width binary vector are provided for comparison:
+//!
+//! - [`fold_presence_counts`]: plain presence/absence folding. Counts are
+//!   discarded entirely; each feature sets exactly one bit.
+//! - [`count_simulation_fold`]: RDKit-style "count simulation". Each feature
+//!   sets up to `max_repeats` bits, one per unit of count, at deterministic
+//!   pseudo-random positions (each unit of count = a different salt).
+//! - [`superimposed_code_counts`]: this spike's technique. Count is encoded
+//!   as a *unary/thermometer* ladder of up to `repetitions` layers (layer
+//!   `l` is active iff `count > l`), and each active layer contributes its
+//!   own `codeword_weight`-bit sparse codeword (not a single bit) into the
+//!   shared vector. Superimposing multi-bit codewords per layer, instead of
+//!   one bit per unit of count, is the one deliberate structural difference
+//!   from `count_simulation_fold` that this spike measures the effect of.
+//!
+//! [`exact_count_tanimoto`] computes the exact multiset (count-aware)
+//! Tanimoto similarity directly on the unfolded `&[(feature_hash, count)]`
+//! pairs — the ground truth the three folding strategies are compared
+//! against in `examples/superimposed_coding_spike_benchmark.rs`.
+
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::bitvec::BitVecN;
+use crate::ecfp::fnv1a as fnv1a_hash;
+
+/// Configuration for [`superimposed_code_counts`].
+#[derive(Clone, Debug)]
+pub struct SuperimposedCodingConfig {
+    /// Width of the output bit vector.
+    pub n_bits: usize,
+    /// Seed mixed into every hash call; same seed + same input ⇒ identical
+    /// output (see the `deterministic_*` tests below).
+    pub seed: u64,
+    /// Max number of unary "count layers" encoded per feature (layer `l` is
+    /// active iff `count > l`). Counts above `repetitions` are clamped —
+    /// this bounds the number of bits any single feature can contribute.
+    pub repetitions: u32,
+    /// Number of independently-hashed bit positions set per active layer.
+    /// `1` degenerates to one-bit-per-layer (structurally identical in
+    /// shape to [`count_simulation_fold`]); values `>1` are the actual
+    /// "superimposed coding" part — each layer becomes a sparse multi-bit
+    /// codeword OR'd into the shared vector, trading more set bits for
+    /// (hoped-for) collision robustness. Swept in the benchmark.
+    pub codeword_weight: u32,
+}
+
+impl Default for SuperimposedCodingConfig {
+    fn default() -> Self {
+        Self {
+            n_bits: 2048,
+            seed: 0,
+            repetitions: 4,
+            codeword_weight: 3,
+        }
+    }
+}
+
+/// Hash `(feature_hash, layer, slot, seed)` to a bit position in `0..n_bits`.
+fn coded_bit(feature_hash: u64, layer: u32, slot: u32, seed: u64, n_bits: usize) -> usize {
+    let mut buf = [0u8; 24];
+    buf[0..8].copy_from_slice(&feature_hash.to_le_bytes());
+    buf[8..12].copy_from_slice(&layer.to_le_bytes());
+    buf[12..16].copy_from_slice(&slot.to_le_bytes());
+    buf[16..24].copy_from_slice(&seed.to_le_bytes());
+    (fnv1a_hash(&buf) % n_bits as u64) as usize
+}
+
+/// Superimposed coding: fold a count fingerprint down to `config.n_bits`
+/// bits by OR-ing, per feature, one `codeword_weight`-bit sparse codeword
+/// per active unary count-layer (see module docs and
+/// [`SuperimposedCodingConfig`]).
+///
+/// Deterministic: identical `counts` + `config` always produce an identical
+/// [`BitVecN`].
+pub fn superimposed_code_counts(
+    counts: &[(u64, u32)],
+    config: &SuperimposedCodingConfig,
+) -> BitVecN {
+    let mut bv = BitVecN::new(config.n_bits);
+    for &(feature_hash, count) in counts {
+        let layers = count.min(config.repetitions);
+        for layer in 0..layers {
+            for slot in 0..config.codeword_weight {
+                let bit = coded_bit(feature_hash, layer, slot, config.seed, config.n_bits);
+                bv.set(bit);
+            }
+        }
+    }
+    bv
+}
+
+/// Plain folding: presence/absence only, counts discarded. Each feature with
+/// `count > 0` sets exactly one bit at `feature_hash % n_bits`. This is the
+/// cheapest baseline and the one most likely to under-approximate
+/// count-aware similarity for high-count features.
+pub fn fold_presence_counts(counts: &[(u64, u32)], n_bits: usize) -> BitVecN {
+    let mut bv = BitVecN::new(n_bits);
+    for &(feature_hash, count) in counts {
+        if count > 0 {
+            bv.set((feature_hash % n_bits as u64) as usize);
+        }
+    }
+    bv
+}
+
+/// RDKit-style "count simulation": each feature with count `c` sets up to
+/// `min(c, max_repeats)` bits, one per unit of count, each at a
+/// deterministic pseudo-random position derived from `(feature_hash, unit,
+/// seed)`. `max_repeats` bounds the number of bits any single feature can
+/// contribute (the literal "repeat forever" reading is unbounded and
+/// impractical, so this spike caps it like any real implementation would).
+pub fn count_simulation_fold(
+    counts: &[(u64, u32)],
+    n_bits: usize,
+    seed: u64,
+    max_repeats: u32,
+) -> BitVecN {
+    let mut bv = BitVecN::new(n_bits);
+    for &(feature_hash, count) in counts {
+        let reps = count.min(max_repeats);
+        for unit in 0..reps {
+            // slot=0: a single bit per unit of count, unlike superimposed
+            // coding's multi-bit-per-layer codeword.
+            let bit = coded_bit(feature_hash, unit, 0, seed, n_bits);
+            bv.set(bit);
+        }
+    }
+    bv
+}
+
+/// Exact count-aware (multiset) Tanimoto similarity on raw, unfolded
+/// `&[(feature_hash, count)]` pairs:
+///
+/// `sum(min(a_i, b_i)) / sum(max(a_i, b_i))` over the union of features,
+/// with the standard empty-union convention of `1.0`.
+///
+/// This is the ground truth the three folding strategies above are compared
+/// against — it never folds or hashes anything.
+///
+/// Precondition: `feature_hash` values within `a` (and within `b`) must be
+/// unique. Duplicates are silently last-wins (each slice is collected into a
+/// map keyed by `feature_hash`), unlike the folding functions above, which
+/// treat every `(feature_hash, count)` entry as an independent contribution.
+pub fn exact_count_tanimoto(a: &[(u64, u32)], b: &[(u64, u32)]) -> f64 {
+    let a_map: FxHashMap<u64, u32> = a.iter().copied().collect();
+    let b_map: FxHashMap<u64, u32> = b.iter().copied().collect();
+    let mut keys: FxHashSet<u64> = FxHashSet::default();
+    keys.extend(a_map.keys());
+    keys.extend(b_map.keys());
+
+    let mut min_sum = 0u64;
+    let mut max_sum = 0u64;
+    for k in keys {
+        let av = *a_map.get(&k).unwrap_or(&0) as u64;
+        let bv = *b_map.get(&k).unwrap_or(&0) as u64;
+        min_sum += av.min(bv);
+        max_sum += av.max(bv);
+    }
+    if max_sum == 0 {
+        1.0
+    } else {
+        min_sum as f64 / max_sum as f64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── exact_count_tanimoto ────────────────────────────────────────────
+
+    #[test]
+    fn exact_tanimoto_identical_inputs_is_one() {
+        let a = [(1u64, 4u32), (2, 7), (3, 1)];
+        assert_eq!(exact_count_tanimoto(&a, &a), 1.0);
+    }
+
+    #[test]
+    fn exact_tanimoto_both_empty_is_one() {
+        assert_eq!(exact_count_tanimoto(&[], &[]), 1.0);
+    }
+
+    #[test]
+    fn exact_tanimoto_hand_computed_example() {
+        // a: {1:4, 2:2}; b: {1:2, 2:2, 3:5}
+        // min sum = min(4,2) + min(2,2) + min(0,5) = 2 + 2 + 0 = 4
+        // max sum = max(4,2) + max(2,2) + max(0,5) = 4 + 2 + 5 = 11
+        // tanimoto = 4/11
+        let a = [(1u64, 4u32), (2, 2)];
+        let b = [(1u64, 2u32), (2, 2), (3, 5)];
+        let t = exact_count_tanimoto(&a, &b);
+        assert!((t - 4.0 / 11.0).abs() < 1e-12, "got {t}");
+        // symmetric
+        assert_eq!(t, exact_count_tanimoto(&b, &a));
+    }
+
+    #[test]
+    fn exact_tanimoto_disjoint_is_zero() {
+        let a = [(1u64, 3u32)];
+        let b = [(2u64, 5u32)];
+        assert_eq!(exact_count_tanimoto(&a, &b), 0.0);
+    }
+
+    // ── fold_presence_counts ────────────────────────────────────────────
+
+    #[test]
+    fn plain_folding_hand_computed_positions() {
+        // feature hashes chosen so `% 16` is trivial by hand.
+        let counts = [(5u64, 3u32), (7u64, 1u32), (21u64, 9u32)]; // 21 % 16 == 5, collides with feature 5
+        let bv = fold_presence_counts(&counts, 16);
+        assert!(bv.get(5), "5 % 16 == 5");
+        assert!(bv.get(7), "7 % 16 == 7");
+        // popcount is 2, not 3: features 5 and 21 collide on bit 5.
+        assert_eq!(bv.popcount(), 2);
+    }
+
+    #[test]
+    fn plain_folding_ignores_count_magnitude() {
+        let small = [(9u64, 1u32)];
+        let large = [(9u64, 1000u32)];
+        assert_eq!(
+            fold_presence_counts(&small, 512),
+            fold_presence_counts(&large, 512),
+            "presence folding must be blind to count value"
+        );
+    }
+
+    #[test]
+    fn plain_folding_zero_count_sets_no_bit() {
+        let counts = [(9u64, 0u32)];
+        assert_eq!(fold_presence_counts(&counts, 512).popcount(), 0);
+    }
+
+    // ── count_simulation_fold ───────────────────────────────────────────
+
+    #[test]
+    fn count_simulation_bounds_popcount_by_min_count_max_repeats() {
+        let counts = [(11u64, 5u32), (13u64, 2u32)];
+        let bv = count_simulation_fold(&counts, 1024, 0, 3);
+        // feature 11: min(5,3)=3 attempted bits; feature 13: min(2,3)=2.
+        // Hash collisions can only reduce popcount, never exceed the sum.
+        assert!(bv.popcount() <= 5);
+    }
+
+    #[test]
+    fn count_simulation_single_bit_universe_collapses_to_one_bit() {
+        // n_bits=1: every hash mod 1 == 0, so any nonzero count sets
+        // exactly bit 0 and nothing else -- fully hand-verifiable.
+        let counts = [(42u64, 7u32)];
+        let bv = count_simulation_fold(&counts, 1, 0, 3);
+        assert_eq!(bv.popcount(), 1);
+        assert!(bv.get(0));
+    }
+
+    #[test]
+    fn count_simulation_zero_count_sets_no_bit() {
+        let counts = [(42u64, 0u32)];
+        assert_eq!(count_simulation_fold(&counts, 512, 0, 3).popcount(), 0);
+    }
+
+    // ── superimposed_code_counts ────────────────────────────────────────
+
+    #[test]
+    fn superimposed_single_bit_universe_collapses_to_one_bit() {
+        // n_bits=1: every coded_bit call maps to bit 0 regardless of layer
+        // or slot, so any nonzero count sets exactly bit 0.
+        let counts = [(42u64, 7u32)];
+        let cfg = SuperimposedCodingConfig {
+            n_bits: 1,
+            seed: 0,
+            repetitions: 4,
+            codeword_weight: 3,
+        };
+        let bv = superimposed_code_counts(&counts, &cfg);
+        assert_eq!(bv.popcount(), 1);
+        assert!(bv.get(0));
+    }
+
+    #[test]
+    fn superimposed_popcount_bounded_by_layers_times_codeword_weight() {
+        let counts = [(11u64, 10u32), (13u64, 1u32)];
+        let cfg = SuperimposedCodingConfig {
+            n_bits: 4096,
+            seed: 7,
+            repetitions: 4,
+            codeword_weight: 3,
+        };
+        let bv = superimposed_code_counts(&counts, &cfg);
+        // feature 11: min(10,4)=4 layers * 3 slots = 12; feature 13: 1*3=3.
+        assert!(bv.popcount() <= 15);
+    }
+
+    #[test]
+    fn superimposed_zero_count_sets_no_bit() {
+        let counts = [(42u64, 0u32)];
+        let cfg = SuperimposedCodingConfig::default();
+        assert_eq!(superimposed_code_counts(&counts, &cfg).popcount(), 0);
+    }
+
+    #[test]
+    fn superimposed_more_repeated_count_never_shrinks_popcount() {
+        // Monotonicity sanity check: going from count=1 to count=5 (more
+        // active layers) can only add bits, never remove them, since layer
+        // l < old count is a strict subset of layer l < new count.
+        let cfg = SuperimposedCodingConfig {
+            n_bits: 4096,
+            seed: 3,
+            repetitions: 8,
+            codeword_weight: 2,
+        };
+        let low = superimposed_code_counts(&[(99u64, 1u32)], &cfg);
+        let high = superimposed_code_counts(&[(99u64, 5u32)], &cfg);
+        assert!(high.popcount() >= low.popcount());
+    }
+
+    // ── structural relationship to count_simulation_fold ───────────────
+
+    #[test]
+    fn superimposed_with_codeword_weight_one_equals_count_simulation_fold() {
+        // codeword_weight=1 means each active layer contributes exactly one
+        // bit via coded_bit(feature_hash, layer, slot=0, seed, n_bits) --
+        // the same formula, same salts, as count_simulation_fold's per-unit
+        // bit. So at codeword_weight=1 and repetitions == max_repeats, the
+        // two functions must produce byte-identical output. This is the
+        // load-bearing fact behind this spike's real finding: the
+        // `codeword_weight` knob is the ONLY structural difference between
+        // "superimposed coding" as implemented here and the RDKit-style
+        // baseline -- see the benchmark's codeword_weight sweep.
+        let counts: Vec<(u64, u32)> = (0u64..40)
+            .map(|i| (i * 97 + 3, (i % 9) as u32 + 1))
+            .collect();
+        let cfg = SuperimposedCodingConfig {
+            n_bits: 1024,
+            seed: 7,
+            repetitions: 4,
+            codeword_weight: 1,
+        };
+        let sup = superimposed_code_counts(&counts, &cfg);
+        let sim = count_simulation_fold(&counts, 1024, 7, 4);
+        assert_eq!(
+            sup, sim,
+            "codeword_weight=1 must degenerate to exactly count_simulation_fold"
+        );
+    }
+
+    // ── determinism ─────────────────────────────────────────────────────
+
+    #[test]
+    fn deterministic_same_seed_identical_output_all_three_strategies() {
+        let counts: Vec<(u64, u32)> = (0u64..50)
+            .map(|i| (i * 97 + 3, (i % 9) as u32 + 1))
+            .collect();
+        let cfg = SuperimposedCodingConfig {
+            n_bits: 1024,
+            seed: 12345,
+            repetitions: 5,
+            codeword_weight: 3,
+        };
+
+        let sup1 = superimposed_code_counts(&counts, &cfg);
+        let sup2 = superimposed_code_counts(&counts, &cfg);
+        assert_eq!(sup1, sup2, "superimposed_code_counts must be deterministic");
+
+        let sim1 = count_simulation_fold(&counts, 1024, 12345, 5);
+        let sim2 = count_simulation_fold(&counts, 1024, 12345, 5);
+        assert_eq!(sim1, sim2, "count_simulation_fold must be deterministic");
+
+        let plain1 = fold_presence_counts(&counts, 1024);
+        let plain2 = fold_presence_counts(&counts, 1024);
+        assert_eq!(plain1, plain2, "fold_presence_counts must be deterministic");
+    }
+
+    #[test]
+    fn deterministic_different_seed_usually_differs() {
+        let counts: Vec<(u64, u32)> = (0u64..50)
+            .map(|i| (i * 97 + 3, (i % 9) as u32 + 1))
+            .collect();
+        let cfg_a = SuperimposedCodingConfig {
+            n_bits: 1024,
+            seed: 1,
+            repetitions: 5,
+            codeword_weight: 3,
+        };
+        let cfg_b = SuperimposedCodingConfig {
+            seed: 2,
+            ..cfg_a.clone()
+        };
+        let a = superimposed_code_counts(&counts, &cfg_a);
+        let b = superimposed_code_counts(&counts, &cfg_b);
+        assert_ne!(a, b, "different seeds should (almost always) diverge");
+    }
+}

--- a/crates/chematic-fp/src/superimposed_coding.rs
+++ b/crates/chematic-fp/src/superimposed_coding.rs
@@ -84,11 +84,16 @@ pub struct SuperimposedCodingConfig {
     /// this bounds the number of bits any single feature can contribute.
     pub repetitions: u32,
     /// Number of independently-hashed bit positions set per active layer.
-    /// `1` degenerates to one-bit-per-layer (structurally identical in
-    /// shape to [`count_simulation_fold`]); values `>1` are the actual
-    /// "superimposed coding" part — each layer becomes a sparse multi-bit
-    /// codeword OR'd into the shared vector, trading more set bits for
-    /// (hoped-for) collision robustness. Swept in the benchmark.
+    /// `1` degenerates to one-bit-per-layer — provably identical to
+    /// [`count_simulation_fold`] when `repetitions` matches that function's
+    /// `max_repeats` and both use the same `seed` (see the
+    /// `superimposed_with_codeword_weight_one_equals_count_simulation_fold`
+    /// test). Values `>1` are the actual "superimposed coding" part this
+    /// spike measures, and — per the module-doc proof above — cannot ever
+    /// beat `1` on Tanimoto fidelity, only match it (collision-free) or
+    /// underperform it (any real, finite `n_bits`). Swept in the benchmark;
+    /// kept configurable so the sweep is possible, not because `>1` is ever
+    /// recommended.
     pub codeword_weight: u32,
 }
 
@@ -98,7 +103,13 @@ impl Default for SuperimposedCodingConfig {
             n_bits: 2048,
             seed: 0,
             repetitions: 4,
-            codeword_weight: 3,
+            // ponytail: 1, not >1 -- the module-doc proof plus this spike's
+            // own benchmark (crates/chematic-fp/examples/
+            // superimposed_coding_spike_benchmark.rs) both show
+            // codeword_weight>1 can only match or underperform 1, never
+            // improve on it. Defaulting to the proven-best setting so
+            // nobody cargo-cults `::default()` into the worst arm.
+            codeword_weight: 1,
         }
     }
 }

--- a/crates/chematic-fp/src/superimposed_coding.rs
+++ b/crates/chematic-fp/src/superimposed_coding.rs
@@ -42,6 +42,29 @@
 //! Tanimoto similarity directly on the unfolded `&[(feature_hash, count)]`
 //! pairs — the ground truth the three folding strategies are compared
 //! against in `examples/superimposed_coding_spike_benchmark.rs`.
+//!
+//! **`codeword_weight` is provably Tanimoto-neutral in the collision-free
+//! limit — it cannot help, only risk collisions.** In the limit `n_bits →
+//! ∞` (no two distinct `(feature_hash, layer, slot)` triples ever hash to
+//! the same bit), a feature `f` with `L_f` active layers contributes
+//! exactly `codeword_weight` distinct bits per layer, so
+//! `|A| = codeword_weight · Σ_f L_f^A`. Two fingerprints only ever share a
+//! bit at address `coded_bit(f, l, slot, seed, n_bits)` when *both* have
+//! layer `l` active for the same `f` (the hash is a pure function of its
+//! inputs — nothing else can land there), and when that happens all
+//! `codeword_weight` slots of that layer collide identically on both
+//! sides. So `|A ∩ B| = codeword_weight · Σ_f min(L_f^A, L_f^B)` and,
+//! via `max = a + b - min`, `|A ∪ B| = codeword_weight · Σ_f max(L_f^A,
+//! L_f^B)`. The `codeword_weight` factor cancels in the ratio:
+//! `Tanimoto = Σ_f min(L_f^A, L_f^B) / Σ_f max(L_f^A, L_f^B)`, independent
+//! of `codeword_weight`. On any *finite* `n_bits`, `codeword_weight > 1`
+//! only adds more chances for unrelated `(feature, layer, slot)` triples to
+//! collide on the same bit, which can only inflate `|A ∩ B|` and `|A ∪ B|`
+//! spuriously relative to this ideal ratio — never improve on it. The
+//! benchmark's `codeword_weight` sweep confirms this empirically: MAE rises
+//! and Pearson correlation falls monotonically as `codeword_weight`
+//! increases, tracking rising mean bit-vector fill (saturation), at every
+//! `n_bits` tested.
 
 use rustc_hash::{FxHashMap, FxHashSet};
 


### PR DESCRIPTION
## What this is

A **bounded reproducibility SPIKE** — research/exploration only, explicitly **not** a production feature request. It does not touch, wrap, or get called from `ecfp4()`, `mol.ecfp4()`, `rdkit_morgan_ecfp4_experimental()`, or any other public fingerprint API. The two existing ECFP4 engines are untouched (see confirmation below). **Do not merge.**

## What it investigates

"Superimposed coding": folding a *count* fingerprint (`&[(feature_hash, count)]`) down to a fixed-width *binary* vector such that binary Tanimoto on the folded bits approximates the true multiset (count-aware) Tanimoto better than plain presence folding or RDKit-style count-simulation folding alone.

New standalone module: `crates/chematic-fp/src/superimposed_coding.rs` (not re-exported at the crate root — reachable only via `chematic_fp::superimposed_coding::*`, same pattern as the existing `diagnostics` module). Provides, for comparison, on the same synthetic inputs:

- `fold_presence_counts` — plain presence/absence folding, counts discarded.
- `count_simulation_fold` — RDKit-style count simulation: up to `max_repeats` bits per feature, one per unit of count, at deterministic pseudo-random positions.
- `superimposed_code_counts` — this spike's design: count encoded as a unary/thermometer ladder of up to `repetitions` layers (layer `l` active iff `count > l`), each active layer contributing its own `codeword_weight`-bit sparse codeword OR'd into the shared vector.
- `exact_count_tanimoto` — exact multiset Tanimoto (`sum(min)/sum(max)`) on the raw unfolded pairs, the ground truth everything else is measured against.

Synthetic benchmark: `crates/chematic-fp/examples/superimposed_coding_spike_benchmark.rs`. Run it: `cargo run -p chematic-fp --release --example superimposed_coding_spike_benchmark`

## Provenance / COI (honest disclosure, as requested)

The general idea comes from a paper distributed under a **CC BY-NC** (non-commercial) license, whose authors disclosed a **conflict of interest** (a commercial fingerprint-tooling business, chemfp). **No code, pseudocode, or reported numbers from that paper were used anywhere in this PR.** Everything here is an independent design over the general *concept* of superimposed coding (a decades-old information-retrieval technique, Mooers 1949, popularized in bit-vector form by Bloom filters — not something the paper invented), verified only against synthetic data generated in this repo. Nothing here reproduces or claims to reproduce that paper's reported results.

## Structural fact, proved not just measured: `codeword_weight` cannot help

`codeword_weight=1` is **provably identical** to `count_simulation_fold` whenever `repetitions == max_repeats` and both use the same `seed` (true throughout this benchmark and the default config) — same `coded_bit(feature_hash, layer/unit, 0, seed, n_bits)` formula either way. Confirmed by both a unit test (`superimposed_with_codeword_weight_one_equals_count_simulation_fold`, using `repetitions=max_repeats=4`, matching seeds) and by the benchmark (their numbers match to 4 decimal places at every row below, same `repetitions=max_repeats=4` setup). That means `codeword_weight` is the *only* structural knob this spike's design adds over the existing RDKit-style baseline (given matched `repetitions`/`max_repeats`/`seed`). `SuperimposedCodingConfig::default()` now ships `codeword_weight: 1` — the proof below shows `>1` can only match or underperform `1`, never beat it, so the default shouldn't hand out the worst arm.

In the module docs I worked out why that knob can't help: in the collision-free limit (`n_bits → ∞`), a feature `f` with `L_f` active layers contributes exactly `codeword_weight` distinct bits per layer, so `|A| = codeword_weight · Σ_f L_f^A`, and two fingerprints only ever share a bit when both have the *same* layer active for the *same* feature (the hash is a pure function of its inputs), in which case all `codeword_weight` slots of that layer collide identically on both sides. So `|A∩B| = codeword_weight · Σ_f min(L_f^A, L_f^B)` and `|A∪B| = codeword_weight · Σ_f max(L_f^A, L_f^B)` — the `codeword_weight` factor cancels exactly in the Tanimoto ratio. On any finite `n_bits`, `codeword_weight > 1` only adds more chances for *unrelated* features to collide on the same bit — it can only hurt, never help. The benchmark's sweep (below) confirms this precisely: MAE rises and correlation falls monotonically as `codeword_weight` increases, tracking rising mean bit-vector fill.

## Measured numbers

Two regimes were run, because the first one I tried turned out to be misleading on its own (see the "what changed" note below).

**Regime A — realistic fill, clamp-free** (`n_features=60`, `max_count=4=max_repeats`, so no arm clamps counts and single-fingerprint popcount lands in real ECFP4's ballpark — tens of active features, not hundreds): pooled `overlap_frac ~ Uniform[0.05, 0.95)`, n=400 pairs, MAE = mean absolute error vs exact count-Tanimoto.

| n_bits | plain MAE | count_sim MAE (=`w=1`) | superimposed `w=2` MAE | `w=3` MAE | `w=5` MAE |
|---|---|---|---|---|---|
| 512 | 0.1958 | **0.0712** | 0.1386 | 0.2021 | 0.3174 |
| 1024 | 0.1854 | **0.0342** | 0.0684 | 0.1020 | 0.1664 |
| 2048 | 0.1793 | **0.0187** | 0.0367 | 0.0535 | 0.0878 |

Pearson r vs ground truth in this regime is ≥0.94 for every arm (plain and count_sim both ≥0.977), so MAE is the metric that differentiates them here, not correlation.

**Regime B — headline / high-fill** (`n_features=400`, `max_count=12 > max_repeats=4`, i.e. every count/count_sim/superimposed arm clamps): pooled results, plus the `ceiling(clamp@R)` row (`exact_count_tanimoto` on *both* fingerprints' counts clamped to `max_repeats`, zero hashing) that isolates how much of an arm's MAE is clamp bias vs. hashing/collision noise:

| n_bits | ceiling MAE | plain MAE | count_sim MAE | `w=2` | `w=3` | `w=5` |
|---|---|---|---|---|---|---|
| 512 | 0.1221 | 0.3365 | 0.5379 | 0.6723 | 0.7008 | 0.7073 |
| 1024 | 0.1213 | 0.2746 | 0.3711 | 0.5353 | 0.6267 | 0.6914 |
| 2048 | 0.1202 | 0.2415 | 0.2542 | 0.3711 | 0.4652 | 0.5917 |

At `n_bits=2048`, roughly half of `count_sim`'s 0.2542 MAE (0.1202) is clamp bias alone, not hashing noise — this regime's `max_count=12` vastly exceeds `repetitions=4`, so even a hypothetical zero-collision encoder couldn't do much better than the ceiling row. This regime also sits at 40–100% mean bit-vector fill (see the `mean_fill` column in the full benchmark output), far denser than real ECFP4 fingerprints (~50–100 active features into 2048 bits, ~5–10% fill) — it's a stress-test of saturation behavior, not a realistic operating point.

Both regimes agree on the one finding this spike set out to check: **`codeword_weight>1` never wins.** `w=1` (=`count_sim`) is the best of the superimposed-coding sweep in every row of both tables; `w=2/3/5` are monotonically worse.

## What changed from my first pass at this write-up (being upfront about it)

My first draft measured only Regime B and concluded "plain folding is competitive with or better than every hash-based strategy." That conclusion doesn't survive the more realistic Regime A, where `count_sim` clearly beats `plain` (e.g. 0.0187 vs 0.1793 MAE at `n_bits=2048`) — Regime B's apparent "plain wins" was an artifact of stacking two confounds (clamp bias from `max_count=12` vs `repetitions=4`, and saturation from `n_features=400` pushing every hash-based arm past 40% fill) that don't reflect how these fingerprints are actually sized in practice. Also worth being explicit: `gen_pair` gives shared features *independent* random counts in A and B; real similar molecules would have correlated counts, which is part of why ground truth sits well below presence-only Jaccard at high overlap in these synthetic pairs.

## Recommendation

**Do not productionize `codeword_weight>1`** — it's now both mathematically provable (above) and empirically confirmed in the realistic regime that it cannot beat plain `count_sim` (`codeword_weight=1`), and it never beats it in the unrealistic high-fill regime either. That part of this spike's naive generalization is a dead end, not a promising direction to iterate on further within this design.

Separately (and not really what this spike was scoped to answer): the existing RDKit-style `count_simulation_fold` baseline itself looks genuinely useful at realistic fill levels (MAE 3–10x lower than plain presence folding across `n_bits` in Regime A) — but that's an existing, well-known technique, not something this spike needed to establish, and productionizing *that* would be a separate, much larger decision (touching real molecule data, real fingerprint sizes, and the two-engine ECFP4 policy in `CLAUDE.md`) that's out of scope here. If "superimposed coding" specifically (i.e., something better than plain count-simulation) is worth revisiting, it would need a structurally different design than the one implemented here — e.g. keeping the bit budget closer to `O(log count)` via log-scale count-bound layers (`count ≥ {1,2,4,8,16}`) instead of unary-per-unit layers — which was not attempted in this bounded spike.

## Verification

- `cargo test -p chematic-fp --lib --quiet`: **267 passed** (250 pre-existing + 17 new in `superimposed_coding`), 0 failed.
- `cargo test -p chematic-fp --tests --quiet`: 267 (lib) + 2 (integration, incl. `rdkit_morgan_stable_api_fixtures` — the ECFP4 bit-exact guard) passed, 0 failed.
- `git diff --stat origin/main -- crates/chematic-fp`: only `src/lib.rs` changes (+7 lines, one new `pub mod` declaration + doc comment) plus the two new files — nothing under `ecfp.rs` / `rdkit_morgan_*.rs` / any existing file touched.
- `bash scripts/check.sh`: **all checks passed** (fmt, clippy `-D warnings`, full workspace lib + integration tests, cargo-deny, publish graph, version consistency).

## Explicitly out of scope (per the spike's own bounds, not attempted)

Wiring into `ecfp4()`/`mol.ecfp4()`/any public fingerprint API, adding to the RDKit-bit-exact engine, performance optimization, `chematic-py`/`chematic-wasm` bindings, and (per the recommendation above) the log-scale-layer redesign that might actually make `codeword_weight`-style superimposed coding work.
