### PR TITLE
fix(core,mol): dative bonds keep donor valence + MOL bond-type-9 round-trips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   currently canonicalize to the same identity; see the FEASIBILITY doc for
   why this is reported, not patched, this round).
 
+### Fixed — `chematic-core` (dative-bond implicit hydrogen count)
+
+- **`valence_inferred_hcount` treated a `BondOrder::Dative` bond's donor
+  side exactly like a covalent single bond when computing implicit
+  hydrogen count**, contradicting `BondOrder::Dative`'s own documented
+  donor→acceptor semantics and RDKit's identical treatment of the same
+  `->`/`<-` SMILES syntax: an un-bracketed dative donor like `N->[Pt]Cl`
+  computed as `NH2` instead of the chemically correct `NH3`, because the
+  donor's own lone-pair-sharing bond was (wrongly) subtracted from its
+  normal covalent valence. Flowed into `molecular_weight`, `exact_mass`,
+  and `chematic-smiles`'s canonical-writer atom invariant. Donor-side dative
+  bonds now contribute 0 to the valence sum instead of `order_int()`'s 1;
+  the acceptor side is unchanged (out of scope — no acceptor in the
+  motivating corpus is in the organic subset). Found via the platinum
+  coordination-chemistry benchmark; not platinum-specific (verified against
+  Fe/Co/Pd/Ru acceptors too). A pre-existing `chematic-smiles` test
+  (`dative_bond_direction.rs`) pinned an exact canonical-SMILES string that
+  depended on the old, wrong invariant; updated to the new correct value,
+  with a replacement case added so the arrow-flip-on-acceptor-first code
+  path it originally covered stays covered.
+- **Known, documented, not-fixed-this-round divergence:** `validate_valence`
+  (built on the separate, public `bond_order_sum`, also used by
+  `chematic-cip`/tautomer enumeration/`chematic-ff`) can still report a
+  false-positive `ValenceError` on a *bracketed* dative donor whose only
+  listed normal valence is exactly met by its own explicit H count (e.g.
+  `[OH2]->[Pt]`) — deliberately not widened, given the larger blast radius;
+  pinned by a new test rather than left undocumented.
+
+### Fixed — `chematic-mol` (MOL V2000/V3000 dative/coordinate bonds)
+
+- **MDL bond type 9 (dative/coordinate — the exact convention RDKit uses to
+  write `Bond::BondType.DATIVE`, V3000 only) silently mapped to
+  `BondOrder::Single`** in both the V2000 and V3000 readers' "unknown code"
+  catch-all, with no error or warning: reading an RDKit-generated V3000
+  molfile containing a dative Pt–N bond silently produced a different
+  molecule (connectivity intact, bond semantics quietly lost). Both readers
+  now map code 9 to `BondOrder::Dative`, preserving the file's donor/
+  acceptor atom order. `mol3000.rs`'s writer now emits code 9 for `Dative`
+  bonds instead of collapsing to plain single (`1`); V2000's writer still
+  collapses `Dative` to `1` on write, matching RDKit's own inability to
+  express a dative bond in V2000 at all. Both readers carry a committed
+  regression test built from the literal RDKit-generated molblock that
+  surfaced this finding.
+
 ## [0.14.0] — 2026-08-11
 
 Stereo-aware distance geometry: declared E/Z (cis/trans) is now enforced as a

