### PR TITLE
fix(perception): fix implicit-H rank-0 sentinel collision in stereo_completeness

### DIFF
--- a/crates/chematic-perception/src/stereo_validation.rs
+++ b/crates/chematic-perception/src/stereo_validation.rs
@@ -252,10 +252,23 @@ pub fn stereo_completeness(mol: &Molecule) -> StereoCompleteness {
             continue;
         } // only tetrahedral candidates
 
-        // Check all neighbours have distinct ranks (including implicit H as rank 0).
+        // Check all neighbours have distinct ranks (including implicit H as a
+        // sentinel rank). `simple_morgan_ranks` normalises to consecutive
+        // ordinals starting at 0 (see its tail: `partition_point(|&u| u <
+        // *r)`), so a real heavy-atom neighbour can legitimately carry rank
+        // 0 -- it's the ordinary "lowest invariant in the molecule" rank,
+        // not a reserved value. Using the literal `0` as the implicit-H
+        // sentinel therefore collided with real rank-0 neighbours (issue
+        // #267's follow-up bug): `dedup()` merged the two, `sorted.len()`
+        // dropped below 4, and a genuine 4-distinct-group stereocenter was
+        // silently skipped. The maximum normalised rank is (number of
+        // distinct invariants - 1), which is always <= atom_count() - 1, so
+        // `atom_count()` itself is never a reachable real rank and is safe
+        // to use as the sentinel here.
+        let implicit_h_rank_sentinel = mol.atom_count() as u64;
         let mut nb_ranks: Vec<u64> = heavy_nbs.iter().map(|nb| ranks[nb.0 as usize]).collect();
         if implicit_h > 0 {
-            nb_ranks.push(0);
+            nb_ranks.push(implicit_h_rank_sentinel);
         }
 
         let mut sorted = nb_ranks.clone();
@@ -387,5 +400,62 @@ mod tests {
         // Also exercise the other public entry point sharing the same helper.
         let errors = validate_stereo(&phosphate);
         assert!(errors.is_empty());
+    }
+
+    // Regression tests for the implicit-H rank-0 sentinel collision (issue
+    // #267 follow-up, distinct from the overflow bug above): `simple_morgan_ranks`
+    // normalises ranks to consecutive ordinals starting at 0, so an ordinary
+    // heavy-atom neighbour can legitimately carry rank 0. Using the literal
+    // `0` as the implicit-H stand-in collided with such a neighbour, `dedup()`
+    // merged them, and a genuine 4-distinct-group stereocenter was silently
+    // dropped (`specified` undercounted).
+
+    #[test]
+    fn test_stereo_completeness_rank_zero_collision_chain() {
+        // Atom indices: 0=C(methyl) 1=C@@H(chiral) 2=Cl 3=C(quaternary) 4=Br
+        // 5=F 6=I. Verified via `simple_morgan_ranks`: ranks = [0, 6, 2, 5, 4,
+        // 1, 3] -- the chiral atom's methyl neighbour (atom 0) is the
+        // lowest-invariant atom in the whole molecule and normalises to rank
+        // 0, colliding with the old implicit-H sentinel. Before the fix this
+        // atom was dropped entirely (specified=0, unspecified=1, total=1,
+        // counting only the separate, unrelated unspecified center at the
+        // quaternary carbon 3, whose 4 heavy neighbours -- 1, Br, F, I -- are
+        // trivially distinct and is not itself affected by this bug); after
+        // the fix both stereocenters are counted.
+        let mol = parse("C[C@@H](Cl)C(Br)(F)I").unwrap();
+        let sc = stereo_completeness(&mol);
+        assert_eq!(
+            sc.specified, 1,
+            "annotated chiral carbon must not be dropped by the rank-0 collision: {sc:?}"
+        );
+        assert_eq!(
+            sc.total_centers, 2,
+            "expected 2 stereocenters total (1 fixed + 1 pre-existing, bug-unrelated \
+             unspecified center at the quaternary carbon): {sc:?}"
+        );
+    }
+
+    #[test]
+    fn test_stereo_completeness_rank_zero_collision_different_neighbor() {
+        // Same collision class as the chain test above, but with a
+        // structurally different colliding neighbour to confirm the fix
+        // isn't specific to "a bare terminal methyl happens to be rank 0".
+        // Atom indices: 0=O 1=C(CH2, bonded to O) 2=C@@H(chiral) 3=N
+        // 4=C(quaternary) 5=Br 6=F 7=I. Verified via `simple_morgan_ranks`:
+        // ranks = [1, 0, 5, 3, 7, 6, 2, 4] -- here it's the chiral atom's
+        // *substituted* CH2-OH neighbour (atom 1, not a plain methyl and not
+        // the neighbour listed first in the SMILES branch order) that lands
+        // on rank 0 and collides with the implicit-H sentinel.
+        let mol = parse("OC[C@@H](N)C(Br)(F)I").unwrap();
+        let sc = stereo_completeness(&mol);
+        assert_eq!(
+            sc.specified, 1,
+            "annotated chiral carbon must not be dropped by the rank-0 collision: {sc:?}"
+        );
+        assert_eq!(
+            sc.total_centers, 2,
+            "expected 2 stereocenters total (1 fixed + 1 pre-existing, bug-unrelated \
+             unspecified center at the quaternary carbon): {sc:?}"
+        );
     }
 }

