### PR TITLE
feat(perception): expose per-atom stereocenter candidates

### DIFF
--- a/crates/chematic-perception/src/lib.rs
+++ b/crates/chematic-perception/src/lib.rs
@@ -50,7 +50,8 @@ pub mod diagnostics {
 }
 pub use sssr::{RingSet, find_sssr};
 pub use stereo_validation::{
-    StereoCompleteness, StereoError, StereoErrorKind, stereo_completeness, validate_stereo,
+    StereoCompleteness, StereoError, StereoErrorKind, stereo_centers, stereo_completeness,
+    validate_stereo,
 };
 pub use stereo2d::{
     StereoAssignment2D, apply_stereo_from_2d, assign_ez_from_2d, assign_stereo_from_2d,

--- a/crates/chematic-perception/src/stereo_validation.rs
+++ b/crates/chematic-perception/src/stereo_validation.rs
@@ -225,14 +225,17 @@ pub fn validate_stereo(mol: &Molecule) -> Vec<StereoError> {
     errors
 }
 
-/// Summarise how many stereocenters in `mol` have been specified vs left open.
+/// Return the tetrahedral stereocenter candidates in `mol` that this
+/// classifier recognises: an sp3 atom with 4 distinct heavy-atom-or-
+/// implicit-H groups, paired with whether it carries an explicit `@`/`@@`
+/// chirality annotation (`true` = specified, `false` = a valid candidate
+/// left unannotated).
 ///
-/// A potential stereocenter is an sp3 atom with 4 distinct heavy-atom
-/// neighbours (counting one implicit H as a distinct group when present).
-pub fn stereo_completeness(mol: &Molecule) -> StereoCompleteness {
+/// This is the single source of truth for stereocenter classification;
+/// [`stereo_completeness`] is defined in terms of it.
+pub fn stereo_centers(mol: &Molecule) -> Vec<(AtomIdx, bool)> {
     let ranks = simple_morgan_ranks(mol);
-    let mut specified = 0usize;
-    let mut unspecified = 0usize;
+    let mut centers = Vec::new();
 
     for (idx, atom) in mol.atoms() {
         // Skip aromatics and obvious non-centers.
@@ -278,17 +281,28 @@ pub fn stereo_completeness(mol: &Molecule) -> StereoCompleteness {
             continue;
         } // symmetric neighbours — not a stereocenter
 
-        if atom.chirality != Chirality::None {
-            specified += 1;
-        } else {
-            unspecified += 1;
-        }
+        centers.push((idx, atom.chirality != Chirality::None));
     }
+
+    centers
+}
+
+/// Summarise how many stereocenters in `mol` have been specified vs left open.
+///
+/// A potential stereocenter is an sp3 atom with 4 distinct heavy-atom
+/// neighbours (counting one implicit H as a distinct group when present).
+pub fn stereo_completeness(mol: &Molecule) -> StereoCompleteness {
+    let centers = stereo_centers(mol);
+    let specified = centers
+        .iter()
+        .filter(|(_, is_specified)| *is_specified)
+        .count();
+    let unspecified = centers.len() - specified;
 
     StereoCompleteness {
         specified,
         unspecified,
-        total_centers: specified + unspecified,
+        total_centers: centers.len(),
     }
 }
 
@@ -455,6 +469,75 @@ mod tests {
             sc.total_centers, 2,
             "expected 2 stereocenters total (1 fixed + 1 pre-existing, bug-unrelated \
              unspecified center at the quaternary carbon): {sc:?}"
+        );
+    }
+
+    #[test]
+    fn test_stereo_centers_mixed_specified_and_unspecified() {
+        // Atom 0 ([C@]) carries an explicit chirality annotation and has 4
+        // distinct fully-explicit heavy neighbours (F, Cl, Br, atom 4) ->
+        // specified stereocenter.
+        // Atom 4 (C(I)(N)O) has no annotation but also has 4 distinct heavy
+        // neighbours (atom 0, I, N, O) -> unspecified candidate.
+        let mol = parse("[C@](F)(Cl)(Br)C(I)(N)O").unwrap();
+        let centers = stereo_centers(&mol);
+
+        assert_eq!(
+            centers.len(),
+            2,
+            "expected exactly 2 stereocenter candidates: {centers:?}"
+        );
+        assert!(
+            centers.contains(&(AtomIdx(0), true)),
+            "atom 0 should be a specified stereocenter: {centers:?}"
+        );
+        assert!(
+            centers.contains(&(AtomIdx(4), false)),
+            "atom 4 should be an unspecified stereocenter candidate: {centers:?}"
+        );
+
+        // stereo_completeness must agree exactly (single source of truth).
+        let sc = stereo_completeness(&mol);
+        assert_eq!(sc.specified, 1);
+        assert_eq!(sc.unspecified, 1);
+        assert_eq!(sc.total_centers, 2);
+    }
+
+    // Regression tests, on `stereo_centers` itself, for the two bugs fixed
+    // upstream of this PR's rebase onto `main` (issue #267 overflow fix,
+    // commit a99fc9b; implicit-H rank-0 sentinel collision fix, commit
+    // 5790bb0). Both were previously exercised only via `stereo_completeness`
+    // aggregate counts; these confirm the new `stereo_centers` API itself is
+    // correct now that it's the single source of truth both bugs lived in.
+
+    #[test]
+    fn test_stereo_centers_negative_formal_charge_no_panic() {
+        // Issue #267's exact repro: acetate's [O-] atom must not overflow
+        // u64 in simple_morgan_ranks (it used to sign-extend and panic in
+        // debug builds). No stereocenters expected -- just confirm
+        // stereo_centers runs to completion with a sensible, empty result.
+        let acetate = parse("CC(=O)[O-]").unwrap();
+        let centers = stereo_centers(&acetate);
+        assert!(
+            centers.is_empty(),
+            "acetate has no stereocenters: {centers:?}"
+        );
+    }
+
+    #[test]
+    fn test_stereo_centers_rank_zero_sentinel_collision_fixed() {
+        // This PR's own body cited this exact repro as a known, pre-existing
+        // limitation: atom 1 is a real, `@@`-annotated stereocenter that
+        // `stereo_centers` used to silently drop because its methyl
+        // neighbour (atom 0) normalises to Morgan rank 0, the same sentinel
+        // value `stereo_centers` used to stand in for the implicit H. Fixed
+        // upstream in commit 5790bb0; confirm atom 1 is now correctly
+        // reported as (AtomIdx(1), true) directly from stereo_centers.
+        let mol = parse("C[C@@H](Cl)C(Br)(F)I").unwrap();
+        let centers = stereo_centers(&mol);
+        assert!(
+            centers.contains(&(AtomIdx(1), true)),
+            "atom 1 must be reported as a specified stereocenter: {centers:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Adds `chematic_perception::stereo_validation::stereo_centers(&Molecule) -> Vec<(AtomIdx, bool)>`, exposing the per-atom tetrahedral-stereocenter classification (`(atom, specified)`) that `stereo_completeness` already computed internally but only surfaced as aggregate counts (`specified`, `unspecified`, `total_centers`).

`stereo_completeness` is now implemented in terms of `stereo_centers` (`.len()` / filtered by the bool), so there is exactly one source of truth for the classification logic instead of two copies that could drift. `StereoCompleteness`'s public field shape is unchanged — purely additive.

Fixes #263

## Test plan

- New test `test_stereo_centers_mixed_specified_and_unspecified` on `[C@](F)(Cl)(Br)C(I)(N)O`: asserts the returned `Vec` contains `(AtomIdx(0), true)` (specified) and `(AtomIdx(4), false)` (unspecified), not just aggregate counts, and cross-checks `stereo_completeness` agrees.
- Two new regression tests added directly against `stereo_centers` (see below) for the two bugs that were previously only fixed/tested via `stereo_completeness`.
- All pre-existing `stereo_validation` tests pass unchanged. `cargo test -p chematic-perception --lib -- stereo_validation`: 14/14 pass.
- `cargo fmt -p chematic-perception -- --check` and `cargo clippy -p chematic-perception --all-targets -- -D warnings` clean locally.
- `bash scripts/check.sh` run to completion locally after the rebase (full workspace, under heavy concurrent load from a sibling agent's MMFF94 benchmark elsewhere in this repo): `All checks passed.` CI on the pushed commit is the authoritative full-workspace gate. The only non-green/pending check is `Rust Criterion regression gate`, which per this repo's standing policy is measurement-broken by pseudo-replication and not treated as regression evidence on its own.

## Rebase note

This branch was rebased onto current `main` to pick up two prerequisite fixes that landed after this PR was originally opened:

- Issue #267 / commit [`a99fc9b`](https://github.com/kent-tokyo/chematic/commit/a99fc9b) — fixed a `u64` overflow in `simple_morgan_ranks` for atoms with a negative formal charge (`atom.charge as u64` sign-extended, e.g. `-1i8 as u64 == u64::MAX`), which panicked in debug builds for any carboxylate/sulfonate/phosphate-type anion.
- Commit [`5790bb0`](https://github.com/kent-tokyo/chematic/commit/5790bb0) — fixed the implicit-H rank-0 sentinel collision in `simple_morgan_ranks`/`stereo_centers`: an implicit H was compared against neighbour ranks using a hardcoded `0` sentinel, but `simple_morgan_ranks` normalises real ranks starting at `0` too, so a stereocenter with a rank-0 heavy neighbour *and* an implicit H was silently miscounted/dropped.

Both are now fixed on `main`, so this PR's own previous "known pre-existing limitation" doc comment on `stereo_centers` (which described the now-fixed sentinel collision as "not fixed here — out of scope") has been deleted as stale. This rebase adds direct regression coverage for both cases on the new `stereo_centers` API itself (not just `stereo_completeness`):

- `test_stereo_centers_negative_formal_charge_no_panic` — issue #267's exact repro (`CC(=O)[O-]`), confirms `stereo_centers` runs to completion with no panic and returns an empty (correct) result.
- `test_stereo_centers_rank_zero_sentinel_collision_fixed` — this PR's own previously-cited repro (`C[C@@H](Cl)C(Br)(F)I`), confirms `stereo_centers` now correctly includes atom 1 as `(AtomIdx(1), true)`, where it was silently dropped before the fix.
