### PR TITLE
fix(chem): extend periodic-table mass data to all 118 elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   regression test built from the literal RDKit-generated molblock that
   surfaced this finding.
 
+### Fixed — `chematic-chem` (periodic-table mass data gap, all elements)
+
+- **`avg_mass`/`mono_mass` (`molecular_weight`/`exact_mass`) covered only
+  ~24 light main-group elements and silently fell back to
+  `atomic_number as f64` for every other element** — meaning every
+  transition metal, lanthanide, actinide, and heavy post-transition element
+  (platinum: atomic number 78, real mass ~195 Da, returned as "78.0 Da";
+  same defect for Fe, Cu, Zn, Au, U, and 90 others) got a wildly wrong LOW
+  mass with no error. Not connected to coordination bonds at all — found
+  via the same platinum benchmark's mass check, but affects any molecule
+  containing an unlisted element, dative bonds or not. Both tables extended
+  to all 118 elements `chematic_core::Element` models, sourced from RDKit's
+  `PeriodicTable::getAtomicWeight`/`GetMostCommonIsotopeMass` (2026.03.3).
+  The ~24 previously-covered elements keep their pre-existing values
+  unchanged (checked element-by-element, not assumed) — most notably
+  selenium, where the pre-existing value is the current IUPAC standard
+  atomic weight and RDKit 2026.03.3 ships the superseded pre-2013 value.
+
 ## [0.14.0] — 2026-08-11
 
 Stereo-aware distance geometry: declared E/Z (cis/trans) is now enforced as a

--- a/crates/chematic-chem/src/descriptors.rs
+++ b/crates/chematic-chem/src/descriptors.rs
@@ -123,56 +123,298 @@ fn is_halogen(an: u8) -> bool {
     matches!(an, 9 | 17 | 35 | 53)
 } // F, Cl, Br, I
 