--- a/crates/chematic-core/src/valence.rs
+++ b/crates/chematic-core/src/valence.rs
@@ -73,9 +73,22 @@ pub fn valence_inferred_hcount(mol: &Molecule, idx: AtomIdx) -> u8 {
     let mut aromatic_count: usize = 0;
     let mut non_aromatic_sum: i32 = 0;
     for (_, bidx) in mol.neighbors(idx) {
-        let order = mol.bond(bidx).order;
+        let bond = mol.bond(bidx);
+        let order = bond.order;
         if order == BondOrder::Aromatic {
             aromatic_count += 1;
+        } else if order == BondOrder::Dative && bond.atom1 == idx {
+            // Donor side of a dative (coordinate) bond: per `BondOrder::Dative`'s
+            // own documented `atom1 (donor) -> atom2 (acceptor)` convention, the
+            // donor shares a lone pair without spending any of its own normal
+            // covalent valence -- e.g. `N->[Pt]` must still imply NH3 (3 implicit
+            // H, valence fully intact), not NH2. Matches RDKit's identical
+            // treatment of the same SMILES dative-arrow syntax. Contributes 0,
+            // unlike a plain covalent bond of the same `order_int()==1`.
+            // The acceptor side (and any other atom for which `idx` is `atom2`)
+            // is intentionally left counted as before -- out of scope here,
+            // since every acceptor in the motivating corpus (Pt, Fe, Co, ...)
+            // is already outside the organic subset and short-circuits above.
         } else {
             non_aromatic_sum += order.order_int() as i32;
         }
@@ -586,6 +599,125 @@ mod tests {
         assert!(
             validate_valence(&mol).is_empty(),
             "Fe with 6 bonds must be skipped"
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // Donor-side dative-bond implicit H -- regression tests for the
+    // platinum coordination-chemistry benchmark
+    // (validation/platinum/FEASIBILITY.md). A bare, un-bracketed donor
+    // atom's own normal covalent valence must not be spent by its own
+    // dative bond: `N->[Pt]` must still mean NH3, matching RDKit's
+    // identical treatment of the same `->` SMILES syntax. Before this fix,
+    // `order_int()`'s `1` for `Dative` was summed exactly like a real
+    // covalent bond, giving NH2 instead.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn test_dative_donor_n_keeps_full_valence() {
+        // N->Pt : N is the donor (atom1). Bare N, no other substituents.
+        let mol = two_atoms(Element::N, Element::PT, BondOrder::Dative);
+        assert_eq!(
+            implicit_hcount(&mol, AtomIdx(0)),
+            3,
+            "a dative donor's own lone pair, not one of its 3 normal covalent \
+             slots, is shared with the acceptor -- N->[Pt] must mean NH3"
+        );
+    }
+
+    #[test]
+    fn test_dative_donor_o_keeps_full_valence() {
+        // O->Fe : O is the donor. Matches the corpus's water/DMSO-oxygen
+        // style dative ligands (see cisplatin_diaqua_activation_product in
+        // pt_corpus.jsonl).
+        let mol = two_atoms(Element::O, Element::FE, BondOrder::Dative);
+        assert_eq!(
+            implicit_hcount(&mol, AtomIdx(0)),
+            2,
+            "O->[Fe] must mean H2O"
+        );
+    }
+
+    #[test]
+    fn test_dative_acceptor_side_unaffected() {
+        // Pt->N (reversed: Pt is the donor per this specific bond's stored
+        // direction, N is the acceptor) -- the fix is donor-side-only by
+        // design (see valence_inferred_hcount's doc comment), so N here
+        // gets no special treatment; this pins that scope boundary rather
+        // than leaving it implicit.
+        let mol = two_atoms(Element::PT, Element::N, BondOrder::Dative);
+        // N is atom2 (the acceptor) here: bond_sum=1 (unchanged, counted
+        // like a normal covalent bond), giving valence 3 - 1 = 2H, not 3.
+        assert_eq!(
+            implicit_hcount(&mol, AtomIdx(1)),
+            2,
+            "acceptor-side implicit H is intentionally untouched by this fix"
+        );
+    }
+
+    #[test]
+    fn test_generalization_not_platinum_specific() {
+        // Same fix, non-Pt acceptors (Fe, Co) -- confirms this is a general
+        // dative-bond fix, not special-cased to Pt (task's generalization
+        // gate, see FEASIBILITY.md section 16/6).
+        for acceptor in [Element::FE, Element::CO, Element::PD, Element::RU] {
+            let mol = two_atoms(Element::N, acceptor, BondOrder::Dative);
+            assert_eq!(
+                implicit_hcount(&mol, AtomIdx(0)),
+                3,
+                "N->{acceptor:?} must mean NH3 regardless of which metal accepts"
+            );
+        }
+    }
+
+    #[test]
+    fn test_known_divergence_bracketed_dative_donor_can_still_false_positive_in_validate_valence() {
+        // KNOWN, DOCUMENTED, NOT FIXED HERE (see FEASIBILITY.md's residual
+        // limitations): `validate_valence` uses `bond_order_sum`, a
+        // separate, PUBLIC function (also used by chematic-cip/tautomer/
+        // chematic-ff) that was deliberately left untouched -- widening it
+        // to exempt donor-side dative bonds too would change its meaning
+        // for those other consumers, a much larger blast radius than this
+        // benchmark measured or scoped. The practical consequence: a
+        // BRACKETED dative donor whose only listed normal valence is
+        // already exactly met by its own explicit H count (e.g. O, whose
+        // only valence is 2) still gets a spurious `ValenceError` from
+        // `validate_valence`, even though `implicit_hcount`/
+        // `valence_inferred_hcount` correctly agree the atom is valid.
+        // Nitrogen is NOT affected in practice ([NH3]->[Pt] does not
+        // trigger this) only because N's valence list [3, 5] happens to
+        // have a second, higher tier that absorbs the extra count -- an
+        // element-specific coincidence, not a general exemption. This
+        // corpus never hits this path (it uses bare, un-bracketed donor
+        // atoms throughout), which is why `pt_corpus.jsonl`'s
+        // `valence_errors` fields are all empty.
+        let mut b = MoleculeBuilder::new();
+        let o = b.add_atom(Atom::bracket(
+            Element::O,
+            None,
+            Default::default(),
+            2,
+            0,
+            None,
+        ));
+        let pt = b.add_atom(Atom::new(Element::PT));
+        b.add_bond(o, pt, BondOrder::Dative).unwrap();
+        let mol = b.build();
+
+        assert_eq!(
+            implicit_hcount(&mol, o),
+            2,
+            "bracket H is stored directly regardless of bond wiring"
+        );
+        assert_eq!(
+            validate_valence(&mol).len(),
+            1,
+            "known false positive: [OH2]->[Pt] is valid water-donor chemistry \
+             but validate_valence still flags it via bond_order_sum's \
+             unchanged (donor-side-inclusive) count -- if this assertion \
+             ever starts failing because it's empty, bond_order_sum was \
+             fixed too and this whole test (and its FEASIBILITY.md note) \
+             should be deleted, not \"corrected\" back to failing"
         );
     }
 }

--- a/crates/chematic-mol/src/mol2000.rs
+++ b/crates/chematic-mol/src/mol2000.rs
@@ -607,6 +607,15 @@ pub fn read_mol_with_diagnostics(input: &str) -> Result<MolReadReport, MolParseE
             6 => BondOrder::QuerySingleOrAromatic,
             7 => BondOrder::QueryDoubleOrAromatic,
             8 => BondOrder::QueryAny,
+            // 9 = dative/coordinate bond, a widely used (if formally
+            // non-standard) MDL extension -- RDKit emits it for
+            // `Bond::BondType::DATIVE` (V3000 only; see mol3000.rs), with
+            // atom1/atom2 in the same donor/acceptor order as
+            // `BondOrder::Dative` itself already documents. Previously fell
+            // through to `Single`, silently discarding the coordination-bond
+            // distinction (and, downstream, corrupting the donor atom's
+            // implicit hydrogen count) on read -- see valence.rs.
+            9 => BondOrder::Dative,
             _ => BondOrder::Single,
         };
 
@@ -1104,6 +1113,36 @@ M  END
         assert_eq!(bonds[1].1.order, BondOrder::Double);
         assert_eq!(bonds[2].1.order, BondOrder::Triple);
         assert_eq!(bonds[3].1.order, BondOrder::Aromatic);
+    }
+
+    /// MDL bond type 9 (dative/coordinate) must read as `BondOrder::Dative`,
+    /// not silently fall through to `Single` -- regression test for the
+    /// platinum coordination-chemistry benchmark
+    /// (`validation/platinum/FEASIBILITY.md`). See `mol3000.rs`'s
+    /// `test_dative_bond_type_9_round_trips` for the RDKit-generated V3000
+    /// version of the same finding (RDKit itself only ever writes bond type
+    /// 9 in V3000, never V2000 -- this V2000 case defensively covers any
+    /// other tool that does).
+    #[test]
+    fn test_parse_bond_type_9_is_dative() {
+        let mol_str = "\
+test
+  chematic
+
+  3  2  0  0  0  0  0  0  0  0  0 V2000
+    0.0000    0.0000    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+    1.0000    0.0000    0.0000 Pt  0  0  0  0  0  0  0  0  0  0  0  0
+    2.0000    0.0000    0.0000 Cl  0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  9  0
+  2  3  1  0
+M  END
+";
+        let (mol, _) = parse_mol(mol_str).expect("parse should succeed");
+        let bonds: Vec<_> = mol.bonds().collect();
+        assert_eq!(bonds[0].1.order, BondOrder::Dative);
+        assert_eq!(mol.atom(bonds[0].1.atom1).element, Element::N);
+        assert_eq!(mol.atom(bonds[0].1.atom2).element, Element::PT);
+        assert_eq!(bonds[1].1.order, BondOrder::Single);
     }
 
     #[test]

