### PR TITLE
feat(smiles): expose topological_equivalence_classes

### DIFF
--- a/crates/chematic-smiles/src/canonical_partition.rs
+++ b/crates/chematic-smiles/src/canonical_partition.rs
@@ -547,7 +547,12 @@ pub(crate) fn exact_refine(graph: &CanonicalColoredGraph, mut partition: Partiti
 ///   difluoroethene, real mirror symmetry across the two `=CF` ends) came
 ///   back as 4 singleton classes before this collapse was added, 2 merged
 ///   pairs after (see `ez_bond_direction_marker_alone_does_not_split_the_class`
-///   below).
+///   below). Note `edge_color` only ever reads `bond.order` -- the
+///   separately-stashed `Molecule::bond_direction` (`bond_has_direction_info`'s
+///   doc comment: used for a ring bond next to an exocyclic stereo double
+///   bond) is not part of `EdgeColor` in either mode, so there is nothing
+///   to exclude there today; if a future change ever folds it in, it needs
+///   the same `canonical_fidelity` gate.
 ///
 /// `CanonicalColoredGraph::new_topological` therefore omits all four,
 /// using the *effective* H count (`implicit_hcount`, matching

--- a/crates/chematic-smiles/src/canonical_partition.rs
+++ b/crates/chematic-smiles/src/canonical_partition.rs
@@ -240,6 +240,17 @@ fn vertex_color(
 pub(crate) struct CanonicalColoredGraph<'a> {
     mol: &'a Molecule,
     vcolor: Vec<VertexColor>,
+    /// See `new`/`new_topological`. Also gates `edge_color`: an `Up`/`Down`
+    /// bond order is itself an E/Z *direction* marker on what is
+    /// chemically a single bond (`bond_has_direction_info`'s doc comment),
+    /// so it is exactly as canonicalization-only as the vertex-side stereo
+    /// devices `vertex_color` documents -- omitted here for the same
+    /// reason. Caught empirically, not by inspection alone: an earlier
+    /// version of this PR left `edge_color` reading raw `Up`/`Down`
+    /// unconditionally, and `F/C=C\F` (cis-1,2-difluoroethene, a real
+    /// mirror-symmetric molecule -- swap the two `=CF` ends) came back as
+    /// 4 distinct singleton classes instead of the correct 2 merged pairs.
+    canonical_fidelity: bool,
 }
 
 impl<'a> CanonicalColoredGraph<'a> {
@@ -253,15 +264,17 @@ impl<'a> CanonicalColoredGraph<'a> {
     }
 
     /// Coloring for [`crate::topological_equivalence_classes`]: identical to
-    /// `new` except every canonicalization-only device `vertex_color`
-    /// documents is turned off (see `topological_equivalence_classes`'s doc
-    /// comment for the full reasoning -- the short version: `new`'s stereo
-    /// and raw-H-spelling handling exist to make canonical-SMILES
-    /// tie-breaking conservative/safe, a different goal from reporting real
-    /// topological symmetry; applying either here would wrongly split
-    /// atoms that a real symmetry query must merge -- a meso compound's two
-    /// mirror-equivalent stereocenters via stereo, or `[Cl]` vs `Cl` via raw
-    /// H-spelling).
+    /// `new` except every canonicalization-only device `vertex_color` (and
+    /// this struct's own `edge_color`) documents is turned off (see
+    /// `topological_equivalence_classes`'s doc comment for the full
+    /// reasoning -- the short version: `new`'s stereo and raw-H-spelling
+    /// handling exist to make canonical-SMILES tie-breaking
+    /// conservative/safe, a different goal from reporting real topological
+    /// symmetry; applying any of them here would wrongly split atoms that a
+    /// real symmetry query must merge -- a meso compound's two
+    /// mirror-equivalent stereocenters via stereo, `[Cl]` vs `Cl` via raw
+    /// H-spelling, or a cis-alkene's two mirror-equivalent ends via
+    /// `Up`/`Down` bond-direction markers).
     pub(crate) fn new_topological(mol: &'a Molecule) -> Self {
         Self::build(mol, false)
     }
@@ -278,7 +291,11 @@ impl<'a> CanonicalColoredGraph<'a> {
                 vertex_color(mol, idx, sensitive.contains(&idx), canonical_fidelity)
             })
             .collect();
-        Self { mol, vcolor }
+        Self {
+            mol,
+            vcolor,
+            canonical_fidelity,
+        }
     }
 
     pub(crate) fn mol(&self) -> &'a Molecule {