-/// Average atomic mass table.
-/// Falls back to `atomic_number as f64` for unlisted elements.
+/// Average atomic mass table (Da), indexed by `atomic_number - 1`.
+///
+/// Previously this table (and [`MONO_MASS_TABLE`] below) covered only ~24
+/// light main-group elements (H..Ca plus As/Se/Br/I) via a `match`, falling
+/// back to `atomic_number as f64` for every other element -- meaning every
+/// transition metal, lanthanide, actinide, and heavy post-transition
+/// element (including platinum, atomic number 78, real average mass
+/// 195.078 Da) silently got a wildly wrong LOW mass (e.g. 78.0) instead of
+/// an error or a correct value. Found via the platinum coordination-
+/// chemistry compatibility benchmark (see `validation/platinum/
+/// FEASIBILITY.md`); not platinum-specific -- affected every unlisted
+/// element identically, so fixed for the whole periodic table rather than
+/// only platinum.
+///
+/// The previously-covered ~24 elements keep their **pre-existing** values
+/// unchanged (each entry below is annotated `(pre-existing)` or `(RDKit)`)
+/// -- this fix only fills the 94 gaps, it does not silently re-derive
+/// values that were already present, which would have been an
+/// undiscussed, unreviewed change unrelated to the bug being fixed (one
+/// exception is real and worth naming: the pre-existing Se entry, 78.971,
+/// is the current IUPAC standard atomic weight; RDKit 2026.03.3 ships the
+/// older pre-2013 IUPAC value, 78.96, for Se specifically -- since Se was
+/// already covered, its 78.971 is kept here rather than silently
+/// downgraded). The newly-added 94 elements are sourced from RDKit's
+/// `PeriodicTable::getAtomicWeight` (2026.03.3) -- the same oracle already
+/// used throughout this repo's validation suite -- covering the rest of
+/// the 118 elements `chematic_core::Element` models.
+static AVG_MASS_TABLE: [f64; 118] = [
+    1.0080,   // 1 H (pre-existing)
+    4.0030,   // 2 He (pre-existing)
+    6.9410,   // 3 Li (pre-existing)
+    9.0120,   // 4 Be (pre-existing)
+    10.8110,  // 5 B (pre-existing)
+    12.0110,  // 6 C (pre-existing)
+    14.0070,  // 7 N (pre-existing)
+    15.9990,  // 8 O (pre-existing)
+    18.9980,  // 9 F (pre-existing)
+    20.1800,  // 10 Ne (pre-existing)
+    22.9900,  // 11 Na (pre-existing)
+    24.3050,  // 12 Mg (pre-existing)
+    26.9820,  // 13 Al (pre-existing)
+    28.0860,  // 14 Si (pre-existing)
+    30.9740,  // 15 P (pre-existing)
+    32.0650,  // 16 S (pre-existing)
+    35.4530,  // 17 Cl (pre-existing)
+    39.9480,  // 18 Ar (pre-existing)
+    39.0980,  // 19 K (pre-existing)
+    40.0780,  // 20 Ca (pre-existing)
+    44.9560,  // 21 Sc (RDKit)
+    47.8670,  // 22 Ti (RDKit)
+    50.9440,  // 23 V (RDKit)
+    51.9960,  // 24 Cr (RDKit)
+    54.9380,  // 25 Mn (RDKit)
+    55.8450,  // 26 Fe (RDKit)
+    58.9330,  // 27 Co (RDKit)
+    58.6930,  // 28 Ni (RDKit)
+    63.5460,  // 29 Cu (RDKit)
+    65.3900,  // 30 Zn (RDKit)
+    69.7230,  // 31 Ga (RDKit)
+    72.6100,  // 32 Ge (RDKit)
+    74.9220,  // 33 As (pre-existing)
+    78.9710,  // 34 Se (pre-existing)
+    79.9040,  // 35 Br (pre-existing)
+    83.8000,  // 36 Kr (RDKit)
+    85.4680,  // 37 Rb (RDKit)
+    87.6200,  // 38 Sr (RDKit)
+    88.9060,  // 39 Y (RDKit)
+    91.2240,  // 40 Zr (RDKit)
+    92.9060,  // 41 Nb (RDKit)
+    95.9400,  // 42 Mo (RDKit)
+    98.0000,  // 43 Tc (RDKit)
+    101.0700, // 44 Ru (RDKit)
+    102.9060, // 45 Rh (RDKit)
+    106.4200, // 46 Pd (RDKit)
+    107.8680, // 47 Ag (RDKit)
+    112.4120, // 48 Cd (RDKit)
+    114.8180, // 49 In (RDKit)
+    118.7110, // 50 Sn (RDKit)
+    121.7600, // 51 Sb (RDKit)
+    127.6000, // 52 Te (RDKit)
+    126.9040, // 53 I (pre-existing)
+    131.2900, // 54 Xe (RDKit)
+    132.9050, // 55 Cs (RDKit)
+    137.3280, // 56 Ba (RDKit)
+    138.9060, // 57 La (RDKit)
+    140.1160, // 58 Ce (RDKit)
+    140.9080, // 59 Pr (RDKit)
+    144.2400, // 60 Nd (RDKit)
+    145.0000, // 61 Pm (RDKit)
+    150.3600, // 62 Sm (RDKit)
+    151.9640, // 63 Eu (RDKit)
+    157.2500, // 64 Gd (RDKit)
+    158.9250, // 65 Tb (RDKit)
+    162.5000, // 66 Dy (RDKit)
+    164.9300, // 67 Ho (RDKit)
+    167.2600, // 68 Er (RDKit)
+    168.9340, // 69 Tm (RDKit)
+    173.0400, // 70 Yb (RDKit)
+    174.9670, // 71 Lu (RDKit)
+    178.4900, // 72 Hf (RDKit)
+    180.9480, // 73 Ta (RDKit)
+    183.8400, // 74 W (RDKit)
+    186.2070, // 75 Re (RDKit)
+    190.2300, // 76 Os (RDKit)
+    192.2170, // 77 Ir (RDKit)
+    195.0780, // 78 Pt (RDKit)
+    196.9670, // 79 Au (RDKit)
+    200.5900, // 80 Hg (RDKit)
+    204.3830, // 81 Tl (RDKit)
+    207.2000, // 82 Pb (RDKit)
+    208.9800, // 83 Bi (RDKit)
+    209.0000, // 84 Po (RDKit)
+    210.0000, // 85 At (RDKit)
+    222.0000, // 86 Rn (RDKit)
+    223.0000, // 87 Fr (RDKit)
+    226.0000, // 88 Ra (RDKit)
+    227.0000, // 89 Ac (RDKit)
+    232.0380, // 90 Th (RDKit)
+    231.0360, // 91 Pa (RDKit)
+    238.0290, // 92 U (RDKit)
+    237.0000, // 93 Np (RDKit)
+    244.0000, // 94 Pu (RDKit)
+    243.0000, // 95 Am (RDKit)
+    247.0000, // 96 Cm (RDKit)
+    247.0000, // 97 Bk (RDKit)
+    251.0000, // 98 Cf (RDKit)
+    252.0000, // 99 Es (RDKit)
+    257.0000, // 100 Fm (RDKit)
+    258.0000, // 101 Md (RDKit)
+    259.0000, // 102 No (RDKit)
+    262.0000, // 103 Lr (RDKit)
+    267.0000, // 104 Rf (RDKit)
+    268.0000, // 105 Db (RDKit)
+    269.0000, // 106 Sg (RDKit)
+    270.0000, // 107 Bh (RDKit)
+    269.0000, // 108 Hs (RDKit)
+    278.0000, // 109 Mt (RDKit)
+    281.0000, // 110 Ds (RDKit)
+    281.0000, // 111 Rg (RDKit)
+    285.0000, // 112 Cn (RDKit)
+    284.0000, // 113 Nh (RDKit)
+    289.0000, // 114 Fl (RDKit)
+    288.0000, // 115 Mc (RDKit)
+    293.0000, // 116 Lv (RDKit)
+    292.0000, // 117 Ts (RDKit)
+    294.0000, // 118 Og (RDKit)
+];
+
+/// Falls back to `atomic_number as f64` only if `element`'s atomic number is
+/// somehow outside `1..=118` (cannot happen for any element
+/// `chematic_core::Element` can construct today; kept as a non-panicking
+/// guard, not a silent-wrong-answer path).
 fn avg_mass(element: Element) -> f64 {
-    match element.atomic_number() {
-        1 => 1.008,    // H
-        2 => 4.003,    // He
-        3 => 6.941,    // Li
-        4 => 9.012,    // Be
-        5 => 10.811,   // B
-        6 => 12.011,   // C
-        7 => 14.007,   // N
-        8 => 15.999,   // O
-        9 => 18.998,   // F
-        10 => 20.180,  // Ne
-        11 => 22.990,  // Na
-        12 => 24.305,  // Mg
-        13 => 26.982,  // Al
-        14 => 28.086,  // Si
-        15 => 30.974,  // P
-        16 => 32.065,  // S
-        17 => 35.453,  // Cl
-        18 => 39.948,  // Ar
-        19 => 39.098,  // K
-        20 => 40.078,  // Ca
-        33 => 74.922,  // As
-        34 => 78.971,  // Se
-        35 => 79.904,  // Br
-        53 => 126.904, // I
-        n => n as f64,
-    }
+    let an = element.atomic_number();
+    AVG_MASS_TABLE
+        .get(an as usize - 1)
+        .copied()
+        .unwrap_or(an as f64)
 }
 
