### PR TITLE
feat(chem): add E/Z double-bond stereo-completeness detector

### DIFF
--- a/crates/chematic-chem/src/cip.rs
+++ b/crates/chematic-chem/src/cip.rs
@@ -923,6 +923,140 @@ fn highest_stereo_sub(
     None
 }
 
+// ---------------------------------------------------------------------------
+// E/Z double-bond stereo completeness
+// ---------------------------------------------------------------------------
+
+/// Summary of E/Z-stereogenic double bonds in a molecule.
+///
+/// The double-bond analog of `chematic_perception::stereo_validation::StereoCompleteness`
+/// for tetrahedral centers: `specified` and `unspecified` both count toward `total`
+/// equally, so a caller can ask "how many potential E/Z centers exist" independent of
+/// whether they were annotated with a `/`/`\` marker in the input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct EzCompleteness {
+    /// Stereogenic double bonds with a `/`/`\` marker that [`assign_ez`] resolves.
+    pub specified: usize,
+    /// Stereogenic double bonds with no resolvable marker.
+    pub unspecified: usize,
+    /// `specified + unspecified`.
+    pub total: usize,
+}
+
+/// Whether `alkene_end`'s two positions (other than the double-bond partner at
+/// `other_end`) are distinguishable -- i.e. this end is not a terminal `=CH2`-style
+/// end and not symmetrically disubstituted.
+///
+/// Mirrors the substituent collection [`assign_ez`]/[`highest_stereo_sub`] already use:
+/// 0 heavy substituents means both positions are implicit H (terminal, matching
+/// `assign_ez`'s own `subs.is_empty()` "terminal alkene" check); 1 heavy substituent is
+/// distinguishable from the implicit H filling the other position as long as that
+/// substituent isn't *itself* an explicit hydrogen atom (e.g. `[H]C=C[H]` from an SDF
+/// with explicit H) -- CIP ranks any other heavy atom above H, so there's no tie to
+/// check in that case; 2 heavy substituents are compared via [`compare_branches`], the
+/// same CIP machinery `highest_stereo_sub` uses to detect a genuine priority tie (e.g.
+/// two identical methyls).
+fn stereogenic_end(mol: &Molecule, other_end: AtomIdx, alkene_end: AtomIdx) -> bool {
+    let subs: Vec<AtomIdx> = mol
+        .neighbors(alkene_end)
+        .filter(|&(nb, bidx)| nb != other_end && mol.bond(bidx).order != BondOrder::Double)
+        .map(|(nb, _)| nb)
+        .collect();
+
+    match subs.len() {
+        0 => false, // terminal =CH2-style end
+        1 => mol.atom(subs[0]).element.atomic_number() != 1,
+        2 => compare_branches(mol, alkene_end, subs[0], subs[1]) != std::cmp::Ordering::Equal,
+        _ => false, // not a normal trigonal alkene carbon
+    }
+}
+
+/// Size of the smallest ring passing through `bidx`, or `None` if `bidx` is acyclic.
+///
+/// A double bond inside a small ring can't isomerize between cis/trans (the ring
+/// constrains the geometry), so it isn't E/Z-stereogenic even when its two ends are
+/// otherwise distinguishable. RDKit applies the same cutoff (`minBondRingSize < 8` is
+/// excluded, see `Code/GraphMol/Chirality.cpp`'s `isBondPotentialStereoBond`), confirmed
+/// directly against a live RDKit oracle here (`Chem.FindPotentialStereo`):
+/// cyclohexene/cycloheptene (6- and 7-membered) report no potential stereo bond,
+/// cyclooctene (8-membered) does.
+///
+/// Computed as the shortest path between the bond's two endpoints that doesn't use the
+/// bond itself, plus 1 -- deliberately *not* routed through SSSR: SSSR can return a
+/// large fundamental cycle instead of a smaller component ring in fused/bridged systems
+/// (see this crate's aromaticity handling for the same caveat), which would silently
+/// under-flag a genuinely ring-locked bond as large enough to be stereogenic. A BFS
+/// shortest cycle is immune to that decomposition choice.
+fn bond_min_ring_size(mol: &Molecule, bidx: BondIdx) -> Option<usize> {
+    let bond = mol.bond(bidx);
+    let (start, goal) = (bond.atom1, bond.atom2);
+
+    let mut dist = vec![usize::MAX; mol.atom_count()];
+    dist[start.0 as usize] = 0;
+    let mut queue: VecDeque<AtomIdx> = VecDeque::from([start]);
+    while let Some(cur) = queue.pop_front() {
+        for (nb, b) in mol.neighbors(cur) {
+            if b == bidx || dist[nb.0 as usize] != usize::MAX {
+                continue;
+            }
+            dist[nb.0 as usize] = dist[cur.0 as usize] + 1;
+            if nb == goal {
+                return Some(dist[nb.0 as usize] + 1);
+            }
+            queue.push_back(nb);
+        }
+    }
+    None
+}
+
+/// Rings below this size can't support E/Z isomerism (ring strain locks the geometry).
+/// Matches RDKit's `isBondPotentialStereoBond` cutoff -- see [`bond_min_ring_size`].
+const MIN_STEREOGENIC_RING_SIZE: usize = 8;
+
+/// Summarise how many E/Z-stereogenic double bonds in `mol` have an explicit
+/// `/`/`\` marker vs. are left unannotated.
+///
+/// A double bond is E/Z-stereogenic when it is non-aromatic (aromatic ring bonds carry
+/// `BondOrder::Aromatic`, not `BondOrder::Double`, so they're excluded by construction --
+/// the same mechanism [`assign_ez`] relies on), not constrained by a small ring (see
+/// [`bond_min_ring_size`]), and both ends have two distinguishable substituents per
+/// [`stereogenic_end`]. Non-stereogenic double bonds (terminal, symmetric on either end,
+/// or ring-locked) are not counted at all -- matching how
+/// `chematic_perception::stereo_validation::stereo_completeness` only counts atoms with
+/// 4 distinct neighbors for tetrahedral centers.
+pub fn ez_completeness(mol: &Molecule) -> EzCompleteness {
+    let mut specified = 0usize;
+    let mut unspecified = 0usize;
+
+    for j in 0..mol.bond_count() {
+        let bidx = BondIdx(j as u32);
+        let bond = mol.bond(bidx);
+        if bond.order != BondOrder::Double {
+            continue;
+        }
+        if bond_min_ring_size(mol, bidx).is_some_and(|size| size < MIN_STEREOGENIC_RING_SIZE) {
+            continue;
+        }
+        let a1 = bond.atom1;
+        let a2 = bond.atom2;
+        if !stereogenic_end(mol, a2, a1) || !stereogenic_end(mol, a1, a2) {
+            continue;
+        }
+
+        if assign_ez(mol, bidx).is_some() {
+            specified += 1;
+        } else {
+            unspecified += 1;
+        }
+    }
+
+    EzCompleteness {
+        specified,
+        unspecified,
+        total: specified + unspecified,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1750,5 +1884,163 @@ mod tests {
             "expected an R/S assignment: {:?}",
             result.assignments
         );
+    }
+
+    // --- ez_completeness ---
+
+    #[test]
+    fn test_ez_completeness_specified() {
+        // C/C=C/C — trans-2-butene: one stereogenic bond, fully marked.
+        let mol = parse("C/C=C/C").unwrap();
+        let ec = ez_completeness(&mol);
+        assert_eq!(ec.specified, 1);
+        assert_eq!(ec.unspecified, 0);
+        assert_eq!(ec.total, 1);
+    }
+
+    #[test]
+    fn test_ez_completeness_unspecified() {
+        // CC=CC — same connectivity as above, no `/`/`\` marker: still
+        // stereogenic (one heavy substituent + implicit H on each end,
+        // always distinguishable), just not annotated.
+        let mol = parse("CC=CC").unwrap();
+        let ec = ez_completeness(&mol);
+        assert_eq!(ec.specified, 0);
+        assert_eq!(ec.unspecified, 1);
+        assert_eq!(ec.total, 1);
+    }
+
+    #[test]
+    fn test_ez_completeness_terminal_not_counted() {
+        // C=C — ethylene: both ends are =CH2 (0 heavy substituents each
+        // side), not stereogenic at all.
+        let mol = parse("C=C").unwrap();
+        let ec = ez_completeness(&mol);
+        assert_eq!(ec.specified, 0);
+        assert_eq!(ec.unspecified, 0);
+        assert_eq!(ec.total, 0);
+    }
+
+    #[test]
+    fn test_ez_completeness_symmetric_end_not_counted() {
+        // CC(C)=CC — the =C end bonded to two methyls is a genuine CIP tie
+        // (confirmed directly via compare_branches below), so the whole
+        // bond is not stereogenic even though the other end (=CC, one
+        // heavy substituent + implicit H) would be on its own.
+        let mol = parse("CC(C)=CC").unwrap();
+        let methyl_a = AtomIdx(0);
+        let methyl_b = AtomIdx(2);
+        let alkene_c = AtomIdx(1);
+        assert_eq!(
+            compare_branches(&mol, alkene_c, methyl_a, methyl_b),
+            std::cmp::Ordering::Equal,
+            "the two methyls must be a genuine CIP tie for this test to be valid"
+        );
+
+        let ec = ez_completeness(&mol);
+        assert_eq!(ec.specified, 0);
+        assert_eq!(ec.unspecified, 0);
+        assert_eq!(ec.total, 0);
+    }
+
+    #[test]
+    fn test_ez_completeness_aromatic_ring_excluded() {
+        // Benzene's ring bonds are BondOrder::Aromatic, not Double -- no
+        // contribution to any count.
+        let mol = parse("c1ccccc1").unwrap();
+        let ec = ez_completeness(&mol);
+        assert_eq!(ec.total, 0);
+    }
+
+    #[test]
+    fn test_ez_completeness_kekule_benzene_ring_locked_excluded() {
+        // C1=CC=CC=C1 -- Kekulized benzene with no aromaticity perception
+        // applied, so every ring bond really is BondOrder::Double (not
+        // Aromatic). Each ring atom still only has 1 heavy substituent per
+        // end (the rest of the ring), so the pure substituent-count check
+        // alone would call these stereogenic -- the small-ring lock (< 8
+        // atoms, RDKit-confirmed) must exclude them anyway.
+        let mol = parse("C1=CC=CC=C1").unwrap();
+        let ec = ez_completeness(&mol);
+        assert_eq!(ec.total, 0, "{ec:?}");
+    }
+
+    #[test]
+    fn test_ez_completeness_small_ring_double_bond_excluded() {
+        // Cyclohexene: a single ring double bond, otherwise satisfies the
+        // substituent-distinguishability check, but a 6-membered ring can't
+        // isomerize -- RDKit's FindPotentialStereo agrees (empty result).
+        let mol = parse("C1=CCCCC1").unwrap();
+        let ec = ez_completeness(&mol);
+        assert_eq!(ec.total, 0, "{ec:?}");
+    }
+
+    #[test]
+    fn test_ez_completeness_large_ring_double_bond_counted() {
+        // Cyclooctene: an 8-membered ring double bond IS large enough for
+        // E/Z isomerism (cis/trans-cyclooctene are both known, isolable
+        // compounds) -- RDKit's FindPotentialStereo reports it as a
+        // potential (unspecified) stereo bond. This is the positive
+        // control for the ring-size cutoff above: it must not become a
+        // blanket "any ring bond is excluded" bug.
+        let mol = parse("C1=CCCCCCC1").unwrap();
+        let ec = ez_completeness(&mol);
+        assert_eq!(ec.specified, 0, "{ec:?}");
+        assert_eq!(ec.unspecified, 1, "{ec:?}");
+        assert_eq!(ec.total, 1, "{ec:?}");
+    }
+
+    #[test]
+    fn test_ez_completeness_bridged_bicyclic_ring_lock_not_sssr_dependent() {
+        // Norbornene (bicyclo[2.2.1]hept-2-ene): the double bond sits in a
+        // real 5-membered ring, but this bridged system's SSSR can also
+        // report a larger fundamental cycle through the same bond depending
+        // on decomposition choice (the same envelope-ring artifact
+        // documented for aromaticity/ring-count elsewhere in this crate).
+        // A min-ring-size check naively routed through `find_sssr` risks
+        // missing the true 5-ring and passing the >= 8 gate. RDKit
+        // (MinBondRingSize=5, FindPotentialStereo -- empty) confirms this
+        // bond is ring-locked and must NOT be counted.
+        let mol = parse("C1=CC2CCC1C2").unwrap();
+        let ec = ez_completeness(&mol);
+        assert_eq!(ec.total, 0, "{ec:?}");
+    }
+
+    #[test]
+    fn test_ez_completeness_partial_marker_is_unspecified() {
+        // C/C=CC -- a marker on only one side of the double bond. The bond
+        // is still structurally stereogenic (1 heavy substituent + implicit
+        // H on each end, distinguishable), but assign_ez has nothing on the
+        // far end to resolve a code from, so it must land in `unspecified`,
+        // not silently drop out of the count or count as `specified`.
+        let mol = parse("C/C=CC").unwrap();
+        let bidx = (0..mol.bond_count())
+            .map(|i| BondIdx(i as u32))
+            .find(|&b| mol.bond(b).order == BondOrder::Double)
+            .unwrap();
+        assert_eq!(
+            assign_ez(&mol, bidx),
+            None,
+            "a one-sided marker must not resolve a code"
+        );
+
+        let ec = ez_completeness(&mol);
+        assert_eq!(ec.specified, 0, "{ec:?}");
+        assert_eq!(ec.unspecified, 1, "{ec:?}");
+        assert_eq!(ec.total, 1, "{ec:?}");
+    }
+
+    #[test]
+    fn test_ez_completeness_aggregates_mixed_specified_and_unspecified() {
+        // C/C=C/CC=CC — first double bond (atoms 1=2) is fully marked
+        // (same local Up/Up pattern as trans-2-butene, shifted down the
+        // chain); second double bond (atoms 4=5) has no marker on either
+        // side but is still stereogenic (one heavy substituent + implicit
+        // H per end).
+        let mol = parse("C/C=C/CC=CC").unwrap();
+        let ec = ez_completeness(&mol);
+        assert_eq!(ec.specified, 1, "{ec:?}");
+        assert_eq!(ec.unspecified, 1, "{ec:?}");
+        assert_eq!(ec.total, 2, "{ec:?}");
     }
 }