--- a/crates/chematic-perception/src/stereo_validation.rs
+++ b/crates/chematic-perception/src/stereo_validation.rs
@@ -443,9 +443,8 @@ mod tests {
         // Atom indices: 0=O 1=C(CH2, bonded to O) 2=C@@H(chiral) 3=N
         // 4=C(quaternary) 5=Br 6=F 7=I. Verified via `simple_morgan_ranks`:
         // ranks = [1, 0, 5, 3, 7, 6, 2, 4] -- here it's the chiral atom's
-        // *substituted* CH2-OH neighbour (atom 1, not a plain methyl and not
-        // the neighbour listed first in the SMILES branch order) that lands
-        // on rank 0 and collides with the implicit-H sentinel.
+        // *substituted* CH2-OH neighbour (atom 1, not a plain methyl) that
+        // lands on rank 0 and collides with the implicit-H sentinel.
         let mol = parse("OC[C@@H](N)C(Br)(F)I").unwrap();
         let sc = stereo_completeness(&mol);
         assert_eq!(


### PR DESCRIPTION
## Root cause

`crates/chematic-perception/src/stereo_validation.rs`'s `simple_morgan_ranks` normalises each atom's Morgan-refinement invariant to a consecutive ordinal starting at **0** (its tail: `sorted.partition_point(|&u| u < *r)`). `stereo_completeness` used the literal value `0` as a stand-in "rank" for an implicit hydrogen when checking whether a candidate stereocenter's 4 groups (heavy-atom neighbours + optionally 1 implicit H) are all distinct:

```rust
let mut nb_ranks: Vec<u64> = heavy_nbs.iter().map(|nb| ranks[nb.0 as usize]).collect();
if implicit_h > 0 {
    nb_ranks.push(0);
}
...
if sorted.len() < 4 { continue; } // symmetric neighbours — not a stereocenter
```

Rank `0` is **not** reserved — it's an ordinary, frequently-reached normalised rank (whichever atom in the whole molecule has the lowest invariant gets it). When a candidate stereocenter has a heavy neighbour that carries real rank `0` *and* also has an implicit H, `nb_ranks` ends up with two entries equal to `0`; `dedup()` collapses them, `sorted.len()` drops below 4, and the atom is silently treated as "not a stereocenter" even though it has 4 genuinely distinct groups and may carry an explicit `@`/`@@` annotation. This **undercounts** `stereo_completeness`'s `specified` count.

This is a distinct bug from #267 (a `u64`-overflow/sign-extension bug in the same function, fixed in #279) — a rank-0 sentinel collision, not a magnitude issue. In fact #279's own PR body independently surfaced this exact mechanism as an unverified "leading explanation" for a ~10% diff it found on a 5,000-molecule corpus when it prototyped an alternate overflow fix, and explicitly deferred it as out of scope. This PR confirms the collision mechanism exists and undercounts `specified` (repro below). I did not re-run that 5,000-molecule diff, so this doesn't independently confirm the collision fully accounts for #279's observed delta — only that the mechanism it flagged is real.

## Repro (added as a regression test)

```
C[C@@H](Cl)C(Br)(F)I
```

Atom 1 is the `@@`-annotated chiral carbon. Its methyl neighbour (atom 0) is the lowest-invariant atom in the whole molecule (`simple_morgan_ranks` gives `[0, 6, 2, 5, 4, 1, 3]`), colliding with the implicit-H sentinel at atom 1.

- **Before fix:** `stereo_completeness(...) == StereoCompleteness { specified: 0, unspecified: 1, total_centers: 1 }` — the annotated stereocenter is dropped entirely; only the unrelated unspecified center at the quaternary carbon (atom 3) is counted.
- **After fix:** `StereoCompleteness { specified: 1, unspecified: 1, total_centers: 2 }` — both real stereocenters are counted.

A second regression test (`OC[C@@H](N)C(Br)(F)I`) exercises the same collision class with a structurally different colliding neighbour (a substituted `-CH2-OH` carbon rather than a bare terminal methyl), confirmed via the same `simple_morgan_ranks` debug print (`ranks = [1, 0, 5, 3, 7, 6, 2, 4]`, atom 1 = the CH2-OH carbon), to rule out the fix being lucky on one geometry.

## Fix

Replace the literal `0` sentinel with `mol.atom_count() as u64`, which is provably never a reachable real rank: the maximum normalised rank from `simple_morgan_ranks` is `(number of distinct invariant values) - 1 <= atom_count() - 1`.

## `validate_stereo` (checked, not changed)

`validate_stereo`'s Rule 3 (`if all_same && implicit_h == 0`) uses `implicit_h` as a plain hydrogen **count**, never pushed into a rank vector alongside real ranks — confirmed by reading the code, not just assumed. It is not affected by this bug and was left unchanged.

## Testing

- Two new regression tests in `stereo_validation.rs`'s test module (`test_stereo_completeness_rank_zero_collision_chain`, `test_stereo_completeness_rank_zero_collision_different_neighbor`). Verified by a before/after diff on the same two molecules (stash the fix, re-measure `stereo_completeness` directly): pre-fix both report `specified: 0` (matching the bug description), post-fix both report `specified: 1` -- then the tests were written to assert the post-fix value.
- Full existing `chematic-perception` test module (11 tests, including all of #279's overflow regression tests) still passes unchanged — no previously-passing test's expected values shifted.
- `bash scripts/check.sh` passes in full: fmt, clippy `-D warnings`, full workspace lib + integration tests, cargo-deny, publish graph, and version consistency all green.
- No public API changes: `stereo_completeness`/`validate_stereo` signatures are untouched.

## Relation to other work

This is the **second** of two prerequisite fixes the repo owner specified before #268 ("expose per-atom stereocenter candidates") can be rebased and merged: fix #267 (#279) → fix implicit-H sentinel collision (this PR) → rebase #268 → add regression fixtures → CI green → merge. This PR does not touch #268 or its branch.

**Based on #279's branch** (`fix/simple-morgan-ranks-negative-charge-overflow-267`), not `main`, since both fixes touch the same function and this avoids a merge conflict. **This PR must be re-targeted to `main` (or merged after) once #279 lands** — right now it is stacked on top of it.

---

**Not merging this myself.** Opening ready for review and stopping here.
