### PR TITLE
chore(release): bump version to 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,87 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] — 2026-08-11
+
+Stereo-aware distance geometry: declared E/Z (cis/trans) is now enforced as a
+genuine bound-matrix constraint at embedding time, not just checked after the
+fact, and the post-minimization gate that protects it is now composable with
+the mechanism that produces it. Resolves the issue #285 release-gate waiver
+from v0.13.0's entry below — the same two named molecules
+(`chembl_tier_b_0126`, `chembl_tier_b_0168`) are the ones this release fixes.
+
+Opt-in only (`enforce_chirality: false` remains the default everywhere); the
+default conformer path (`generate_coords_etkdg`/`Mol.conformer_ensemble()`)
+is untouched.
+
+### Fixed — `chematic-3d` (declared-E/Z distance-geometry embedding, issue #285)
+
+- **Root cause found and fixed**: `apply_vdw_bounds`'s generic non-bonded Van
+  der Waals lower bound (sum of radii — two carbons: 3.40 Å) was being
+  applied to a declared-E/Z alkene's own 1-4 substituent pair regardless of
+  which stereochemistry was declared, structurally excluding the correct cis
+  geometry (analytic ≈2.88 Å for `but2ene_Z`) from ever being sampled or
+  reconstructed. Not an eigendecomposition sign-convention artifact as an
+  earlier diagnosis speculated — that candidate mechanism was empirically
+  refuted before this one was confirmed.
+- New `apply_declared_ez_bounds` (`enforce_chirality`-only): for each
+  declared E/Z double bond, computes the analytic same-side/opposite-side
+  1-4 distance from the same bond-length/angle model `build_bond_angle_bounds`
+  already uses, and intersects it into the bond matrix *before* the generic
+  Van der Waals floor applies — the correct geometry becomes reachable by
+  construction, not by repair, retry, reflection, or perturbation after the
+  fact (all three considered and rejected — see `docs/etkdg_3d_gap_rfc.md`
+  for the full comparison).
+- Unlike tetrahedral chirality (`@`/`@@`), which a pairwise distance matrix
+  can never encode (a molecule and its mirror image have identical pairwise
+  distances), declared E/Z is genuinely distance-representable: cis and
+  trans are two different scalar separations for the same atom pair, not
+  mirror images. Ring-fused tetrahedral stereocenters (`testosterone`,
+  `cholesterol`) are unaffected by this fix and remain a known, separately-
+  scoped gap.
+- Measured on the 265-molecule corpus (declared-E/Z subset, 39 molecules,
+  through production `embed_pipeline_v2`): stereo-satisfied count 22 → 42,
+  violated 23 → 3, pipeline success/geometry-soundness unchanged (32/39 both
+  ways). 18 molecules newly fixed, 2 addressed by the fix below.
+
+### Added — `chematic-3d` (`enforce_chirality` + `StereoPolicy::VerifyOnly` composition)
+
+- `embed_pipeline_v2`'s config-validation gate previously rejected
+  `enforce_chirality: true` for any `stereo_policy` other than `Ignore`,
+  reasoning that the two stereo mechanisms were unrelated and composing them
+  would be confusing. Corpus measurement disproved this: `enforce_chirality`
+  protects embedding-time correctness only, and force-field minimization has
+  no notion of declared stereo and can walk a correctly-embedded E/Z bond
+  back across its boundary afterward (found on 2 real molecules,
+  `chembl_tier_b_0076`/`chembl_tier_b_0083` — confirmed by re-running with no
+  force field, which leaves them correct). `enforce_chirality: true` is now
+  also allowed with `StereoPolicy::VerifyOnly`, whose existing post-
+  minimization gate catches exactly this failure mode as a typed error
+  instead of silently returning a `success` result with wrong stereo.
+  `StereoPolicy::RepairAndVerify` remains rejected in this combination —
+  composing its own repair pass with `enforce_chirality`'s is a separate,
+  not-yet-validated question.
+
+### Added — `chematic-py`, `chematic-wasm` (`enforce_chirality` exposure)
+
+- `enforce_chirality` (default `false`, fully backward compatible) is now a
+  real, settable parameter on `PipelineV2Config`/`PipelineV2Config.safe()`
+  (Python) and the `enforceChirality` JSON field (WASM) — previously neither
+  binding's config construction threaded the field through at all, so it was
+  unconditionally `false` regardless of caller intent, making the fix above
+  unreachable from Python or WASM callers.
+
+### Fixed — `chematic-rxn` (`suzuki_biaryl` retro-template, issue #294)
+
+- `[c:1][c:2]>>[c:1]Br.[c:2]B(O)O` never matched a real biaryl bond at all:
+  two adjacent aromatic atoms with no explicit bond token default to an
+  aromatic bond in this crate's SMILES convention, so the template only ever
+  matched *intra-ring* aromatic bonds, not a genuine inter-ring biaryl
+  connection. Fixed to `[c:1]-[c:2]` (explicit single bond) — no ring-
+  topology check needed. Found while investigating this: 14 of 59
+  `DEFAULT_TEMPLATES` entries silently never parse at all (`retro_disconnect`
+  swallows the `SmirksParse` error) — filed as issue #296, not fixed here.
+
 ## [0.13.0] — 2026-08-10
 
 ### Added — `chematic-mol` (XYZ / multi-frame XYZ)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,5 +23,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.13.0
