### PR TITLE
release: v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] — 2026-08-12
+
+Anticancer platinum coordination-chemistry compatibility fixes, plus Extended
+XYZ (extxyz) read/write support. Patch release: all `chematic-core`/
+`chematic-mol`/`chematic-chem` changes are bug fixes to existing behavior
+(no new production capability gated behind a flag); the extxyz addition is
+new functionality but additive at the Python/WASM binding layer. Note: the
+Rust-only `XyzFrame`/`XyzError`/`write_extxyz` signature changes below are a
+real break to the v0.14.0 Rust API surface already published to crates.io,
+not merely a break to something unreleased — flagged here for anyone
+depending on `chematic-mol`'s Rust API directly rather than via SMILES/JSON
+bindings.
+
 ### Added — platinum coordination-chemistry compatibility benchmark
 
 - `validation/platinum/pt_corpus.jsonl` (18-entry hand-verified corpus of
@@ -92,6 +105,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unchanged (checked element-by-element, not assumed) — most notably
   selenium, where the pre-existing value is the current IUPAC standard
   atomic weight and RDKit 2026.03.3 ships the superseded pre-2013 value.
+
+### Fixed — `chematic-chem` (`trained-solubility-mlp` feature, unrelated to the above)
+
+- **`mlp_solubility`'s embedded model weights (`W1_BYTES`/`B1_BYTES`) never actually compiled under the opt-in `trained-solubility-mlp` feature**: both `include_bytes!` paths had one `../` too many, resolving outside the repository entirely and failing to build with "No such file or directory" whenever the feature was enabled. Found while running this release's `cargo clippy --all-features` gate, the first time this feature has ever been exercised. Fixed to the correct 3-level-up path; a `needless_range_loop` clippy lint the fix then exposed in the same function was also fixed (semantics unchanged). Verified past compiling: with the feature enabled, `mlp_solubility` now actually loads the trained weights and produces plausible output where water is predicted more soluble than octane. `trained-solubility-mlp` is off by default, so this has no effect on any default build, and is unrelated to the platinum/extxyz work above.
 
 ### Added — `chematic-mol` (Extended XYZ / extxyz)
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,5 +23,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.14.0
-date-released: "2026-08-11"
+version: 0.14.1
+date-released: "2026-08-12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 rust-version = "1.85"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.14.0
+# chematic v0.14.1
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-07-17, v0.4.29 vs RDKit 2026.03.3 --
@@ -419,6 +419,14 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +1
 
 ## Recent Development
 
+**v0.14.1** (2026-08-12): **Anticancer platinum coordination-chemistry compatibility fixes, Extended XYZ (extxyz) read/write**
+- `chematic-core`: `valence_inferred_hcount` treated a `BondOrder::Dative` bond's donor side exactly like a covalent single bond when computing implicit hydrogen count — an un-bracketed dative donor like `N->[Pt]Cl` computed as `NH2` instead of the chemically correct `NH3`. Donor-side dative bonds now contribute 0 to the valence sum; found via a platinum coordination-chemistry benchmark but general (verified against Fe/Co/Pd/Ru acceptors too), not platinum-specific
+- `chematic-mol`: MDL bond type 9 (dative/coordinate — RDKit's own V3000 convention for `Bond::BondType.DATIVE`) silently mapped to `BondOrder::Single` in both V2000 and V3000 readers, quietly discarding coordination-bond semantics on read. Both readers now map code 9 to `BondOrder::Dative`; V3000's writer now emits code 9 instead of collapsing to plain single
+- `chematic-chem`: `avg_mass`/`mono_mass` covered only ~24 light main-group elements and silently fell back to `atomic_number as f64` for every other element — every transition metal, lanthanide, actinide, and heavy post-transition element (platinum: atomic number 78, real mass ~195 Da, previously returned "78.0 Da") got a wildly wrong mass with no error. Extended to all 118 `Element` values, sourced from RDKit's periodic table data, with the ~24 previously-covered values kept as-is where they differ (selenium: this project's value is the current IUPAC standard, RDKit ships the superseded pre-2013 value)
+- `chematic-mol`: new Extended XYZ (extxyz) format support — `parse_extxyz`/`write_extxyz`, `ExtxyzReader`/`ExtxyzWriter`, `parse_extxyz_all`, built as an extension of the existing multi-frame `XyzFrame` type (ASE's `Lattice=` cell matrix, typed per-atom `Properties=` columns, arbitrary `key=value` frame metadata); a plain XYZ file round-trips through the extxyz reader/writer unchanged. Python: `from_extxyz`/`from_extxyz_all`/`to_extxyz`. WASM: `mol_from_extxyz`/`extxyz_frame_json`/`to_extxyz_json`. **Breaking (Rust API only)**: `XyzFrame` gained three public fields, `XyzError` gained seven variants, `write_extxyz` now returns `Result<String, XyzError>` — a real break to the `chematic-mol` v0.14.0 Rust API already published to crates.io, not merely an unreleased-API change
+- Platinum coordination-chemistry stereochemistry (square-planar cis/trans identity, e.g. cisplatin vs. transplatin) remains unrepresented — measured and explicitly not fixed this release, see `validation/platinum/FEASIBILITY.md`
+- Full details in `CHANGELOG.md`'s `[0.14.1]` section
+
 **v0.14.0** (2026-08-11): **Stereo-aware distance geometry — declared E/Z enforced as a bound-matrix constraint, `enforce_chirality` composable with post-minimization stereo verification, Python/WASM exposure**
 - `chematic-3d`: root-caused and fixed the issue #285 release-gate waiver from v0.13.0 — `apply_vdw_bounds`'s generic non-bonded Van der Waals lower bound was being applied to a declared-E/Z alkene's own 1-4 substituent pair regardless of declared stereochemistry, structurally excluding the correct cis geometry from ever being sampled. New `apply_declared_ez_bounds` (`enforce_chirality`-only) intersects an analytic same-side/opposite-side 1-4 distance bound into the bond matrix *before* the generic Van der Waals floor applies, so the correct geometry is reachable by construction, not by post-hoc repair/retry/reflection. Unlike tetrahedral chirality (which a pairwise distance matrix can never encode — a molecule and its mirror image have identical pairwise distances), declared E/Z is genuinely distance-representable, since cis/trans are two different scalar separations, not mirror images. Measured on the 265-molecule corpus's declared-E/Z subset (39 molecules): stereo-satisfied 22 → 42, violated 23 → 3, pipeline success/soundness unchanged
 - `chematic-3d`: `embed_pipeline_v2`'s config-validation gate previously rejected `enforce_chirality: true` for any `stereo_policy` other than `Ignore`. Corpus measurement found this wrong — `enforce_chirality` protects embedding-time correctness only, and force-field minimization (which has no notion of declared stereo) can walk a correctly-embedded E/Z bond back across its boundary afterward (found on 2 real molecules, confirmed by re-running with no force field). `enforce_chirality: true` is now also allowed with `StereoPolicy::VerifyOnly`, whose existing post-minimization gate catches exactly this failure mode as a typed error instead of a silent wrong-stereo `success`
@@ -533,7 +541,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v0.14.0)
+├── Cargo.toml                    workspace root (v0.14.1)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)
@@ -586,7 +594,7 @@ If you use chematic in academic or research work, please cite:
   author    = {kent-tokyo},
   title     = {chematic: A pure-Rust cheminformatics toolkit},
   url       = {https://github.com/kent-tokyo/chematic},
-  version   = {0.14.0},
+  version   = {0.14.1},
   year      = {2026},
 }
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -106,7 +106,7 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.14.0
+# chematic v0.14.1
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-06, v0.4.22 vs RDKit 2026.03.3 --
@@ -282,6 +282,22 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi      
 ---
 
 ## 最近の開発
