### PR TITLE
feat(perception): add is_macrocycle ring-size predicate

### DIFF
--- a/crates/chematic-perception/src/lib.rs
+++ b/crates/chematic-perception/src/lib.rs
@@ -122,6 +122,25 @@ pub fn is_fused_ring_system(mol: &Molecule) -> bool {
     false
 }
 
+/// Return `true` if `ring` is a macrocycle (>= 9 atoms).
+///
+/// `9` matches RDKit's own `minMacrocycleRingSize` (the ring size at which
+/// RDKit's ETKDG embedder switches to macrocycle-specific torsion
+/// sampling). This is a pure ring-size classification over the atom list
+/// returned by [`find_sssr`]/[`ring_family::find_ring_families`] — it takes
+/// no bond/force-field context and lives here so callers don't need the
+/// full `chematic-3d` dependency chain just to ask "is this ring a
+/// macrocycle?" (see issue #266).
+///
+/// Note (pre-existing, not touched by this function): `chematic-3d`
+/// independently hardcodes this same threshold twice —
+/// `rdkit_shape_descriptors::MACROCYCLE_RING_THRESHOLD` and
+/// `etkdg_knowledge::classify::MACROCYCLE_MIN`, both `9`, neither shared
+/// with this function or with each other.
+pub fn is_macrocycle(ring: &[AtomIdx]) -> bool {
+    ring.len() >= 9
+}
+
 /// Apply aromaticity to `mol` in-place (wrapper for [`apply_aromaticity`]).
 pub fn aromatize(mol: &mut Molecule) {
     *mol = apply_aromaticity(mol);
@@ -231,6 +250,46 @@ mod tests {
         assert!(
             !is_fused_ring_system(&m),
             "spiro compound shares only 1 atom, not fused"
+        );
+    }
+
+    #[test]
+    fn test_is_macrocycle_boundary() {
+        // Exact >=9 boundary: 8-membered false, 9-membered true.
+        let ring8: Vec<AtomIdx> = (0..8).map(AtomIdx).collect();
+        let ring9: Vec<AtomIdx> = (0..9).map(AtomIdx).collect();
+        assert!(
+            !is_macrocycle(&ring8),
+            "8-membered ring is not a macrocycle"
+        );
+        assert!(is_macrocycle(&ring9), "9-membered ring is a macrocycle");
+    }
+
+    #[test]
+    fn test_is_macrocycle_cyclododecane() {
+        // Cyclododecane: 12-membered ring, well above the threshold.
+        let m = mol("C1CCCCCCCCCCC1");
+        let ring_set = find_sssr(&m);
+        let rings = ring_set.rings();
+        assert_eq!(rings.len(), 1);
+        assert!(is_macrocycle(&rings[0]), "cyclododecane is a macrocycle");
+    }
+
+    #[test]
+    fn test_is_macrocycle_small_rings() {
+        // Benzene (6) and cyclohexane (6) are well under the threshold.
+        let benzene = mol("c1ccccc1");
+        let rings = find_sssr(&benzene);
+        assert!(
+            !is_macrocycle(&rings.rings()[0]),
+            "benzene is not a macrocycle"
+        );
+
+        let cyclohexane = mol("C1CCCCC1");
+        let rings = find_sssr(&cyclohexane);
+        assert!(
+            !is_macrocycle(&rings.rings()[0]),
+            "cyclohexane is not a macrocycle"
         );
     }
 


### PR DESCRIPTION
## Summary

Adds `chematic_perception::is_macrocycle(ring: &[AtomIdx]) -> bool` — a pure ring-size classifier (`ring.len() >= 9`) that operates directly on the atom list returned by `find_sssr`/`find_ring_families`, with no dependency on `chematic-3d`'s 3D/force-field chain.

Previously the only macrocycle-ring classifier was `chematic_3d::detect_macrocycle_status` (`crates/chematic-3d/src/rdkit_shape_descriptors.rs`), gated behind the `chematic-3d` crate's `threed` feature even though ring-size classification is a pure 2D/topology question. This adds the equivalent predicate at the `chematic-perception` layer, where `find_sssr` already lives.

Fixes #266

## Threshold

`9`, matching `chematic-3d`'s `MACROCYCLE_RING_THRESHOLD` (itself sourced from RDKit's `minMacrocycleRingSize`).

**Pre-existing observation, not fixed by this PR:** `chematic-3d` independently hardcodes this same `9` threshold *twice*, unshared — `rdkit_shape_descriptors::MACROCYCLE_RING_THRESHOLD` and `etkdg_knowledge::classify::MACROCYCLE_MIN`. Both currently `9`, both use `>=`, but they are two separate constants that could drift independently. `chematic-perception` can't depend on `chematic-3d` (crate-layer direction in `CLAUDE.md` goes the other way), so unifying all three is out of scope here — documented in the new function's doc comment as a known duplication.

## Independence from #268

This PR is independent of #268 (`feat(perception): expose per-atom stereocenter candidates`) — different functions (`is_macrocycle` vs `stereo_centers`/`stereo_completeness`), no overlapping lines in `lib.rs` (this PR only touches the ring-helper section and adds new tests after `is_fused_ring_system`; #268 only touches the `stereo_validation` re-export list and `stereo_validation.rs`). Both branch from `main` independently and are mergeable in either order.

## Test plan

- `test_is_macrocycle_boundary`: exact boundary on bare `Vec<AtomIdx>` — 8-membered → `false`, 9-membered → `true`.
- `test_is_macrocycle_cyclododecane`: `C1CCCCCCCCCCC1` (12-membered ring) via `find_sssr` → `true`.
- `test_is_macrocycle_small_rings`: benzene and cyclohexane (6-membered) via `find_sssr` → `false`.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p chematic-perception --all-targets -- -D warnings`: clean.
- `cargo test -p chematic-perception --lib`: all tests including the 3 new ones pass.

Full-workspace `bash scripts/check.sh` could not be run to completion locally in this session — the sandbox is under heavy load from concurrent sibling-agent builds sharing the same host (load average ~24-33 on 10 cores), which kills long-running background commands before the multi-crate `--lib`/`--tests` phases finish. Verified piecewise instead as listed above (every phase that can be affected by this diff, since the change is confined to `chematic-perception`). CI on the pushed commit is the authoritative full-workspace gate for this PR.