--- a/crates/chematic-mol/src/mol3000.rs
+++ b/crates/chematic-mol/src/mol3000.rs
@@ -461,6 +461,16 @@ pub fn read_mol_v3000_with_diagnostics(input: &str) -> Result<MolReadReport, Mol
                     6 => BondOrder::QuerySingleOrAromatic,
                     7 => BondOrder::QueryDoubleOrAromatic,
                     8 => BondOrder::QueryAny,
+                    // 9 = dative/coordinate bond. This is how RDKit itself
+                    // writes `Bond::BondType::DATIVE` in V3000 (it cannot
+                    // represent a dative bond in V2000 at all, so it upgrades
+                    // automatically) -- `a1`/`a2` are already in the same
+                    // donor/acceptor order the file encodes, matching
+                    // `BondOrder::Dative`'s documented atom1(donor) ->
+                    // atom2(acceptor) convention. Previously fell through to
+                    // `Single`, silently discarding coordination bonds from
+                    // any RDKit- (or other-tool-) generated V3000 molfile.
+                    9 => BondOrder::Dative,
                     _ => BondOrder::Single,
                 };
 
@@ -1022,6 +1032,54 @@ M  END
     }
 
     // -----------------------------------------------------------------------
+    // Test: MDL bond type 9 (dative/coordinate) round-trips, not silently
+    // corrupted to Single -- regression test for the platinum coordination-
+    // chemistry benchmark (validation/platinum/FEASIBILITY.md). The molblock
+    // below is not hand-crafted: it is exactly what RDKit 2026.03.3 writes
+    // for `Chem.MolFromSmiles` + `AddBond(n, pt, Chem.BondType.DATIVE)` +
+    // `Chem.MolToMolBlock(mol, forceV3000=True)` -- RDKit auto-upgrades to
+    // V3000 for any dative bond (it cannot express one in V2000 either).
+    // Before this fix, bond type 9 fell through the reader's `_ =>
+    // BondOrder::Single` catch-all with no error, no warning: a
+    // structurally valid file silently produced a different molecule.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_dative_bond_type_9_round_trips() {
+        // NOT built with a `"\` line-continuation: the real molblock's second
+        // header line is blank-then-indented (RDKit writes no molecule name),
+        // and a leading `\`-continuation would silently swallow that blank
+        // line along with its indentation (rustc even warns "multiple lines
+        // skipped by escaped newline" if written that way) -- explicit `\n`
+        // keeps this byte-for-byte identical to RDKit's own output.
+        let mol_str = "\n     RDKit          2D\n\n  0  0  0  0  0  0  0  0  0  0999 V3000\nM  V30 BEGIN CTAB\nM  V30 COUNTS 3 2 0 0 0\nM  V30 BEGIN ATOM\nM  V30 1 N 0.000000 0.000000 0.000000 0\nM  V30 2 Pt 1.299038 0.750000 0.000000 0 VAL=2\nM  V30 3 Cl 2.598076 1.500000 0.000000 0\nM  V30 END ATOM\nM  V30 BEGIN BOND\nM  V30 1 9 1 2\nM  V30 2 1 2 3\nM  V30 END BOND\nM  V30 END CTAB\nM  END\n";
+        let (mol, meta) = parse_mol_v3000(mol_str).expect("parse RDKit dative molblock");
+        let bonds: Vec<_> = mol.bonds().collect();
+        assert_eq!(
+            bonds[0].1.order,
+            BondOrder::Dative,
+            "bond type 9 must read as Dative, not silently fall through to Single"
+        );
+        // atom1/atom2 preserve the file's donor/acceptor order (N -> Pt).
+        assert_eq!(mol.atom(bonds[0].1.atom1).element, Element::N);
+        assert_eq!(mol.atom(bonds[0].1.atom2).element, Element::PT);
+        assert_eq!(bonds[1].1.order, BondOrder::Single);
+
+        let written = write_mol_v3000(&mol, &meta, &[]);
+        assert!(
+            written.contains("M  V30 1 9 1 2"),
+            "Dative must write back out as bond type 9: {written}"
+        );
+
+        // Full round trip: re-parsing the freshly-written molblock still
+        // gives a Dative bond with the same donor/acceptor order.
+        let (rt_mol, _) = parse_mol_v3000(&written).expect("re-parse written molblock");
+        let rt_bonds: Vec<_> = rt_mol.bonds().collect();
+        assert_eq!(rt_bonds[0].1.order, BondOrder::Dative);
+        assert_eq!(rt_mol.atom(rt_bonds[0].1.atom1).element, Element::N);
+        assert_eq!(rt_mol.atom(rt_bonds[0].1.atom2).element, Element::PT);
+    }
+
+    // -----------------------------------------------------------------------
     // Test 15: atom-map number stored when nonzero
     // -----------------------------------------------------------------------
     #[test]
