### PR TITLE
chore: gitignore ROADMAP.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ Thumbs.db
 # demo/pkg is committed directly (static WASM bundle for GitHub Pages)
 # internal roadmap notes, not tracked
 tasks/todo.md
+ROADMAP.md


### PR DESCRIPTION
## Summary
- Adds `ROADMAP.md` to `.gitignore`, matching the existing treatment of `tasks/todo.md` — both are internal, frequently-rewritten planning docs not meant to be tracked in git.

## Test plan
- N/A — `.gitignore`-only change, no code/behavior affected.