### PR TITLE
fix(perception): fix u64 overflow in simple_morgan_ranks for negative formal charge

### DIFF
--- a/crates/chematic-perception/src/stereo_validation.rs
+++ b/crates/chematic-perception/src/stereo_validation.rs
@@ -71,15 +71,29 @@ pub struct StereoCompleteness {
 // ---------------------------------------------------------------------------
 
 /// Compute simple Morgan connectivity ranks for atoms in `mol`.
-/// Uses initial invariant = atomic_number * 1000 + degree.
+/// Uses initial invariant = atomic_number * 1_000_000 + charge_term * 1000 + degree.
 fn simple_morgan_ranks(mol: &Molecule) -> Vec<u64> {
     let n = mol.atom_count();
     let mut ranks: Vec<u64> = (0..n)
         .map(|i| {
             let idx = AtomIdx(i as u32);
             let atom = mol.atom(idx);
-            let deg = mol.neighbors(idx).count() as u64;
-            atom.element.atomic_number() as u64 * 1_000_000 + atom.charge as u64 * 1000 + deg
+            let deg = mol.neighbors(idx).count() as i64;
+            // `atom.charge` (i8) sign-extends on a plain `as u64` cast for
+            // negative values (e.g. -1i8 as u64 == u64::MAX), which made the
+            // old `atom.charge as u64 * 1000` overflow `u64` unconditionally
+            // for any negatively-charged atom (issue #267). Computing the
+            // whole invariant in i64 and reinterpreting as u64 only once, at
+            // the end, avoids that overflow while leaving the value
+            // bit-for-bit identical to before for the (already-correct)
+            // charge >= 0 case. `atomic_number()` is always >= 1 (never a
+            // 0/wildcard sentinel here), so `an * 1_000_000` always dominates
+            // even the most extreme i8 charge magnitude (128_000 at most),
+            // keeping the final sum non-negative for every realistic and
+            // every representable i8 charge.
+            let an = atom.element.atomic_number() as i64;
+            let charge = atom.charge as i64;
+            (an * 1_000_000 + charge * 1000 + deg) as u64
         })
         .collect();
 
@@ -331,5 +345,47 @@ mod tests {
         let mol = parse("c1ccccc1").unwrap();
         let sc = stereo_completeness(&mol);
         assert_eq!(sc.total_centers, 0);
+    }
+
+    // Regression tests for issue #267: `atom.charge as u64` sign-extends for
+    // negative i8 charges (e.g. -1i8 as u64 == u64::MAX), which made the
+    // Morgan-rank invariant's `* 1000` multiply overflow `u64` -- panicking
+    // in debug builds and silently corrupting the invariant in release.
+
+    #[test]
+    fn test_stereo_completeness_negative_charge_no_panic() {
+        // Acetate: the [O-] atom must not trigger an overflow panic.
+        let acetate = parse("CC(=O)[O-]").unwrap();
+        let sc = stereo_completeness(&acetate);
+        assert_eq!(sc.total_centers, 0);
+    }
+
+    #[test]
+    fn test_stereo_completeness_positive_charge_no_panic() {
+        // Small positive i8 charge never overflowed, but keep it as a
+        // regression fixture per the issue's exact repro.
+        let cation = parse("C[NH3+]").unwrap();
+        let sc = stereo_completeness(&cation);
+        assert_eq!(sc.total_centers, 0);
+    }
+
+    #[test]
+    fn test_stereo_completeness_mixed_salt_no_panic() {
+        // Disconnected salt combining both a negative and a positive charge.
+        let salt = parse("CC(=O)[O-].C[NH3+]").unwrap();
+        let sc = stereo_completeness(&salt);
+        assert_eq!(sc.total_centers, 0);
+    }
+
+    #[test]
+    fn test_stereo_completeness_doubly_negative_charge_no_panic() {
+        // A doubly-deprotonated phosphate: charge -2, more extreme than the
+        // issue's -1 repro, to make sure the fix isn't a -1-only special case.
+        let phosphate = parse("[O-]P(=O)([O-])OC").unwrap();
+        let sc = stereo_completeness(&phosphate);
+        assert_eq!(sc.total_centers, 0);
+        // Also exercise the other public entry point sharing the same helper.
+        let errors = validate_stereo(&phosphate);
+        assert!(errors.is_empty());
     }
 }


### PR DESCRIPTION
## Root cause

`crates/chematic-perception/src/stereo_validation.rs`'s private helper `simple_morgan_ranks` (used by both `stereo_completeness` and `validate_stereo`) computed each atom's initial Morgan-rank invariant as:

```rust
atom.element.atomic_number() as u64 * 1_000_000 + atom.charge as u64 * 1000 + deg
```

`atom.charge` is `i8`. A plain `as u64` cast **sign-extends** negative values before reinterpreting the bits as unsigned (`-1i8 as u64 == u64::MAX`), so `atom.charge as u64 * 1000` overflowed `u64` unconditionally for **any** negatively-charged atom. This is a sign-extension bug, not a magnitude issue — it fired identically for a charge of `-1` or `-128`. In debug builds this panicked with `attempt to multiply with overflow` on any molecule containing a negatively-charged atom (any carboxylate, sulfonate, phosphate, or other common anion); in release builds it wrapped silently, corrupting the invariant used for stereocenter detection.

## Fix

Compute the whole per-atom invariant in `i64` and reinterpret as `u64` only once, at the end:

```rust
let an = atom.element.atomic_number() as i64;
let charge = atom.charge as i64;
(an * 1_000_000 + charge * 1000 + deg) as u64
```

`atomic_number()` is always `>= 1` (1–118, never a 0/wildcard sentinel), so `an * 1_000_000` always dominates even the most extreme representable `i8` charge magnitude (`128_000` at most), keeping the sum non-negative — and therefore the final `u64` cast safe — for every representable charge, not just the realistic `-4..+8` range.

This also leaves the invariant **bit-for-bit identical to before** for the already-correct `charge >= 0` case (the old code was never actually wrong there — only the negative branch sign-extended). I initially prototyped a `(charge as i64 + 128) as u64` shift (matching the pattern already used in `chematic-smiles/src/canonical.rs`, `chematic-3d/src/etkdg_knowledge/canon_rank.rs`, and `chematic-fp/src/hdf.rs`), but a before/after diff over `scripts/descriptor_census_corpus.smi`'s 5,000 real drug-like SMILES showed it silently changed `stereo_completeness()`'s output on ~10% of *neutral* molecules. The diff shape (some molecules' `total_centers` went up, others down, e.g. 23→21) is consistent with `stereo_completeness` separately pushing a hardcoded sentinel `0` to represent an implicit-H "rank" (line ~244): shifting every atom's invariant by a constant changes which real atom lands on normalized ordinal `0` in the WL/hash refinement, which can collide with that sentinel. I have **not** instrumented this to confirm it's the exact mechanism — it's the leading explanation for the diff, not a verified root cause — but either way it's a distinct, pre-existing issue in `stereo_completeness`'s implicit-H handling, unrelated to the overflow fix, and out of scope for this PR. Noting it here for visibility rather than fixing it. The `i64`-then-cast approach sidesteps the whole question by not perturbing the non-negative-charge invariant space at all; the same 5,000-molecule diff shows **zero** differences with this version of the fix.

## Testing

- Added regression tests in `stereo_validation.rs`'s own test module using the issue's exact repro (acetate `CC(=O)[O-]`, cation `C[NH3+]`, and the mixed salt), plus an additional doubly-deprotonated-phosphate case (`charge = -2`) to confirm the fix isn't a `-1`-only special case.
- Confirmed the pre-fix code panics with exactly `attempt to multiply with overflow` on the acetate case (via a temporary `#[should_panic]` test against the unpatched helper), proving the regression tests exercise the real bug.
- `bash scripts/check.sh` passes: fmt, clippy (`-D warnings`), full workspace lib + integration tests (debug profile, i.e. overflow checks *on*), cargo-deny, publish graph, and version consistency all green.
- `cargo test -p chematic-perception --lib stereo_validation --release` also passes. To be precise about what these regression tests actually detect: they catch the **debug-mode panic** (confirmed by a temporary `#[should_panic(expected = "attempt to multiply with overflow")]` test run against the unpatched helper). They do **not** detect release-mode corruption — all four assert `total_centers == 0` on molecules with no stereocenters, which holds whether the invariant is correct or garbage, so they'd pass against the buggy code in release too. Release-mode wrapping is prevented **by construction** here (the sum can no longer leave `u64` range for any representable charge), not by test detection.
- No public API changes: `simple_morgan_ranks` is a private helper, and `stereo_completeness`'s / `validate_stereo`'s signatures are untouched — not a breaking change.

## Relation to other work

This is a required precondition for #268 ("expose per-atom stereocenter candidates"), which the repo owner has said needs this overflow fixed first before it can be rebased and merged. This PR does not touch #268 or its branch.

Fixes #267

---

**Not merging this myself** — this repo's policy requires explicit human merge approval. Opening ready for review and stopping here.
