### PR TITLE
docs(3d): record that distance bounds cannot encode chirality sign

### DIFF
--- a/docs/etkdg_3d_gap_rfc.md
+++ b/docs/etkdg_3d_gap_rfc.md
@@ -566,6 +566,31 @@ Which of these (or which combination) is the right next step is a policy/
 scope decision, not a pure implementation one — see `ROADMAP.md`'s S-tier
 item 1 status notes for the live decision state.
 
+**Update (2026-08-11) — check-and-repair's chirality-blind *process*, not
+just the static bound matrix, needs saying explicitly.** Implementing the
+first option above (`enforce_chirality`, PR #295) surfaced a sharper version
+of the reflection-invariance point: it isn't only the *static* pairwise
+bound matrix that can't encode a chirality sign — `refine_coords`'s
+iterative SHAKE-like bounds-satisfaction *process* is equally chirality-blind
+at every step, and given enough iterations it can walk a correctly-repaired
+geometry back across the achiral fence, undoing `repair_stereo`'s fix
+entirely (reproduced directly: repair a violated tetrahedral center, verify
+it's `Satisfied` pre-refinement, run the existing 800-iteration
+`refine_coords` pass, verify again — `Violated`, on a real molecule, not a
+contrived one). A single check-and-repair pass followed by refinement is
+therefore not sufficient by itself; PR #295 treats each post-refine
+reversion as an ordinary bad stochastic draw and relies on the existing
+`max_attempts` retry loop (full, untuned `REFINE_ITERS` every attempt, no
+new short-refine constant — an initial attempt to tune one was tried and
+abandoned, see that PR's body) to eventually land in a seed where the repair
+survives. Measured yield: 86.2%-93.1% (25-27/29) on the declared-stereo
+subset of `scripts/etkdg_vs_rdkit_gap.py::CORPUS`, embedder alone. This
+does not change which of the three options above is "the" fix for the
+ring-fused case (still unresolved, still needs the chiral-volume-penalty
+option or equivalent) — it only clarifies that option 1's *mechanism*, not
+just its ring-fused *scope limit*, is inherently probabilistic rather than
+deterministic-once-repaired.
+
 ### Phase 4 — ring handling
 **Current**: `dg.rs` has hand-picked chair/envelope/crown templates by ring
 size (6/5/≥8), correctly tested for those cases in isolation, but Phase 0's

--- a/docs/etkdg_3d_gap_rfc.md
+++ b/docs/etkdg_3d_gap_rfc.md
@@ -525,6 +525,47 @@ molecules with declared stereochemistry, without needing `RepairAndVerify`'s
 post-hoc repair pass as a crutch — repair should become the rare exception,
 not the primary mechanism, for stereo satisfaction going forward.
 
+**Correction (2026-08-11) — the "injected into `build_bound_matrix`'s
+bounds" design above is mathematically impossible, do not attempt it as
+written.** A pairwise distance matrix is reflection-invariant: a molecule
+and its full mirror image have an *identical* distance matrix (every
+pairwise distance is preserved by a reflection). This is not an
+implementation gap, it's a property of Euclidean distance geometry itself —
+no amount of clever `DistanceBoundAdjustment`-style pairwise bound narrowing
+(the mechanism `pipeline_v2.rs` already uses for macrocycle 1-4 relaxation,
+`crates/chematic-3d/src/pipeline_v2.rs:629`) can encode which of the two
+mirror-image arrangements a bound-matrix-only embedder should produce,
+because the bounds themselves cannot distinguish them. Anyone re-deriving a
+design from the macrocycle-adjustment precedent will naturally reach for
+this approach and should stop here instead.
+
+The design space that actually works operates on **real 3D coordinates**,
+not just pairwise distances, since only actual coordinates (not a distance
+matrix) can carry a chirality sign at all:
+- **Check-and-repair after embedding**: what `stereo_constraints.rs`
+  (`verify_stereo`/`repair_stereo`) already does — reflect/rotate a
+  bridge-eligible substituent group post-embedding. Structurally cannot fix
+  ring-fused stereocenters (no bridge-eligible substituent to move without
+  corrupting the ring — issue #210's testosterone/cholesterol case).
+- **Check-and-retry with a new stochastic seed**: cheap to wire (the
+  existing `max_attempts` retry loop in `embed_distance_geometry_v2_with_
+  adjustments` already retries for other failure causes), but success
+  probability per attempt is roughly independent-per-stereocenter, so for a
+  molecule with *k* declared centers the naive per-attempt success rate is
+  roughly on the order of 2^-k — likely still near-zero within a handful of
+  attempts for a molecule like cholesterol (8 declared centers). Needs
+  measuring before being presented as a fix for the ring-fused case.
+- **A genuine chiral-volume/improper-torsion penalty term inside
+  `refine_coords`'s SHAKE-like iteration**: since this operates on real
+  coordinates each pass (not a static distance matrix), it *can* discriminate
+  mirror images the way a real force field's improper-torsion term does.
+  Not yet attempted; the harder but mathematically sound path for the
+  ring-fused case specifically.
+
+Which of these (or which combination) is the right next step is a policy/
+scope decision, not a pure implementation one — see `ROADMAP.md`'s S-tier
+item 1 status notes for the live decision state.
+
 ### Phase 4 — ring handling
 **Current**: `dg.rs` has hand-picked chair/envelope/crown templates by ring
 size (6/5/≥8), correctly tested for those cases in isolation, but Phase 0's


### PR DESCRIPTION
## Summary
- Adds a "Correction (2026-08-11)" note to `docs/etkdg_3d_gap_rfc.md`'s Phase 3 section: a pairwise distance matrix is reflection-invariant (a molecule and its mirror image have identical pairwise distances), so `DistanceBoundAdjustment`-style pairwise bound narrowing (the mechanism already used for macrocycle 1-4 relaxation) cannot encode chirality sign, no matter how the pairs are chosen.
- Found while scoping the follow-up PR to #292 (wiring `StereoConstraintSet` into embedding) — this invalidates the RFC's own prior "injected into `build_bound_matrix`'s bounds" phrasing for chirality specifically.
- Lists the three approaches that actually work (all operate on real coordinates, not just pairwise distances): check-and-repair post-embedding (existing `stereo_constraints::repair_stereo`, structurally can't fix ring-fused centers), check-and-retry with a new seed (cheap but ~2^-k success rate for k declared centers), and a genuine chiral-volume penalty term inside `refine_coords`'s iteration (harder, mathematically sound for the ring-fused case).
- Docs-only, no code/behavior affected.

## Test plan
- N/A — planning document only. `bash scripts/check.sh` passes (no code touched).