### PR TITLE
feat(3d): allow enforce_chirality + VerifyOnly; expose enforce_chirality in Python/WASM (#285)

### DIFF
--- a/crates/chematic-3d/src/distance_geometry_v2.rs
+++ b/crates/chematic-3d/src/distance_geometry_v2.rs
@@ -32,12 +32,19 @@
 //! `enforce_chirality` is NOT one of these no-op placeholders — see the
 //! "`enforce_chirality`" section below for what it actually does.
 //!
-//! # Not wired into the live pipeline
+//! # Not wired into the default conformer path (stale note corrected 2026-08-11)
 //!
-//! Nothing in `etkdg.rs` or `Mol.conformer_ensemble()` calls this module. Per the
-//! master plan §1b, that integration is an explicit Wave 2 Coordinator step performed
-//! only after this PR, Agent F's force-field bridge, and Agent E's torsion knowledge
-//! are all separately merged.
+//! `etkdg.rs`'s `generate_coords_etkdg` and `Mol.conformer_ensemble()`
+//! (`generate_conformer_ensemble`/`generate_conformer_ensemble_with_config`) still
+//! use the older `dg.rs` deterministic-midpoint embedder, not this module, and this
+//! remains true today. What changed since this note was first written: `pipeline_v2.rs`
+//! (Wave 2 → Wave 3 Coordinator Integration 1) now calls into this module directly
+//! ([`embed_distance_geometry_v2_with_adjustments`]), and `pipeline_v2::embed_pipeline_v2`
+//! itself **is** reachable from outside Rust-internal code — `Mol.embed_pipeline_v2()`
+//! (chematic-py) and `embed_pipeline_v2_json` (chematic-wasm) both call it, an opt-in
+//! surface distinct from (and not yet routed through) the default conformer path above.
+//! `chematic-mcp` does not expose it. See `pipeline_v2.rs`'s own module doc for its
+//! stage order and the `enforce_chirality`/`StereoPolicy` interaction.
 //!
 //! # `enforce_chirality` (added 2026-08-11, issue #291/#293; E/Z bound fix
 //! 2026-08-11, issue #285)

--- a/crates/chematic-3d/src/pipeline_v2.rs
+++ b/crates/chematic-3d/src/pipeline_v2.rs
@@ -13,8 +13,13 @@
 //! [`generate_coords`](crate::generate_coords),
 //! [`generate_conformer_ensemble`](crate::generate_conformer_ensemble),
 //! [`generate_conformer_ensemble_with_config`](crate::generate_conformer_ensemble_with_config),
-//! and the Python/WASM/MCP surfaces are untouched by this PR — [`embed_pipeline_v2`]
-//! is a new, additive, Rust-only, opt-in entry point.
+//! remain untouched — those still use the older `dg.rs` embedder, unrelated to this
+//! module. **Correction (2026-08-11, stale since this PR's original text):**
+//! `embed_pipeline_v2` is no longer Rust-only — `Mol.embed_pipeline_v2()`
+//! (`chematic-py`) and `embed_pipeline_v2_json` (`chematic-wasm`) both call it
+//! directly, added by later PRs without this doc being updated. It remains opt-in
+//! (a caller must explicitly choose this entry point; nothing routes through it
+//! implicitly) and `chematic-mcp` still does not expose it.
 //!
 //! # The most important semantics — read this twice
 //!
@@ -75,15 +80,28 @@
 //!
 //! # Judgment calls made in this file (see PR body for the full account)
 //!
-//! - `embed.enforce_chirality = true` is rejected as [`PipelineV2FailureCause::InvalidConfiguration`]
-//!   at stage 1 whenever `stereo_policy != StereoPolicy::Ignore`: this pipeline's own
-//!   stages 7–11 are the stereo gate, and letting the raw embedder's *unrelated*
-//!   `enforce_chirality` mechanism (repair-then-retry per attempt inside
-//!   `distance_geometry_v2`, added 2026-08-11 — see that module's own doc) additionally
-//!   reject/repair the same molecule for a different, unrelated reason would be
-//!   confusing, not defense-in-depth — even now that it's a real mechanism rather
-//!   than the fail-closed stub it used to be. Whether the two stereo mechanisms
-//!   should ever be composed is an open question for a later PR, not decided here.
+//! - **Revised 2026-08-11 (v0.14.0 release gate)**: `embed.enforce_chirality = true`
+//!   was originally rejected as [`PipelineV2FailureCause::InvalidConfiguration`] at
+//!   stage 1 for every `stereo_policy != StereoPolicy::Ignore`, reasoning that this
+//!   pipeline's own stages 7–11 stereo gate and the raw embedder's `enforce_chirality`
+//!   mechanism were unrelated and composing them would be confusing, not defense-in-
+//!   depth. Direct 265-molecule-corpus measurement disproved that: `enforce_chirality`
+//!   protects embedding-time correctness only (verified via `stereo_before`, populated
+//!   before stage 10 runs), and stage 10's force-field minimization has no notion of
+//!   declared stereo and can walk a correctly-embedded E/Z bond back across its
+//!   boundary (`chembl_tier_b_0076`/`chembl_tier_b_0083`: `stereo_before` fully
+//!   satisfied under `enforce_chirality`, `final_stereo` violated after MMFF94
+//!   minimization; re-running with `ForceFieldPolicy::None` on the same molecules
+//!   keeps `final_stereo` satisfied, isolating minimization as the cause). The two
+//!   mechanisms are complementary stages of defense, not redundant: `enforce_chirality`
+//!   without a post-minimization gate can silently report `success` on a geometry
+//!   whose final declared stereo is wrong. `StereoPolicy::Ignore` and
+//!   `StereoPolicy::VerifyOnly` are now both allowed with `enforce_chirality: true`
+//!   (VerifyOnly's stage 11 "Violated => failure" gate is exactly the fail-closed
+//!   check that catches this class of drift). `StereoPolicy::RepairAndVerify` remains
+//!   rejected in this combination — composing `enforce_chirality`'s own repair-then-
+//!   retry with stage 8's repair pass is a separate, not-yet-validated question,
+//!   deliberately deferred rather than decided by omission.
 //! - The `use_small_ring_torsions`/`use_macrocycle_torsions` fail-closed gate (stage
 //!   6) is scoped exactly to `TorsionKnowledgeSource::SmallRingExperimental` /
 //!   `MacrocycleAdaptation` potentials — not to `BasicChemicalKnowledge`'s flat-ring
@@ -572,11 +590,24 @@ pub fn embed_pipeline_v2(
     // -----------------------------------------------------------------
     // Stage 1: validate config.
     // -----------------------------------------------------------------
-    if config.embed.enforce_chirality && config.stereo_policy != StereoPolicy::Ignore {
-        // See the module docs' judgment-call section: this pipeline's own stages
-        // 7-11 are the stereo gate; `embed.enforce_chirality` is a different,
-        // separate repair/retry mechanism inside the raw embedder, and letting
-        // both run would be confusing, not defense-in-depth.
+    if config.embed.enforce_chirality && config.stereo_policy == StereoPolicy::RepairAndVerify {
+        // See the module docs' judgment-call section (revised 2026-08-11, v0.14.0
+        // release gate): `embed.enforce_chirality` and this pipeline's own stage
+        // 7-11 stereo gate are complementary, not redundant -- `enforce_chirality`
+        // protects embedding-time correctness only, and stage 10's force-field
+        // minimization has no notion of declared stereo and can walk a correctly-
+        // embedded E/Z bond back across its boundary (measured directly on the
+        // 265-molecule corpus: `chembl_tier_b_0076`/`chembl_tier_b_0083` embed
+        // correctly under `enforce_chirality` but MMFF94 minimization flips them --
+        // confirmed by re-running with `ForceFieldPolicy::None`, which does not).
+        // `StereoPolicy::Ignore` and `StereoPolicy::VerifyOnly` are both allowed
+        // with `enforce_chirality: true` (VerifyOnly's stage 11 gate is exactly
+        // the fail-closed check needed to catch that kind of post-minimization
+        // drift). `StereoPolicy::RepairAndVerify` remains excluded here -- its
+        // stage 8 repair pass was designed and validated against embeddings that
+        // never ran `enforce_chirality`'s own repair-then-retry first, and
+        // composing the two repair mechanisms is a separate, not-yet-validated
+        // question (deliberately deferred, not decided by omission).
         timings.total_ms = overall_start.elapsed().as_millis() as u64;
         return Err(evidence.fail(
             PipelineV2FailureCause::InvalidConfiguration,
@@ -1133,11 +1164,15 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn enforce_chirality_with_nonignore_stereo_policy_is_invalid_configuration() {
+    fn enforce_chirality_with_repair_and_verify_stereo_policy_is_invalid_configuration() {
+        // Revised 2026-08-11: enforce_chirality's InvalidConfiguration gate now only
+        // excludes RepairAndVerify (composing its stage-8 repair with
+        // enforce_chirality's own repair-then-retry is a separate, deliberately
+        // deferred question) -- see the module doc's revised judgment-call entry.
         let mol = parse("C[C@H](O)CC").unwrap();
         let mut config = config_none();
         config.embed.enforce_chirality = true;
-        config.stereo_policy = StereoPolicy::VerifyOnly;
+        config.stereo_policy = StereoPolicy::RepairAndVerify;
         let err = embed_pipeline_v2(&mol, &config).unwrap_err();
         assert!(matches!(
             err.cause,
@@ -1148,13 +1183,108 @@ mod tests {
 
     #[test]
     fn enforce_chirality_with_ignore_stereo_policy_is_allowed() {
-        // enforce_chirality only conflicts with THIS pipeline's own stereo gate when
-        // that gate is actually active (non-Ignore).
         let mol = parse("CCCC").unwrap(); // no declared stereo at all
         let mut config = config_none();
         config.embed.enforce_chirality = true;
         config.stereo_policy = StereoPolicy::Ignore;
         assert!(embed_pipeline_v2(&mol, &config).is_ok());
+    }
+
+    #[test]
+    fn enforce_chirality_with_verify_only_stereo_policy_is_allowed() {
+        // Revised 2026-08-11: previously InvalidConfiguration -- now allowed, since
+        // VerifyOnly's stage 11 gate is exactly what catches a force field
+        // undoing enforce_chirality's embedding-time correctness (see the module
+        // doc's revised judgment-call entry for the corpus evidence).
+        let mol = parse("C[C@H](O)CC").unwrap();
+        let mut config = config_none();
+        config.embed.enforce_chirality = true;
+        config.embed.max_attempts = 8;
+        config.stereo_policy = StereoPolicy::VerifyOnly;
+        let result = embed_pipeline_v2(&mol, &config);
+        if let Err(e) = &result {
+            assert!(
+                !matches!(e.cause, PipelineV2FailureCause::InvalidConfiguration),
+                "must not be rejected as InvalidConfiguration, got {e:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn enforce_chirality_with_verify_only_never_reports_success_with_violated_final_stereo() {
+        // Motivated by the corpus-measured chembl_tier_b_0076/0083 failure mode
+        // (265-molecule v0.14.0 release-gate re-measurement): enforce_chirality can
+        // deliver correct declared E/Z at embedding time (verified via
+        // `stereo_before`, populated before stage 10 runs) while MMFF94
+        // minimization -- which has no notion of declared stereo -- walks it back
+        // across the boundary afterward (confirmed separately for that exact
+        // molecule/seed: re-running with `ForceFieldPolicy::None` leaves
+        // `final_stereo` satisfied, isolating minimization as the cause -- see the
+        // module doc's revised judgment-call entry). Before this PR's gate
+        // relaxation, `StereoPolicy::Ignore` was the only option compatible with
+        // enforce_chirality, and Ignore never gates on stereo -- a caller could get
+        // a `success` result whose geometry silently violates its own declared E/Z.
+        //
+        // This test asserts the general invariant, not a specific outcome for this
+        // one molecule/seed: whether MMFF94 happens to revert the fix is itself
+        // non-deterministic across build profiles (verified while writing this test
+        // -- an unoptimized debug build converged differently than the release
+        // build the corpus measurement used, for the identical seed), so asserting
+        // "this exact call must fail" would make the test flaky by build profile.
+        // What must hold regardless: `enforce_chirality`'s own part of the contract
+        // (embedding-time correctness, `stereo_before`) always succeeds for this
+        // molecule, and `Ok` is never returned with a violated `final_stereo` --
+        // VerifyOnly's stage 11 gate must have caught it if minimization did revert
+        // the fix.
+        let mol = parse("COc1cc2nc(N3CCN(C(=O)/C=C/c4ccc(NC(=O)CBr)cc4)CC3)nc(N)c2cc1OC").unwrap(); // chembl_tier_b_0083
+        let mut config = config_none();
+        config.embed.random_seed = 20260801; // the corpus benchmark's exact seed
+        config.embed.enforce_chirality = true;
+        config.embed.max_attempts = 8;
+        config.embed.use_exp_torsions = true;
+        config.embed.use_small_ring_torsions = true;
+        config.embed.use_macrocycle_torsions = true;
+        config.embed.use_macrocycle_14_bounds = true;
+        config.stereo_policy = StereoPolicy::VerifyOnly;
+        config.force_field_policy = ForceFieldPolicy::Mmff94BondAngleStrict;
+        // Capped well below the 200-iteration production default: in an
+        // unoptimized debug build (what `cargo test` uses in CI), this specific
+        // 36-atom macrocycle-containing molecule's MMFF94 minimization is slow
+        // enough at 200 iterations to make the test take minutes -- 40 is still
+        // enough to exercise "did minimization move the geometry", the actual
+        // invariant under test, without that cost.
+        config.force_field_max_iterations = 40;
+        config.ring_torsion_policy = RingTorsionApplicationPolicy::DiagnosticOnly;
+        config.total_timeout_ms = Some(60_000);
+
+        match embed_pipeline_v2(&mol, &config) {
+            Ok(r) => {
+                assert!(
+                    r.stereo_before.is_fully_satisfied(),
+                    "enforce_chirality's embedding-time fix must be correct -- got {:?}",
+                    r.stereo_before
+                );
+                assert!(
+                    r.final_stereo.is_fully_satisfied(),
+                    "must never report success with a geometry violating declared stereo -- \
+                     got final_stereo {:?}",
+                    r.final_stereo
+                );
+            }
+            Err(e) => {
+                assert!(
+                    !matches!(e.cause, PipelineV2FailureCause::InvalidConfiguration),
+                    "must not be rejected as InvalidConfiguration: {e:?}"
+                );
+                assert!(
+                    e.stereo_before
+                        .as_ref()
+                        .is_some_and(StereoVerification::is_fully_satisfied),
+                    "enforce_chirality's embedding-time fix must be correct -- got {:?}",
+                    e.stereo_before
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/chematic-py/python/chematic/__init__.pyi
+++ b/crates/chematic-py/python/chematic/__init__.pyi
@@ -2837,6 +2837,7 @@ class PipelineV2Config:
         gate_mmff94_stretch_bend: bool,
         ring_torsion_policy: str,
         total_timeout_ms: Optional[int],
+        enforce_chirality: bool = False,
     ) -> None: ...
     @staticmethod
     def safe(
@@ -2856,6 +2857,7 @@ class PipelineV2Config:
         gate_mmff94_torsion_oop: bool = False,
         gate_mmff94_stretch_bend: bool = False,
         total_timeout_ms: Optional[int] = None,
+        enforce_chirality: bool = False,
     ) -> "PipelineV2Config":
         """Convenience constructor.
 
@@ -2882,6 +2884,13 @@ class PipelineV2Config:
     gate_mmff94_stretch_bend: bool
     ring_torsion_policy: str
     total_timeout_ms: Optional[int]
+    enforce_chirality: bool
+    """When True, each embedding attempt is checked against declared E/Z (and,
+    where the raw embedder's own repair can reach it, tetrahedral) stereo;
+    compatible with ``stereo_policy="ignore"``/``"verify_only"``, rejected as
+    a :class:`PipelineV2Error` with ``"repair_and_verify"`` (a separate,
+    not-yet-validated combination). Default ``False``, matching the Rust
+    ``EmbedParameters`` default -- existing callers are unaffected."""
 
     def __repr__(self) -> str: ...
 

--- a/crates/chematic-py/src/pipeline_v2.rs
+++ b/crates/chematic-py/src/pipeline_v2.rs
@@ -139,6 +139,25 @@ pub struct PyPipelineV2Config {
 impl PyPipelineV2Config {
     #[new]
     #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (
+        embed_seed,
+        max_attempts,
+        embed_timeout_ms,
+        use_exp_torsions,
+        use_small_ring_torsions,
+        use_macrocycle_torsions,
+        use_macrocycle_14_bounds,
+        include_legacy_torsion_heuristic,
+        stereo_policy,
+        fail_on_unevaluable_stereo,
+        force_field_policy,
+        force_field_max_iterations,
+        gate_mmff94_torsion_oop,
+        gate_mmff94_stretch_bend,
+        ring_torsion_policy,
+        total_timeout_ms,
+        enforce_chirality = false,
+    ))]
     fn new(
         embed_seed: u64,
         max_attempts: usize,
@@ -156,6 +175,15 @@ impl PyPipelineV2Config {
         gate_mmff94_stretch_bend: bool,
         ring_torsion_policy: &str,
         total_timeout_ms: Option<u64>,
+        // Trailing, defaulted (`false`, matching `EmbedParameters::default()`) so
+        // existing callers' positional/keyword calls keep working unchanged --
+        // added after `enforce_chirality` (v0.14.0, issue #285's E/Z bound fix)
+        // gained a real production effect. See `distance_geometry_v2.rs`'s module
+        // doc for what it does; see `pipeline_v2.rs`'s for why it's compatible
+        // with `stereo_policy="ignore"`/`"verify_only"` but not
+        // `"repair_and_verify"` (raises `PipelineV2Error` at validate-config
+        // otherwise).
+        enforce_chirality: bool,
     ) -> PyResult<Self> {
         Ok(Self {
             inner: pv2::PipelineV2Config {
@@ -167,6 +195,7 @@ impl PyPipelineV2Config {
                     use_small_ring_torsions,
                     use_macrocycle_torsions,
                     use_macrocycle_14_bounds,
+                    enforce_chirality,
                     ..EmbedParameters::default()
                 },
                 torsion_optimization: TorsionOptimizationConfig::default(),
@@ -206,6 +235,7 @@ impl PyPipelineV2Config {
         gate_mmff94_torsion_oop = false,
         gate_mmff94_stretch_bend = false,
         total_timeout_ms = None,
+        enforce_chirality = false,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn safe(
@@ -225,6 +255,7 @@ impl PyPipelineV2Config {
         gate_mmff94_torsion_oop: bool,
         gate_mmff94_stretch_bend: bool,
         total_timeout_ms: Option<u64>,
+        enforce_chirality: bool,
     ) -> PyResult<Self> {
         Self::new(
             embed_seed,
@@ -243,6 +274,7 @@ impl PyPipelineV2Config {
             gate_mmff94_stretch_bend,
             ring_torsion_policy,
             total_timeout_ms,
+            enforce_chirality,
         )
     }
 
@@ -309,6 +341,10 @@ impl PyPipelineV2Config {
     #[getter]
     fn total_timeout_ms(&self) -> Option<u64> {
         self.inner.total_timeout_ms
+    }
+    #[getter]
+    fn enforce_chirality(&self) -> bool {
+        self.inner.embed.enforce_chirality
     }
 
     fn __repr__(&self) -> String {

--- a/crates/chematic-py/tests/test_pipeline_v2.py
+++ b/crates/chematic-py/tests/test_pipeline_v2.py
@@ -377,6 +377,77 @@ def test_safe_uses_conservative_defaults_for_everything_else():
     assert config.max_attempts == 8
     assert config.embed_timeout_ms is None
     assert config.total_timeout_ms is None
+    assert config.enforce_chirality is False
+
+
+# ---------------------------------------------------------------------------
+# enforce_chirality (v0.14.0, issue #285's E/Z bound fix) -- Python parity
+# ---------------------------------------------------------------------------
+
+
+def test_enforce_chirality_defaults_false_and_is_backward_compatible():
+    """Existing callers that never pass enforce_chirality must keep working
+    unchanged -- .safe() and the explicit constructor both default it False."""
+    config = _safe_config()
+    assert config.enforce_chirality is False
+
+    explicit = chematic.PipelineV2Config(
+        embed_seed=1,
+        max_attempts=4,
+        embed_timeout_ms=None,
+        use_exp_torsions=False,
+        use_small_ring_torsions=False,
+        use_macrocycle_torsions=False,
+        use_macrocycle_14_bounds=False,
+        include_legacy_torsion_heuristic=False,
+        stereo_policy="ignore",
+        fail_on_unevaluable_stereo=False,
+        force_field_policy="none",
+        force_field_max_iterations=100,
+        gate_mmff94_torsion_oop=False,
+        gate_mmff94_stretch_bend=False,
+        ring_torsion_policy="fail_closed",
+        total_timeout_ms=None,
+    )
+    assert explicit.enforce_chirality is False
+
+
+def test_enforce_chirality_true_fixes_but2ene_z_raw_embed():
+    """Direct Python-level confirmation that enforce_chirality reaches
+    distance_geometry_v2.rs's apply_declared_ez_bounds (issue #285): but2ene_Z
+    (C/C=C\\C) is the exact molecule that fix targets -- raw embedding (no
+    force field) must satisfy declared E/Z once enforce_chirality is set,
+    across multiple seeds, matching the Rust-level corpus measurement."""
+    mol = chematic.from_smiles(r"C/C=C\C")
+    for seed in range(5):
+        config = _safe_config(
+            force_field="none",
+            stereo_policy="ignore",
+            embed_seed=seed,
+            max_attempts=1,
+            enforce_chirality=True,
+        )
+        result = mol.embed_pipeline_v2(config)
+        assert result["final_stereo"]["is_fully_satisfied"] is True, (
+            f"seed {seed}: raw embed must already satisfy declared E/Z"
+        )
+
+
+def test_enforce_chirality_with_repair_and_verify_raises():
+    """Matches the Rust-level InvalidConfiguration gate: enforce_chirality is
+    incompatible with stereo_policy="repair_and_verify" (composing the two
+    repair mechanisms is a separate, not-yet-validated question -- see
+    pipeline_v2.rs's module doc)."""
+    mol = chematic.from_smiles(r"C/C=C\C")
+    config = _safe_config(
+        force_field="none",
+        stereo_policy="repair_and_verify",
+        enforce_chirality=True,
+    )
+    with pytest.raises(chematic.PipelineV2Error) as excinfo:
+        mol.embed_pipeline_v2(config)
+    assert excinfo.value.diagnostics["stage"] == "validate_config"
+    assert excinfo.value.diagnostics["cause"] == {"kind": "invalid_configuration"}
 
 
 # ---------------------------------------------------------------------------

--- a/crates/chematic-wasm/src/pipeline_v2.rs
+++ b/crates/chematic-wasm/src/pipeline_v2.rs
@@ -207,6 +207,13 @@ struct PipelineV2ConfigJson {
     ring_torsion_policy: RingTorsionPolicyJson,
     #[serde(deserialize_with = "deserialize_present")]
     total_timeout_ms: Option<Option<u64>>,
+    // #[serde(default)]: same precedent as `gate_mmff94_stretch_bend` above --
+    // added after the JSON config was already a documented external API
+    // (v0.14.0, issue #285's E/Z bound fix). Existing callers' configs must
+    // keep parsing (as `false`, matching `EmbedParameters::default()` and
+    // every existing arm's unchanged behavior).
+    #[serde(default)]
+    enforce_chirality: bool,
 }
 
 impl PipelineV2ConfigJson {
@@ -226,6 +233,7 @@ impl PipelineV2ConfigJson {
                 use_small_ring_torsions: self.use_small_ring_torsions,
                 use_macrocycle_torsions: self.use_macrocycle_torsions,
                 use_macrocycle_14_bounds: self.use_macrocycle_14_bounds,
+                enforce_chirality: self.enforce_chirality,
                 ..EmbedParameters::default()
             },
             torsion_optimization: TorsionOptimizationConfig::default(),
@@ -1625,6 +1633,97 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // enforce_chirality (v0.14.0, issue #285's E/Z bound fix) -- WASM parity
+    // -----------------------------------------------------------------------
+
+    fn enforce_chirality_config_json(stereo_policy: &str, enforce_chirality: bool) -> String {
+        format!(
+            r#"{{
+                "embedSeed": 0,
+                "maxAttempts": 1,
+                "embedTimeoutMs": null,
+                "useExpTorsions": false,
+                "useSmallRingTorsions": false,
+                "useMacrocycleTorsions": false,
+                "useMacrocycle14Bounds": false,
+                "includeLegacyTorsionHeuristic": false,
+                "stereoPolicy": "{stereo_policy}",
+                "failOnUnevaluableStereo": false,
+                "forceFieldPolicy": "none",
+                "forceFieldMaxIterations": 200,
+                "gateMmff94TorsionOop": false,
+                "gateMmff94StretchBend": false,
+                "ringTorsionPolicy": "fail_closed",
+                "totalTimeoutMs": null,
+                "enforceChirality": {enforce_chirality}
+            }}"#
+        )
+    }
+
+    #[test]
+    fn enforce_chirality_true_fixes_but2ene_z_raw_embed() {
+        // Direct WASM-level confirmation that `enforceChirality` in the JSON
+        // config reaches distance_geometry_v2.rs's apply_declared_ez_bounds
+        // (issue #285): but2ene_Z is the exact molecule that fix targets --
+        // raw embedding (no force field) must satisfy declared E/Z once
+        // enforceChirality is set, across multiple seeds, matching the
+        // Rust-level corpus measurement and the Python binding's parity test.
+        let mol = parse_smiles(r"C/C=C\C").expect("but2ene_Z");
+        for seed in 0..5u64 {
+            let config = format!(
+                r#"{{
+                    "embedSeed": {seed},
+                    "maxAttempts": 1,
+                    "embedTimeoutMs": null,
+                    "useExpTorsions": false,
+                    "useSmallRingTorsions": false,
+                    "useMacrocycleTorsions": false,
+                    "useMacrocycle14Bounds": false,
+                    "includeLegacyTorsionHeuristic": false,
+                    "stereoPolicy": "ignore",
+                    "failOnUnevaluableStereo": false,
+                    "forceFieldPolicy": "none",
+                    "forceFieldMaxIterations": 200,
+                    "gateMmff94TorsionOop": false,
+                    "gateMmff94StretchBend": false,
+                    "ringTorsionPolicy": "fail_closed",
+                    "totalTimeoutMs": null,
+                    "enforceChirality": true
+                }}"#
+            );
+            let json = embed_pipeline_v2_json(&mol, &config);
+            let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+            assert_eq!(value["ok"], true, "seed {seed}: {json}");
+            assert_eq!(
+                value["result"]["finalStereo"]["isFullySatisfied"], true,
+                "seed {seed}: raw embed must already satisfy declared E/Z"
+            );
+        }
+    }
+
+    #[test]
+    fn enforce_chirality_defaults_false_missing_field_still_parses() {
+        // #[serde(default)] precedent (matches gateMmff94StretchBend): configs
+        // written before this field existed must keep parsing, as `false`.
+        let mol = parse_smiles("CCCCCCCCCC").expect("decane");
+        let config = safe_config_json("none", "ignore", "fail_closed"); // no enforceChirality key
+        let json = embed_pipeline_v2_json(&mol, &config);
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["ok"], true, "{json}");
+    }
+
+    #[test]
+    fn enforce_chirality_with_repair_and_verify_is_invalid_configuration() {
+        let mol = parse_smiles(r"C/C=C\C").expect("but2ene_Z");
+        let config = enforce_chirality_config_json("repair_and_verify", true);
+        let json = embed_pipeline_v2_json(&mol, &config);
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["ok"], false, "{json}");
+        assert_eq!(value["error"]["stage"], "validate_config");
+        assert_eq!(value["error"]["cause"]["kind"], "invalid_configuration");
+    }
+
+    // -----------------------------------------------------------------------
     // Cross-binding parity: validation/pipeline_v2_wasm_parity_fixtures.json
     //
     // Generated once by scripts/gen_pipeline_v2_wasm_parity_fixtures.py via the
@@ -1760,6 +1859,7 @@ mod tests {
                     use_small_ring_torsions: cfg["useSmallRingTorsions"].as_bool().unwrap(),
                     use_macrocycle_torsions: cfg["useMacrocycleTorsions"].as_bool().unwrap(),
                     use_macrocycle_14_bounds: cfg["useMacrocycle14Bounds"].as_bool().unwrap(),
+                    enforce_chirality: cfg["enforceChirality"].as_bool().unwrap_or(false),
                     ..EmbedParameters::default()
                 },
                 torsion_optimization: TorsionOptimizationConfig::default(),


### PR DESCRIPTION
## Summary

Two related fixes closing the gap between PR #300's `enforce_chirality` E/Z bound fix and its actual usability, found while running the v0.14.0 265-molecule release-gate re-measurement.

### 1. `pipeline_v2.rs`: relax the Stage 1 composition gate

The Stage 1 `InvalidConfiguration` gate previously rejected `enforce_chirality=true` for any `stereo_policy` other than `Ignore`, reasoning that this pipeline's own stage 7-11 stereo gate and `enforce_chirality`'s raw-embedder repair-then-retry were unrelated mechanisms, and composing them would be confusing rather than defense-in-depth.

**Direct 265-molecule-corpus measurement disproved this.** `enforce_chirality` protects embedding-time correctness only — verified via `stereo_before`, which is populated *before* force-field minimization runs. Stage 10's MMFF94 minimization has no notion of declared stereo and can walk a correctly-embedded E/Z bond back across its boundary:

```
chembl_tier_b_0076 / ff=None:                  stereo_before(sat=2,viol=0) final_stereo(sat=2,viol=0)
chembl_tier_b_0076 / ff=Mmff94BondAngleStrict:  stereo_before(sat=2,viol=0) final_stereo(sat=1,viol=1)
chembl_tier_b_0083 / ff=None:                  stereo_before(sat=1,viol=0) final_stereo(sat=1,viol=0)
chembl_tier_b_0083 / ff=Mmff94BondAngleStrict:  stereo_before(sat=1,viol=0) final_stereo(sat=0,viol=1)
```

Re-running with `ForceFieldPolicy::None` keeps `final_stereo` satisfied for both, isolating minimization as the cause. Under the old gate, a caller's only option (`StereoPolicy::Ignore`) never gates on stereo at all — meaning a caller could get a `success` result whose geometry silently violates its own declared E/Z, with no way to detect it.

`enforce_chirality=true` is now allowed with `StereoPolicy::Ignore` **or** `StereoPolicy::VerifyOnly` — `VerifyOnly`'s existing stage 11 "Violated => failure" gate is exactly the fail-closed check needed to catch this class of post-minimization drift. `StereoPolicy::RepairAndVerify` remains rejected in this combination: composing `enforce_chirality`'s own repair-then-retry with stage 8's repair pass is a separate, not-yet-validated question, deliberately deferred rather than decided by omission.

### 2. Python/WASM: expose `enforce_chirality`

Neither binding's config construction ever threaded `enforce_chirality` through to `EmbedParameters` — it was `false` unconditionally, regardless of what a caller wanted, with no way to opt in. Added as a trailing, defaulted (`false`) parameter/field on both sides (`PyPipelineV2Config::new`/`::safe` in Python, `PipelineV2ConfigJson`'s `enforceChirality` with `#[serde(default)]` in WASM, matching the existing `gate_mmff94_stretch_bend` precedent for adding a field to an already-documented external API without breaking existing callers).

Without this, v0.14.0's headline (`enforce_chirality`'s declared-E/Z bound constraint) would have been reachable only from Rust-internal callers — no actual Python or WASM user could have turned it on.

## Test plan

- [x] `pipeline_v2.rs`: 4 tests — `enforce_chirality_with_repair_and_verify_stereo_policy_is_invalid_configuration` (still rejected), `enforce_chirality_with_ignore_stereo_policy_is_allowed`, `enforce_chirality_with_verify_only_stereo_policy_is_allowed` (newly allowed), `enforce_chirality_with_verify_only_never_reports_success_with_violated_final_stereo` (invariant fixture using chembl_tier_b_0083's exact corpus seed — asserts the general property, not a specific outcome, since whether MMFF94 happens to revert the fix is itself non-deterministic across build profiles, confirmed while writing this test).
- [x] Python: `test_enforce_chirality_defaults_false_and_is_backward_compatible`, `test_enforce_chirality_true_fixes_but2ene_z_raw_embed` (5 seeds), `test_enforce_chirality_with_repair_and_verify_raises`. Full `test_pipeline_v2.py` suite: 20/20 pass. Full `chematic-py` test suite: 670/670 pass.
- [x] WASM: `enforce_chirality_true_fixes_but2ene_z_raw_embed` (5 seeds), `enforce_chirality_defaults_false_missing_field_still_parses`, `enforce_chirality_with_repair_and_verify_is_invalid_configuration`. Full `chematic-wasm` suite: 246/246 pass.
- [x] Full `chematic-3d` suite: 513/513 pass.
- [x] `cargo clippy`/`cargo fmt` clean on all three crates.

Not merging — parked for review per standing project policy. The 27-molecule paired baseline/current timeout re-measurement (isolating whether last measurement's 159 regression-control mismatches were code- or environment-caused) is running separately and will follow as its own commit/PR with the release-gate evidence.