+
+**v0.14.1**（2026-08-12）: **抗がん白金配位化学の互換性修正、Extended XYZ（extxyz）読み書き対応**
+- `chematic-core`: `valence_inferred_hcount`が`BondOrder::Dative`結合のdonor側を通常の共有結合と同じに扱っていたため、implicit水素数計算が誤っていた——`N->[Pt]Cl`のような括弧なしdative donorが`NH3`ではなく`NH2`と計算されていた。donor側dative結合はvalence合計に0を寄与するよう修正。白金配位化学ベンチマークで発見したが、Fe/Co/Pd/Ruのacceptorでも検証済みの一般的な修正（白金固有ではない）
+- `chematic-mol`: MDL bond type 9（dative/coordinate結合——RDKit実装が`Bond::BondType.DATIVE`をV3000で書く際に使う規約）が、V2000・V3000両readerで`BondOrder::Single`へ暗黙に丸められ、配位結合の意味情報が読み込み時に静かに失われていた。両readerともcode 9を`BondOrder::Dative`として解釈するよう修正、V3000のwriterもcode 9を出力するよう修正
+- `chematic-chem`: `avg_mass`/`mono_mass`が軽い主族元素約24種のみをカバーし、それ以外の全元素で`atomic_number as f64`へ静かにfallbackしていた——遷移金属・ランタノイド・アクチノイド・重い後周期元素は全てエラーなしで大きく誤った質量を返していた（白金：原子番号78、実際の質量約195Daのところ「78.0 Da」を返していた）。`Element`が持つ全118元素へ拡張、RDKitの周期表データを出典として使用。既存約24元素の値はそのまま維持（セレンなど、本プロジェクトの値が現行IUPAC標準でRDKit側が2013年以前の旧値を採用しているケースは既存値を優先）
+- `chematic-mol`: Extended XYZ（extxyz）形式の新規対応——`parse_extxyz`/`write_extxyz`、`ExtxyzReader`/`ExtxyzWriter`、`parse_extxyz_all`。既存のmulti-frame `XyzFrame`型の拡張として実装（ASEの`Lattice=`セル行列、型付きper-atom `Properties=`列、任意の`key=value`フレームメタデータ）。プレーンXYZファイルはextxyz readerを通しても無変更で往復する。Python: `from_extxyz`/`from_extxyz_all`/`to_extxyz`。WASM: `mol_from_extxyz`/`extxyz_frame_json`/`to_extxyz_json`。**Breaking（Rust APIのみ）**: `XyzFrame`に公開フィールド3つ追加、`XyzError`にvariant 7つ追加、`write_extxyz`の戻り値が`Result<String, XyzError>`に変更——これは既にcrates.io公開済みのv0.14.0 Rust APIに対する実際の破壊的変更であり、未リリースAPIへの変更ではない点に注意
+- 白金配位化学の立体化学（square-planar cis/trans、例：cisplatinとtransplatinの区別）は依然として表現不可能——今回のリリースでは測定のみ行い、意図的に未修正（`validation/platinum/FEASIBILITY.md`参照）
+- 詳細は`CHANGELOG.md`の`[0.14.1]`セクション参照
+
+**v0.14.0**（2026-08-11）: **立体化学を考慮したdistance geometry——宣言済みE/Zをbound-matrix制約として強制、`enforce_chirality`とpost-minimization stereo verificationの組み合わせ対応、Python/WASM公開**
+- `chematic-3d`: v0.13.0のissue #285 release-gate waiverの根本原因を特定・修正——`apply_vdw_bounds`の汎用non-bonded Van der Waals下限が、宣言されたE/Z立体化学に関わらず宣言済みE/Zアルケンの1-4置換基ペアに適用され、正しいcis配座が構造的にサンプリング対象から除外されていた。新規`apply_declared_ez_bounds`（`enforce_chirality`時のみ）が、汎用Van der Waals下限の適用より前に、same-side/opposite-sideの1-4距離の解析的境界をbond matrixへ交差させることで、post-hocな修復・retry・reflectionではなく構造的に正しい配座へ到達可能にした。四面体キラリティ（distance matrixでは原理的に表現不可能——分子とその鏡像はpairwise distanceが同一）と異なり、宣言済みE/Zはcis/transが異なるスカラー距離であるため、genuinely distance-representable。265分子コーパスの宣言済みE/Zサブセット（39分子）で測定：stereo-satisfied 22→42、violated 23→3、pipeline成功率・健全性は無変化
+- `chematic-3d`: `embed_pipeline_v2`のconfig検証ゲートが従来`stereo_policy`が`Ignore`以外なら`enforce_chirality: true`を拒否していたが、コーパス測定によりこれが誤りと判明——`enforce_chirality`はembedding時の正しさのみを保証し、force-field minimization（宣言済みstereoの概念を持たない）が正しくembedされたE/Z結合を事後的に境界の反対側へ動かしうる（実分子2件で確認、force field無しの再実行で検証）。`enforce_chirality: true`は`StereoPolicy::VerifyOnly`とも併用可能になり、既存のpost-minimizationゲートがこの失敗モードをsilentな誤stereo「成功」ではなく型付きエラーとして検出する
+- `chematic-py`、`chematic-wasm`: `enforce_chirality`（デフォルト`false`）が`PipelineV2Config`/`PipelineV2Config.safe()`（Python）および`enforceChirality` JSONフィールド（WASM）で実際に設定可能なパラメータ/フィールドに——どちらのbindingもこれまでこのフィールドを一切引き渡していなかったため、上記の修正はPython・WASM双方から到達不可能だった
+- `chematic-rxn`: `suzuki_biaryl`のretro-template修正（issue #294）——`[c:1][c:2]`は実際のbiaryl結合に一切マッチせず、環内芳香族結合のみにマッチしていた（このクレートのSMILES規約では、隣接する2つの芳香族原子間に明示的な結合トークンがない場合デフォルトで芳香族結合になるため）。`[c:1]-[c:2]`に修正。副次的発見：`DEFAULT_TEMPLATES`59件中14件が一切パースされていなかった——issue #296として記録、本修正では対応せず
+- opt-in限定——`enforce_chirality: false`が引き続き全箇所でデフォルト。デフォルトのconformer経路（`generate_coords_etkdg`/`Mol.conformer_ensemble()`）は無変更
+- 詳細は`CHANGELOG.md`の`[0.14.0]`セクション参照
 
 **v0.13.0**（2026-08-10）: **MMFF94 stretch-bend／torsionパラメータ選択パリティ（両方breaking）、per-atomステレオセンターAPI、E/Z完全性判定、macrocycle検出、notation非依存atropisomer検出・割り当て、XYZ入出力**
 - `chematic-ff`: `mmff94_stbn`/`mmff94_stbn_type_only`が`MMFF94_STBN`テーブルのlookup keyとして、これまで代用していた粗いangle type（0-8）ではなく、RDKit実装の本来の細かいstretch-bend type（`getMMFFStretchBendType`、0-11）を使うように（issue #227）— 265分子コーパスで427件のstretch-bend routing候補中220件が、RDKitの汎用Dfsb周期表デフォルト値から正しい専用パラメータへ移行。`angle_type_for`のring-offset式もRDKit実装の`getMMFFAngleType`に合わせて修正。**Breaking**: `mmff94_stbn`/`mmff94_stbn_type_only`の先頭`u8`引数は`stretch_bend_type`（`angle_type`ではない）— 新規`pub stretch_bend_type_for`で計算

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.14.0 | Yes | Current release — active support |
+| v0.14.1 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.14.0) receives all security updates.  
+**Active Support**: Latest release (v0.14.1) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -16,12 +16,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.14.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.14.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.14.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.14.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.14.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.14.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.14.1" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.14.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.1" }
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #219); web-time
 # is a drop-in Instant replacement backed by Performance.now() there, and

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -16,14 +16,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.14.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.14.1" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.14.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.14.0" }
-chematic-cip        = { path = "../chematic-cip",        version = "0.14.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.1" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.14.1" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.14.1" }
+chematic-cip        = { path = "../chematic-cip",        version = "0.14.1" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-chem/src/mlp.rs
+++ b/crates/chematic-chem/src/mlp.rs
@@ -52,9 +52,9 @@ pub const MLP_SOLUBILITY_TRAINED: bool = cfg!(feature = "trained-solubility-mlp"
 // The weights are conditionally compiled when data files are present.
 // If the files do not exist the fallback path (esol_solubility) is used.
 #[cfg(feature = "trained-solubility-mlp")]
-const W1_BYTES: &[u8] = include_bytes!("../../../../data/mlp_w1.bin");
+const W1_BYTES: &[u8] = include_bytes!("../../../data/mlp_w1.bin");
 #[cfg(feature = "trained-solubility-mlp")]
-const B1_BYTES: &[u8] = include_bytes!("../../../../data/mlp_b1.bin");
+const B1_BYTES: &[u8] = include_bytes!("../../../data/mlp_b1.bin");
 
 // Cache parsed weights so that repeated calls to `mlp_solubility` (e.g. in a
 // virtual-screening loop over 100 k molecules) pay the ~8 KB deserialization
@@ -88,9 +88,9 @@ pub fn mlp_solubility(mol: &Molecule) -> f64 {
         }
 
         let mut acc = b[0];
-        for i in 0..2048 {
+        for (i, wi) in w.iter().enumerate().take(2048) {
             if fp.get(i) {
-                acc += w[i];
+                acc += wi;
             }
         }
         acc as f64

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.14.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.14.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -22,10 +22,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.14.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.14.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.14.0" }
+chematic-core = { path = "../chematic-core", version = "0.14.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.14.1" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.14.1" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.14.0" }
+chematic-core = { path = "../chematic-core", version = "0.14.1" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.14.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.14.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -22,13 +22,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.14.0" }
+chematic-core = { path = "../chematic-core", version = "0.14.1" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.14.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.14.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.14.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.14.1" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.14.1" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.14.1" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -18,10 +18,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.14.0", path = "../chematic-core" }
-chematic-smiles = { version = "0.14.0", path = "../chematic-smiles" }
-chematic-chem = { version = "0.14.0", path = "../chematic-chem" }
-chematic-rxn = { version = "0.14.0", path = "../chematic-rxn" }
+chematic-core = { version = "0.14.1", path = "../chematic-core" }
+chematic-smiles = { version = "0.14.1", path = "../chematic-smiles" }
+chematic-chem = { version = "0.14.1", path = "../chematic-chem" }
+chematic-rxn = { version = "0.14.1", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.14.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.14.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -17,15 +17,15 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.14.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.14.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.14.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.14.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.14.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.14.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.14.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.14.1", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.14.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.1" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.14.1" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.14.1" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.14.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
 
 [dev-dependencies]
 # Real JSON Schema 2020-12 validator, used only in tests to independently

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -16,10 +16,10 @@ documentation = "https://docs.rs/chematic-mol"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.14.0" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.14.0" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.14.0" }
-chematic-smiles      = { path = "../chematic-smiles",      version = "0.14.0" }
+chematic-core        = { path = "../chematic-core",        version = "0.14.1" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.14.1" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.14.1" }
+chematic-smiles      = { path = "../chematic-smiles",      version = "0.14.1" }
 serde_json           = "1.0"
 
 [dev-dependencies]

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.14.0" }
+chematic-core = { path = "../chematic-core", version = "0.14.1" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,16 +25,16 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.14.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.14.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.14.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.14.0", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.14.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.14.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.14.0" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.14.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.14.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.14.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.14.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.14.1" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.14.1" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.14.1", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.14.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.1" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.14.1" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.14.1" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.14.1" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.14.1" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.14.1" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -22,9 +22,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 perf-instrumentation = []
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.14.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.14.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.14.0" }
+chematic-core   = { path = "../chematic-core",   version = "0.14.1" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.14.1" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.14.1" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.14.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
+chematic-core = { path = "../chematic-core", version = "0.14.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
 rustc-hash = "2"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #221); web-time

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.14.0" }
+chematic-core = { path = "../chematic-core", version = "0.14.1" }
 
 [features]
 # Feature-gated internal work counters for the orbit-pruning canonical

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -26,16 +26,16 @@ wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["console"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.14.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.14.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.14.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.14.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.14.0", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.14.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.14.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.14.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.14.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.14.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.14.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.14.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.14.1", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.14.1" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.14.1", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.14.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.1" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.14.1" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.14.1" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.14.1" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.14.1" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.14.1" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -33,15 +33,15 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.14.0", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.0", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.14.0", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.14.0", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.14.0", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.14.0", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.14.0", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.0", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.14.0", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.14.0", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.14.0", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.14.0", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.14.1", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.1", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.14.1", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.14.1", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.14.1", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.14.1", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.14.1", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.1", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.14.1", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.14.1", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.14.1", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.14.1", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Patch release combining #307-#310 (already merged to main): anticancer platinum coordination-chemistry compatibility fixes (dative-bond implicit-H count, MOL bond-type-9 dative bonds, 118-element periodic-table mass-data coverage) plus Extended XYZ (extxyz) read/write support.

Also fixes a pre-existing, unrelated bug found while running this release's `cargo clippy --all-features` gate for the first time this project has ever exercised the opt-in `trained-solubility-mlp` feature: an off-by-one `include_bytes!` path that made the feature fail to compile at all whenever enabled (`crates/chematic-chem/src/mlp.rs`).

Full details in `CHANGELOG.md`'s `[0.14.1]` section.

## Version rationale

Chosen as 0.14.1 (patch) per explicit user decision, despite `chematic-mol`'s `XyzFrame`/`XyzError`/`write_extxyz` Rust-API changes being a real break to the already-published v0.14.0 Rust API surface (this project's own prior precedent — PR #249/#250 — treated an identical situation as warranting a minor bump). Real-world blast radius judged small since few external consumers construct `XyzFrame` via Rust struct literals directly.

## Release gates run locally (all green)

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` (found + fixed the `mlp.rs` bug above)
- `cargo test --workspace` (71/71 test groups, 0 failed)
- `cargo deny --all-features check` (advisories/bans/licenses/sources ok)
- `cargo publish --dry-run` per crate in dependency order (only `chematic-core`, the sole crate with no internal `chematic-*` deps, can be dry-run-verified against the real registry before the rest are actually published — a structural Cargo limitation, same as at v0.14.0)
- Python bindings: `cargo check -p chematic-py` + `maturin develop --release` + `pytest` (680 passed)
- WASM: `wasm-pack build --target nodejs` and `--target web`, all `.test.mjs` smoke tests including the web-target `totalTimeoutMs: 0` boundary test (green and non-flaky in this run)
- `chematic-rxn`: `all_default_templates_parse` (59/59 `DEFAULT_TEMPLATES` parse) + `suzuki_biaryl` issue #294 regression tests
- `scripts/check.sh` (version consistency, publish graph, full local gate) — `All checks passed.`

## Test plan

- [x] All gates above run locally, green
- [ ] CI green on this PR