-date-released: "2026-07-29"
+version: 0.14.0
+date-released: "2026-08-11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.13.0
+# chematic v0.14.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-07-17, v0.4.29 vs RDKit 2026.03.3 --
@@ -419,6 +419,14 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +1
 
 ## Recent Development
 
+**v0.14.0** (2026-08-11): **Stereo-aware distance geometry — declared E/Z enforced as a bound-matrix constraint, `enforce_chirality` composable with post-minimization stereo verification, Python/WASM exposure**
+- `chematic-3d`: root-caused and fixed the issue #285 release-gate waiver from v0.13.0 — `apply_vdw_bounds`'s generic non-bonded Van der Waals lower bound was being applied to a declared-E/Z alkene's own 1-4 substituent pair regardless of declared stereochemistry, structurally excluding the correct cis geometry from ever being sampled. New `apply_declared_ez_bounds` (`enforce_chirality`-only) intersects an analytic same-side/opposite-side 1-4 distance bound into the bond matrix *before* the generic Van der Waals floor applies, so the correct geometry is reachable by construction, not by post-hoc repair/retry/reflection. Unlike tetrahedral chirality (which a pairwise distance matrix can never encode — a molecule and its mirror image have identical pairwise distances), declared E/Z is genuinely distance-representable, since cis/trans are two different scalar separations, not mirror images. Measured on the 265-molecule corpus's declared-E/Z subset (39 molecules): stereo-satisfied 22 → 42, violated 23 → 3, pipeline success/soundness unchanged
+- `chematic-3d`: `embed_pipeline_v2`'s config-validation gate previously rejected `enforce_chirality: true` for any `stereo_policy` other than `Ignore`. Corpus measurement found this wrong — `enforce_chirality` protects embedding-time correctness only, and force-field minimization (which has no notion of declared stereo) can walk a correctly-embedded E/Z bond back across its boundary afterward (found on 2 real molecules, confirmed by re-running with no force field). `enforce_chirality: true` is now also allowed with `StereoPolicy::VerifyOnly`, whose existing post-minimization gate catches exactly this failure mode as a typed error instead of a silent wrong-stereo `success`
+- `chematic-py`, `chematic-wasm`: `enforce_chirality` (default `false`) is now a real, settable parameter/field on `PipelineV2Config`/`PipelineV2Config.safe()` (Python) and the `enforceChirality` JSON field (WASM) — neither binding had ever threaded the field through before, so the fix above was previously unreachable from Python or WASM callers
+- `chematic-rxn`: fixed `suzuki_biaryl`'s retro-template (issue #294) — `[c:1][c:2]` never matched a real biaryl bond, only intra-ring aromatic bonds, since two adjacent aromatic atoms with no explicit bond token default to aromatic in this crate's SMILES convention. Fixed to `[c:1]-[c:2]`. Found along the way: 14 of 59 `DEFAULT_TEMPLATES` entries silently never parse at all — filed as issue #296, not fixed here
+- Opt-in only — `enforce_chirality: false` remains the default everywhere; the default conformer path (`generate_coords_etkdg`/`Mol.conformer_ensemble()`) is untouched
+- Full details in `CHANGELOG.md`'s `[0.14.0]` section
+
 **v0.13.0** (2026-08-10): **MMFF94 stretch-bend + torsion parameter-selection parity (both breaking), per-atom stereocenter API, E/Z completeness, macrocycle detection, notation-invariant atropisomer detection/assignment, XYZ I/O**
 - `chematic-ff`: `mmff94_stbn`/`mmff94_stbn_type_only` now key the `MMFF94_STBN` table lookup on RDKit's real, finer-grained "stretch-bend type" (`getMMFFStretchBendType`, 0-11) instead of the coarser angle type (0-8) previously used as a stand-in (issue #227) — 220 of 427 stretch-bend routing candidates on the 265-molecule Wave 1 corpus move from RDKit's generic Dfsb periodic-row default to the correct, specific parameter; `angle_type_for`'s ring-offset formula also corrected to match RDKit's real `getMMFFAngleType`. **Breaking**: `mmff94_stbn`/`mmff94_stbn_type_only`'s leading `u8` parameter is now `stretch_bend_type`, not `angle_type` — same shape, different required value; use the new `pub stretch_bend_type_for` to compute it
 - `chematic-ff`: `torsion_type_for` now classifies from the real j-k bond's MMFF bond type (reusing `bond_type_for`) plus RDKit's real local-bond-adjacency ring-4/5 override, instead of atom-type-membership alone — corrects 76.9% of the 1,107 previously-missing torsion instances via classification alone, and, corpus-wide, corrects 1,792 of 13,530 torsion instances that resolved to a *silently wrong* parameter value before (not just missing coverage) — 99.1% of the corrected values independently confirmed against a live RDKit oracle, 0 newly lost. **Breaking**: `torsion_type_for`'s signature changed from `(rings, i, j, k, l, tj, tk)` to `(mol, i, j, k, l, ti, tj, tk, tl)`
