### PR TITLE
chore(release): v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,94 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] — 2026-08-10
+
+### Added — `chematic-mol` (XYZ / multi-frame XYZ)
+
+- `parse_xyz`/`write_xyz`, `XyzFrame`/`XyzAtom`, `XyzReader` (multi-frame),
+  `parse_xyz_all`, `XyzWriter`, `XyzError`. Explicit hydrogens are kept as
+  real atoms, never folded into `implicit_hcount()`. No connectivity/bond-
+  order inference is performed, not even opt-in — XYZ carries coordinates
+  and elements only. Fails closed on atom-count mismatch, non-finite
+  coordinates, and unknown elements.
+
+### Added — `chematic-perception` (per-atom stereocenter candidates, issue #263)
+
+- `stereo_centers(&Molecule) -> Vec<(AtomIdx, bool)>` exposes the per-atom
+  tetrahedral-stereocenter classification (`(atom, specified)`) that
+  `stereo_completeness` already computed internally but only surfaced as
+  aggregate counts. `stereo_completeness` is now implemented in terms of
+  `stereo_centers`, so there is one source of truth for the classification
+  logic instead of two. Purely additive — `StereoCompleteness`'s public
+  field shape is unchanged.
+- Two real bugs in the shared `simple_morgan_ranks` helper (used by both
+  `stereo_centers` and `validate_stereo`) were found and fixed while adding
+  this API:
+  - **Negative formal charge caused a `u64` overflow (issue #267).** The
+    initial invariant computed `atom.charge as u64 * 1000` where
+    `atom.charge: i8` — a plain `as u64` cast sign-extends negative values
+    (`-1i8 as u64 == u64::MAX`), so the multiply overflowed unconditionally
+    for any negatively-charged atom: panicking in debug builds on any
+    ordinary anion (carboxylate, sulfonate, phosphate, ...), silently
+    wrapping to a corrupted invariant in release builds. Fixed by computing
+    the whole invariant in `i64` and casting to `u64` once at the end
+    (bit-for-bit identical to the old code for `charge >= 0`).
+  - **Implicit-hydrogen rank-0 sentinel collided with a real atom's
+    normalized rank 0.** `simple_morgan_ranks` normalizes each atom's
+    Morgan-refinement invariant to a consecutive ordinal starting at `0` —
+    so an ordinary heavy-atom neighbor can legitimately hold rank `0` (e.g.
+    a plain methyl carbon with the lowest invariant in the molecule).
+    `stereo_completeness`/`stereo_centers` used the literal value `0` as a
+    stand-in rank for an implicit hydrogen when checking whether a
+    candidate stereocenter's 4 groups were all distinct; when a real rank-0
+    neighbor and an implicit H coincided at the same center, `dedup()`
+    merged the two `0`s and the atom was silently dropped as "not a
+    stereocenter" — undercounting real, correctly `@`/`@@`-annotated
+    stereocenters (repro: `C[C@@H](Cl)C(Br)(F)I`, atom 1). Fixed by using
+    `mol.atom_count()` as the implicit-H sentinel instead of `0` (provably
+    unreachable as a real normalized rank, since the max is
+    `atom_count() - 1`).
+
+### Added — `chematic-chem` (E/Z double-bond stereo-completeness, issue #264)
+
+- `ez_completeness(&Molecule) -> EzCompleteness { specified, unspecified,
+  total }`. Excludes terminal/symmetric double bonds and bonds in rings
+  smaller than 8 atoms (matching RDKit's `isBondPotentialStereoBond`/
+  `MinBondRingSize` cutoff, oracle-verified), using a BFS shortest-cycle-
+  through-bond check (not SSSR alone, which would miss bridged-bicyclic
+  cases like norbornene) to determine ring membership correctly.
+
+### Added — `chematic-perception` (macrocycle predicate, issue #266)
+
+- `is_macrocycle(ring: &[AtomIdx]) -> bool { ring.len() >= 9 }` — a single
+  shared predicate matching the two hardcoded `9`s already duplicated in
+  `chematic-3d` (`MACROCYCLE_RING_THRESHOLD`,
+  `etkdg_knowledge::classify`'s `MACROCYCLE_MIN`). The duplication in
+  `chematic-3d` itself is not unified by this change.
+
+### Fixed — `chematic-chem` (atropisomer detection/assignment notation-invariance, issues #262, #276)
+
+- `detect_atropisomers` rewritten to use `chematic_perception::find_sssr`
+  structurally (independent of `BondOrder`) to confirm two aromatic carbons
+  belong to separate SSSR rings, then requires at least one substituted
+  ortho ring position on each ring — instead of the previous
+  `bond.order == BondOrder::Single` gate, which made the same real molecule
+  give different answers depending on whether the SMILES wrote the
+  inter-ring bond explicitly or left it implicit. Also fixes a false
+  positive on para-substituted biaryls (e.g. 4,4'-dimethylbiphenyl is no
+  longer flagged).
+- `assign_atropisomer_chirality` had its own, separate, redundant
+  `bond.order == BondOrder::Single` gate before annotating a detected
+  atropisomeric bond with `Up`/`Down` chirality — the same class of
+  notation-dependence issue #262 removed from `detect_atropisomers`, just
+  one function later: an implicit-notation biaryl bond that `detect_
+  atropisomers` correctly flagged as atropisomeric could still silently
+  get skipped for chirality assignment. Fixed by gating on `AtropisomerType
+  ::Biaryl` (matching `detect_atropisomers`'s own classification) instead
+  of the bond order — not a blanket deletion of the check, since a naive
+  deletion would have let the gate's incidental protection of
+  `AtropisomerType::Allene`'s central `Double` bond regress too.
+
 ### Fixed — `chematic-ff` (MMFF94 stretch-bend classification-key bug, issue #227 Priority 2C, **breaking**)
 
 - **Root cause (the fix the user asked for): stretch-bend used the *angle
@@ -188,6 +276,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the reference call site.
 - Recommends a **minor** version bump (breaking Rust signature semantics),
   consistent with v0.12.0's own precedent for `mmff94_stbn`.
+
+### Known issue — release-gate waiver (issue #285)
+
+- The combined v0.13.0 release-gate remeasurement (265-molecule Wave 1
+  corpus, both MMFF94 fixes above together) found 2 molecules
+  (`chembl_tier_b_0126`, `chembl_tier_b_0168`) regress by 1 declared-
+  stereocenter satisfaction each in the un-gated/stretch-bend-gated MMFF94
+  arms. Root-caused to a **pre-existing distance-geometry embedding defect**
+  (present since v0.12.0, not introduced by either fix above): the
+  declared alkene in both molecules is placed with the wrong E/Z sign at
+  the embedding stage itself, before force-field minimization ever runs.
+  What changed is that the *old*, mistyped torsion terms happened to pull
+  this dihedral back to the declared configuration during minimization —
+  an accidental rescue that the corrected torsion classification no longer
+  performs. Confirmed via RDKit's own MMFF94 (`MMFFGetMoleculeForceField`),
+  given the identical pre-minimization starting geometry chematic uses,
+  exhibiting the same failure to rescue — two independent MMFF94
+  implementations agree on identical coordinates, so the MMFF94 fixes
+  themselves are correct. `sound=True` in every case (this is a stereo-
+  correctness defect, not a geometry-sanity regression). Net corpus-wide
+  stereo satisfaction still improves (`mmff94_strict`: 49 → 48 declared-
+  stereocenter violations). Shipped under an explicit release waiver rather
+  than blocking v0.13.0 — see issue #285 for the fix, planned for a later
+  release.
 
 ## [0.12.0] — 2026-08-09
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,5 +23,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.12.0
+version: 0.13.0
 date-released: "2026-07-29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.12.0
+# chematic v0.13.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-07-17, v0.4.29 vs RDKit 2026.03.3 --
@@ -419,6 +419,17 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +1
 
 ## Recent Development
 
+**v0.13.0** (2026-08-10): **MMFF94 stretch-bend + torsion parameter-selection parity (both breaking), per-atom stereocenter API, E/Z completeness, macrocycle detection, notation-invariant atropisomer detection/assignment, XYZ I/O**
+- `chematic-ff`: `mmff94_stbn`/`mmff94_stbn_type_only` now key the `MMFF94_STBN` table lookup on RDKit's real, finer-grained "stretch-bend type" (`getMMFFStretchBendType`, 0-11) instead of the coarser angle type (0-8) previously used as a stand-in (issue #227) — 220 of 427 stretch-bend routing candidates on the 265-molecule Wave 1 corpus move from RDKit's generic Dfsb periodic-row default to the correct, specific parameter; `angle_type_for`'s ring-offset formula also corrected to match RDKit's real `getMMFFAngleType`. **Breaking**: `mmff94_stbn`/`mmff94_stbn_type_only`'s leading `u8` parameter is now `stretch_bend_type`, not `angle_type` — same shape, different required value; use the new `pub stretch_bend_type_for` to compute it
+- `chematic-ff`: `torsion_type_for` now classifies from the real j-k bond's MMFF bond type (reusing `bond_type_for`) plus RDKit's real local-bond-adjacency ring-4/5 override, instead of atom-type-membership alone — corrects 76.9% of the 1,107 previously-missing torsion instances via classification alone, and, corpus-wide, corrects 1,792 of 13,530 torsion instances that resolved to a *silently wrong* parameter value before (not just missing coverage) — 99.1% of the corrected values independently confirmed against a live RDKit oracle, 0 newly lost. **Breaking**: `torsion_type_for`'s signature changed from `(rings, i, j, k, l, tj, tk)` to `(mol, i, j, k, l, ti, tj, tk, tl)`
+- `chematic-mol`: XYZ / multi-frame XYZ read-write (`parse_xyz`/`write_xyz`, `XyzReader`/`XyzWriter`) — explicit hydrogens kept as real atoms, no connectivity/bond-order inference, fails closed on atom-count mismatch or non-finite coordinates
+- `chematic-perception`: `stereo_centers(&Molecule) -> Vec<(AtomIdx, bool)>` exposes per-atom tetrahedral-stereocenter classification (issue #263), previously only available as an aggregate count; fixed two bugs found while adding it — a `u64` overflow for negatively-charged atoms in the shared Morgan-rank helper (issue #267), and an implicit-hydrogen rank-0 sentinel colliding with a real atom's normalized rank 0 that silently dropped genuine specified stereocenters
+- `chematic-chem`: `ez_completeness(&Molecule) -> EzCompleteness` (issue #264) reports specified/unspecified/total declared E/Z double bonds, matching RDKit's own stereo-bond-eligibility rules (terminal/symmetric bonds excluded, ring bonds <8 atoms excluded via BFS shortest-cycle, not SSSR alone — correctly handles bridged-bicyclic cases like norbornene)
+- `chematic-chem`: `detect_atropisomers`/`assign_atropisomer_chirality` are now fully notation-invariant (issues #262, #276) — detection is SSSR-based (two aromatic carbons in separate rings, both with ortho substitution) rather than keyed off whether the SMILES wrote the inter-ring bond explicitly or left it implicit; chirality assignment's own redundant bond-order gate is now aligned with detection's own classification instead of re-deriving a separate, notation-sensitive check
+- `chematic-perception`: `is_macrocycle(ring: &[AtomIdx]) -> bool` (issue #266) — a single shared ≥9-atom-ring predicate, replacing duplicated hardcoded thresholds in `chematic-3d`
+- **v0.13.0 release-gate note**: 2 of 265 Wave 1 corpus molecules (`chembl_tier_b_0126`/`0168`) show a 1-stereocenter-satisfaction regression, root-caused to a pre-existing distance-geometry embedding defect (present since v0.12.0) that used to be accidentally masked by the now-fixed torsion classification bug — confirmed via RDKit's own MMFF94, given identical starting coordinates, exhibiting the same behavior. Shipped under an explicit waiver (issue #285); not a new defect introduced by this release's MMFF94 fixes
+- Full details in `CHANGELOG.md`'s `[0.13.0]` section
+
 **v0.12.0** (2026-08-09): **MMFF94 stretch-bend production fix (breaking), 3D starting-geometry fix for fused/multi-ring molecules**
 - `chematic-ff`: `mmff94_stbn` now falls back to RDKit's real 29-row periodic-table-row stretch-bend defaults when the specific/generic MMFF-type table has no row — unconditional production behavior for every MMFF94 policy, not behind an opt-in flag. Missing stretch-bend instances on the 265-molecule Wave 1 corpus: 2,107 → 0. **Breaking**: `mmff94_stbn` gained 3 required `atomic_num_{i,j,k}: u8` parameters (prior type-only behavior kept as new `mmff94_stbn_type_only`); Python's raw `PipelineV2Config(...)` constructor gained a new required `gate_mmff94_stretch_bend` argument (`.safe(...)` unaffected)
 - `chematic-3d`: `dg::generate_coords` no longer produces atom-coincident or wildly-stretched starting geometry for several multi-ring topologies (issue #185/#252) — root/ring-vertex collision, ring-fusion-order mismatch, and fixed-offset ring-island anchoring were all independent bugs, not a UFF minimizer defect as issue #185 originally suspected. All 28 `MinimizationFailed` cases on the 265-molecule corpus now resolve to `Ok`, 0 regressions. Two known, separately-tracked residual limitations remain unfixed: fused-ring seam orientation (issue #255) and chain-bridged ring islands (issue #256)
@@ -514,7 +525,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v0.12.0)
+├── Cargo.toml                    workspace root (v0.13.0)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)
@@ -567,7 +578,7 @@ If you use chematic in academic or research work, please cite:
   author    = {kent-tokyo},
   title     = {chematic: A pure-Rust cheminformatics toolkit},
   url       = {https://github.com/kent-tokyo/chematic},
-  version   = {0.12.0},
+  version   = {0.13.0},
   year      = {2026},
 }
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -106,7 +106,7 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.12.0
+# chematic v0.13.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-06, v0.4.22 vs RDKit 2026.03.3 --
@@ -282,6 +282,17 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi      
 ---
 
 ## 最近の開発
+
+**v0.13.0**（2026-08-10）: **MMFF94 stretch-bend／torsionパラメータ選択パリティ（両方breaking）、per-atomステレオセンターAPI、E/Z完全性判定、macrocycle検出、notation非依存atropisomer検出・割り当て、XYZ入出力**
+- `chematic-ff`: `mmff94_stbn`/`mmff94_stbn_type_only`が`MMFF94_STBN`テーブルのlookup keyとして、これまで代用していた粗いangle type（0-8）ではなく、RDKit実装の本来の細かいstretch-bend type（`getMMFFStretchBendType`、0-11）を使うように（issue #227）— 265分子コーパスで427件のstretch-bend routing候補中220件が、RDKitの汎用Dfsb周期表デフォルト値から正しい専用パラメータへ移行。`angle_type_for`のring-offset式もRDKit実装の`getMMFFAngleType`に合わせて修正。**Breaking**: `mmff94_stbn`/`mmff94_stbn_type_only`の先頭`u8`引数は`stretch_bend_type`（`angle_type`ではない）— 新規`pub stretch_bend_type_for`で計算
+- `chematic-ff`: `torsion_type_for`が、atom-type membershipのみに頼る旧分類ではなく、j-k結合の実際のMMFF bond type（`bond_type_for`を再利用）とRDKit実装のlocal bond-adjacencyベースring 4/5-override判定を使うように — 1,107件の欠落torsion候補のうち76.9%が分類修正のみで解決、コーパス全体13,530件のtorsion中1,792件の「値はあるが誤ったパラメータ」だったsilent wrong-parameter populationも是正（99.1%をRDKit oracleで直接検証、新規消失0件）。**Breaking**: `torsion_type_for`のシグネチャが`(rings, i, j, k, l, tj, tk)`から`(mol, i, j, k, l, ti, tj, tk, tl)`へ変更
+- `chematic-mol`: XYZ／multi-frame XYZ読み書き（`parse_xyz`/`write_xyz`、`XyzReader`/`XyzWriter`）— 明示的水素は実atomとして保持、結合次数推定なし、原子数不一致・非有限座標はfail closed
+- `chematic-perception`: `stereo_centers(&Molecule) -> Vec<(AtomIdx, bool)>`がper-atomのtetrahedral stereocenter分類を公開（issue #263、従来は集計カウントのみ）— 追加時に2件のバグを発見・修正: 負電荷atomでのMorgan-rankヘルパーの`u64` overflow（issue #267）、implicit hydrogenのrank-0センチネルが実atomの正規化rank 0と衝突し正しく指定されたstereocenterを見落としていた問題
+- `chematic-chem`: `ez_completeness(&Molecule) -> EzCompleteness`（issue #264）が宣言済みE/Z二重結合の specified/unspecified/total を、RDKit実装のstereo-bond適格性ルール（末端・対称結合を除外、8員未満のring結合をBFS最短閉路で除外——SSSRのみでは検出できないbridged-bicyclic系（norbornene等）も正しく扱う）に沿って報告
+- `chematic-chem`: `detect_atropisomers`/`assign_atropisomer_chirality`が完全にnotation非依存に（issue #262、#276）— 検出はSSSRベース（別々の環に属する2つの芳香族炭素、両環ともortho置換あり）で、SMILESが環間結合を明示的に書くか暗黙にするかに依存しない。chirality割り当て側の冗長なbond-order判定も、検出側の分類と一致するよう修正
+- `chematic-perception`: `is_macrocycle(ring: &[AtomIdx]) -> bool`（issue #266）— `chematic-3d`側に重複していたハードコードされた閾値を単一の共有述語に統一
+- **v0.13.0リリースゲート注記**: 265分子Wave 1コーパス中2分子（`chembl_tier_b_0126`/`0168`）で立体中心充足数の1件退行を確認、根本原因はv0.12.0から存在するdistance-geometry埋め込み段階の既存バグ（今回修正したtorsion分類バグに偶然マスクされていた）と特定 — RDKit自身のMMFF94も同一の出発座標を与えると同じ挙動を示すことを確認済み。明示的waiverの下でリリース（issue #285）— 今回のMMFF94修正が新たに生んだ不具合ではない
+- 詳細は`CHANGELOG.md`の`[0.13.0]`セクション参照
 
 **v0.12.0**（2026-08-09）: **MMFF94 stretch-bend本番修正（breaking）、fused/multi-ring分子の3D初期構造修正**
 - `chematic-ff`: `mmff94_stbn`がRDKit実装の29行周期表行stretch-bendデフォルトへfallbackするように — 265分子コーパスでstretch-bend欠落2,107→0。**Breaking**: `mmff94_stbn`に`atomic_num_{i,j,k}: u8`が必須引数として追加（旧動作は`mmff94_stbn_type_only`として維持）、Python生`PipelineV2Config(...)`コンストラクタに`gate_mmff94_stretch_bend`が新規必須引数として追加（`.safe(...)`は無変更）

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.12.0 | Yes | Current release — active support |
+| v0.13.0 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.12.0) receives all security updates.  
+**Active Support**: Latest release (v0.13.0) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -16,12 +16,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.12.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.12.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.12.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.12.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.12.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.13.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.13.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.13.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.13.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.13.0" }
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #219); web-time
 # is a drop-in Instant replacement backed by Performance.now() there, and

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -16,14 +16,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.12.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.13.0" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.12.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.12.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.12.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.12.0" }
-chematic-cip        = { path = "../chematic-cip",        version = "0.12.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.13.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.13.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.13.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.13.0" }
+chematic-cip        = { path = "../chematic-cip",        version = "0.13.0" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.12.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.13.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -22,10 +22,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.12.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.12.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.12.0" }
+chematic-core = { path = "../chematic-core", version = "0.13.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.13.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.13.0" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.12.0" }
+chematic-core = { path = "../chematic-core", version = "0.13.0" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.12.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.13.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -22,13 +22,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.12.0" }
+chematic-core = { path = "../chematic-core", version = "0.13.0" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.12.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.12.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.12.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.13.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.13.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.13.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -18,10 +18,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.12.0", path = "../chematic-core" }
-chematic-smiles = { version = "0.12.0", path = "../chematic-smiles" }
-chematic-chem = { version = "0.12.0", path = "../chematic-chem" }
-chematic-rxn = { version = "0.12.0", path = "../chematic-rxn" }
+chematic-core = { version = "0.13.0", path = "../chematic-core" }
+chematic-smiles = { version = "0.13.0", path = "../chematic-smiles" }
+chematic-chem = { version = "0.13.0", path = "../chematic-chem" }
+chematic-rxn = { version = "0.13.0", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.12.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.13.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -17,15 +17,15 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.12.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.12.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.12.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.12.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.12.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.12.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.12.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.12.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.13.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.13.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.13.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.13.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.13.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.13.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.13.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.13.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
 
 [dev-dependencies]
 # Real JSON Schema 2020-12 validator, used only in tests to independently

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -16,10 +16,10 @@ documentation = "https://docs.rs/chematic-mol"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.12.0" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.12.0" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.12.0" }
-chematic-smiles      = { path = "../chematic-smiles",      version = "0.12.0" }
+chematic-core        = { path = "../chematic-core",        version = "0.13.0" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.13.0" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.13.0" }
+chematic-smiles      = { path = "../chematic-smiles",      version = "0.13.0" }
 serde_json           = "1.0"
 
 [dev-dependencies]

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.12.0" }
+chematic-core = { path = "../chematic-core", version = "0.13.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,16 +25,16 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.12.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.12.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.12.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.12.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.12.0", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.12.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.12.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.12.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.12.0" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.12.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.12.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.12.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.13.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.13.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.13.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.13.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.13.0", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.13.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.13.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.13.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.13.0" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.13.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.13.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.13.0" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -22,9 +22,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 perf-instrumentation = []
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.12.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.12.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.12.0" }
+chematic-core   = { path = "../chematic-core",   version = "0.13.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.13.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.13.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.12.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
+chematic-core = { path = "../chematic-core", version = "0.13.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
 rustc-hash = "2"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #221); web-time

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.12.0" }
+chematic-core = { path = "../chematic-core", version = "0.13.0" }
 
 [features]
 # Feature-gated internal work counters for the orbit-pruning canonical

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -26,16 +26,16 @@ wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["console"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.12.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.12.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.12.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.12.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.12.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.12.0", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.12.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.12.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.12.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.12.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.12.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.12.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.12.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.13.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.13.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.13.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.13.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.13.0", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.13.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.13.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.13.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.13.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.13.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.13.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.13.0" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -33,15 +33,15 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.12.0", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.12.0", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.12.0", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.12.0", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.12.0", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.12.0", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.12.0", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.12.0", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.12.0", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.12.0", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.12.0", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.12.0", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.13.0", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.13.0", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.13.0", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.13.0", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.13.0", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.13.0", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.13.0", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.13.0", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.13.0", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.13.0", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.13.0", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.13.0", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

v0.13.0: MMFF94 stretch-bend + torsion parameter-selection parity (issue #227, both breaking), per-atom stereocenter API, E/Z completeness, macrocycle detection, notation-invariant atropisomer detection/assignment, XYZ/multi-frame XYZ I/O.

Version bump only (`0.12.0` → `0.13.0` via `scripts/bump_version.py`), plus README.md/README_ja.md "Recent Development" entries and CHANGELOG.md `[0.13.0]` section (renamed from `[Unreleased]`, with missing entries added for features that shipped without their own CHANGELOG entry, plus a release-gate waiver note). No production code changes beyond what's already on `main`.

## Release-gate evidence

PR #284 (merged) is the frozen v0.13.0 combined remeasurement against `main@2b608d3`: 9/10 gate conditions cleanly PASS (zero success/soundness/timeout regression across the 265-molecule Wave 1 corpus, RepairAndVerify success rate unchanged, reproducibility confirmed). Gate 7 (E/Z + tetrahedral stereo, zero regression) required a post-merge investigation, resolved as a **waiver-pass**: the 2-molecule regression (`chembl_tier_b_0126`/`0168`) is root-caused to a pre-existing distance-geometry embedding defect (present since v0.12.0), previously masked by the now-fixed torsion classification bug, confirmed via RDKit's own MMFF94 exhibiting the identical behavior on identical starting coordinates — not a new defect this release introduces. Tracked as issue #285 for a future release.

## Test plan

- [x] `bash scripts/check.sh` passes (fmt, clippy `-D warnings`, full workspace tests, cargo-deny, publish graph, version consistency)
- [x] Version consistency: `0.13.0` across all 18 publishable crates + Python/npm package metadata
- [ ] CI green on this PR