### PR TITLE
fix(chem): make detect_atropisomers notation-invariant, add real ortho check

### DIFF
--- a/crates/chematic-chem/src/atropisomer.rs
+++ b/crates/chematic-chem/src/atropisomer.rs
@@ -3,7 +3,8 @@
 //! Detects rotationally constrained bonds (biaryl, allene) and assigns
 //! M/P stereochemistry based on CIP rules adapted for axial centers.
 
-use chematic_core::{BondIdx, BondOrder, Molecule};
+use chematic_core::{AtomIdx, BondIdx, BondOrder, Molecule};
+use chematic_perception::find_sssr;
 
 /// Type of atropisomeric bond/center.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -16,31 +17,92 @@ pub enum AtropisomerType {
     Constrained,
 }
 
+/// Given an SSSR ring (ordered atom cycle) and one of its members, return the
+/// two atoms adjacent to it *within that ring* (its ortho positions relative
+/// to `atom`'s exocyclic bond).
+fn ring_ortho_atoms(ring: &[AtomIdx], atom: AtomIdx) -> Option<(AtomIdx, AtomIdx)> {
+    let idx = ring.iter().position(|&a| a == atom)?;
+    let n = ring.len();
+    Some((ring[(idx + n - 1) % n], ring[(idx + 1) % n]))
+}
+
 /// Detect atropisomeric (rotationally constrained) bonds in a molecule.
 ///
 /// Returns list of bond indices and their atropisomer type.
 /// Detects: biaryl systems with ortho substitution, allenes, and other constrained bonds.
