### PR TITLE
docs(3d): correct but2ene_Z diagnosis with measured sign-variability contrast

### DIFF
--- a/crates/chematic-3d/src/distance_geometry_v2.rs
+++ b/crates/chematic-3d/src/distance_geometry_v2.rs
@@ -88,18 +88,31 @@
 //!   retry-odds problem: at a fixed base seed, the *raw* (pre-repair,
 //!   `enforce_chirality: false`) embedding is already `Violated` for all of 10
 //!   tested derived seeds, deterministically, not ~50/50 as the "coin flip per
-//!   center" framing predicts. Isolated further: the raw *coordinates* do differ
-//!   substantially seed to seed (summed atom displacement vs. the previous seed's
-//!   geometry was several Å, not near-zero), yet the sign of the C0-C1=C2-C3
-//!   dihedral was identical across all 10 — ruling out "bounds too tight to vary
-//!   the geometry" as the mechanism. The likely cause is a fixed sign/orientation
-//!   convention somewhere in the MDS reconstruction chain (`mds_embed` /
-//!   `distance_to_gram_matrix` / `jacobi_eigendecompose`) that is independent of
-//!   the sampled distance matrix — not confirmed further, not this PR's scope to
-//!   fix. Either way, raising `max_attempts` cannot reliably help here, unlike the
-//!   bridge-eligible tetrahedral case. This is a distinct, disclosed gap from both
-//!   the ring-fused case and the general reflection-invariance point above; tracked
-//!   as a follow-up issue, not fixed in this PR. The remaining single-base-seed-only
+//!   center" framing predicts. Isolated further (2026-08-11, follow-up
+//!   diagnosis): the raw coordinates *do* vary seed to seed (in-plane spread
+//!   ~3.1-3.5 Å / ~1.3-1.5 Å, out-of-plane spread ~0.4-0.9 Å -- real 3D content,
+//!   not a planar collapse), yet the sign of the C0-C1=C2-C3 dihedral was
+//!   identical across all 10 draws. Contrasted directly against a larger,
+//!   more conformationally flexible molecule with the same simple 1-declared-
+//!   E/Z-bond shape (`cinnamic_acid_E`, `OC(=O)/C=C/c1ccccc1`, same probe, same
+//!   10 seeds): its raw dihedral sign split 5-positive/5-negative -- genuine
+//!   per-seed variability, exactly what the retry loop is designed to exploit.
+//!   **The measured fact is this contrast** (0/10 sign flips for the small/rigid
+//!   molecule vs. 5/10 for the larger/flexible one) -- the *mechanism* behind it
+//!   (why the small molecule's sampled distance matrices consistently reconstruct
+//!   to the same handedness) is not yet isolated; a plausible but unverified
+//!   candidate is that `jacobi_eigendecompose`'s eigenvector-sign outcome is a
+//!   deterministic, presumably-continuous function of the input Gram matrix, and
+//!   a tightly-bounded (low-conformational-freedom) molecule's sampled distance
+//!   matrices across different seeds stay too numerically close to one another
+//!   to cross whatever boundary would flip it -- not confirmed, do not treat as
+//!   established. **Operational consequence, which *is* established regardless
+//!   of mechanism**: for at least this molecule class, `max_attempts` retry is
+//!   structurally unable to help, because there is no real per-seed variability
+//!   to exploit -- this is a distinct, disclosed gap from both the ring-fused
+//!   case and the general reflection-invariance point above; tracked as a
+//!   follow-up (issue #285 comment), not fixed here. The remaining
+//!   single-base-seed-only
 //!   failures (`atorvastatin_fragment` at one seed, `cinnamic_acid_E` at another)
 //!   match the expected `max_attempts`-retry-loop variance already documented above
 //!   (occasional exhaustion of 8 attempts for a molecule the mechanism *can* fix),


### PR DESCRIPTION
## Summary

Doc-only correction. No code change.

PR #295's module doc (`crates/chematic-3d/src/distance_geometry_v2.rs`) noted that `but2ene_Z` (`C/C=C\C`) fails `enforce_chirality` deterministically — the raw embedding is `Violated` for all of 10 tested seeds, unlike the "coin flip per attempt" model the retry loop is designed around — and guessed at a mechanism: "a fixed sign/orientation convention somewhere in the MDS reconstruction chain," explicitly flagged as "not confirmed further."

This PR replaces that guess with a measured contrast, per the investigation requested this session.

## What was measured

Raw dihedral sign (C0-C1=C2-C3, `enforce_chirality: false`) across the same 10 seeds, for two molecules with the same "1 declared E/Z bond" shape but different size/rigidity:

| molecule | shape | sign outcomes (10 seeds) |
|---|---|---|
| `but2ene_Z` (`C/C=C\C`) | small, rigid, 4 heavy atoms | **0/10 flips** |
| `cinnamic_acid_E` (`OC(=O)/C=C/c1ccccc1`) | larger, more conformationally flexible | **5/10** — genuine variability |

`but2ene_Z`'s raw coordinates do vary meaningfully seed to seed (in-plane spread ~3.1-3.5 Å / ~1.3-1.5 Å, out-of-plane spread ~0.4-0.9 Å) — not a planar collapse, ruling out "bounds too tight to move at all" as the explanation.

## What this does and doesn't establish

- **Established** (stated as fact in the updated doc): for this molecule class, `max_attempts` retry is structurally unable to help — there's no real per-seed sign variability to exploit, unlike the larger/flexible case where there is.
- **Not established** (stated as an unverified candidate, not a conclusion): *why* — a plausible mechanism is that `jacobi_eigendecompose`'s eigenvector-sign outcome is a deterministic, presumably-continuous function of the input Gram matrix, and a tightly-bounded molecule's sampled distance matrices across different seeds stay too numerically close to cross whatever boundary would flip the sign. Named explicitly as unconfirmed so a future reader doesn't cite it as settled.

Also posted as a correction comment on issue #285 (which my earlier, now-superseded comment on this topic was posted to), including a concrete next diagnostic: check whether #285's own two named molecules fall into the "small/rigid" (deterministic, retry-proof) or "flexible" (retry-exploitable) class.

## Scope

Diagnosis only, as requested — no fix attempted. A fix (perturbing the Gram matrix, seeding an explicit reflection when raw verify fails deterministically, or a chiral-volume penalty term) is a real design decision with more than one viable answer, left for a separate PR after discussion.

## Verification

`cargo test -p chematic-3d --lib distance_geometry_v2` — 21 passed, 0 failed (no test changes, doc-only diff). `bash scripts/check.sh` — all green.

Merge is not requested yet — parking for explicit go-ahead per this project's standing policy.
