### PR TITLE
fix(rxn): suzuki_biaryl requires explicit single bond, not implicit aromatic (#294)

### DIFF
--- a/crates/chematic-rxn/src/retro.rs
+++ b/crates/chematic-rxn/src/retro.rs
@@ -277,8 +277,15 @@ pub static DEFAULT_TEMPLATES: &[RetroTemplate] = &[
     },
     // ── C–C bond ─────────────────────────────────────────────────────────────
     RetroTemplate {
+        // Explicit `-` (not the default implicit-aromatic bond two adjacent
+        // aromatic atoms get in this crate's SMILES-based template parser) is
+        // load-bearing: a real biaryl axis is *never* an aromatic bond (the two
+        // rings' own aromatic systems don't extend across it), only ordinary
+        // intra-ring aromatic bonds are. Without the `-`, `[c:1][c:2]` matched
+        // every intra-ring aromatic C-C bond and *zero* real biaryl bonds --
+        // the opposite of what was intended (issue #294).
         name: "suzuki_biaryl",
-        smirks: "[c:1][c:2]>>[c:1]Br.[c:2]B(O)O",
+        smirks: "[c:1]-[c:2]>>[c:1]Br.[c:2]B(O)O",
         reaction_class: RetroClass::CCBond,
     },
     RetroTemplate {
@@ -544,8 +551,46 @@ mod tests {
         // benzene has no breakable bonds for any template
         let m = mol("c1ccccc1");
         let results = retro_disconnect(&m, DEFAULT_TEMPLATES, 0);
-        // May still get trivial C-C or C-H hits — just check it doesn't panic
-        let _ = results;
+        assert!(
+            results.is_empty(),
+            "plain benzene has no real disconnection, got: {:?}",
+            results.iter().map(|r| &r.template_name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_suzuki_biaryl_does_not_match_intra_ring_bonds() {
+        // Issue #294: `[c:1][c:2]` with no ring-crossing constraint matched
+        // any aromatic C-C bond, including ordinary intra-ring ones.
+        for smiles in ["c1ccccc1", "c1ccc2ccccc2c1", "c1ccncc1"] {
+            let m = mol(smiles);
+            let results = retro_disconnect(&m, DEFAULT_TEMPLATES, 50);
+            assert!(
+                !results.iter().any(|r| r.template_name == "suzuki_biaryl"),
+                "{smiles}: suzuki_biaryl must not fire on a molecule with no biaryl bond"
+            );
+        }
+
+        // Two rings connected only by an ether oxygen -- no direct ring-to-ring
+        // C-C bond exists, so suzuki_biaryl must not fire (aryl_ether_ullmann
+        // is the correct match here).
+        let diphenyl_ether = mol("c1ccccc1Oc1ccccc1");
+        let results = retro_disconnect(&diphenyl_ether, DEFAULT_TEMPLATES, 50);
+        assert!(
+            !results.iter().any(|r| r.template_name == "suzuki_biaryl"),
+            "diphenyl ether has no biaryl C-C bond"
+        );
+    }
+
+    #[test]
+    fn test_suzuki_biaryl_matches_real_biaryl_bond() {
+        // biphenyl: the two rings ARE connected by a real (non-ring) C-C bond.
+        let biphenyl = mol("c1ccc(-c2ccccc2)cc1");
+        let results = retro_disconnect(&biphenyl, DEFAULT_TEMPLATES, 50);
+        assert!(
+            results.iter().any(|r| r.template_name == "suzuki_biaryl"),
+            "suzuki_biaryl must still fire on a genuine biaryl bond"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #294.

## Corrected root cause (differs from the original issue's hypothesis)

The issue's original hypothesis was "`[c:1][c:2]` matches any bonded pair of aromatic carbons because there's no constraint requiring the two atoms to belong to different ring systems" — i.e. a **missing ring-crossing constraint**.

The actual root cause is sharper than that, and the fix follows directly from it: two adjacent aromatic atoms written with no explicit bond token between them (`[c:1][c:2]`) default to an **aromatic** bond in this crate's SMILES-based template parser, not "any bond." That means the template didn't just *additionally* match intra-ring bonds on top of correctly matching biaryl bonds — it **only ever matched intra-ring aromatic bonds, and never matched a real biaryl axis at all**, since a bond directly connecting two separate aromatic ring systems is by chemical definition a single (non-aromatic) bond — aromaticity doesn't extend across it. Confirmed empirically: `run_reactants("[c:1][c:2]>>...", &[&biphenyl])` returns 12 matches (all 12 intra-ring C-C bonds, 6 per ring) and **zero** of them is the actual ring-connecting bond.

So the fix is not "add a ring-crossing constraint" (there's no ring-topology machinery involved at all) — it's requiring the correct bond type: `[c:1]-[c:2]` (explicit single bond). This directly encodes "a single bond joining two aromatic carbons," which *is* the biaryl axis, and structurally cannot match an intra-ring aromatic bond (those are `BondOrder::Aromatic`, not `Single`) or a bond across an ether/other linker (also not a direct C-C single bond between two aromatic atoms).

## Investigation path (why this took a few iterations)

1. First attempt: `[c:1]!@[c:2]` (SMARTS ring-bond negation). This **silently broke the template entirely** — `chematic-rxn`'s reactant-template parser is `chematic_smiles::parse` (a concrete-molecule SMILES parser via `transform.rs::prepare_reaction`/`mol_to_query`), not a SMARTS parser, and doesn't support `!@` at all. `run_reactants` returned `Err(SmirksParse(...))`, silently caught by `retro_disconnect`'s `Err(_) => continue`, so the template matched nothing — worse than the original bug (a true-positive regression test on biphenyl caught this).
2. Considered a Rust-level post-match ring-bond filter (mirroring `transform.rs`'s existing `has_stereo`/`has_ez_stereo` post-checks for properties the VF2 query can't express) — implemented and tested, but a diagnostic probe showed the underlying `[c:1][c:2]` match set for biphenyl never included the real biaryl bond in the first place (see above), so a post-match filter would have had nothing correct to keep.
3. That probe is what surfaced the actual bond-order-default root cause, and the one-character `[c:1]-[c:2]` fix — no ring-topology check needed at all. Reverted the `!@` attempt and the post-match-filter machinery entirely; this PR is exactly the one-line template change plus tests.

Investigating (1) also surfaced a much larger, separately-filed issue: **#296** — 14/59 `DEFAULT_TEMPLATES` entries silently never parse at all (unrelated SMARTS-syntax-unsupported and malformed-string bugs across several other templates), found while checking whether `negishi`'s `[CX4:2]` (a similarly-shaped template) actually works. Not fixed here — deliberately out of scope for this narrow fix, tracked separately.

## Tests

- `test_suzuki_biaryl_does_not_match_intra_ring_bonds` — negative control, exactly the issue's 4 reproduction cases: benzene, naphthalene, pyridine (no biaryl bond at all), and diphenyl ether (two rings, but connected via O, not a direct C-C bond).
- `test_suzuki_biaryl_matches_real_biaryl_bond` — positive control (biphenyl), added specifically because the negative-only test set passed *vacuously* under the broken `!@` attempt (0 matches ever, on anything) — this is the test that caught that regression during development.
- `test_retro_no_match` (pre-existing, previously a placebo assertion — `let _ = results;` with a comment already anticipating this exact bug) tightened to a real `assert!(results.is_empty())` for plain benzene.

`cargo test -p chematic-rxn --lib` — 161 passed, 0 failed. `bash scripts/check.sh` — all green (fmt, clippy -D warnings, build, cargo-deny, publish graph, version consistency).

Merge is not requested yet — parking for explicit go-ahead per this project's standing policy.