--- a/crates/chematic-chem/src/lib.rs
+++ b/crates/chematic-chem/src/lib.rs
@@ -47,8 +47,8 @@ pub mod workflow;
 pub mod xlogp3;
 
 pub use cip::{
-    CipAssignment, CipMode, CipModeAssignment, CipModeError, CipUnresolvedReason, assign_cip,
-    assign_cip_with_mode, tetrahedral_stereo_neighbors,
+    CipAssignment, CipMode, CipModeAssignment, CipModeError, CipUnresolvedReason, EzCompleteness,
+    assign_cip, assign_cip_with_mode, ez_completeness, tetrahedral_stereo_neighbors,
 };
 pub use descriptors::{
     Bcut2D, CarbonTypes, InformationContent, RingBundle, aromatic_ring_count, autocorr_2d,


### PR DESCRIPTION
## Summary

Adds `chematic_chem::cip::ez_completeness(&Molecule) -> EzCompleteness` — the E/Z double-bond analog of `chematic_perception::stereo_validation::stereo_completeness` for tetrahedral centers.

Fixes #264

```rust
pub struct EzCompleteness {
    pub specified: usize,
    pub unspecified: usize,
    pub total: usize, // specified + unspecified
}
pub fn ez_completeness(mol: &Molecule) -> EzCompleteness
```

Re-exported from the crate root (`chematic_chem::EzCompleteness` / `ez_completeness`).

## Specified vs. unspecified vs. not-stereogenic-at-all

For every `BondOrder::Double` bond (aromatic ring bonds carry `BondOrder::Aromatic`, not `Double`, so they're excluded by construction — the same mechanism the existing `assign_ez` already relies on):

- **Stereogenic** iff both ends have two distinguishable substituent positions (`stereogenic_end`, mirroring the substituent collection `assign_ez`/`highest_stereo_sub` already use): 0 heavy substituents = terminal `=CH2`-style end (excluded); 1 heavy substituent is distinguishable from the implicit H filling the other slot, unless that lone substituent is itself an explicit H atom; 2 heavy substituents are compared via the existing `compare_branches` CIP machinery (ties, e.g. two identical methyls, are excluded).
- A double bond is also excluded if it sits in a ring smaller than 8 atoms — such rings can't isomerize between cis/trans (geometry is locked). This matches RDKit's own cutoff (`isBondPotentialStereoBond`, `Code/GraphMol/Chirality.cpp`: `minBondRingSize < 8` is excluded), confirmed directly against a live RDKit oracle (`Chem.FindPotentialStereo`): cyclohexene/cycloheptene (6-/7-membered) report no potential stereo bond, cyclooctene (8-membered) does. Ring size is computed via BFS shortest-cycle-through-the-bond rather than SSSR, since SSSR can return a large fundamental/envelope cycle instead of the true small ring in fused or bridged systems (documented elsewhere in this crate for aromaticity/ring-count) — a norbornene regression test pins this.
- Among stereogenic bonds: **specified** if `assign_ez` resolves a code (a `/`/`\` marker that fully determines the geometry); **unspecified** otherwise (no marker, or a marker on only one side that doesn't resolve). Both count equally toward `total`, mirroring `stereo_completeness`'s symmetric treatment of tetrahedral centers — the point is to answer "how many potential E/Z centers exist," independent of annotation.
- Non-stereogenic double bonds (terminal, symmetric on either end, or ring-locked) are not counted at all.

## Tests

All in `crates/chematic-chem/src/cip.rs`:
- `C/C=C/C` (trans-2-butene) → 1 specified, 0 unspecified, 1 total
- `CC=CC` (same connectivity, no marker) → 0 specified, 1 unspecified, 1 total
- `C=C` (ethylene, terminal) and `CC(C)=CC` (genuine CIP tie on one end, verified via `compare_branches` directly) → 0 total
- `c1ccccc1` (aromatic benzene) and `C1=CC=CC=C1` (Kekulized benzene, still ring-locked even though every bond really is `BondOrder::Double`) → 0 total
- `C1=CCCCC1` (cyclohexene, 6-ring) → 0 total; `C1=CCCCCCC1` (cyclooctene, 8-ring) → 1 unspecified (positive control, so the ring-size gate isn't a blanket "any ring bond excluded" bug)
- `C1=CC2CCC1C2` (norbornene, bridged bicyclic) → 0 total — regression test for the SSSR-envelope-ring failure mode the BFS ring-size check was written to avoid
- `C/C=CC` (marker on only one side) → 0 specified, 1 unspecified, 1 total, with a direct `assign_ez(...) == None` check
- `C/C=C/CC=CC` (mixed specified + unspecified in one molecule) → 1 specified, 1 unspecified, 2 total, for aggregation

All ring-size and RDKit-cutoff claims were spot-checked against a live RDKit oracle (`Chem.FindPotentialStereo`, `MinBondRingSize`) before writing the corresponding test, not assumed.

## Verification

`bash scripts/check.sh` run to completion locally (isolated `CARGO_TARGET_DIR` to avoid contending with a concurrent build in the same worktree): fmt clean, clippy clean workspace-wide, all lib + integration tests green, `cargo deny` clean, publish graph OK, version consistent. Full log ends with `All checks passed.`

Not merging — leaving open for review per repo convention.