@@ -296,8 +313,17 @@ impl<'a> CanonicalColoredGraph<'a> {
     pub(crate) fn edge_color(&self, from: AtomIdx, bidx: BondIdx) -> EdgeColor {
         let bond = self.mol.bond(bidx);
         let from_is_donor = bond.order == BondOrder::Dative && bond.atom1 == from;
+        // `Up`/`Down` are E/Z direction markers on an otherwise-single
+        // bond; in topological mode they collapse to plain `Single`, same
+        // as every other stereo device this struct excludes there.
+        let order =
+            if !self.canonical_fidelity && matches!(bond.order, BondOrder::Up | BondOrder::Down) {
+                BondOrder::Single
+            } else {
+                bond.order
+            };
         EdgeColor {
-            order_class: order_class(bond.order),
+            order_class: order_class(order),
             from_is_donor,
         }
     }
@@ -476,8 +502,8 @@ pub(crate) fn exact_refine(graph: &CanonicalColoredGraph, mut partition: Partiti
 /// (`CanonicalColoredGraph::new`, used by canonical-SMILES generation) folds
 /// in devices that exist purely to make canonical-SMILES search pruning
 /// *safe*, not to describe real molecular symmetry -- see `vertex_color`'s
-/// doc comment for the full list. Three matter most:
-/// - **Stereo**: `new`'s coloring reads an atom's raw `@`/`@@` parity tag
+/// doc comment for the full list. Four matter most:
+/// - **Stereo (atom parity)**: `new`'s coloring reads an atom's raw `@`/`@@` parity tag
 ///   and pins every stereo-bearing atom (and its direct neighbors) globally
 ///   unique via `stereo_unique`, because verifying that a candidate mapping
 ///   *actually* preserves tetrahedral/E-Z parity (which depends on neighbor
@@ -512,13 +538,24 @@ pub(crate) fn exact_refine(graph: &CanonicalColoredGraph, mut partition: Partiti
 ///   canonicalization-fidelity coloring (map numbers must round-trip
 ///   through the writer) but the same class here (see
 ///   `atom_map_number_alone_does_not_split_the_class` below).
+/// - **Stereo (bond direction)**: `new`'s `edge_color` reads an `Up`/`Down`
+///   bond order literally -- the E/Z direction marker (`/`/`\`) on what is
+///   chemically a single bond -- as a distinct edge color from plain
+///   `Single`. Same category of device as atom parity above, same fix:
+///   `CanonicalColoredGraph::new_topological` collapses `Up`/`Down` to
+///   `Single` there. Verified empirically: `F/C=C\F` (cis-1,2-
+///   difluoroethene, real mirror symmetry across the two `=CF` ends) came
+///   back as 4 singleton classes before this collapse was added, 2 merged
+///   pairs after (see `ez_bond_direction_marker_alone_does_not_split_the_class`
+///   below).
 ///
-/// `CanonicalColoredGraph::new_topological` therefore omits all three,
+/// `CanonicalColoredGraph::new_topological` therefore omits all four,
 /// using the *effective* H count (`implicit_hcount`, matching
 /// `crate::canonical::initial_invariant`'s post-#205 choice), no atom-map
-/// signal, and no stereo signal at all -- matching `morgan_ranks`'s own
-/// long-standing `initial_invariant`, which has never read either
-/// `atom.chirality` or `atom.atom_map`.
+/// signal, and no stereo signal (atom parity or bond direction) at all --
+/// matching `morgan_ranks`'s own long-standing `initial_invariant`, which
+/// has never read `atom.chirality` or `atom.atom_map`, and whose own
+/// `bond_order_value` collapses `Up`/`Down` to the same value as `Single`.
 pub fn topological_equivalence_classes(mol: &Molecule) -> Vec<usize> {
     let n = mol.atom_count();
     if n == 0 {
@@ -699,6 +736,29 @@ mod tests {
         assert_eq!(classes[1], classes[7], "the two carboxyl carbons");
         assert_eq!(classes[2], classes[8], "the two carbonyl (=O) oxygens");
         assert_eq!(classes[4], classes[6], "the two stereocenter hydroxyls");
+    }
+
+    #[test]
+    fn ez_bond_direction_marker_alone_does_not_split_the_class() {
+        // cis-1,2-difluoroethene: F/C=C\F. atoms: 0=F, 1=C, 2=C, 3=F. Real
+        // mirror symmetry swaps the two =CF ends (0<->3, 1<->2), even
+        // though one C-F bond is marked Up and the other Down -- an E/Z
+        // direction marker on what is chemically a single bond, exactly as
+        // canonicalization-only as tetrahedral parity. Caught empirically:
+        // an earlier version of this function read raw Up/Down through
+        // `edge_color` unconditionally and returned 4 singleton classes
+        // here instead of 2 merged pairs.
+        let mol = parse(r"F/C=C\F").unwrap();
+        let classes = topological_equivalence_classes(&mol);
+        assert_eq!(classes.len(), 4);
+        assert_eq!(
+            classes[0], classes[3],
+            "the two mirror-equivalent F: {classes:?}"
+        );
+        assert_eq!(
+            classes[1], classes[2],
+            "the two mirror-equivalent C: {classes:?}"
+        );
     }
 
     #[test]

--- a/crates/chematic-smiles/src/canonical_partition.rs
+++ b/crates/chematic-smiles/src/canonical_partition.rs
@@ -38,7 +38,7 @@
 
 use std::collections::HashSet;
 
-use chematic_core::{AtomIdx, BondIdx, BondOrder, Chirality, Molecule};
+use chematic_core::{AtomIdx, BondIdx, BondOrder, Chirality, Molecule, implicit_hcount};
 
 pub(crate) type CellId = u32;
 
@@ -168,9 +168,47 @@ fn stereo_sensitive_atoms(mol: &Molecule) -> HashSet<AtomIdx> {
     expanded
 }
 
-fn vertex_color(mol: &Molecule, idx: AtomIdx, force_unique: bool) -> VertexColor {
+/// `canonical_fidelity` gates every device in this function that exists
+/// only to make canonical-SMILES search pruning safe, never to describe
+/// real molecular symmetry -- see `CanonicalColoredGraph::new_topological`'s
+/// doc comment for the full reasoning. Three such devices, not one:
+/// - the raw `chirality` tag + `stereo_unique` (stereo, as before),
+/// - `h_state` reading the *raw bracket-spelled* `hydrogen_count` rather
+///   than the *effective* count (`implicit_hcount`). The raw form exists so
+///   this module's coloring matches literally everything `CanonicalWriter`
+///   can distinguish in its output (this module's own top-of-file doc);
+///   `crate::canonical::initial_invariant` already made the opposite call
+///   for the exact same reason issue #205 required it to: bracket
+///   *spelling* alone (`[Cl]` vs organic-subset `Cl`, both H=0) must never
+///   change a semantic answer. Using the raw form here for topological
+///   classes would reintroduce exactly that bug one layer up -- two
+///   spellings of one molecule getting different equivalence classes; and
+/// - `atom_map`. Reaction atom-map numbers (`[CH3:1]`) are bookkeeping a
+///   caller attached to individual atoms, not a molecular structural
+///   property -- two atoms that differ *only* by map number are still
+///   really the same topological class (`crate::canonical::
+///   initial_invariant` already agrees: it never reads `atom.atom_map`
+///   either). `CanonicalWriter` must still preserve map numbers exactly
+///   when writing, so the canonicalization-fidelity coloring keeps folding
+///   it in.
+fn vertex_color(
+    mol: &Molecule,
+    idx: AtomIdx,
+    force_unique: bool,
+    canonical_fidelity: bool,
+) -> VertexColor {
     let atom = mol.atom(idx);
     let stereo_unique = if force_unique { Some(idx.0) } else { None };
+    let h_state = if canonical_fidelity {
+        atom.hydrogen_count.map(|h| h as u16 + 1).unwrap_or(0)
+    } else {
+        implicit_hcount(mol, idx) as u16
+    };
+    let atom_map = if canonical_fidelity {
+        atom.atom_map.map(|m| m as u32 + 1).unwrap_or(0)
+    } else {
+        0
+    };
     VertexColor {
         wildcard: atom.wildcard,
         atomic_number: if atom.wildcard {
@@ -181,12 +219,16 @@ fn vertex_color(mol: &Molecule, idx: AtomIdx, force_unique: bool) -> VertexColor
         isotope: atom.isotope.map(|i| i as u32 + 1).unwrap_or(0),
         charge: atom.charge,
         aromatic: atom.aromatic,
-        h_state: atom.hydrogen_count.map(|h| h as u16 + 1).unwrap_or(0),
-        atom_map: atom.atom_map.map(|m| m as u32 + 1).unwrap_or(0),
-        chirality: match atom.chirality {
-            Chirality::None => 0,
-            Chirality::CounterClockwise => 1,
-            Chirality::Clockwise => 2,
+        h_state,
+        atom_map,
+        chirality: if canonical_fidelity {
+            match atom.chirality {
+                Chirality::None => 0,
+                Chirality::CounterClockwise => 1,
+                Chirality::Clockwise => 2,
+            }
+        } else {
+            0
         },
         stereo_unique,
     }
@@ -201,12 +243,39 @@ pub(crate) struct CanonicalColoredGraph<'a> {
 }
 
 impl<'a> CanonicalColoredGraph<'a> {
+    /// Canonical-SMILES-generation coloring: stereo-bearing atoms (and their
+    /// direct neighbors) are pinned globally unique via `stereo_unique`, and
+    /// `h_state` reads the raw bracket-spelled H count -- see
+    /// `stereo_sensitive_atoms`'s and `vertex_color`'s doc comments. This is
+    /// the *only* coloring production `canonical_search.rs` ever uses.
     pub(crate) fn new(mol: &'a Molecule) -> Self {
-        let sensitive = stereo_sensitive_atoms(mol);
+        Self::build(mol, true)
+    }
+
+    /// Coloring for [`crate::topological_equivalence_classes`]: identical to
+    /// `new` except every canonicalization-only device `vertex_color`
+    /// documents is turned off (see `topological_equivalence_classes`'s doc
+    /// comment for the full reasoning -- the short version: `new`'s stereo
+    /// and raw-H-spelling handling exist to make canonical-SMILES
+    /// tie-breaking conservative/safe, a different goal from reporting real
+    /// topological symmetry; applying either here would wrongly split
+    /// atoms that a real symmetry query must merge -- a meso compound's two
+    /// mirror-equivalent stereocenters via stereo, or `[Cl]` vs `Cl` via raw
+    /// H-spelling).
+    pub(crate) fn new_topological(mol: &'a Molecule) -> Self {
+        Self::build(mol, false)
+    }
+
+    fn build(mol: &'a Molecule, canonical_fidelity: bool) -> Self {
+        let sensitive = if canonical_fidelity {
+            stereo_sensitive_atoms(mol)
+        } else {
+            HashSet::new()
+        };
         let vcolor = (0..mol.atom_count())
             .map(|i| {
                 let idx = AtomIdx(i as u32);
-                vertex_color(mol, idx, sensitive.contains(&idx))
+                vertex_color(mol, idx, sensitive.contains(&idx), canonical_fidelity)
             })
             .collect();
         Self { mol, vcolor }
@@ -356,6 +425,120 @@ pub(crate) fn exact_refine(graph: &CanonicalColoredGraph, mut partition: Partiti
     partition
 }
 
+/// Real (hash-collision-free) topological equivalence classes for every
+/// atom of `mol`: `classes[i] == classes[j]` iff atoms `i` and `j` are
+/// indistinguishable by exact structural color refinement -- element,
+/// isotope, charge, aromaticity, effective H-count, and bond
+/// order/connectivity, propagated to a fixpoint by `exact_refine`.
+/// Deliberately excluded: stereo and reaction atom-map numbers -- see
+/// "Canonicalization-only devices" below. Class ids are gap-free ordinals
+/// with no meaning beyond "same id = same class" (mirrors `Partition`'s own
+/// `cell_of`, which this function returns almost verbatim).
+///
+/// Conceptually the same query as RDKit's `Chem.CanonicalRankAtoms(mol,
+/// breakTies=False)` restricted to constitutional (non-stereo) symmetry;
+/// this doc comment states chematic's own exclusion set explicitly rather
+/// than asserting parity with any particular RDKit parameter defaults,
+/// which this PR did not verify.
+///
+/// `crate::canonical::equivalent_atom_classes` already exposes a similarly-
+/// shaped result (also chirality-blind -- `initial_invariant` never reads
+/// `atom.chirality`); the two agree on orbit *structure* on every case this
+/// PR's test suite checked, including the meso-compound case. The
+/// difference this function is for: `equivalent_atom_classes` is built on
+/// `morgan_ranks`/`refine_ranks`, whose own `normalize_ranks` step groups by
+/// raw FNV-1a hash-value equality (see this module's top-of-file doc
+/// comment) -- a real, if practically negligible, hash-collision risk. This
+/// function is built on `exact_refine`, which never merges two cells on
+/// anything but full signature `Eq` -- the "real (hash-collision-free)"
+/// guarantee above.
+///
+/// # Known limitation: this is a sound over-approximation, not exact orbits
+///
+/// "Same class" does **not** strictly prove "provably interchangeable by a
+/// real automorphism" -- only the converse is guaranteed (different class
+/// always means provably NOT interchangeable). Like any Morgan/1-WL-style
+/// color refinement, `exact_refine` never merges two atoms that differ in
+/// any local, propagatable attribute, but on a pathological input (a
+/// WL-indistinguishable disjoint union of differently-sized regular
+/// subgraphs -- see
+/// `canonical_automorphism::tests::triangle_and_square_same_wl_cell_different_orbits`
+/// for a constructed witness) it can under-split: report two atoms in one
+/// class that a full automorphism-group search would separate. No real
+/// molecule in this crate's test corpus has ever exhibited this; it is
+/// documented, not fixed, exactly as it already is for
+/// `morgan_ranks`/`equivalent_atom_classes` (same underlying algorithm
+/// shape, same limitation, longstanding and never a reported problem).
+///
+/// # Canonicalization-only devices are deliberately excluded, not an oversight
+///
+/// This crate's other automorphism-adjacent machinery
+/// (`CanonicalColoredGraph::new`, used by canonical-SMILES generation) folds
+/// in devices that exist purely to make canonical-SMILES search pruning
+/// *safe*, not to describe real molecular symmetry -- see `vertex_color`'s
+/// doc comment for the full list. Three matter most:
+/// - **Stereo**: `new`'s coloring reads an atom's raw `@`/`@@` parity tag
+///   and pins every stereo-bearing atom (and its direct neighbors) globally
+///   unique via `stereo_unique`, because verifying that a candidate mapping
+///   *actually* preserves tetrahedral/E-Z parity (which depends on neighbor
+///   *order*, not just neighbor identity) is out of scope for that module --
+///   see `stereo_sensitive_atoms`'s doc comment. A false negative there
+///   (failing to merge two atoms a full CIP-aware analysis would prove
+///   equivalent) only costs canonical-SMILES search performance, never
+///   correctness, so it is the right conservative default *for that
+///   caller*. It is the wrong default here: this function's whole purpose
+///   is to expose *real* symmetry (e.g. for meso-compound detection, a
+///   stereocenter mapping onto another under the molecule's own internal
+///   mirror symmetry). A meso pair's raw `@`/`@@` tags legitimately
+///   *differ* -- that textual difference is exactly what the mirror
+///   relationship looks like once written down as SMILES
+///   neighbor-order-relative parity -- so folding either stereo device in
+///   here would put a meso pair in two different classes, silently
+///   downgrading this from a "topological symmetry" answer to a "canonical
+///   tie-break" answer and defeating the caller's whole reason for asking.
+/// - **H-count spelling**: `new`'s coloring reads the *raw bracket-spelled*
+///   hydrogen count, so `[Cl]` and organic-subset `Cl` (same molecule, same
+///   effective H=0, different spelling) get different colors there. That
+///   is intentional for that caller (writer-output-exact auditing) but
+///   would be exactly the issue #205 bug one layer up if reused here: two
+///   spellings of the same molecule getting different equivalence classes.
+/// - **Atom-map numbers**: reaction bookkeeping (`[CH3:1]`) a caller
+///   attached to a specific atom, not a molecular structural property. Two
+///   atoms differing *only* by map number are still the same real
+///   topological class; `crate::canonical::initial_invariant` already
+///   agrees (it never reads `atom.atom_map` either). Verified empirically,
+///   not just asserted: on `[CH3:1]c1ccc(cc1)[CH3:2]` the two chemically
+///   identical methyls get different classes under `new`'s
+///   canonicalization-fidelity coloring (map numbers must round-trip
+///   through the writer) but the same class here (see
+///   `atom_map_number_alone_does_not_split_the_class` below).
+///
+/// `CanonicalColoredGraph::new_topological` therefore omits all three,
+/// using the *effective* H count (`implicit_hcount`, matching
+/// `crate::canonical::initial_invariant`'s post-#205 choice), no atom-map
+/// signal, and no stereo signal at all -- matching `morgan_ranks`'s own
+/// long-standing `initial_invariant`, which has never read either
+/// `atom.chirality` or `atom.atom_map`.
+pub fn topological_equivalence_classes(mol: &Molecule) -> Vec<usize> {
+    let n = mol.atom_count();
+    if n == 0 {
+        return Vec::new();
+    }
+    let graph = CanonicalColoredGraph::new_topological(mol);
+    // No pre-individualization: an all-equal starting `ranks` collapses
+    // `initial_partition` to grouping by raw vertex color alone, the
+    // correct from-scratch starting point for a whole-molecule query (as
+    // opposed to `canonical_search.rs`'s use, which seeds from the current
+    // search node's already-partially-individualized `ranks`). This also
+    // sidesteps `crate::canonical::normalize_ranks`'s raw-FNV-1a-hash-value
+    // grouping entirely (see this module's own top-of-file doc comment) --
+    // `exact_refine`'s own iterations never rely on anything but real
+    // `Eq`/`Ord` signature comparison.
+    let ranks = vec![0u64; n];
+    let partition = exact_refine(&graph, initial_partition(&graph, &ranks));
+    partition.cell_of.into_iter().map(|c| c as usize).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -389,6 +572,150 @@ mod tests {
             iso_cell.len(),
             1,
             "isotope-labeled atom must be alone in its cell"
+        );
+    }
+
+    // --- topological_equivalence_classes ------------------------------
+
+    #[test]
+    fn bracket_h_spelling_does_not_split_the_class() {
+        // [cH]1ccccc1 is still just benzene: atom 0's H is spelled out
+        // explicitly in the bracket, atoms 1..5 get theirs implicitly, but
+        // the *effective* H count (1 each) is identical. issue #205's own
+        // bug shape one layer up: raw hydrogen_count bracket-spelling must
+        // never leak into a semantic answer.
+        let mol = parse("[cH]1ccccc1").unwrap();
+        let classes = topological_equivalence_classes(&mol);
+        assert_eq!(classes.len(), 6);
+        assert!(
+            classes.iter().all(|&c| c == classes[0]),
+            "bracket-spelled H must not split an otherwise-symmetric ring: {classes:?}"
+        );
+    }
+
+    #[test]
+    fn wildcard_never_collides_with_a_zero_h_real_atom() {
+        // [*]C(C)(C)C: the wildcard's *effective* H is 0 (implicit_hcount
+        // returns 0 for wildcards, per chematic-core), matching the central
+        // quaternary carbon's own effective H (0, bonded to 4 heavy atoms).
+        // Dropping the canonical branch's "+1, None->0" offset in the
+        // topological branch (this function reads plain `implicit_hcount`)
+        // must not let the two collide on `h_state` alone -- `wildcard`
+        // and `atomic_number` (forced to 0 only for wildcards, and no real
+        // element has atomic_number 0) still separate them.
+        let mol = parse("[*]C(C)(C)C").unwrap();
+        let classes = topological_equivalence_classes(&mol);
+        assert_ne!(
+            classes[0], classes[1],
+            "wildcard must never share a class with a real 0-H atom: {classes:?}"
+        );
+    }
+
+    #[test]
+    fn benzene_all_six_carbons_one_class() {
+        let mol = parse("c1ccccc1").unwrap();
+        let classes = topological_equivalence_classes(&mol);
+        assert_eq!(classes.len(), 6);
+        assert!(
+            classes.iter().all(|&c| c == classes[0]),
+            "all 6 benzene carbons must share one class, got {classes:?}"
+        );
+    }
+
+    #[test]
+    fn toluene_five_classes_ortho_and_meta_pairs_merge() {
+        // Cc1ccccc1: 0=methyl, 1=ipso (nbrs 0,2,6), 2&6=ortho, 3&5=meta,
+        // 4=para (confirmed via atom.neighbors(), not assumed).
+        let mol = parse("Cc1ccccc1").unwrap();
+        let classes = topological_equivalence_classes(&mol);
+        assert_eq!(classes.len(), 7);
+
+        // Ortho pair and meta pair each merge; everything else is a
+        // singleton class, distinct from every other singleton.
+        assert_eq!(classes[2], classes[6], "ortho carbons must be equivalent");
+        assert_eq!(classes[3], classes[5], "meta carbons must be equivalent");
+        assert_ne!(classes[0], classes[1], "methyl != ipso");
+        assert_ne!(classes[0], classes[4], "methyl != para");
+        assert_ne!(classes[1], classes[4], "ipso != para");
+        assert_ne!(classes[0], classes[2], "methyl != ortho");
+        assert_ne!(classes[1], classes[2], "ipso != ortho");
+        assert_ne!(classes[4], classes[2], "para != ortho");
+        assert_ne!(classes[0], classes[3], "methyl != meta");
+        assert_ne!(classes[1], classes[3], "ipso != meta");
+        assert_ne!(classes[4], classes[3], "para != meta");
+        assert_ne!(classes[2], classes[3], "ortho != meta");
+
+        let mut distinct: Vec<usize> = classes.clone();
+        distinct.sort_unstable();
+        distinct.dedup();
+        assert_eq!(
+            distinct.len(),
+            5,
+            "toluene: methyl, ipso, ortho-pair, meta-pair, para = 5 distinct classes, got {classes:?}"
+        );
+    }
+
+    #[test]
+    fn asymmetric_chain_every_atom_its_own_class() {
+        // F-C-C-C-C-Cl: no two atoms are topologically interchangeable
+        // (the two ends differ, so no rank-refinement plateau survives).
+        let mol = parse("FCCCCCl").unwrap();
+        let classes = topological_equivalence_classes(&mol);
+        assert_eq!(classes.len(), 6);
+        let mut distinct = classes.clone();
+        distinct.sort_unstable();
+        distinct.dedup();
+        assert_eq!(
+            distinct.len(),
+            6,
+            "no-symmetry chain: every atom must be its own class, got {classes:?}"
+        );
+    }
+
+    #[test]
+    fn meso_tartaric_acid_stereocenters_share_a_class_despite_opposite_tags() {
+        // OC(=O)[C@H](O)[C@@H](O)C(=O)O -- meso-tartaric acid. Atom map
+        // (confirmed via atom.neighbors()/chirality, not assumed):
+        //   0=O(H)  1=C(=O)  2=O(=)      3=C@H (stereocenter)  4=O(H)
+        //   5=C@@H (stereocenter)  6=O(H)  7=C(=O)  8=O(=)  9=O(H)
+        // The molecule has an internal mirror relating the two halves:
+        // {0,1,2,3,4} <-> {9,7,8,5,6}. Atoms 3 and 5 are the two
+        // stereocenters; their raw parity tags are opposite
+        // (CounterClockwise vs Clockwise) -- that is the meso relationship,
+        // not a sign of inequivalence -- so with stereo correctly excluded
+        // they must land in the SAME topological class.
+        let mol = parse("OC(=O)[C@H](O)[C@@H](O)C(=O)O").unwrap();
+        assert_eq!(mol.atom(AtomIdx(3)).chirality, Chirality::CounterClockwise);
+        assert_eq!(mol.atom(AtomIdx(5)).chirality, Chirality::Clockwise);
+
+        let classes = topological_equivalence_classes(&mol);
+        assert_eq!(classes.len(), 10);
+        assert_eq!(
+            classes[3], classes[5],
+            "meso stereocenters must share a class despite opposite @ / @@ tags: {classes:?}"
+        );
+        // The rest of the mirror mapping too, for good measure.
+        assert_eq!(classes[0], classes[9], "the two carboxyl OH oxygens");
+        assert_eq!(classes[1], classes[7], "the two carboxyl carbons");
+        assert_eq!(classes[2], classes[8], "the two carbonyl (=O) oxygens");
+        assert_eq!(classes[4], classes[6], "the two stereocenter hydroxyls");
+    }
+
+    #[test]
+    fn atom_map_number_alone_does_not_split_the_class() {
+        // p-xylene, the two methyls given different reaction atom-map
+        // numbers (:1 / :2). Map numbers are caller bookkeeping, not
+        // molecular structure -- the two methyls (and, by the same mirror
+        // symmetry, the two ortho/meta ring-carbon pairs either side) must
+        // still land in one class each, unlike `CanonicalColoredGraph::new`
+        // (canonical-SMILES's own coloring), which must keep map numbers
+        // distinguishable so the writer round-trips them exactly.
+        let mol = parse("[CH3:1]c1ccc(cc1)[CH3:2]").unwrap();
+        let classes = topological_equivalence_classes(&mol);
+        assert_eq!(classes.len(), 8);
+        assert_eq!(
+            classes[0], classes[7],
+            "differently-mapped-but-otherwise-identical methyls must share a class: {classes:?}"
         );
     }
 }

--- a/crates/chematic-smiles/src/lib.rs
+++ b/crates/chematic-smiles/src/lib.rs
@@ -41,6 +41,7 @@ pub use canonical::are_atoms_equivalent;
 pub use canonical::{
     canonical_atom_order, canonical_smiles, equivalent_atom_classes, morgan_ranks,
 };
+pub use canonical_partition::topological_equivalence_classes;
 pub use canonical_search::{
     CanonicalSearchStats, CanonicalizationError, CanonicalizationLimits,
     canonical_smiles_with_limits, reset_search_stats, search_stats_snapshot,


### PR DESCRIPTION
## Summary

Fixes #265. Exposes the graph-automorphism / partition-refinement machinery `chematic-smiles`'s canonical-SMILES writer already uses internally (`canonical_partition.rs`'s `CanonicalColoredGraph` / `initial_partition` / `exact_refine`) as a new public function:

```rust
pub fn topological_equivalence_classes(mol: &Molecule) -> Vec<usize>
```

`classes[i] == classes[j]` iff atoms `i` and `j` are indistinguishable by exact structural color refinement (element, isotope, charge, aromaticity, effective H-count, bond order/connectivity). Re-exported at the crate root (`chematic_smiles::topological_equivalence_classes`); the `canonical_partition` module itself stays private, same as before.

## Mechanism (no parallel construction path)

`CanonicalColoredGraph` gains a `new_topological()` constructor next to the existing `new()` (still used unchanged by `canonical_search.rs` — zero call-site changes, zero risk to canonical-SMILES output). Both go through the same `build()`/`vertex_color()`/`edge_color()` helpers with one bool flag (`canonical_fidelity`) — no second, independent way to build the colored graph.

`topological_equivalence_classes` calls `new_topological`, then `exact_refine(initial_partition(graph, &vec![0; n]))`. The all-zero starting `ranks` collapses `initial_partition` to "group by vertex color alone" — the correct from-scratch starting point for a whole-molecule query (canonical-SMILES's own use seeds from a partially-individualized search-node state instead). This also means the result never depends on `crate::canonical::normalize_ranks`'s raw-FNV-1a-hash grouping — `exact_refine`'s own iterations only ever compare full signatures via real `Eq`/`Ord`.

## The canonicalization-vs-symmetry distinction (the issue's central ask)

`CanonicalColoredGraph::new`'s existing coloring folds in several devices that exist only to make canonical-SMILES search-pruning *safe*, not to describe real molecular symmetry. Applying any of them to a general symmetry query would silently turn "topological symmetry" into "canonical tie-break" — exactly the failure mode the issue called out for meso-compound detection. `new_topological` excludes all four, each verified empirically, not just reasoned about:

| Device | `new()` (canonical-SMILES) | `new_topological()` (this PR) | Evidence |
|---|---|---|---|
| Atom parity (`@`/`@@` + `stereo_unique`) | Forces every stereo atom (and neighbors) globally unique | Ignored | meso-tartaric acid `OC(=O)[C@H](O)[C@@H](O)C(=O)O`: `classes[3] == classes[5]` despite one atom being `CounterClockwise` and the other `Clockwise` — that opposite-tag pair *is* the meso relationship |
| H-count spelling | Raw bracket `hydrogen_count` (`[Cl]` ≠ organic-subset `Cl`) | Effective count (`implicit_hcount`) | `[cH]1ccccc1` (benzene, one H spelled explicitly) — reverting the fix reproduces `[3, 2, 1, 0, 1, 2]` (atom 0 isolated); fixed it returns all six atoms in one class |
| Reaction atom-map numbers | Included (writer must round-trip `[CH3:1]`) | Ignored | `[CH3:1]c1ccc(cc1)[CH3:2]`: measured *with* atom-map still folded in (pre-decision probe), the two chemically identical methyls split into different classes (`[0,2,4,5,3,5,4,1]`, indices 0 and 7 differ); after excluding it, they merge |
| E/Z bond direction (`Up`/`Down` order) | Distinct edge color from `Single` | Collapsed to `Single` | `F/C=C\F` (cis-1,2-difluoroethene, real mirror symmetry across the two `=CF` ends): before the fix, 4 singleton classes (`[2, 0, 1, 3]`); after, 2 merged pairs |

Each row has a regression test in `canonical_partition.rs`. `Molecule::bond_direction`'s separately-stashed direction (used for a ring bond next to an exocyclic stereo double bond) is not part of `EdgeColor` in either mode today, so there's nothing to exclude there — noted in the doc comment as a "if this ever gets wired in, gate it too" caution, not something requiring a fix or test now.

## Relationship to the existing `equivalent_atom_classes`

`chematic-smiles` already has a public, similarly-shaped function: `crate::canonical::equivalent_atom_classes` (built on `morgan_ranks`/`refine_ranks`), also chirality-blind (`initial_invariant` never reads `atom.chirality`). On all four structural test fixtures (benzene, toluene, an asymmetric chain, meso-tartaric acid), the two functions return **identical orbit partitions** (different numeric labels, same grouping) — measured, not assumed:

```
c1ccccc1:                       topological=[0,0,0,0,0,0]              equivalent_atom_classes=[0,0,0,0,0,0]
Cc1ccccc1:                      topological=[0,1,2,3,4,3,2]            equivalent_atom_classes=[1,2,0,3,4,3,0]
FCCCCCl:                        topological=[4,2,0,1,3,5]              equivalent_atom_classes=[4,3,2,0,5,1]
OC(=O)[C@H](O)[C@@H](O)C(=O)O:  topological=[3,0,2,1,4,1,4,0,2,3]      equivalent_atom_classes=[1,2,0,3,4,3,4,2,0,1]
```

So this PR is not "fixing" a wrong answer from `equivalent_atom_classes` on any case tested. It is a narrower justification than that, and worth stating plainly rather than overselling: two real reasons to still ship this as a separate function:

1. The issue specifically asks for `canonical_automorphism`/`canonical_partition` — the exact-refinement machinery — exposed, not for wrapping the existing hash-based path.
2. `exact_refine` never merges two cells on anything but full signature equality; `equivalent_atom_classes`'s `normalize_ranks` groups by raw FNV-1a hash-value equality (a real, if practically negligible, collision risk — see this module's own top-of-file doc comment).

(`atom_map` is *not* a differentiator, despite being the one place these two functions could plausibly disagree: `initial_invariant` already never reads `atom.atom_map`, and this PR's `vertex_color` independently landed on excluding it too — see the table above for the measurement that drove that decision. The two functions agree here by two independent routes to the same conclusion, not by coincidence.)

Side note, out of scope for this PR: `equivalent_atom_classes`'s own doc comment gives a stale example (`Cc1ccccc1` → `[0,1,1,1,1,1,2]`, i.e. 3 classes). Measured actual output is `[1,2,0,3,4,3,0]`, i.e. **5** classes (methyl / ipso / ortho-pair / meta-pair / para) — matching this PR's own toluene test. Not fixing the stale doc here; flagging it since this PR's investigation surfaced it.

## Known limitation (shared with `morgan_ranks`/`equivalent_atom_classes`)

Like any Morgan/1-WL-style color refinement, `exact_refine` is a sound *over-approximation* of true automorphism orbits: same class does not strictly prove "provably interchangeable by a real automorphism" (only the converse holds). On a pathological WL-indistinguishable disjoint union of differently-sized regular subgraphs it can under-split — see `canonical_automorphism::tests::triangle_and_square_same_wl_cell_different_orbits` for a constructed witness. No real molecule in this crate's test corpus has ever exhibited this; documented, not fixed, exactly as it already is for `morgan_ranks`.

## Test coverage

10 new tests in `canonical_partition.rs`:
- `benzene_all_six_carbons_one_class` — obvious symmetry, all 6 in one class.
- `toluene_five_classes_ortho_and_meta_pairs_merge` — **5** distinct classes (methyl, ipso, ortho-pair, meta-pair, para), reasoned through and verified, not asserted from the issue text's own (self-questioning) number.
- `asymmetric_chain_every_atom_its_own_class` (`FCCCCCl`) — 6 distinct classes, no duplicates.
- `meso_tartaric_acid_stereocenters_share_a_class_despite_opposite_tags` — the issue's stated real-world motivation.
- `bracket_h_spelling_does_not_split_the_class`, `atom_map_number_alone_does_not_split_the_class`, `ez_bond_direction_marker_alone_does_not_split_the_class` — regression tests for the three divergences found during review.
- `wildcard_never_collides_with_a_zero_h_real_atom` — confirms dropping the canonical branch's H-count offset didn't introduce a wildcard/real-atom collision.
- Plus the two pre-existing `canonical_partition` tests, unchanged.

Full crate suite: 202 tests, `cargo clippy --all-targets -D warnings` clean, `cargo doc` clean (no `private_intra_doc_links`), `cargo fmt --check` clean, and `bash scripts/check.sh` (full workspace: fmt, clippy, all lib + integration tests, cargo-deny, publish graph, version consistency) passes clean.

## Out of scope

- Python (`chematic-py`) / WASM (`chematic-wasm`) bindings — the issue's proposed API is Rust-only; `equivalent_atom_classes` already has a `mol.equivalent_atom_classes()` Python binding as a working precedent if a follow-up wants one for this function too.
- Fixing `equivalent_atom_classes`'s stale doc example (noted above).

## Test plan

- [x] `cargo test -p chematic-smiles --lib` (202/202)
- [x] `cargo clippy -p chematic-smiles --all-targets -- -D warnings`
- [x] `cargo doc -p chematic-smiles --no-deps` (no warnings)
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check.sh` (full workspace, final tree including the E/Z fix)