@@ -525,7 +533,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v0.13.0)
+├── Cargo.toml                    workspace root (v0.14.0)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)
@@ -578,7 +586,7 @@ If you use chematic in academic or research work, please cite:
   author    = {kent-tokyo},
   title     = {chematic: A pure-Rust cheminformatics toolkit},
   url       = {https://github.com/kent-tokyo/chematic},
-  version   = {0.13.0},
+  version   = {0.14.0},
   year      = {2026},
 }
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -106,7 +106,7 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.13.0
+# chematic v0.14.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-06, v0.4.22 vs RDKit 2026.03.3 --

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.13.0 | Yes | Current release — active support |
+| v0.14.0 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.13.0) receives all security updates.  
+**Active Support**: Latest release (v0.14.0) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -16,12 +16,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.13.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.13.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.13.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.13.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.13.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.14.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.14.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.14.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.14.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.0" }
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #219); web-time
 # is a drop-in Instant replacement backed by Performance.now() there, and

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -16,14 +16,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.13.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.14.0" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.13.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.13.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.13.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.13.0" }
-chematic-cip        = { path = "../chematic-cip",        version = "0.13.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.14.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.14.0" }
+chematic-cip        = { path = "../chematic-cip",        version = "0.14.0" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.13.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.14.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -22,10 +22,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.13.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.13.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.13.0" }
+chematic-core = { path = "../chematic-core", version = "0.14.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.14.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.14.0" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.13.0" }
+chematic-core = { path = "../chematic-core", version = "0.14.0" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.13.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.14.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -22,13 +22,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.13.0" }
+chematic-core = { path = "../chematic-core", version = "0.14.0" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.13.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.13.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.13.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.14.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.14.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.14.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -18,10 +18,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.13.0", path = "../chematic-core" }
-chematic-smiles = { version = "0.13.0", path = "../chematic-smiles" }
-chematic-chem = { version = "0.13.0", path = "../chematic-chem" }
-chematic-rxn = { version = "0.13.0", path = "../chematic-rxn" }
+chematic-core = { version = "0.14.0", path = "../chematic-core" }
+chematic-smiles = { version = "0.14.0", path = "../chematic-smiles" }
+chematic-chem = { version = "0.14.0", path = "../chematic-chem" }
+chematic-rxn = { version = "0.14.0", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.13.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.14.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -17,15 +17,15 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.13.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.13.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.13.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.13.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.13.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.13.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.13.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.13.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.14.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.14.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.14.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.14.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.14.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.14.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
 
 [dev-dependencies]
 # Real JSON Schema 2020-12 validator, used only in tests to independently

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -16,10 +16,10 @@ documentation = "https://docs.rs/chematic-mol"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.13.0" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.13.0" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.13.0" }
-chematic-smiles      = { path = "../chematic-smiles",      version = "0.13.0" }
+chematic-core        = { path = "../chematic-core",        version = "0.14.0" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.14.0" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.14.0" }
+chematic-smiles      = { path = "../chematic-smiles",      version = "0.14.0" }
 serde_json           = "1.0"
 
 [dev-dependencies]

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.13.0" }
+chematic-core = { path = "../chematic-core", version = "0.14.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,16 +25,16 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.13.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.13.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.13.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.13.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.13.0", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.13.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.13.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.13.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.13.0" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.13.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.13.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.13.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.14.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.14.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.14.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.14.0", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.14.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.14.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.14.0" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.14.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.14.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.14.0" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -22,9 +22,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 perf-instrumentation = []
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.13.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.13.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.13.0" }
+chematic-core   = { path = "../chematic-core",   version = "0.14.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.14.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.14.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.13.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
+chematic-core = { path = "../chematic-core", version = "0.14.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
 rustc-hash = "2"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #221); web-time

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.13.0" }
+chematic-core = { path = "../chematic-core", version = "0.14.0" }
 
 [features]
 # Feature-gated internal work counters for the orbit-pruning canonical

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -26,16 +26,16 @@ wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["console"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.13.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.13.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.13.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.13.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.13.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.13.0", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.13.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.13.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.13.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.13.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.13.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.13.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.13.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.14.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.14.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.14.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.14.0", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.14.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.14.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.14.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.14.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.14.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.14.0" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -33,15 +33,15 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.13.0", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.13.0", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.13.0", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.13.0", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.13.0", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.13.0", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.13.0", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.13.0", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.13.0", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.13.0", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.13.0", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.13.0", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.14.0", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.0", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.14.0", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.14.0", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.14.0", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.14.0", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.14.0", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.0", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.14.0", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.14.0", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.14.0", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.14.0", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Version bump PR for v0.14.0. `scripts/bump_version.py --old 0.13.0` handled the mechanical propagation (README.md/README_ja.md/CITATION.cff/SECURITY.md/demo/pkg/package.json/all per-crate `Cargo.toml` intra-workspace version pins); `CITATION.cff`'s `date-released` and CHANGELOG.md/README.md's "Recent Development" section were updated by hand.

Everything in this release (PR #300, #301, #302) is already merged to `main`; this PR only bumps the version number and writes it up.

## What v0.14.0 ships

- **`chematic-3d`**: declared E/Z now enforced as a genuine bound-matrix constraint at embedding time (issue #285's `but2ene_Z` root cause, previously an unconfirmed diagnosis) — resolves the issue #285 release-gate waiver documented in v0.13.0's own CHANGELOG entry.
- **`chematic-3d`**: `enforce_chirality` is now composable with `StereoPolicy::VerifyOnly`, closing a gap the 265-corpus re-measurement found: force-field minimization can revert a correctly-embedded E/Z bond, and the old gate had no way to catch that.
- **`chematic-py`/`chematic-wasm`**: `enforce_chirality` exposed to both bindings for the first time (previously Rust-internal-only).
- **`chematic-rxn`**: `suzuki_biaryl` retro-template fix (issue #294).

Full details in `CHANGELOG.md`'s `[0.14.0]` section and `README.md`'s "Recent Development".

## Test plan

- [x] `scripts/bump_version.py --old 0.13.0 --dry-run` reviewed before running for real.
- [x] `scripts/check.sh`: all checks pass, including its own version-consistency check (`Version consistent: 0.14.0`) and the README "Recent Development" staleness warning (now resolved).
- [x] `cargo test --workspace --exclude chematic-py`: 0 failures (chematic-py excluded from plain `cargo build`/`test` for the usual pre-existing, unrelated pyo3-direct-cargo-build linker reason — built and tested separately via maturin below).
- [x] Python (`maturin develop --release`): `chematic.__version__ == "0.14.0"`, full `pytest` suite 670/670 pass.
- [x] WASM: `cargo test -p chematic-wasm --lib`: 246/246 pass.

Not merging, not tagging, not publishing — parked for explicit approval per standing project policy. Tag/publish to crates.io/PyPI/npm is a separately gated step after this merges.