@@ -1103,7 +1161,7 @@ pub fn write_mol_v3000(mol: &Molecule, metadata: &MolMetadata, coords: &[(f64, f
         let a2 = bond.atom2.0 + 1;
         let order = match bond.order {
             BondOrder::Zero => 0,
-            BondOrder::Single | BondOrder::Up | BondOrder::Down | BondOrder::Dative => 1,
+            BondOrder::Single | BondOrder::Up | BondOrder::Down => 1,
             BondOrder::Double => 2,
             BondOrder::Triple => 3,
             BondOrder::Aromatic => 4,
@@ -1111,6 +1169,14 @@ pub fn write_mol_v3000(mol: &Molecule, metadata: &MolMetadata, coords: &[(f64, f
             BondOrder::QuerySingleOrAromatic => 6,
             BondOrder::QueryDoubleOrAromatic => 7,
             BondOrder::QueryAny => 8,
+            // Matches RDKit's own V3000 convention for `Bond::BondType::DATIVE`
+            // (see the reader's matching case above); `atom1`/`atom2` are
+            // already in donor/acceptor order. V2000's writer (mol2000.rs)
+            // still collapses `Dative` to a plain single bond, since RDKit
+            // itself cannot express a dative bond in V2000 either -- full
+            // dative round-tripping through chematic's own MOL writer
+            // requires V3000, same as RDKit.
+            BondOrder::Dative => 9,
             BondOrder::Quadruple => 4,
         };
         let i = bidx.0 + 1;
@@ -1220,7 +1286,7 @@ pub fn write_mol_v3000_with_conformer(
         let a2 = bond.atom2.0 + 1;
         let order = match bond.order {
             BondOrder::Zero => 0,
-            BondOrder::Single | BondOrder::Up | BondOrder::Down | BondOrder::Dative => 1,
+            BondOrder::Single | BondOrder::Up | BondOrder::Down => 1,
             BondOrder::Double => 2,
             BondOrder::Triple => 3,
             BondOrder::Aromatic => 4,
@@ -1228,6 +1294,14 @@ pub fn write_mol_v3000_with_conformer(
             BondOrder::QuerySingleOrAromatic => 6,
             BondOrder::QueryDoubleOrAromatic => 7,
             BondOrder::QueryAny => 8,
+            // Matches RDKit's own V3000 convention for `Bond::BondType::DATIVE`
+            // (see the reader's matching case above); `atom1`/`atom2` are
+            // already in donor/acceptor order. V2000's writer (mol2000.rs)
+            // still collapses `Dative` to a plain single bond, since RDKit
+            // itself cannot express a dative bond in V2000 either -- full
+            // dative round-tripping through chematic's own MOL writer
+            // requires V3000, same as RDKit.
+            BondOrder::Dative => 9,
             BondOrder::Quadruple => 4,
         };
         let i = bidx.0 + 1;

--- a/crates/chematic-smiles/tests/dative_bond_direction.rs
+++ b/crates/chematic-smiles/tests/dative_bond_direction.rs
@@ -161,25 +161,28 @@ fn writers_emit_the_full_two_character_token() {
     }
 }
 
-/// The critical case: two molecules that differ *only* in which endpoint of
-/// the dative bond is stored as `atom1`. Their canonical rank vectors are
-/// identical (same elements, same connectivity — nothing in the ranking is
-/// dative-direction-aware), so the canonical writer reaches the same atom
-/// first in both. It picks the iron; for `n_to_fe` that is the *acceptor*,
-/// so the arrow has to be written backwards relative to storage order.
+/// `n_to_fe`/`fe_to_n` differ *only* in which endpoint of the dative bond is
+/// stored as `atom1`, but their canonical rank vectors are no longer
+/// identical: the donor's implicit-H count is part of its ranking
+/// invariant (`initial_invariant` in `canonical.rs`), and a donor's
+/// implicit H count now correctly excludes the dative bond's own
+/// contribution (see `chematic_core::valence::valence_inferred_hcount` --
+/// found and fixed via the platinum coordination-chemistry benchmark,
+/// `validation/platinum/FEASIBILITY.md`: an un-bracketed dative donor like
+/// bare `N` must still mean NH3, not NH2). That changed N's invariant in
+/// `n_to_fe` (N is the donor there) but not in `fe_to_n` (N is the
+/// *acceptor* there, untouched by the donor-side-only fix) -- so `a`'s
+/// canonical form flipped which atom is written first, while `b`'s did not.
 ///
 /// Both expected strings are derived from `BondOrder::Dative`'s own
-/// definition rather than from what the writer happens to produce: reading
-/// `[Fe]<-N` left to right, the arrow points from N into Fe, i.e. N is the
-/// donor — which is `n_to_fe`, whose `atom1` is N even though it is written
-/// second.
+/// definition rather than from what the writer happens to produce.
 #[test]
-fn canonical_writer_flips_the_arrow_when_the_acceptor_is_written_first() {
+fn canonical_writer_orders_dative_endpoints_by_current_rank() {
     let a = canonical_smiles(&n_to_fe());
     let b = canonical_smiles(&fe_to_n());
 
-    assert_eq!(a, "[Fe]<-N", "acceptor written first ⇒ reversed arrow");
-    assert_eq!(b, "[Fe]->N", "donor written first ⇒ forward arrow");
+    assert_eq!(a, "N->[Fe]", "donor (N) now ranks first ⇒ forward arrow");
+    assert_eq!(b, "[Fe]->N", "donor (Fe) written first ⇒ forward arrow");
 
     // And each one still means what it meant before it was written.
     assert_eq!(
@@ -189,6 +192,29 @@ fn canonical_writer_flips_the_arrow_when_the_acceptor_is_written_first() {
     assert_eq!(
         dative_donor_acceptor(&parse(&b).unwrap()),
         (Element::FE, Element::N)
+    );
+}
+
+/// The arrow-flip-on-acceptor-first path (the actual code under test by the
+/// name of the test above, before O/N/Fe's specific ranks shifted it away
+/// from N/Fe) is still exercised here with an O donor instead: an oxygen
+/// donor's implicit-H count is *also* correctly donor-exempted by the same
+/// fix, but O still ranks below Fe, so Fe (the acceptor) is written first
+/// and the writer must still emit a reversed `<-` arrow to keep the
+/// donor/acceptor pair intact.
+#[test]
+fn canonical_writer_flips_the_arrow_when_the_acceptor_is_written_first() {
+    let mut b = MoleculeBuilder::new();
+    let o = b.add_atom(atom(Element::O));
+    let fe = b.add_atom(atom(Element::FE));
+    b.add_bond(o, fe, BondOrder::Dative).unwrap();
+    let mol = b.build();
+
+    let out = canonical_smiles(&mol);
+    assert_eq!(out, "[Fe]<-O", "acceptor written first ⇒ reversed arrow");
+    assert_eq!(
+        dative_donor_acceptor(&parse(&out).unwrap()),
+        (Element::O, Element::FE)
     );
 }
 


### PR DESCRIPTION
## Summary

Found via the platinum coordination-chemistry compatibility benchmark (#307, `validation/platinum/FEASIBILITY.md`). Both defects are general (not platinum-specific) — verified against Fe/Co/Pd/Ru acceptors too, not just Pt.

- **`chematic-core`**: `valence_inferred_hcount` treated a `BondOrder::Dative` bond's donor side exactly like a covalent single bond when computing implicit hydrogen count, contradicting the bond type's own documented donor→acceptor convention and RDKit's identical treatment of the same `->`/`<-` SMILES syntax — an un-bracketed dative donor like `N->[Pt]Cl` computed as `NH2` instead of the chemically correct `NH3`. Donor-side dative bonds now contribute 0 to the valence sum. The acceptor side is intentionally left unchanged (out of scope — no acceptor in the motivating corpus is organic-subset). **Known, documented, not-fixed divergence**: `validate_valence` (built on the separate, public `bond_order_sum`, also used by `chematic-cip`/tautomer/`chematic-ff`) can still false-positive on a *bracketed* dative donor — pinned by a new test rather than left undocumented, deliberately not widened given the larger blast radius.
- **`chematic-mol`**: MDL bond type 9 (dative/coordinate — the convention RDKit uses for `Bond::BondType.DATIVE`, V3000 only) silently mapped to `BondOrder::Single` in both V2000 and V3000 readers' "unknown code" catch-all. Reading an RDKit-generated V3000 molfile with a dative Pt–N bond silently produced a different molecule (connectivity intact, semantics quietly lost). Both readers now map code 9 to `BondOrder::Dative`; `mol3000.rs`'s writer now emits code 9 instead of collapsing to plain single. V2000's writer is intentionally unchanged (RDKit itself cannot write a dative bond in V2000 either).

**Fallout, fixed not silently absorbed**: `chematic-smiles`'s `dative_bond_direction.rs` pinned an exact canonical-SMILES string that depended on the old, wrong implicit-H invariant. Updated to the new correct value, with a replacement case added so the arrow-flip-on-acceptor-first code path it originally covered stays covered.

**Regression tests added:**
- `crates/chematic-core/src/valence.rs`: 5 new unit tests (donor N/O keep full valence, acceptor side unaffected by design, generalizes across Fe/Co/Pd/Ru, and the `validate_valence` divergence pinned).
- `crates/chematic-mol/src/mol3000.rs`: `test_dative_bond_type_9_round_trips`, built from the literal RDKit-generated molblock that surfaced this finding.
- `crates/chematic-mol/src/mol2000.rs`: `test_parse_bond_type_9_is_dative`.

Before/after numbers (18-compound corpus): formula-matches-expected 1/18 → 18/18. Full per-fix attribution (isolated from the mass-table fix in #309) in `validation/platinum/FEASIBILITY.md` §7.

## Isolation

Does not touch `crates/chematic-3d/`. Independent of PR #309 (mass-table fix) — verified green in isolation (see commit message / test plan below).

## Test plan

- [x] `cargo test -p chematic-core -p chematic-mol -p chematic-smiles --lib --tests` green, with this PR's changes applied **in isolation** (mass-table fix from #309 stashed out) — not just in combination
- [x] `cargo test --workspace` green with both this PR and #309 applied together
- [x] `cargo clippy -p chematic-core -p chematic-mol -p chematic-smiles -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Human review