+///
+/// ## Scope / simplifications
+///
+/// Biaryl detection uses an intentionally simplified heuristic, not full
+/// IUPAC-grade atropisomer chemistry (e.g. Cahn's "3 of 4 ortho substituents"
+/// bulk-threshold rule, or a real steric-bulk/A-value model): a bond is
+/// flagged as `AtropisomerType::Biaryl` when it connects two aromatic carbons
+/// in two *different* SSSR rings (i.e. a genuine inter-ring connector, not a
+/// fused-ring shared edge) and **at least one** ring atom adjacent to each
+/// ipso carbon (an "ortho position") has degree > 2 (i.e. carries some
+/// non-H substituent) on **both** rings. This does not weigh substituent
+/// size/bulk, doesn't require *both* ortho positions per ring, and doesn't
+/// model 5-membered heteroaryl axes. It is structural (SSSR-based) rather
+/// than `BondOrder`-based, so it is invariant to whether the SMILES wrote an
+/// explicit `-` between the rings or left the bond implicit.
+///
+/// Two further known imprecisions of the "degree > 2" ortho test: a
+/// ring-fusion atom (e.g. the shared carbon of a 1-arylnaphthalene's fused
+/// ring) has degree 3 from its own ring bonds alone and reads as
+/// "substituted" even with no exocyclic group there — arguably reasonable
+/// (a fused ring is real steric bulk too) but not distinguished from an
+/// actual substituent. And for biaryls where one ring is itself part of a
+/// fused polycyclic system, which SSSR cycle the ortho lookup walks can be
+/// affected by the same envelope-ring/fundamental-cycle SSSR decomposition
+/// artifacts documented on [`chematic_perception::count_aromatic_rings`];
+/// this function does not apply that correction.
 pub fn detect_atropisomers(mol: &Molecule) -> Vec<(BondIdx, AtropisomerType)> {
     let mut result = Vec::new();
+    let rings = find_sssr(mol);
+    let rings = rings.rings();
 
     for (bidx, bond) in mol.bonds() {
         let a1 = mol.atom(bond.atom1);
         let a2 = mol.atom(bond.atom2);
 
-        // Check for biaryl: both aromatic C, C-C single bond
+        // Check for biaryl: both aromatic C, each in its own aromatic SSSR
+        // ring, connected by a genuine inter-ring bond (no shared ring).
+        // Deliberately independent of `bond.order`: whether the SMILES wrote
+        // an explicit single bond or left it implicit must not change the
+        // answer for the same real molecule (issue #262).
         if a1.aromatic
             && a2.aromatic
             && a1.element.atomic_number() == 6
             && a2.element.atomic_number() == 6
-            && bond.order == BondOrder::Single
         {
-            // Check if has ortho substituents (neighbor atoms with degree > 1)
-            let a1_degree = mol.neighbors(bond.atom1).count();
-            let a2_degree = mol.neighbors(bond.atom2).count();
+            let ring1 = rings
+                .iter()
+                .find(|r| r.contains(&bond.atom1) && r.iter().all(|&a| mol.atom(a).aromatic));
+            let ring2 = rings
+                .iter()
+                .find(|r| r.contains(&bond.atom2) && r.iter().all(|&a| mol.atom(a).aromatic));
 
-            // Rotational constraint typically requires bulky ortho groups
-            if a1_degree >= 3 && a2_degree >= 3 {
-                result.push((bidx, AtropisomerType::Biaryl));
+            let shares_ring = rings
+                .iter()
+                .any(|r| r.contains(&bond.atom1) && r.contains(&bond.atom2));
+
+            if let (Some(ring1), Some(ring2)) = (ring1, ring2)
+                && !shares_ring
+            {
+                // Ortho check: at least one ring-adjacent neighbor of each
+                // ipso carbon must carry a non-ring substituent (degree > 2).
+                let ring1_ortho_substituted =
+                    ring_ortho_atoms(ring1, bond.atom1).is_some_and(|(p, n)| {
+                        mol.neighbors(p).count() > 2 || mol.neighbors(n).count() > 2
+                    });
+                let ring2_ortho_substituted =
+                    ring_ortho_atoms(ring2, bond.atom2).is_some_and(|(p, n)| {
+                        mol.neighbors(p).count() > 2 || mol.neighbors(n).count() > 2
+                    });
+
+                if ring1_ortho_substituted && ring2_ortho_substituted {
+                    result.push((bidx, AtropisomerType::Biaryl));
+                }
             }
         }
 
@@ -141,13 +203,130 @@ mod tests {
 
     #[test]
     fn detect_atropisomers_biaryl() {
-        // Biaryl: biphenyl has no ortho substituents, so no atropisomer detected
+        // Unsubstituted biphenyl has no ortho substituents on either ring,
+        // so it must not be flagged as an atropisomer (implicit inter-ring
+        // bond notation).
         let m = mol("c1ccccc1c2ccccc2");
         let atrops = detect_atropisomers(&m);
-        // Function should not panic and return results
         assert!(
             atrops.is_empty(),
             "biphenyl without ortho subs should have no atropisomers"
+        );
+    }
+
+    #[test]
+    fn detect_atropisomers_biphenyl_notation_invariant() {
+        // issue #262 bug 1: the same real molecule (biphenyl) must return the
+        // same result regardless of whether the SMILES spells the inter-ring
+        // bond explicitly (`-`) or leaves it implicit.
+        let explicit = mol("c1ccccc1-c2ccccc2");
+        let implicit = mol("c1ccccc1c2ccccc2");
+        assert_eq!(
+            detect_atropisomers(&explicit).len(),
+            detect_atropisomers(&implicit).len(),
+            "biphenyl must give the same result under both notations"
+        );
+        assert!(detect_atropisomers(&explicit).is_empty());
+        assert!(detect_atropisomers(&implicit).is_empty());
+    }
+
+    #[test]
+    fn detect_atropisomers_ortho_dimethylbiphenyl() {
+        // 2,2'-dimethylbiphenyl: bulky methyl at the ortho position on both
+        // rings -> genuine atropisomer.
+        let m = mol("Cc1ccccc1-c1ccccc1C");
+        let atrops = detect_atropisomers(&m);
+        assert_eq!(
+            atrops.len(),
+            1,
+            "2,2'-dimethylbiphenyl should have exactly 1 atropisomeric bond"
+        );
+        assert_eq!(atrops[0].1, AtropisomerType::Biaryl);
+    }
+
+    #[test]
+    fn detect_atropisomers_ortho_dimethylbiphenyl_notation_invariant() {
+        // Same as the biphenyl notation-invariance test above, but on a
+        // *positive* case: an empty-vs-empty match alone can't distinguish
+        // "notation-invariant" from "the biaryl branch never fires" (which
+        // was exactly how the old `detect_atropisomers_biaryl` test passed
+        // for the wrong reason, see issue #262). This asserts the same
+        // nonzero result under both notations.
+        let explicit = mol("Cc1ccccc1-c2ccccc2C");
+        let implicit = mol("Cc1ccccc1c2ccccc2C");
+        assert_eq!(
+            detect_atropisomers(&explicit).len(),
+            detect_atropisomers(&implicit).len(),
+            "2,2'-dimethylbiphenyl must give the same result under both notations"
+        );
+        assert_eq!(detect_atropisomers(&explicit).len(), 1);
+        assert_eq!(detect_atropisomers(&implicit).len(), 1);
+    }
+
+    #[test]
+    fn detect_atropisomers_para_dimethylbiphenyl_not_flagged() {
+        // issue #262 bug 2: 4,4'-dimethylbiphenyl has substituents at the
+        // *para* position, not ortho -> no rotational hindrance, must not be
+        // flagged.
+        let m = mol("Cc1ccc(cc1)-c1ccc(C)cc1");
+        let atrops = detect_atropisomers(&m);
+        assert!(
+            atrops.is_empty(),
+            "4,4'-dimethylbiphenyl (para-substituted) should have no atropisomers"
+        );
+    }
+
+    #[test]
+    fn detect_atropisomers_naphthalene_fusion_bond_not_biaryl() {
+        // Regression/robustness check on a real fused polycyclic aromatic:
+        // both bridgehead atoms of naphthalene have degree 3 (like any
+        // biaryl ipso carbon), so the old `a1_degree >= 3 && a2_degree >= 3`
+        // heuristic was one `bond.order` accident away from misclassifying
+        // a ring-fusion bond as a biaryl axis. It happened not to fire here
+        // because `apply_aromaticity()` (verified below) assigns
+        // `BondOrder::Aromatic` to ring bonds, which the old code's
+        // `bond.order == BondOrder::Single` gate excluded — but that made
+        // the old code's correctness on fused systems an accident of
+        // bond-order bookkeeping, not a real check. The new SSSR-based
+        // `shares_ring` exclusion is not order-dependent and rejects this
+        // bond on structural grounds: naphthalene's two SSSR rings both
+        // contain the bridgehead pair, so the fusion bond is correctly
+        // recognized as a shared/fused-ring edge, not a genuine inter-ring
+        // connector, regardless of what bond order it carries.
+        let m = mol("C1=CC2=CC=CC=C2C=C1");
+        let m = chematic_perception::apply_aromaticity(&m);
+
+        // Pin down the premise this test claims to exercise, rather than
+        // asserting only the end result (which could pass for unrelated
+        // reasons, e.g. apply_aromaticity not flagging anything aromatic).
+        assert!(
+            m.atoms().all(|(_, a)| a.aromatic),
+            "apply_aromaticity must flag every naphthalene atom aromatic, else this test is vacuous"
+        );
+        let bridgeheads: Vec<_> = m
+            .atoms()
+            .filter(|(idx, _)| m.neighbors(*idx).count() == 3)
+            .map(|(idx, _)| idx)
+            .collect();
+        assert_eq!(
+            bridgeheads.len(),
+            2,
+            "naphthalene should have exactly 2 degree-3 bridgehead atoms"
+        );
+        let (_, fusion_bond) = m
+            .bond_between(bridgeheads[0], bridgeheads[1])
+            .expect("bridgeheads must be directly bonded (the fusion bond)");
+        assert_eq!(
+            fusion_bond.order,
+            BondOrder::Aromatic,
+            "apply_aromaticity is expected to assign BondOrder::Aromatic to ring bonds; if this \
+             changes, the comment above (and the PR description) needs updating to match"
+        );
+
+        let atrops = detect_atropisomers(&m);
+        assert!(
+            atrops.is_empty(),
+            "naphthalene's ring-fusion bond must not be flagged as a biaryl axis, got {atrops:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #262. `detect_atropisomers` had two bugs, both in the biaryl branch of `crates/chematic-chem/src/atropisomer.rs`:

1. **Notation-dependence.** The biaryl check gated on `bond.order == BondOrder::Single`. An inter-ring bond between two aromatic rings parses to `BondOrder::Single` when the SMILES writes it explicitly (`c1ccccc1-c2ccccc2`) but to `BondOrder::Aromatic` when left implicit (`c1ccccc1c2ccccc2`, see `crates/chematic-smiles/src/parser.rs:858`) — so the exact same real molecule got different answers depending on notation.
2. **No real ortho check.** The heuristic was `mol.neighbors(atom1).count() >= 3 && mol.neighbors(atom2).count() >= 3`. Every biaryl ipso carbon already has degree 3 in *any* substitution pattern (2 ring bonds + 1 inter-ring bond), so this fired on para/meta-substituted biaryls identically to ortho-substituted ones — it checked the ipso atom's own degree, not ortho-position occupancy.

## Fix

- Biaryl detection is now structural, based on `chematic_perception::find_sssr` instead of `bond.order`: a bond qualifies when both endpoints are aromatic carbons that each belong to their own SSSR ring, and the two rings share no common SSSR ring (i.e. it's a genuine inter-ring connector, not a fused-ring shared edge). This is invariant to explicit-vs-implicit bond notation. It's also more robust on fused polycyclic aromatics on structural grounds rather than by bond-order accident: naphthalene's ring-fusion bond connects two degree-3 bridgeheads (the same shape the old degree check looked for), and the old code's correctness there depended entirely on `apply_aromaticity` happening to assign `BondOrder::Aromatic` (not `Single`) to that bond, which is what the old `bond.order == BondOrder::Single` gate was filtering on — not a real "is this actually a biaryl axis" check. The new `shares_ring` exclusion rejects it because both bridgeheads sit in both of naphthalene's SSSR rings, regardless of bond order (verified in the new `detect_atropisomers_naphthalene_fusion_bond_not_biaryl` test, which pins down both the aromatic-flag premise and the actual bond order rather than asserting only the empty result).
- Added a real ortho-substituent check: for each ipso carbon, look up its two ring-adjacent neighbors within its own SSSR ring (the ortho positions) and require at least one of them to have degree > 2 (i.e. carry a non-H substituent) — on **both** rings.

## Scope

This is an intentionally simplified heuristic ("at least one substituent per ring at an ortho position"), not full IUPAC-grade atropisomer chemistry (Cahn's "3 of 4 ortho positions" bulk-threshold rule, or an actual steric-bulk/A-value model). Documented as such in a new doc-comment section on `detect_atropisomers`.

Out of scope for this PR: `assign_atropisomer_chirality` still separately gates wedge assignment on `bond.order == BondOrder::Single`, so a newly-flagged implicit-notation atropisomeric bond won't get a wedge from that function yet — same-shaped issue, but it's a different function than the one #262 reports, so left alone here.

## Tests

Added to `crates/chematic-chem/src/atropisomer.rs`'s existing test module:
- `detect_atropisomers_biphenyl_notation_invariant` — `c1ccccc1-c2ccccc2` and `c1ccccc1c2ccccc2` now agree (both empty).
- `detect_atropisomers_ortho_dimethylbiphenyl` — `Cc1ccccc1-c1ccccc1C` (2,2'-dimethylbiphenyl) → 1 atropisomeric bond.
- `detect_atropisomers_ortho_dimethylbiphenyl_notation_invariant` — same explicit/implicit notation pair as the biphenyl test, but on the *positive* (nonzero) result, since empty-vs-empty alone can't distinguish "notation-invariant" from "the biaryl branch never fires" (which is exactly how the old `detect_atropisomers_biaryl` test passed for the wrong reason).
- `detect_atropisomers_para_dimethylbiphenyl_not_flagged` — `Cc1ccc(cc1)-c1ccc(C)cc1` (4,4'-dimethylbiphenyl) → 0 atropisomeric bonds (this was the issue's reported false positive: returned 1 before the fix).
- `detect_atropisomers_naphthalene_fusion_bond_not_biaryl` — Kekulized naphthalene post-`apply_aromaticity` → 0 atropisomeric bonds. Both bridgeheads are degree-3 aromatic carbons (the same shape the old degree check looked for), so this is a real guard on the new `shares_ring` exclusion, not a decorative test: the test pins down that `apply_aromaticity` flags all atoms aromatic and that the fusion bond comes back `BondOrder::Aromatic` (not `Single`), then asserts the empty result.

Also fixed the existing `detect_atropisomers_biaryl` test's comment, which described testing "no ortho substituents" but was actually passing due to bug 1 (implicit-notation biphenyl never reached the `BondOrder::Single` gate at all).

## Test plan

- [x] `cargo test -p chematic-chem --lib atropisomer` — 9/9 pass
- [x] `bash scripts/check.sh` — "All checks passed." (fmt, clippy `-D warnings`, full workspace lib+integration tests, `cargo deny`, publish graph, version consistency)