-/// Monoisotopic (most-abundant isotope) mass table.
-/// Falls back to `atomic_number as f64` for unlisted elements.
+/// Monoisotopic (most-abundant-isotope) mass table (Da), indexed the same
+/// way as [`AVG_MASS_TABLE`] -- see its doc comment for provenance, the bug
+/// this replaced, and why the pre-existing ~12 covered elements keep their
+/// original values rather than being silently re-derived from RDKit.
+static MONO_MASS_TABLE: [f64; 118] = [
+    1.00783,   // 1 H (pre-existing)
+    4.00260,   // 2 He (RDKit)
+    7.01600,   // 3 Li (RDKit)
+    9.01218,   // 4 Be (RDKit)
+    11.00931,  // 5 B (RDKit)
+    12.00000,  // 6 C (pre-existing)
+    14.00310,  // 7 N (pre-existing)
+    15.99490,  // 8 O (pre-existing)
+    18.99840,  // 9 F (pre-existing)
+    19.99244,  // 10 Ne (RDKit)
+    22.98977,  // 11 Na (RDKit)
+    23.98504,  // 12 Mg (RDKit)
+    26.98154,  // 13 Al (RDKit)
+    27.97690,  // 14 Si (pre-existing)
+    30.97380,  // 15 P (pre-existing)
+    31.97210,  // 16 S (pre-existing)
+    34.96890,  // 17 Cl (pre-existing)
+    39.96238,  // 18 Ar (RDKit)
+    38.96371,  // 19 K (RDKit)
+    39.96259,  // 20 Ca (RDKit)
+    44.95591,  // 21 Sc (RDKit)
+    47.94795,  // 22 Ti (RDKit)
+    50.94396,  // 23 V (RDKit)
+    51.94051,  // 24 Cr (RDKit)
+    54.93805,  // 25 Mn (RDKit)
+    55.93494,  // 26 Fe (RDKit)
+    58.93319,  // 27 Co (RDKit)
+    57.93534,  // 28 Ni (RDKit)
+    62.92960,  // 29 Cu (RDKit)
+    63.92914,  // 30 Zn (RDKit)
+    68.92557,  // 31 Ga (RDKit)
+    73.92118,  // 32 Ge (RDKit)
+    74.92160,  // 33 As (RDKit)
+    79.91650,  // 34 Se (pre-existing)
+    78.91830,  // 35 Br (pre-existing)
+    83.91151,  // 36 Kr (RDKit)
+    84.91179,  // 37 Rb (RDKit)
+    87.90561,  // 38 Sr (RDKit)
+    88.90585,  // 39 Y (RDKit)
+    89.90470,  // 40 Zr (RDKit)
+    92.90638,  // 41 Nb (RDKit)
+    97.90541,  // 42 Mo (RDKit)
+    96.90636,  // 43 Tc (RDKit)
+    101.90435, // 44 Ru (RDKit)
+    102.90550, // 45 Rh (RDKit)
+    105.90349, // 46 Pd (RDKit)
+    106.90510, // 47 Ag (RDKit)
+    113.90336, // 48 Cd (RDKit)
+    114.90388, // 49 In (RDKit)
+    119.90219, // 50 Sn (RDKit)
+    120.90382, // 51 Sb (RDKit)
+    129.90622, // 52 Te (RDKit)
+    126.90450, // 53 I (pre-existing)
+    131.90415, // 54 Xe (RDKit)
+    132.90545, // 55 Cs (RDKit)
+    137.90525, // 56 Ba (RDKit)
+    138.90635, // 57 La (RDKit)
+    139.90544, // 58 Ce (RDKit)
+    140.90765, // 59 Pr (RDKit)
+    141.90772, // 60 Nd (RDKit)
+    144.91275, // 61 Pm (RDKit)
+    151.91973, // 62 Sm (RDKit)
+    152.92123, // 63 Eu (RDKit)
+    157.92410, // 64 Gd (RDKit)
+    158.92535, // 65 Tb (RDKit)
+    163.92917, // 66 Dy (RDKit)
+    164.93032, // 67 Ho (RDKit)
+    165.93029, // 68 Er (RDKit)
+    168.93421, // 69 Tm (RDKit)
+    173.93886, // 70 Yb (RDKit)
+    174.94077, // 71 Lu (RDKit)
+    179.94655, // 72 Hf (RDKit)
+    180.94800, // 73 Ta (RDKit)
+    183.95093, // 74 W (RDKit)
+    186.95575, // 75 Re (RDKit)
+    191.96148, // 76 Os (RDKit)
+    192.96293, // 77 Ir (RDKit)
+    194.96479, // 78 Pt (RDKit)
+    196.96657, // 79 Au (RDKit)
+    201.97064, // 80 Hg (RDKit)
+    204.97443, // 81 Tl (RDKit)
+    207.97665, // 82 Pb (RDKit)
+    208.98040, // 83 Bi (RDKit)
+    208.98243, // 84 Po (RDKit)
+    209.98715, // 85 At (RDKit)
+    222.01757, // 86 Rn (RDKit)
+    223.01974, // 87 Fr (RDKit)
+    226.02540, // 88 Ra (RDKit)
+    227.02775, // 89 Ac (RDKit)
+    232.03806, // 90 Th (RDKit)
+    231.03588, // 91 Pa (RDKit)
+    238.05079, // 92 U (RDKit)
+    236.04657, // 93 Np (RDKit)
+    238.04956, // 94 Pu (RDKit)
+    241.05683, // 95 Am (RDKit)
+    243.06139, // 96 Cm (RDKit)
+    247.07031, // 97 Bk (RDKit)
+    249.07485, // 98 Cf (RDKit)
+    252.08298, // 99 Es (RDKit)
+    257.09510, // 100 Fm (RDKit)
+    258.09843, // 101 Md (RDKit)
+    259.10103, // 102 No (RDKit)
+    262.10963, // 103 Lr (RDKit)
+    267.12153, // 104 Rf (RDKit)
+    268.12545, // 105 Db (RDKit)
+    271.13347, // 106 Sg (RDKit)
+    270.13362, // 107 Bh (RDKit)
+    269.13406, // 108 Hs (RDKit)
+    278.15481, // 109 Mt (RDKit)
+    281.16206, // 110 Ds (RDKit)
+    281.16537, // 111 Rg (RDKit)
+    285.17411, // 112 Cn (RDKit)
+    284.17873, // 113 Nh (RDKit)
+    289.19042, // 114 Fl (RDKit)
+    288.19274, // 115 Mc (RDKit)
+    293.20449, // 116 Lv (RDKit)
+    292.20746, // 117 Ts (RDKit)
+    294.21392, // 118 Og (RDKit)
+];
+
+/// See [`avg_mass`]'s doc comment for the fallback rationale.
 fn mono_mass(element: Element) -> f64 {
-    match element.atomic_number() {
-        1 => 1.00783,   // H  (1H)
-        6 => 12.0000,   // C  (12C)
-        7 => 14.0031,   // N  (14N)
-        8 => 15.9949,   // O  (16O)
-        9 => 18.9984,   // F  (19F)
-        14 => 27.9769,  // Si (28Si)
-        15 => 30.9738,  // P  (31P)
-        16 => 31.9721,  // S  (32S)
-        17 => 34.9689,  // Cl (35Cl)
-        35 => 78.9183,  // Br (79Br)
-        34 => 79.9165,  // Se (80Se)
-        53 => 126.9045, // I  (127I)
-        n => n as f64,
-    }
+    let an = element.atomic_number();
+    MONO_MASS_TABLE
+        .get(an as usize - 1)
+        .copied()
+        .unwrap_or(an as f64)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Found via the platinum coordination-chemistry compatibility benchmark (#307, `validation/platinum/FEASIBILITY.md`). **Not platinum- or coordination-bond-specific**: this bug affects any molecule containing an element outside the previous ~24-element list, dative bonds or not.

`avg_mass`/`mono_mass` (feeding `molecular_weight`/`exact_mass`) covered only H..Ca plus As/Se/Br/I via a partial `match`, silently falling back to `atomic_number as f64` for every other element — every transition metal, lanthanide, actinide, and heavy post-transition element got a wildly wrong LOW mass with no error, no panic, no diagnostic (platinum: atomic number 78, real mass ~195 Da, silently returned "78.0 Da"; same defect for Fe, Cu, Zn, Au, U, and 90 others).

Both tables extended to all 118 elements `chematic_core::Element` models, sourced from RDKit's `PeriodicTable::getAtomicWeight`/`GetMostCommonIsotopeMass` (2026.03.3 — the same oracle already used throughout this repo's validation suite).

**The ~24 previously-covered elements keep their pre-existing values unchanged** — checked element-by-element rather than assumed safe to blanket-overwrite: two of the 24 differ from RDKit's table by <0.002 (B, S — immaterial rounding) and one differs meaningfully (**Se**: pre-existing 78.971 is the current IUPAC standard atomic weight; RDKit 2026.03.3 ships the superseded pre-2013 value, 78.96 — kept as-is rather than silently downgraded).

Before/after numbers (18-compound platinum corpus, measured together with PR #308's dative-bond fix since mass depends on both): exact-mass-matches-expected 0/12 → 12/12. Isolated attribution of this fix alone (mass-table fix only, dative-bond fix reverted) in `validation/platinum/FEASIBILITY.md` §7 — cisplatin's mass goes from 179.9753 → 296.9401 with this fix alone (the residual ~2 Da gap is PR #308's fix, not this one).

## Isolation

Does not touch `crates/chematic-3d/`. Independent of PR #308 (dative-bond fix) — verified green in isolation.

## Test plan

- [x] `cargo test -p chematic-chem` green, this PR's change applied **in isolation**
- [x] `cargo test --workspace` green with both this PR and #308 applied together
- [x] `cargo clippy -p chematic-chem -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Human review, especially of the Se/B/S provenance decision above
