### PR TITLE
feat(crystal): chematic-crystal foundation -- periodic structures, PBC, neighbors, supercells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   minimum-image distance, cutoff neighbor enumeration, and diagonal
   supercells. Deliberately **not** an extension of `chematic_core::Molecule`
   -- see `docs/rfcs/chematic_crystal_foundation.md`. Optional `serde`
-  feature; optional `crystal` feature on the `chematic` facade (not yet
-  added to `full`, pending human confirmation). No symmetry, no CIF parser
-  changes, no Python/WASM/MCP bindings in this PR.
+  feature; optional `crystal` feature on the `chematic` facade, included
+  in `full` (does not change `default`, which stays empty). No symmetry,
+  no CIF parser changes, no Python/WASM/MCP bindings in this PR.
 
 ## [0.14.1] — 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — chematic-crystal (new crate, draft)
+
+- `crates/chematic-crystal`: periodic (crystal) structure representation
+  and geometry -- `Lattice` (triclinic-capable, validated matrix/inverse/
+  reciprocal vectors), `FractionalCoord`/`CartesianCoord`, `PeriodicSite`/
+  `SiteSpecies`/`Occupancy` (multi-species disorder-ready), and
+  `PeriodicStructure` with exact (not `round()`-approximate) periodic
+  minimum-image distance, cutoff neighbor enumeration, and diagonal
+  supercells. Deliberately **not** an extension of `chematic_core::Molecule`
+  -- see `docs/rfcs/chematic_crystal_foundation.md`. Optional `serde`
+  feature; optional `crystal` feature on the `chematic` facade (not yet
+  added to `full`, pending human confirmation). No symmetry, no CIF parser
+  changes, no Python/WASM/MCP bindings in this PR.
+
 ## [0.14.1] — 2026-08-12
 
 Anticancer platinum coordination-chemistry compatibility fixes, plus Extended

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/chematic-rxn",
     "crates/chematic-ff",
     "crates/chematic-ewald",
+    "crates/chematic-crystal",
     "crates/chematic-inchi",
     "crates/chematic-wasm",
     "crates/chematic",

--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ chematic/
 │   ├── chematic-wasm/            130+ WASM exports → npm @kent-tokyo/chematic
 │   ├── chematic-py/              PyO3 Python bindings → pip install chematic
 │   ├── chematic-ewald/           PME Ewald summation, B-spline interpolation
+│   ├── chematic-crystal/         Periodic crystal structures: lattice, PBC, neighbors, supercells (not Molecule)
 │   └── chematic/                 Umbrella crate with feature flags
 ├── demo/                         Interactive WASM playground (→ /playground/ on GitHub Pages)
 │   ├── index.html

--- a/crates/chematic-crystal/Cargo.toml
+++ b/crates/chematic-crystal/Cargo.toml
@@ -24,9 +24,19 @@ chematic-core = { path = "../chematic-core", version = "0.14.1" }
 serde         = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
-serde_json = "1.0"
+# float_roundtrip: without it, serde_json's default float parser is not
+# guaranteed to be correctly-rounded -- observed directly (a 1-ULP mismatch
+# on a from_parameters-derived matrix entry, e.g. 3.453503973595536e-16
+# serialized then parsed back as 3.4535039735955363e-16) while writing this
+# crate's serde round-trip tests. Downstream consumers who need exact float
+# round-tripping via serde_json need the same feature; noted in the README.
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 criterion  = { version = "0.8", features = ["html_reports"] }
 
 [[bench]]
 name = "crystal_bench"
 harness = false
+
+[[test]]
+name = "serde_roundtrip"
+required-features = ["serde"]

--- a/crates/chematic-crystal/Cargo.toml
+++ b/crates/chematic-crystal/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "chematic-crystal"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Periodic crystal structure representation and geometry (lattice, fractional/Cartesian coordinates, PBC distance, periodic neighbors, supercells) for chematic -- pure Rust, WASM-compatible"
+keywords = ["crystal", "lattice", "periodic", "materials", "cheminformatics"]
+categories = ["science", "data-structures"]
+readme = "README.md"
+homepage.workspace = true
+documentation = "https://docs.rs/chematic-crystal"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+serde = ["dep:serde"]
+
+[dependencies]
+chematic-core = { path = "../chematic-core", version = "0.14.1" }
+serde         = { version = "1.0", features = ["derive"], optional = true }
+
+[dev-dependencies]
+serde_json = "1.0"
+criterion  = { version = "0.8", features = ["html_reports"] }
+
+[[bench]]
+name = "crystal_bench"
+harness = false

--- a/crates/chematic-crystal/README.md
+++ b/crates/chematic-crystal/README.md
@@ -1,0 +1,9 @@
+# chematic-crystal
+
+Periodic crystal structure representation and geometry for the
+[chematic](https://github.com/kent-tokyo/chematic) ecosystem.
+
+Status: v0.1 foundation, in progress -- API surface and docs are being
+filled in through this crate's implementation phases. See
+`docs/rfcs/chematic_crystal_foundation.md` and `docs/crystal_scope.md` in
+the workspace root for the full design record and scope boundary.

--- a/crates/chematic-crystal/README.md
+++ b/crates/chematic-crystal/README.md
@@ -193,10 +193,10 @@ CPU: Apple M4. rustc 1.97.0. Commit: `fa63822` (chematic-crystal Phase 4).
 | `make_supercell([2,2,2])` | cubic | 125 -> 1000 | -- | -- | criterion | 101.4 us |
 
 The O(n^2) scaling is expected and visible above (125 -> 1000 sites, an 8x
-increase, is roughly a 50-60x slowdown, consistent with a 64x pair-count
-increase (8^2) partly offset by a smaller per-pair search box at this fixed
-cutoff/density ratio); a spatial-partitioning neighbor list (cell lists /
-Verlet lists) is
+increase, is roughly a 50-65x slowdown -- cubic 49.5x, triclinic 64.9x --
+bracketing the 64x pair-count increase (8^2) expected from O(n^2) scaling
+at this fixed cutoff/density ratio); a spatial-partitioning neighbor list
+(cell lists / Verlet lists) is
 the natural next step if this becomes a bottleneck for a real workload, but
 is explicitly deferred past v0.1.
 

--- a/crates/chematic-crystal/README.md
+++ b/crates/chematic-crystal/README.md
@@ -1,9 +1,236 @@
 # chematic-crystal
 
 Periodic crystal structure representation and geometry for the
-[chematic](https://github.com/kent-tokyo/chematic) ecosystem.
+[chematic](https://github.com/kent-tokyo/chematic) ecosystem: lattices,
+fractional/Cartesian coordinates, periodic sites, periodic boundary
+conditions, exact minimum-image distance, periodic neighbor enumeration,
+and diagonal supercells. Pure Rust, `#![forbid(unsafe_code)]`,
+WASM-compatible, one required dependency (`chematic-core`, for `Element`).
 
-Status: v0.1 foundation, in progress -- API surface and docs are being
-filled in through this crate's implementation phases. See
-`docs/rfcs/chematic_crystal_foundation.md` and `docs/crystal_scope.md` in
-the workspace root for the full design record and scope boundary.
+`v0.1` is a structural/geometric foundation, not a symmetry or materials-
+property library -- see "Out of scope" below and
+`docs/crystal_scope.md`/`docs/rfcs/chematic_crystal_foundation.md` in the
+workspace root for the full design record.
+
+## What this crate is not: `Molecule`
+
+`chematic_core::Molecule` is a bond graph: atoms, typed bonds, aromaticity,
+implicit hydrogens, stereo perception. `PeriodicStructure` is a lattice +
+sites (element/occupancy + fractional position) with **no bond graph at
+all**. These are deliberately separate first-class types, not variants of
+each other:
+
+- A crystal's "neighbor" relationship is a geometric/distance fact under
+  periodic boundary conditions, not chemical bonding. This crate never
+  auto-derives a `Bond` from periodic proximity.
+- `chematic-crystal` does not depend on `chematic-core::Molecule`, and
+  nothing in `chematic-core::Molecule` gains periodic-structure fields from
+  this crate.
+
+## Quick start
+
+```rust
+use chematic_core::Element;
+use chematic_crystal::{
+    FractionalCoord, Lattice, PeriodicSite, PeriodicStructure, SiteSpecies,
+};
+
+let lattice = Lattice::cubic(5.64).unwrap();
+let sites = vec![
+    PeriodicSite::new(
+        vec![SiteSpecies::full(Element::NA)],
+        FractionalCoord::new([0.0, 0.0, 0.0]),
+        Some("Na1".to_string()),
+    )
+    .unwrap(),
+    PeriodicSite::new(
+        vec![SiteSpecies::full(Element::CL)],
+        FractionalCoord::new([0.5, 0.5, 0.5]),
+        Some("Cl1".to_string()),
+    )
+    .unwrap(),
+];
+let structure = PeriodicStructure::new(lattice, sites).unwrap();
+
+let neighbors = structure.neighbors_within(5.0).unwrap();
+let supercell = structure.make_supercell([2, 2, 2]).unwrap();
+```
+
+See `examples/basic_structure.rs` (`cargo run -p chematic-crystal --example
+basic_structure`) for a runnable version with printed output.
+
+## Conventions
+
+### Lattice matrix
+
+`Lattice::matrix()` is `[[f64; 3]; 3]` with **rows = lattice vectors a, b,
+c** (`matrix[0]` = a, `matrix[1]` = b, `matrix[2]` = c). Cartesian is
+obtained from fractional by row-vector x matrix:
+
+```text
+cartesian = fractional . matrix
+cartesian_k = sum_j fractional_j * matrix[j][k]
+```
+
+This matches `chematic_ewald::BoxVectors`'s existing row convention
+(`chematic-crystal` does not depend on `chematic-ewald`; the convention is
+just kept compatible for a possible future bridge). Reciprocal vectors use
+the crystallographic (no `2*pi`) convention `a_i . b_j = delta_ij`; under
+the row convention, reciprocal row `b_j` is **column `j`** of
+`inverse_matrix()`, not row `j`.
+
+### Coordinates and units
+
+- `FractionalCoord([f64; 3])`: dimensionless, lattice-relative. Not
+  range-restricted by the type -- use `.wrapped()` to reduce into `[0, 1)`
+  (via `rem_euclid(1.0)`; `1.0` maps to `0.0`, negative values wrap up).
+- `CartesianCoord([f64; 3])`: Angstrom -- the same unit convention as the
+  rest of chematic (`chematic_core::coords3d::Point3`, MOL/SDF, PDB).
+- Public constructors (`Lattice::from_matrix`/`from_parameters`/`cubic`/
+  `orthorhombic`, `PeriodicSite::new`, `PeriodicStructure::new`) reject
+  `NaN`/`Infinity`. The coordinate newtypes' fields are `pub` (matching the
+  crate's immutable-by-default design), so a value built via direct struct
+  literal isn't automatically checked -- call `.is_finite()` or run it
+  through a structure's `validate()` if it didn't come from a validated
+  constructor.
+
+### PBC distance / minimum image
+
+`periodic::minimum_image(lattice, from, to)` returns the **exact** nearest
+periodic image -- not an approximation. A naive `delta_frac -=
+delta_frac.round()` reduction is only guaranteed correct for cells close to
+orthogonal; for sufficiently skewed triclinic cells it can pick the wrong
+image (verified concretely by a pinned regression fixture in
+`tests/periodicity.rs`: a real triclinic cell where naive rounding reports
+8.92 Angstrom for a pair whose true nearest-image distance is 1.73
+Angstrom). Instead, `minimum_image` derives a finite, provably sufficient
+search box from the lattice's own reciprocal vectors and checks every
+candidate inside it -- exact for any lattice this crate's validation
+accepts. Full derivation: `docs/rfcs/chematic_crystal_foundation.md`.
+
+`PeriodicDisplacement` reports which image was chosen (`image: [i32; 3]`),
+the Cartesian and fractional displacement, and the distance. Ties (multiple
+images at the same minimal distance) are broken deterministically by
+ascending iteration order.
+
+### Neighbor images
+
+`PeriodicStructure::neighbors_within(cutoff)` (Angstrom, **inclusive**:
+`distance <= cutoff`) returns a **full** neighbor list:
+
+- `(same site, image [0,0,0])` is always excluded (the trivial self-pair).
+- `(same site, nonzero image)` is **not** auto-excluded -- physically valid
+  when the cell is smaller than the cutoff.
+- For distinct sites `i != j`, both `(center=i, neighbor=j, image=n)` and
+  `(center=j, neighbor=i, image=-n)` can appear as independent entries --
+  each describes a different center's neighbor shell, not a duplicate.
+- Distance `0` (or near-`0`) for distinct sites/images is kept, not
+  filtered -- e.g. two disorder-split sites at the same position.
+- Output is sorted by `(center_index, neighbor_index, image[0], image[1],
+  image[2])` for determinism.
+- Uses the same reciprocal-vector search-box machinery as `minimum_image`,
+  with the cutoff as the bound; a cutoff far larger than the cell (a likely
+  unit-conversion mistake) is rejected with `CrystalError::
+  NeighborSearchTooLarge` rather than silently examining an enormous number
+  of candidate images.
+
+### Occupancy
+
+`SiteSpecies { element, occupancy }` -- a `PeriodicSite` holds `Vec
+<SiteSpecies>` so multi-species (disordered) sites are representable.
+`Occupancy` is validated finite and `>= 0`; the *sum* of occupancies at one
+site must not exceed `1.0 + Occupancy::SUM_TOLERANCE` (summing to less than
+`1.0` is legal -- a vacancy). An empty species list is rejected
+(`CrystalError::EmptySpeciesList`), not silently treated as a vacant site.
+`v0.1` stores this data faithfully but does not implement disorder-aware
+chemistry (no averaged scattering, no partial-occupancy energetics) on top
+of it.
+
+## Out of scope (v0.1)
+
+No space-group determination, symmetry-operation search, Wyckoff
+positions, primitive/conventional cell conversion, Niggli reduction, or
+spglib (or any) FFI. No CIF parser rewrite (`chematic_mol::cif` is
+untouched; see `docs/rfcs/chematic_crystal_foundation.md` for a migration
+sketch). No POSCAR I/O, XRD, crystal fingerprinting, oxidation-state
+inference, coordination-geometry classification, DFT, formation-energy or
+phase-diagram computation, band structure, phonons, defect generation, or
+surface/slab construction. No materials-ML models and **no prediction of
+stability or synthesizability** -- this crate stores and computes pure
+geometry. No Python/WASM/MCP bindings. No arbitrary 3x3 integer supercell
+transform (diagonal `[nx, ny, nz]` only). No spatial-partitioning neighbor-
+search optimization -- the baseline is an exact bounded enumeration, not
+necessarily the fastest possible one.
+
+`mikiwame` (explainable materials diagnostics) and `gugen` (materials
+synthesis/process planning) are separate downstream projects layered on top
+of this crate; neither is implemented here. Full list:
+`docs/crystal_scope.md`.
+
+## Benchmarks
+
+Baseline measurements only -- `v0.1` prioritizes correctness over
+performance (see "no spatial-partitioning optimization" above). Method:
+`criterion` (`cargo bench -p chematic-crystal`), except the ~10000-site
+neighbor search, which is a single wall-clock timing (see
+`benches/crystal_bench.rs`'s module doc for why: the naive O(n^2 *
+search-box) baseline takes long enough per call at that size that
+criterion's minimum sampling would make the benchmark run impractically
+slow, for a number this PR isn't claiming is fast).
+
+CPU: Apple M4. rustc 1.97.0. Commit: `fa63822` (chematic-crystal Phase 4).
+
+| Operation | Cell shape | Sites | Cutoff | Neighbors found | Method | Time |
+|---|---|---|---|---|---|---|
+| `frac_to_cart` (1000 points, 1 lattice) | triclinic | -- | -- | -- | criterion | 2.14 us total (~2.1 ns/point) |
+| `cart_to_frac` (1000 points, 1 lattice) | triclinic | -- | -- | -- | criterion | 4.81 us total (~4.8 ns/point) |
+| `neighbors_within` | cubic | 125 (~100) | 6.5 A | 4000 | criterion | 10.09 ms |
+| `neighbors_within` | triclinic | 125 (~100) | 6.5 A | 7500 | criterion | 9.02 ms |
+| `neighbors_within` | cubic | 1000 | 6.5 A | 32000 | criterion | 499.4 ms |
+| `neighbors_within` | triclinic | 1000 | 6.5 A | 60000 | criterion | 585.3 ms |
+| `neighbors_within` | cubic | 10648 (~10000) | 6.5 A | 340736 | single-run wall clock | ~54.3 s |
+| `neighbors_within` | triclinic | 10648 (~10000) | 6.5 A | 638880 | single-run wall clock | ~47.2 s |
+| `make_supercell([2,2,2])` | cubic | 125 -> 1000 | -- | -- | criterion | 101.4 us |
+
+The O(n^2) scaling is expected and visible above (125 -> 1000 sites, an 8x
+increase, is roughly a 50-60x slowdown, consistent with a 64x pair-count
+increase (8^2) partly offset by a smaller per-pair search box at this fixed
+cutoff/density ratio); a spatial-partitioning neighbor list (cell lists /
+Verlet lists) is
+the natural next step if this becomes a bottleneck for a real workload, but
+is explicitly deferred past v0.1.
+
+## Testing
+
+`cargo test -p chematic-crystal --all-features` runs unit tests (lattice
+construction/validation, coordinate wrapping, occupancy, structure
+validation), integration tests (`tests/periodicity.rs`,
+`tests/neighbor.rs`: brute-force-oracle comparisons on cubic/orthorhombic/
+triclinic cells, two pinned regression fixtures for skewed/near-singular
+triclinic minimum-image, a randomized fixed-seed property test,
+site-order-permutation invariance), and (with `--features serde`)
+`tests/serde_roundtrip.rs` (JSON round-trip, field-name stability, invalid-
+value rejection). `cargo test -p chematic-crystal --doc` runs the doc
+examples above.
+
+## Optional `serde` support
+
+Enable the `serde` feature for `Serialize`/`Deserialize` on every public
+type. Every implementation is hand-written, not derived: this crate's
+types enforce invariants at construction (finite coordinates, non-negative
+occupancy, occupancy-sum tolerance, matrix non-singularity), and a plain
+`#[derive(Deserialize)]` would silently skip all of them by assigning
+fields directly -- every `Deserialize` impl here routes through the type's
+own validated constructor instead. `SiteSpecies` round-trips its `Element`
+through `symbol()`/`from_symbol()` as a string (`chematic-core` has no
+serde support of its own). `Lattice` persists only `matrix`, not the
+derived `inverse` -- deserializing re-derives and re-validates it via
+`from_matrix`.
+
+If you serialize/deserialize through `serde_json` specifically and need
+exact float round-tripping, enable serde_json's `float_roundtrip` feature
+-- its default float parser is not guaranteed correctly-rounded (observed
+directly while writing this crate's own round-trip tests: a
+`from_parameters`-derived matrix entry serialized as
+`3.453503973595536e-16` parsed back as `3.4535039735955363e-16`, 1 ULP
+off, without that feature).

--- a/crates/chematic-crystal/benches/crystal_bench.rs
+++ b/crates/chematic-crystal/benches/crystal_bench.rs
@@ -1,4 +1,134 @@
-//! Benchmarks land in Phase 4 (neighbor search / supercell); this stub
-//! exists so `Cargo.toml`'s `[[bench]]` target resolves during earlier
-//! phases.
-fn main() {}
+//! Baseline performance measurements. Correctness comes first in `v0.1`
+//! (see `docs/crystal_scope.md`'s "no spatial-partitioning optimization"
+//! non-goal) -- these benchmarks exist to record where the naive O(n^2 *
+//! search-box) neighbor search currently stands, not to defend a
+//! performance target. Recorded numbers (CPU, rustc version, commit SHA,
+//! site count, cell shape, cutoff, neighbor count, method) are kept in
+//! this crate's README under "Benchmarks".
+
+use chematic_core::Element;
+use chematic_crystal::{FractionalCoord, Lattice, PeriodicSite, PeriodicStructure, SiteSpecies};
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+/// `n` sites on a simple grid inside a cubic cell sized so the average
+/// nearest-neighbor spacing stays ~3 Angstrom regardless of `n` (density
+/// held roughly constant across site counts, so cutoff-relative behavior
+/// is comparable).
+fn grid_structure_cubic(n_per_axis: usize) -> PeriodicStructure {
+    let spacing = 3.0;
+    let a = spacing * n_per_axis as f64;
+    let lattice = Lattice::cubic(a).unwrap();
+    let mut sites = Vec::new();
+    for i in 0..n_per_axis {
+        for j in 0..n_per_axis {
+            for k in 0..n_per_axis {
+                let f = FractionalCoord::new([
+                    i as f64 / n_per_axis as f64,
+                    j as f64 / n_per_axis as f64,
+                    k as f64 / n_per_axis as f64,
+                ]);
+                sites
+                    .push(PeriodicSite::new(vec![SiteSpecies::full(Element::C)], f, None).unwrap());
+            }
+        }
+    }
+    PeriodicStructure::new(lattice, sites).unwrap()
+}
+
+/// Same site count/spacing as [`grid_structure_cubic`], but a skewed
+/// triclinic cell instead of cubic.
+fn grid_structure_triclinic(n_per_axis: usize) -> PeriodicStructure {
+    let spacing = 3.0;
+    let a = spacing * n_per_axis as f64;
+    let lattice = Lattice::from_parameters(a, a * 1.05, a * 0.95, 75.0, 100.0, 60.0).unwrap();
+    let mut sites = Vec::new();
+    for i in 0..n_per_axis {
+        for j in 0..n_per_axis {
+            for k in 0..n_per_axis {
+                let f = FractionalCoord::new([
+                    i as f64 / n_per_axis as f64,
+                    j as f64 / n_per_axis as f64,
+                    k as f64 / n_per_axis as f64,
+                ]);
+                sites
+                    .push(PeriodicSite::new(vec![SiteSpecies::full(Element::C)], f, None).unwrap());
+            }
+        }
+    }
+    PeriodicStructure::new(lattice, sites).unwrap()
+}
+
+fn bench_frac_to_cart(c: &mut Criterion) {
+    let lattice = Lattice::from_parameters(5.0, 6.0, 7.0, 75.0, 100.0, 60.0).unwrap();
+    let points: Vec<FractionalCoord> = (0..1000)
+        .map(|i| {
+            let t = i as f64 / 1000.0;
+            FractionalCoord::new([t, (t * 1.3) % 1.0, (t * 2.7) % 1.0])
+        })
+        .collect();
+    c.bench_function("frac_to_cart_1000", |b| {
+        b.iter(|| {
+            for p in &points {
+                let _ = black_box(lattice.frac_to_cart(black_box(*p)));
+            }
+        })
+    });
+}
+
+fn bench_cart_to_frac(c: &mut Criterion) {
+    let lattice = Lattice::from_parameters(5.0, 6.0, 7.0, 75.0, 100.0, 60.0).unwrap();
+    let points: Vec<_> = (0..1000)
+        .map(|i| {
+            let t = i as f64;
+            chematic_crystal::CartesianCoord::new([t % 5.0, (t * 1.3) % 6.0, (t * 2.7) % 7.0])
+        })
+        .collect();
+    c.bench_function("cart_to_frac_1000", |b| {
+        b.iter(|| {
+            for p in &points {
+                let _ = black_box(lattice.cart_to_frac(black_box(*p)));
+            }
+        })
+    });
+}
+
+fn bench_neighbor_search(c: &mut Criterion) {
+    // n_per_axis^3 sites: 5^3=125 (~100), 10^3=1000. The naive O(n^2 *
+    // search-box) baseline (see this file's module doc -- spatial
+    // partitioning is an explicit non-goal for v0.1) makes a ~10000-site
+    // structure (22^3=10648) take on the order of a minute per *single*
+    // call; criterion's minimum sample_size(10) would make that an
+    // impractically slow `cargo bench` run for what v0.1 already documents
+    // as "not optimized yet". That size is instead measured once via plain
+    // wall-clock timing and recorded directly in README.md's Benchmarks
+    // section rather than run through criterion here.
+    for (label, n_per_axis) in [("100", 5usize), ("1000", 10)] {
+        let cubic = grid_structure_cubic(n_per_axis);
+        let cutoff = 6.5; // a few shells at 3 Angstrom grid spacing
+        c.bench_function(&format!("neighbor_search_cubic_{label}"), |b| {
+            b.iter(|| black_box(cubic.neighbors_within(black_box(cutoff)).unwrap()))
+        });
+
+        let triclinic = grid_structure_triclinic(n_per_axis);
+        c.bench_function(&format!("neighbor_search_triclinic_{label}"), |b| {
+            b.iter(|| black_box(triclinic.neighbors_within(black_box(cutoff)).unwrap()))
+        });
+    }
+}
+
+fn bench_supercell(c: &mut Criterion) {
+    let base = grid_structure_cubic(5); // 125 sites
+    c.bench_function("supercell_generation_2x2x2_from_125_sites", |b| {
+        b.iter(|| black_box(base.make_supercell(black_box([2, 2, 2])).unwrap()))
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_frac_to_cart,
+    bench_cart_to_frac,
+    bench_neighbor_search,
+    bench_supercell
+);
+criterion_main!(benches);

--- a/crates/chematic-crystal/benches/crystal_bench.rs
+++ b/crates/chematic-crystal/benches/crystal_bench.rs
@@ -1,0 +1,4 @@
+//! Benchmarks land in Phase 4 (neighbor search / supercell); this stub
+//! exists so `Cargo.toml`'s `[[bench]]` target resolves during earlier
+//! phases.
+fn main() {}

--- a/crates/chematic-crystal/examples/basic_structure.rs
+++ b/crates/chematic-crystal/examples/basic_structure.rs
@@ -1,0 +1,59 @@
+//! Example: build a CsCl-type periodic structure (one cation + one anion
+//! per cubic cell, anion at the body center -- the same site arrangement
+//! as CsCl, AlNi, or beta-brass; illustrated here with Na/Cl for
+//! familiarity, not a claim about real NaCl, which is rock-salt-type and
+//! needs 8 sites in its conventional cubic cell), inspect the lattice,
+//! enumerate periodic neighbors, and expand a supercell.
+//!
+//! Run: `cargo run -p chematic-crystal --example basic_structure`
+
+use chematic_core::Element;
+use chematic_crystal::{
+    CrystalError, FractionalCoord, Lattice, PeriodicSite, PeriodicStructure, SiteSpecies,
+};
+
+fn main() -> Result<(), CrystalError> {
+    // Illustrative cubic cell, a = 5.64 Angstrom.
+    let lattice = Lattice::cubic(5.64)?;
+    println!(
+        "lattice: volume={:.3} A^3, condition_indicator={:.3}",
+        lattice.volume(),
+        lattice.condition_indicator()
+    );
+
+    let sites = vec![
+        PeriodicSite::new(
+            vec![SiteSpecies::full(Element::NA)],
+            FractionalCoord::new([0.0, 0.0, 0.0]),
+            Some("Na1".to_string()),
+        )?,
+        PeriodicSite::new(
+            vec![SiteSpecies::full(Element::CL)],
+            FractionalCoord::new([0.5, 0.5, 0.5]),
+            Some("Cl1".to_string()),
+        )?,
+    ];
+    let structure = PeriodicStructure::new(lattice, sites)?;
+    println!("structure: {} sites", structure.site_count());
+
+    // Nearest cross-species distance (body diagonal / 2 ~= 4.885 A here),
+    // via periodic minimum image.
+    let neighbors = structure.neighbors_within(5.0)?;
+    println!("neighbors within 5.0 A: {}", neighbors.len());
+    for nb in neighbors.iter().take(3) {
+        println!(
+            "  center={} neighbor={} image={:?} distance={:.4}",
+            nb.center_index, nb.neighbor_index, nb.image, nb.distance
+        );
+    }
+
+    // 2x2x2 supercell: 8x the sites, 8x the volume, same local geometry.
+    let supercell = structure.make_supercell([2, 2, 2])?;
+    println!(
+        "supercell [2,2,2]: {} sites, volume={:.3} A^3",
+        supercell.site_count(),
+        supercell.lattice().volume()
+    );
+
+    Ok(())
+}

--- a/crates/chematic-crystal/src/error.rs
+++ b/crates/chematic-crystal/src/error.rs
@@ -1,0 +1,195 @@
+//! Error type for `chematic-crystal`.
+
+use std::fmt;
+
+/// Errors returned by `chematic-crystal`'s validated constructors.
+///
+/// Every variant that carries a numeric field is worded so the message is
+/// self-contained (no separate lookup table needed to interpret it).
+#[derive(Debug, Clone, PartialEq)]
+pub enum CrystalError {
+    /// A field that must be finite (no `NaN`, no `+-Infinity`) was not.
+    NonFinite {
+        /// Name of the offending field/quantity (e.g. `"matrix[1][2]"`).
+        field: &'static str,
+    },
+    /// A crystallographic length (`a`, `b`, or `c`) was not a positive
+    /// finite number.
+    NonPositiveLength {
+        /// Which lattice vector (`"a"`, `"b"`, or `"c"`).
+        axis: &'static str,
+        /// The rejected value.
+        value: f64,
+    },
+    /// A crystallographic angle (alpha, beta, gamma) was outside the open
+    /// interval `(0, 180)` degrees, i.e. does not define a non-degenerate
+    /// parallelepiped.
+    InvalidAngle {
+        /// Which angle (`"alpha"`, `"beta"`, or `"gamma"`).
+        angle: &'static str,
+        /// The rejected value, in degrees.
+        value: f64,
+    },
+    /// The 3x3 lattice matrix is exactly singular (zero volume): the three
+    /// lattice vectors are linearly dependent.
+    SingularMatrix,
+    /// The lattice matrix is not exactly singular but is numerically too
+    /// close to it for a stable inverse -- see
+    /// [`Lattice::MIN_CONDITION_INDICATOR`](crate::lattice::Lattice::MIN_CONDITION_INDICATOR)
+    /// for the threshold and its rationale.
+    NearSingularMatrix {
+        /// The computed `|det(M)| / (|a| |b| |c|)` condition indicator.
+        condition: f64,
+        /// The rejection threshold it fell below.
+        threshold: f64,
+    },
+    /// The lattice volume computed to a non-finite value (can only happen
+    /// from non-finite inputs that individually passed other checks, e.g.
+    /// via extreme cancellation -- guarded defensively).
+    NonFiniteVolume,
+    /// An [`Occupancy`](crate::site::Occupancy) value was negative.
+    NegativeOccupancy {
+        /// The rejected value.
+        value: f64,
+    },
+    /// An [`Occupancy`](crate::site::Occupancy) value was non-finite.
+    NonFiniteOccupancy,
+    /// The sum of occupancies at one [`PeriodicSite`](crate::site::PeriodicSite)
+    /// exceeded `1.0` by more than the configured tolerance.
+    OccupancySumExceeded {
+        /// The computed sum.
+        sum: f64,
+        /// The tolerance above `1.0` that was allowed.
+        tolerance: f64,
+    },
+    /// A [`PeriodicSite`](crate::site::PeriodicSite) was constructed with an
+    /// empty species list.
+    EmptySpeciesList,
+    /// Lattice angles that individually satisfy `InvalidAngle`'s per-angle
+    /// range but do not jointly define a real (non-degenerate) 3D
+    /// parallelepiped -- e.g. `alpha=170, beta=170, gamma=170` fails the
+    /// triangle-like consistency constraint between the three angles.
+    IncompatibleAngles {
+        /// alpha, in degrees.
+        alpha: f64,
+        /// beta, in degrees.
+        beta: f64,
+        /// gamma, in degrees.
+        gamma: f64,
+    },
+    /// A [`PeriodicSite`](crate::site::PeriodicSite) at the given index
+    /// failed its own validation; wraps the underlying reason.
+    InvalidSite {
+        /// Index of the offending site (in structure order).
+        index: usize,
+        /// The underlying validation failure.
+        source: Box<CrystalError>,
+    },
+    /// A diagonal supercell multiplier was not `>= 1`.
+    NonPositiveSupercellMultiplier {
+        /// Which axis (`0`, `1`, or `2`).
+        axis: usize,
+        /// The rejected value.
+        value: u32,
+    },
+    /// A requested cutoff-radius neighbor search was rejected: the exact
+    /// bounded image search implies more candidate periodic images than
+    /// [`neighbor::MAX_NEIGHBOR_IMAGE_CANDIDATES`](crate::neighbor::MAX_NEIGHBOR_IMAGE_CANDIDATES)
+    /// -- almost always a cutoff far larger than the cell (a likely unit or
+    /// input error) rather than a legitimate search.
+    NeighborSearchTooLarge {
+        /// The computed candidate-image count that triggered the guard.
+        candidate_count: u64,
+        /// The configured limit.
+        limit: u64,
+    },
+    /// A cutoff radius was not finite and positive.
+    InvalidCutoff {
+        /// The rejected value.
+        value: f64,
+    },
+}
+
+impl fmt::Display for CrystalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CrystalError::NonFinite { field } => {
+                write!(f, "{field} must be finite (got NaN or Infinity)")
+            }
+            CrystalError::NonPositiveLength { axis, value } => {
+                write!(
+                    f,
+                    "lattice length {axis} must be a positive finite number, got {value}"
+                )
+            }
+            CrystalError::InvalidAngle { angle, value } => {
+                write!(
+                    f,
+                    "lattice angle {angle} must be in the open interval (0, 180) degrees, got {value}"
+                )
+            }
+            CrystalError::SingularMatrix => {
+                write!(
+                    f,
+                    "lattice matrix is singular (zero volume): lattice vectors are linearly dependent"
+                )
+            }
+            CrystalError::NearSingularMatrix {
+                condition,
+                threshold,
+            } => {
+                write!(
+                    f,
+                    "lattice matrix is near-singular: condition indicator {condition} is below the minimum {threshold}"
+                )
+            }
+            CrystalError::NonFiniteVolume => {
+                write!(f, "lattice volume computed to a non-finite value")
+            }
+            CrystalError::NegativeOccupancy { value } => {
+                write!(f, "occupancy must be >= 0, got {value}")
+            }
+            CrystalError::NonFiniteOccupancy => {
+                write!(f, "occupancy must be finite (got NaN or Infinity)")
+            }
+            CrystalError::OccupancySumExceeded { sum, tolerance } => {
+                write!(
+                    f,
+                    "species occupancies sum to {sum}, which exceeds 1.0 + tolerance ({tolerance})"
+                )
+            }
+            CrystalError::EmptySpeciesList => {
+                write!(f, "species list must not be empty")
+            }
+            CrystalError::IncompatibleAngles { alpha, beta, gamma } => {
+                write!(
+                    f,
+                    "angles alpha={alpha}, beta={beta}, gamma={gamma} do not define a valid (non-degenerate) parallelepiped cell"
+                )
+            }
+            CrystalError::InvalidSite { index, source } => {
+                write!(f, "site {index}: {source}")
+            }
+            CrystalError::NonPositiveSupercellMultiplier { axis, value } => {
+                write!(
+                    f,
+                    "supercell multiplier for axis {axis} must be >= 1, got {value}"
+                )
+            }
+            CrystalError::NeighborSearchTooLarge {
+                candidate_count,
+                limit,
+            } => {
+                write!(
+                    f,
+                    "neighbor search would examine {candidate_count} candidate periodic images, exceeding the limit of {limit} -- check that the cutoff is not far larger than the cell"
+                )
+            }
+            CrystalError::InvalidCutoff { value } => {
+                write!(f, "cutoff must be a finite, positive number, got {value}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CrystalError {}

--- a/crates/chematic-crystal/src/lattice.rs
+++ b/crates/chematic-crystal/src/lattice.rs
@@ -311,7 +311,41 @@ impl Lattice {
             [inv[0][2], inv[1][2], inv[2][2]],
         ]
     }
+}
 
+/// Serializes/deserializes only `matrix` -- `inverse` is cached derived
+/// state, not persisted (persisting it would let a hand-edited JSON file
+/// carry a `matrix`/`inverse` pair that no longer agree). Deserializing
+/// re-derives `inverse` and re-runs every constructor validation via
+/// [`Lattice::from_matrix`], so a deserialized `Lattice` has exactly the
+/// same guarantees as one built through the normal constructors.
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use super::Lattice;
+    use crate::error::CrystalError;
+    use serde::de::Error as _;
+    use serde::ser::SerializeStruct;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    impl Serialize for Lattice {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            let mut state = serializer.serialize_struct("Lattice", 1)?;
+            state.serialize_field("matrix", &self.matrix)?;
+            state.end()
+        }
+    }
+
+    #[derive(Deserialize)]
+    struct LatticeData {
+        matrix: [[f64; 3]; 3],
+    }
+
+    impl<'de> Deserialize<'de> for Lattice {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let data = LatticeData::deserialize(deserializer)?;
+            Lattice::from_matrix(data.matrix).map_err(|e: CrystalError| D::Error::custom(e.to_string()))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -396,6 +430,10 @@ mod tests {
     // -- reciprocal relation ------------------------------------------------
 
     #[test]
+    // Cross-product of two independent 3x3 matrices' rows, keyed off both
+    // numeric indices for the `i == j` Kronecker-delta comparison -- not a
+    // single-array walk `enumerate()` would simplify.
+    #[allow(clippy::needless_range_loop)]
     fn reciprocal_relation_a_dot_b_is_kronecker_delta() {
         let l = Lattice::from_parameters(5.0, 6.0, 7.0, 80.0, 95.0, 110.0).unwrap();
         let m = l.matrix();
@@ -410,6 +448,8 @@ mod tests {
     }
 
     #[test]
+    // See the allow above: `recip[i][j]` vs `inv[j][i]` needs both indices.
+    #[allow(clippy::needless_range_loop)]
     fn reciprocal_matrix_is_inverse_transpose() {
         let l = Lattice::from_parameters(5.0, 6.0, 7.0, 80.0, 95.0, 110.0).unwrap();
         let inv = l.inverse_matrix();

--- a/crates/chematic-crystal/src/lattice.rs
+++ b/crates/chematic-crystal/src/lattice.rs
@@ -1,0 +1,523 @@
+//! [`Lattice`]: a validated 3x3 lattice matrix + cached inverse.
+//!
+//! # Matrix convention
+//!
+//! `matrix()` rows are the lattice vectors **a, b, c** (`matrix[0]` = a,
+//! `matrix[1]` = b, `matrix[2]` = c). A Cartesian point is obtained from a
+//! fractional one by row-vector x matrix:
+//!
+//! ```text
+//! cartesian = fractional . matrix
+//! cartesian_k = sum_j fractional_j * matrix[j][k]
+//! ```
+//!
+//! This matches `chematic_ewald::BoxVectors`'s row convention (see
+//! `docs/rfcs/chematic_crystal_foundation.md`), without `chematic-crystal`
+//! depending on `chematic-ewald`.
+//!
+//! Reciprocal vectors use the crystallographic (no `2*pi`) convention,
+//! `a_i . b_j = delta_ij`; under the row convention, reciprocal row `b_j` is
+//! **column `j`** of `inverse`, not row `j` -- asserted directly by this
+//! module's tests rather than trusted by inspection.
+
+use crate::error::CrystalError;
+use crate::site::{CartesianCoord, FractionalCoord};
+use crate::validation::{require_finite, require_finite3};
+
+// ---------------------------------------------------------------------------
+// Small vector helpers (crate-internal; periodic.rs/neighbor.rs reuse these)
+// ---------------------------------------------------------------------------
+
+pub(crate) fn dot3(u: [f64; 3], v: [f64; 3]) -> f64 {
+    u[0] * v[0] + u[1] * v[1] + u[2] * v[2]
+}
+
+pub(crate) fn cross3(u: [f64; 3], v: [f64; 3]) -> [f64; 3] {
+    [
+        u[1] * v[2] - u[2] * v[1],
+        u[2] * v[0] - u[0] * v[2],
+        u[0] * v[1] - u[1] * v[0],
+    ]
+}
+
+pub(crate) fn norm3(u: [f64; 3]) -> f64 {
+    dot3(u, u).sqrt()
+}
+
+pub(crate) fn scale3(u: [f64; 3], s: f64) -> [f64; 3] {
+    [u[0] * s, u[1] * s, u[2] * s]
+}
+
+/// Signed volume `a . (b x c)` of the parallelepiped with rows `m[0..3]`.
+/// Equal to `det(m)`.
+fn signed_volume(m: &[[f64; 3]; 3]) -> f64 {
+    dot3(m[0], cross3(m[1], m[2]))
+}
+
+// ---------------------------------------------------------------------------
+// Lattice
+// ---------------------------------------------------------------------------
+
+/// A validated 3x3 lattice matrix (rows = lattice vectors a, b, c) with its
+/// cached inverse.
+///
+/// All constructors reject `NaN`/`Infinity`, non-positive crystallographic
+/// lengths, angles that don't define a non-degenerate parallelepiped, and
+/// matrices that are exactly or numerically singular (see
+/// [`Self::MIN_CONDITION_INDICATOR`]).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Lattice {
+    matrix: [[f64; 3]; 3],
+    inverse: [[f64; 3]; 3],
+}
+
+impl Lattice {
+    /// Minimum accepted crystallographic length, in Angstrom.
+    ///
+    /// Below this, a length is essentially guaranteed to be a unit-
+    /// conversion or parsing error rather than a physically meaningful
+    /// lattice constant -- real crystal lattice parameters are on the order
+    /// of a few Angstrom at the very smallest; `1e-6` is far below any
+    /// physical crystal while staying safely above float noise for any
+    /// input that was ever a real length.
+    pub const MIN_LENGTH: f64 = 1e-6;
+
+    /// Minimum accepted dimensionless condition indicator, `|det(M)| /
+    /// (|a| |b| |c|)`.
+    ///
+    /// This ratio is the fraction of the bounding box volume that the
+    /// actual parallelepiped occupies: `1.0` for a fully orthogonal cell,
+    /// `-> 0` as the three lattice vectors approach coplanarity (a singular
+    /// matrix). `1e-3` is a conservative floor well below any physically
+    /// reasonable crystallographic cell (even a very acute/obtuse but real
+    /// cell rarely drops under ~0.05) while still catching near-degenerate
+    /// matrices before the inverse -- needed by every fractional<->Cartesian
+    /// conversion and the minimum-image algorithm -- becomes numerically
+    /// unstable.
+    pub const MIN_CONDITION_INDICATOR: f64 = 1e-3;
+
+    /// Tolerance (relative to `c^2`) for the `cz^2 >= 0` consistency check
+    /// in [`Self::from_parameters`]: floating-point evaluation of the IUCr
+    /// formula can land a hair below zero for angles that are, up to
+    /// rounding, exactly degenerate. Genuine angle incompatibilities miss
+    /// by far more than this.
+    const ANGLE_CONSISTENCY_TOLERANCE: f64 = 1e-9;
+
+    /// Build a lattice directly from a 3x3 matrix (rows = a, b, c).
+    pub fn from_matrix(matrix: [[f64; 3]; 3]) -> Result<Self, CrystalError> {
+        require_finite3(matrix[0], "matrix[0]")?;
+        require_finite3(matrix[1], "matrix[1]")?;
+        require_finite3(matrix[2], "matrix[2]")?;
+
+        let lengths = [norm3(matrix[0]), norm3(matrix[1]), norm3(matrix[2])];
+        for (len, axis) in lengths.iter().zip(["a", "b", "c"]) {
+            if *len <= Self::MIN_LENGTH {
+                return Err(CrystalError::NonPositiveLength {
+                    axis,
+                    value: *len,
+                });
+            }
+        }
+
+        let signed_vol = signed_volume(&matrix);
+        if !signed_vol.is_finite() {
+            return Err(CrystalError::NonFiniteVolume);
+        }
+        let volume = signed_vol.abs();
+        if volume == 0.0 {
+            return Err(CrystalError::SingularMatrix);
+        }
+
+        let bounding_box = lengths[0] * lengths[1] * lengths[2];
+        let condition = volume / bounding_box;
+        if condition < Self::MIN_CONDITION_INDICATOR {
+            return Err(CrystalError::NearSingularMatrix {
+                condition,
+                threshold: Self::MIN_CONDITION_INDICATOR,
+            });
+        }
+
+        // Reciprocal rows b1, b2, b3 (a_i . b_j = delta_ij), computed from
+        // the *signed* volume so the algebraic identity M . M^-1 = I holds
+        // exactly (not just up to sign) for left-handed input matrices too.
+        let b1 = scale3(cross3(matrix[1], matrix[2]), 1.0 / signed_vol);
+        let b2 = scale3(cross3(matrix[2], matrix[0]), 1.0 / signed_vol);
+        let b3 = scale3(cross3(matrix[0], matrix[1]), 1.0 / signed_vol);
+        // inverse's *columns* are b1, b2, b3 (see module doc: reciprocal
+        // row j = inverse column j).
+        let inverse = [
+            [b1[0], b2[0], b3[0]],
+            [b1[1], b2[1], b3[1]],
+            [b1[2], b2[2], b3[2]],
+        ];
+        for row in inverse {
+            require_finite3(row, "inverse")?;
+        }
+
+        Ok(Self { matrix, inverse })
+    }
+
+    /// Build a lattice from cell parameters: lengths `a, b, c` in Angstrom,
+    /// angles `alpha, beta, gamma` in degrees (`alpha` = angle between b
+    /// and c, `beta` = angle between a and c, `gamma` = angle between a and
+    /// b -- standard crystallographic convention).
+    ///
+    /// Uses the same IUCr placement `chematic_mol::cif::UnitCell` derives
+    /// its Cartesian conversion from (a along x, b in the xy-plane, c
+    /// completing the frame), so a CIF-parsed cell and a `from_parameters`
+    /// cell built from the same six numbers agree on Cartesian output.
+    pub fn from_parameters(
+        a: f64,
+        b: f64,
+        c: f64,
+        alpha: f64,
+        beta: f64,
+        gamma: f64,
+    ) -> Result<Self, CrystalError> {
+        for (len, axis) in [a, b, c].into_iter().zip(["a", "b", "c"]) {
+            require_finite(len, axis)?;
+            if len <= Self::MIN_LENGTH {
+                return Err(CrystalError::NonPositiveLength { axis, value: len });
+            }
+        }
+        for (angle, name) in [alpha, beta, gamma].into_iter().zip(["alpha", "beta", "gamma"]) {
+            require_finite(angle, name)?;
+            if !(angle > 0.0 && angle < 180.0) {
+                return Err(CrystalError::InvalidAngle { angle: name, value: angle });
+            }
+        }
+
+        let (ca, cb, cg, sg) = (
+            alpha.to_radians().cos(),
+            beta.to_radians().cos(),
+            gamma.to_radians().cos(),
+            gamma.to_radians().sin(),
+        );
+
+        let a_vec = [a, 0.0, 0.0];
+        let b_vec = [b * cg, b * sg, 0.0];
+        let cx = c * cb;
+        let cy = c * (ca - cb * cg) / sg;
+        let cz_sq = c * c - cx * cx - cy * cy;
+        if cz_sq < -Self::ANGLE_CONSISTENCY_TOLERANCE * c * c {
+            return Err(CrystalError::IncompatibleAngles { alpha, beta, gamma });
+        }
+        let cz = cz_sq.max(0.0).sqrt();
+        let c_vec = [cx, cy, cz];
+
+        Self::from_matrix([a_vec, b_vec, c_vec])
+    }
+
+    /// A cubic cell with edge length `a` (all angles 90 degrees).
+    pub fn cubic(a: f64) -> Result<Self, CrystalError> {
+        require_finite(a, "a")?;
+        if a <= Self::MIN_LENGTH {
+            return Err(CrystalError::NonPositiveLength { axis: "a", value: a });
+        }
+        Self::from_matrix([[a, 0.0, 0.0], [0.0, a, 0.0], [0.0, 0.0, a]])
+    }
+
+    /// An orthorhombic cell with edge lengths `a, b, c` (all angles 90
+    /// degrees).
+    pub fn orthorhombic(a: f64, b: f64, c: f64) -> Result<Self, CrystalError> {
+        for (len, axis) in [a, b, c].into_iter().zip(["a", "b", "c"]) {
+            require_finite(len, axis)?;
+            if len <= Self::MIN_LENGTH {
+                return Err(CrystalError::NonPositiveLength { axis, value: len });
+            }
+        }
+        Self::from_matrix([[a, 0.0, 0.0], [0.0, b, 0.0], [0.0, 0.0, c]])
+    }
+
+    /// The lattice matrix (rows = a, b, c).
+    #[inline]
+    pub fn matrix(&self) -> [[f64; 3]; 3] {
+        self.matrix
+    }
+
+    /// The cached matrix inverse (`matrix() . inverse_matrix() == I`).
+    #[inline]
+    pub fn inverse_matrix(&self) -> [[f64; 3]; 3] {
+        self.inverse
+    }
+
+    /// Cell volume in cubic Angstrom (always `>= 0`; the signed determinant
+    /// is not exposed since it depends on lattice-vector handedness, which
+    /// is not a meaningful distinction for volume).
+    pub fn volume(&self) -> f64 {
+        signed_volume(&self.matrix).abs()
+    }
+
+    /// Dimensionless condition indicator `|det(M)| / (|a| |b| |c|)` -- see
+    /// [`Self::MIN_CONDITION_INDICATOR`].
+    pub fn condition_indicator(&self) -> f64 {
+        let lengths = self.lengths();
+        self.volume() / (lengths[0] * lengths[1] * lengths[2])
+    }
+
+    /// Lattice vector lengths `[|a|, |b|, |c|]`, in Angstrom.
+    pub fn lengths(&self) -> [f64; 3] {
+        [
+            norm3(self.matrix[0]),
+            norm3(self.matrix[1]),
+            norm3(self.matrix[2]),
+        ]
+    }
+
+    /// Lattice angles `[alpha, beta, gamma]` in degrees (alpha = angle(b,
+    /// c), beta = angle(a, c), gamma = angle(a, b)).
+    pub fn angles_degrees(&self) -> [f64; 3] {
+        let angle = |u: [f64; 3], v: [f64; 3]| -> f64 {
+            let cos_theta = (dot3(u, v) / (norm3(u) * norm3(v))).clamp(-1.0, 1.0);
+            cos_theta.acos().to_degrees()
+        };
+        [
+            angle(self.matrix[1], self.matrix[2]), // alpha: b,c
+            angle(self.matrix[0], self.matrix[2]), // beta: a,c
+            angle(self.matrix[0], self.matrix[1]), // gamma: a,b
+        ]
+    }
+
+    /// Fractional -> Cartesian: `cartesian = fractional . matrix`.
+    pub fn frac_to_cart(&self, frac: FractionalCoord) -> CartesianCoord {
+        let f = frac.0;
+        let m = self.matrix;
+        CartesianCoord([
+            f[0] * m[0][0] + f[1] * m[1][0] + f[2] * m[2][0],
+            f[0] * m[0][1] + f[1] * m[1][1] + f[2] * m[2][1],
+            f[0] * m[0][2] + f[1] * m[1][2] + f[2] * m[2][2],
+        ])
+    }
+
+    /// Cartesian -> Fractional: `fractional = cartesian . inverse`.
+    pub fn cart_to_frac(&self, cart: CartesianCoord) -> FractionalCoord {
+        let r = cart.0;
+        let inv = self.inverse;
+        FractionalCoord([
+            r[0] * inv[0][0] + r[1] * inv[1][0] + r[2] * inv[2][0],
+            r[0] * inv[0][1] + r[1] * inv[1][1] + r[2] * inv[2][1],
+            r[0] * inv[0][2] + r[1] * inv[1][2] + r[2] * inv[2][2],
+        ])
+    }
+
+    /// Reciprocal lattice matrix (rows = reciprocal vectors b1, b2, b3,
+    /// crystallographic convention `a_i . b_j = delta_ij`, no `2*pi`
+    /// factor). Equal to the transpose of [`Self::inverse_matrix`].
+    pub fn reciprocal_matrix(&self) -> [[f64; 3]; 3] {
+        let inv = self.inverse;
+        [
+            [inv[0][0], inv[1][0], inv[2][0]],
+            [inv[0][1], inv[1][1], inv[2][1]],
+            [inv[0][2], inv[1][2], inv[2][2]],
+        ]
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EPS: f64 = 1e-9;
+
+    fn assert_close(a: f64, b: f64, tol: f64) {
+        assert!((a - b).abs() < tol, "{a} vs {b} (tol {tol})");
+    }
+
+    // -- volumes --------------------------------------------------------
+
+    #[test]
+    fn cubic_volume() {
+        let l = Lattice::cubic(3.0).unwrap();
+        assert_close(l.volume(), 27.0, EPS);
+    }
+
+    #[test]
+    fn orthorhombic_volume() {
+        let l = Lattice::orthorhombic(2.0, 3.0, 4.0).unwrap();
+        assert_close(l.volume(), 24.0, EPS);
+    }
+
+    #[test]
+    fn triclinic_volume() {
+        // Known cell, cross-checked against the standard IUCr formula
+        // V = abc*sqrt(1 - cos^2a - cos^2b - cos^2g + 2 cos(a)cos(b)cos(g)).
+        let (a, b, c) = (5.0, 6.0, 7.0);
+        let (alpha, beta, gamma) = (80.0, 95.0, 110.0);
+        let l = Lattice::from_parameters(a, b, c, alpha, beta, gamma).unwrap();
+        let (ca, cb, cg) = (
+            alpha.to_radians().cos(),
+            beta.to_radians().cos(),
+            gamma.to_radians().cos(),
+        );
+        let expected =
+            a * b * c * (1.0 - ca * ca - cb * cb - cg * cg + 2.0 * ca * cb * cg).sqrt();
+        assert_close(l.volume(), expected, 1e-6);
+    }
+
+    #[test]
+    fn from_parameters_known_value_cubic() {
+        let l = Lattice::from_parameters(4.0, 4.0, 4.0, 90.0, 90.0, 90.0).unwrap();
+        assert_close(l.volume(), 64.0, EPS);
+        let angles = l.angles_degrees();
+        for a in angles {
+            assert_close(a, 90.0, 1e-6);
+        }
+        let lengths = l.lengths();
+        for len in lengths {
+            assert_close(len, 4.0, 1e-9);
+        }
+    }
+
+    // -- round-trips ------------------------------------------------------
+
+    #[test]
+    fn frac_cart_frac_round_trip_triclinic() {
+        let l = Lattice::from_parameters(5.0, 6.0, 7.0, 75.0, 100.0, 60.0).unwrap();
+        let f0 = FractionalCoord::new([0.13, 0.71, 0.42]);
+        let cart = l.frac_to_cart(f0);
+        let f1 = l.cart_to_frac(cart);
+        for i in 0..3 {
+            assert_close(f0.0[i], f1.0[i], 1e-9);
+        }
+    }
+
+    #[test]
+    fn cart_frac_cart_round_trip_triclinic() {
+        let l = Lattice::from_parameters(5.0, 6.0, 7.0, 75.0, 100.0, 60.0).unwrap();
+        let c0 = CartesianCoord::new([1.23, -4.56, 2.34]);
+        let frac = l.cart_to_frac(c0);
+        let c1 = l.frac_to_cart(frac);
+        for i in 0..3 {
+            assert_close(c0.0[i], c1.0[i], 1e-9);
+        }
+    }
+
+    // -- reciprocal relation ------------------------------------------------
+
+    #[test]
+    fn reciprocal_relation_a_dot_b_is_kronecker_delta() {
+        let l = Lattice::from_parameters(5.0, 6.0, 7.0, 80.0, 95.0, 110.0).unwrap();
+        let m = l.matrix();
+        let recip = l.reciprocal_matrix();
+        for i in 0..3 {
+            for j in 0..3 {
+                let d = dot3(m[i], recip[j]);
+                let expected = if i == j { 1.0 } else { 0.0 };
+                assert_close(d, expected, 1e-9);
+            }
+        }
+    }
+
+    #[test]
+    fn reciprocal_matrix_is_inverse_transpose() {
+        let l = Lattice::from_parameters(5.0, 6.0, 7.0, 80.0, 95.0, 110.0).unwrap();
+        let inv = l.inverse_matrix();
+        let recip = l.reciprocal_matrix();
+        for i in 0..3 {
+            for j in 0..3 {
+                assert_close(recip[i][j], inv[j][i], 1e-12);
+            }
+        }
+    }
+
+    // -- rejections -------------------------------------------------------
+
+    #[test]
+    fn singular_matrix_rejected() {
+        // Three coplanar (in fact collinear-ish) rows: c = a + b.
+        let m = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, 0.0]];
+        assert_eq!(Lattice::from_matrix(m), Err(CrystalError::SingularMatrix));
+    }
+
+    #[test]
+    fn near_singular_matrix_rejected() {
+        // c almost coplanar with a,b (tiny out-of-plane component).
+        let m = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, 1e-8]];
+        let err = Lattice::from_matrix(m).unwrap_err();
+        assert!(matches!(err, CrystalError::NearSingularMatrix { .. }));
+    }
+
+    #[test]
+    fn nan_rejected() {
+        let m = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, f64::NAN]];
+        assert!(matches!(
+            Lattice::from_matrix(m),
+            Err(CrystalError::NonFinite { .. })
+        ));
+    }
+
+    #[test]
+    fn infinity_rejected() {
+        let m = [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, f64::INFINITY],
+        ];
+        assert!(matches!(
+            Lattice::from_matrix(m),
+            Err(CrystalError::NonFinite { .. })
+        ));
+    }
+
+    #[test]
+    fn zero_length_vector_rejected() {
+        let m = [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
+        assert!(matches!(
+            Lattice::from_matrix(m),
+            Err(CrystalError::NonPositiveLength { .. })
+        ));
+    }
+
+    #[test]
+    fn from_parameters_rejects_non_positive_length() {
+        assert!(matches!(
+            Lattice::from_parameters(0.0, 4.0, 4.0, 90.0, 90.0, 90.0),
+            Err(CrystalError::NonPositiveLength { .. })
+        ));
+        assert!(matches!(
+            Lattice::from_parameters(-1.0, 4.0, 4.0, 90.0, 90.0, 90.0),
+            Err(CrystalError::NonPositiveLength { .. })
+        ));
+    }
+
+    #[test]
+    fn from_parameters_rejects_out_of_range_angle() {
+        assert!(matches!(
+            Lattice::from_parameters(4.0, 4.0, 4.0, 0.0, 90.0, 90.0),
+            Err(CrystalError::InvalidAngle { .. })
+        ));
+        assert!(matches!(
+            Lattice::from_parameters(4.0, 4.0, 4.0, 180.0, 90.0, 90.0),
+            Err(CrystalError::InvalidAngle { .. })
+        ));
+        assert!(matches!(
+            Lattice::from_parameters(4.0, 4.0, 4.0, 190.0, 90.0, 90.0),
+            Err(CrystalError::InvalidAngle { .. })
+        ));
+    }
+
+    #[test]
+    fn from_parameters_rejects_incompatible_angles() {
+        // Three angles each individually valid (< 180) but jointly
+        // impossible for a real 3D cell.
+        let err = Lattice::from_parameters(4.0, 4.0, 4.0, 179.0, 179.0, 179.0).unwrap_err();
+        assert!(matches!(err, CrystalError::IncompatibleAngles { .. }));
+    }
+
+    #[test]
+    fn cubic_rejects_non_positive() {
+        assert!(matches!(
+            Lattice::cubic(0.0),
+            Err(CrystalError::NonPositiveLength { .. })
+        ));
+        assert!(matches!(
+            Lattice::cubic(-2.0),
+            Err(CrystalError::NonPositiveLength { .. })
+        ));
+        assert!(matches!(
+            Lattice::cubic(f64::NAN),
+            Err(CrystalError::NonFinite { .. })
+        ));
+    }
+}

--- a/crates/chematic-crystal/src/lattice.rs
+++ b/crates/chematic-crystal/src/lattice.rs
@@ -163,6 +163,21 @@ impl Lattice {
     /// its Cartesian conversion from (a along x, b in the xy-plane, c
     /// completing the frame), so a CIF-parsed cell and a `from_parameters`
     /// cell built from the same six numbers agree on Cartesian output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use chematic_crystal::Lattice;
+    ///
+    /// // Quartz-like triclinic-ish cell (illustrative numbers, not a
+    /// // real quartz refinement).
+    /// let lattice = Lattice::from_parameters(4.9, 4.9, 5.4, 90.0, 90.0, 120.0)?;
+    /// assert!(lattice.volume() > 0.0);
+    /// let [alpha, beta, gamma] = lattice.angles_degrees();
+    /// assert!((gamma - 120.0).abs() < 1e-6);
+    /// assert!((alpha - 90.0).abs() < 1e-6 && (beta - 90.0).abs() < 1e-6);
+    /// # Ok::<(), chematic_crystal::CrystalError>(())
+    /// ```
     pub fn from_parameters(
         a: f64,
         b: f64,
@@ -285,6 +300,17 @@ impl Lattice {
     }
 
     /// Fractional -> Cartesian: `cartesian = fractional . matrix`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use chematic_crystal::{FractionalCoord, Lattice};
+    ///
+    /// let lattice = Lattice::cubic(4.0)?;
+    /// let cart = lattice.frac_to_cart(FractionalCoord::new([0.5, 0.0, 0.0]));
+    /// assert!((cart.0[0] - 2.0).abs() < 1e-12);
+    /// # Ok::<(), chematic_crystal::CrystalError>(())
+    /// ```
     pub fn frac_to_cart(&self, frac: FractionalCoord) -> CartesianCoord {
         let f = frac.0;
         let m = self.matrix;

--- a/crates/chematic-crystal/src/lattice.rs
+++ b/crates/chematic-crystal/src/lattice.rs
@@ -112,10 +112,7 @@ impl Lattice {
         let lengths = [norm3(matrix[0]), norm3(matrix[1]), norm3(matrix[2])];
         for (len, axis) in lengths.iter().zip(["a", "b", "c"]) {
             if *len <= Self::MIN_LENGTH {
-                return Err(CrystalError::NonPositiveLength {
-                    axis,
-                    value: *len,
-                });
+                return Err(CrystalError::NonPositiveLength { axis, value: *len });
             }
         }
 
@@ -180,10 +177,16 @@ impl Lattice {
                 return Err(CrystalError::NonPositiveLength { axis, value: len });
             }
         }
-        for (angle, name) in [alpha, beta, gamma].into_iter().zip(["alpha", "beta", "gamma"]) {
+        for (angle, name) in [alpha, beta, gamma]
+            .into_iter()
+            .zip(["alpha", "beta", "gamma"])
+        {
             require_finite(angle, name)?;
             if !(angle > 0.0 && angle < 180.0) {
-                return Err(CrystalError::InvalidAngle { angle: name, value: angle });
+                return Err(CrystalError::InvalidAngle {
+                    angle: name,
+                    value: angle,
+                });
             }
         }
 
@@ -212,7 +215,10 @@ impl Lattice {
     pub fn cubic(a: f64) -> Result<Self, CrystalError> {
         require_finite(a, "a")?;
         if a <= Self::MIN_LENGTH {
-            return Err(CrystalError::NonPositiveLength { axis: "a", value: a });
+            return Err(CrystalError::NonPositiveLength {
+                axis: "a",
+                value: a,
+            });
         }
         Self::from_matrix([[a, 0.0, 0.0], [0.0, a, 0.0], [0.0, 0.0, a]])
     }
@@ -311,6 +317,16 @@ impl Lattice {
             [inv[0][2], inv[1][2], inv[2][2]],
         ]
     }
+
+    /// Row norms `[|b1|, |b2|, |b3|]` of the reciprocal matrix. Used by the
+    /// exact bounded-search minimum-image algorithm ([`crate::periodic`])
+    /// and cutoff neighbor search ([`crate::neighbor`]) to derive a finite,
+    /// provably sufficient search box -- see
+    /// `docs/rfcs/chematic_crystal_foundation.md`.
+    pub(crate) fn reciprocal_row_norms(&self) -> [f64; 3] {
+        let recip = self.reciprocal_matrix();
+        [norm3(recip[0]), norm3(recip[1]), norm3(recip[2])]
+    }
 }
 
 /// Serializes/deserializes only `matrix` -- `inverse` is cached derived
@@ -343,7 +359,8 @@ mod serde_impl {
     impl<'de> Deserialize<'de> for Lattice {
         fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
             let data = LatticeData::deserialize(deserializer)?;
-            Lattice::from_matrix(data.matrix).map_err(|e: CrystalError| D::Error::custom(e.to_string()))
+            Lattice::from_matrix(data.matrix)
+                .map_err(|e: CrystalError| D::Error::custom(e.to_string()))
         }
     }
 }
@@ -384,8 +401,7 @@ mod tests {
             beta.to_radians().cos(),
             gamma.to_radians().cos(),
         );
-        let expected =
-            a * b * c * (1.0 - ca * ca - cb * cb - cg * cg + 2.0 * ca * cb * cg).sqrt();
+        let expected = a * b * c * (1.0 - ca * ca - cb * cb - cg * cg + 2.0 * ca * cb * cg).sqrt();
         assert_close(l.volume(), expected, 1e-6);
     }
 
@@ -489,11 +505,7 @@ mod tests {
 
     #[test]
     fn infinity_rejected() {
-        let m = [
-            [1.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0],
-            [0.0, 0.0, f64::INFINITY],
-        ];
+        let m = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, f64::INFINITY]];
         assert!(matches!(
             Lattice::from_matrix(m),
             Err(CrystalError::NonFinite { .. })

--- a/crates/chematic-crystal/src/lib.rs
+++ b/crates/chematic-crystal/src/lib.rs
@@ -26,11 +26,13 @@
 
 pub mod error;
 pub mod lattice;
+pub mod periodic;
 pub mod site;
 pub mod structure;
 pub mod validation;
 
 pub use error::CrystalError;
 pub use lattice::Lattice;
+pub use periodic::{PeriodicDisplacement, minimum_image};
 pub use site::{CartesianCoord, FractionalCoord, Occupancy, PeriodicSite, SiteSpecies};
 pub use structure::PeriodicStructure;

--- a/crates/chematic-crystal/src/lib.rs
+++ b/crates/chematic-crystal/src/lib.rs
@@ -27,8 +27,10 @@
 pub mod error;
 pub mod lattice;
 pub mod site;
+pub mod structure;
 pub mod validation;
 
 pub use error::CrystalError;
 pub use lattice::Lattice;
 pub use site::{CartesianCoord, FractionalCoord, Occupancy, PeriodicSite, SiteSpecies};
+pub use structure::PeriodicStructure;

--- a/crates/chematic-crystal/src/lib.rs
+++ b/crates/chematic-crystal/src/lib.rs
@@ -1,0 +1,34 @@
+#![forbid(unsafe_code)]
+//! `chematic-crystal` — periodic (crystal) structure representation and
+//! geometry for the chematic ecosystem.
+//!
+//! This crate is a pure structural/geometric foundation: [`Lattice`],
+//! fractional/Cartesian coordinates, [`PeriodicSite`]/[`PeriodicStructure`],
+//! periodic-boundary-condition displacement and distance, periodic neighbor
+//! enumeration, and diagonal supercells. It is deliberately **not** an
+//! extension of `chematic_core::Molecule` -- see the crate README and
+//! `docs/rfcs/chematic_crystal_foundation.md` for why a periodic crystal
+//! and a molecular bond graph are kept as distinct first-class types.
+//!
+//! # Scope
+//!
+//! No symmetry (space groups, Wyckoff positions, Niggli reduction), no CIF
+//! parser, no XRD, no DFT, no materials-property prediction. See
+//! `docs/crystal_scope.md` for the full non-goal list.
+//!
+//! # Design principles
+//!
+//! - Pure Rust, `#![forbid(unsafe_code)]`, zero required dependencies
+//!   beyond `chematic-core` (optional `serde`).
+//! - Compiles to `wasm32-unknown-unknown` without modification.
+//! - Public constructors reject `NaN`/`Infinity` rather than propagate them.
+//! - Deterministic output ordering everywhere (no float-keyed sorts).
+
+pub mod error;
+pub mod lattice;
+pub mod site;
+pub mod validation;
+
+pub use error::CrystalError;
+pub use lattice::Lattice;
+pub use site::{CartesianCoord, FractionalCoord, Occupancy, PeriodicSite, SiteSpecies};

--- a/crates/chematic-crystal/src/lib.rs
+++ b/crates/chematic-crystal/src/lib.rs
@@ -26,13 +26,16 @@
 
 pub mod error;
 pub mod lattice;
+pub mod neighbor;
 pub mod periodic;
 pub mod site;
 pub mod structure;
+pub mod supercell;
 pub mod validation;
 
 pub use error::CrystalError;
 pub use lattice::Lattice;
+pub use neighbor::PeriodicNeighbor;
 pub use periodic::{PeriodicDisplacement, minimum_image};
 pub use site::{CartesianCoord, FractionalCoord, Occupancy, PeriodicSite, SiteSpecies};
 pub use structure::PeriodicStructure;

--- a/crates/chematic-crystal/src/neighbor.rs
+++ b/crates/chematic-crystal/src/neighbor.rs
@@ -1,0 +1,353 @@
+//! Cutoff-radius periodic neighbor enumeration.
+//!
+//! Reuses [`crate::periodic::axis_bound`]/[`crate::periodic::padded_axis_range`]
+//! -- the same reciprocal-vector-derived search-box machinery
+//! [`crate::periodic::minimum_image`] uses, with the cutoff radius itself as
+//! the bound (no naive-round bootstrap candidate needed here, since the
+//! bound is already given rather than something to be discovered).
+
+use crate::error::CrystalError;
+use crate::lattice::norm3;
+use crate::periodic::{axis_bound, padded_axis_range};
+use crate::site::FractionalCoord;
+use crate::structure::PeriodicStructure;
+
+/// Safety cap on the number of candidate periodic images examined per site
+/// pair. The search-box width is identical for every pair in a structure
+/// (it depends only on the cutoff and the lattice's reciprocal vectors, not
+/// on any pair's own offset), so this is checked once per
+/// [`neighbors_within`] call rather than per pair. Exists to turn "cutoff
+/// accidentally far larger than the cell" (a likely unit-conversion
+/// mistake -- e.g. an Angstrom cutoff passed as picometers) into a prompt
+/// error instead of a search that silently examines billions of image
+/// candidates.
+pub const MAX_NEIGHBOR_IMAGE_CANDIDATES: u64 = 5_000_000;
+
+/// One periodic neighbor relationship: `neighbor_index`'s image at `image`
+/// is within cutoff of `center_index`'s zero image.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PeriodicNeighbor {
+    pub center_index: usize,
+    pub neighbor_index: usize,
+    /// Which periodic image of the neighbor site this entry describes.
+    pub image: [i32; 3],
+    /// Cartesian displacement from the center site to this neighbor image.
+    pub displacement: [f64; 3],
+    /// Euclidean length of `displacement`, in Angstrom.
+    pub distance: f64,
+}
+
+/// Enumerate every periodic neighbor pair within `cutoff` (Angstrom,
+/// inclusive: `distance <= cutoff`).
+///
+/// This is a **full** neighbor list: for two distinct sites `i != j`, both
+/// `(center=i, neighbor=j, image=n)` and `(center=j, neighbor=i,
+/// image=-n)` can appear as independent entries (each is a different
+/// center's neighbor shell, not a duplicate of the other). `(same site,
+/// zero image)` is always excluded; `(same site, nonzero image)` is kept
+/// when within cutoff (physically valid for cells smaller than the
+/// cutoff). Output is sorted by `(center_index, neighbor_index, image[0],
+/// image[1], image[2])` for determinism.
+///
+/// # Errors
+///
+/// [`CrystalError::InvalidCutoff`] if `cutoff` is not finite and positive;
+/// [`CrystalError::NeighborSearchTooLarge`] if the implied per-pair search
+/// box exceeds [`MAX_NEIGHBOR_IMAGE_CANDIDATES`].
+pub fn neighbors_within(
+    structure: &PeriodicStructure,
+    cutoff: f64,
+) -> Result<Vec<PeriodicNeighbor>, CrystalError> {
+    if !cutoff.is_finite() || cutoff <= 0.0 {
+        return Err(CrystalError::InvalidCutoff { value: cutoff });
+    }
+
+    let lattice = structure.lattice();
+    let recip_norms = lattice.reciprocal_row_norms();
+
+    // Per-axis search width is the same for every pair (only the box's
+    // center shifts per pair, via `raw`, not its size) -- so the guard
+    // only needs computing once. Stay in f64 until the very end so a
+    // pathological cutoff can't overflow an integer type first.
+    let mut axis_width_f = [0.0f64; 3];
+    for (axis, width) in axis_width_f.iter_mut().enumerate() {
+        // 2*half is axis_bound's raw span; +3 matches padded_axis_range's
+        // +-1 padding on each side plus one for inclusive-ceiling slack.
+        *width = 2.0 * cutoff * recip_norms[axis] + 3.0;
+    }
+    let candidate_count_f = axis_width_f[0] * axis_width_f[1] * axis_width_f[2];
+    if !candidate_count_f.is_finite() || candidate_count_f > MAX_NEIGHBOR_IMAGE_CANDIDATES as f64 {
+        return Err(CrystalError::NeighborSearchTooLarge {
+            candidate_count: if candidate_count_f.is_finite() {
+                candidate_count_f as u64
+            } else {
+                u64::MAX
+            },
+            limit: MAX_NEIGHBOR_IMAGE_CANDIDATES,
+        });
+    }
+
+    let sites = structure.sites();
+    let n = sites.len();
+    let mut results = Vec::new();
+
+    for i in 0..n {
+        for j in 0..n {
+            let raw = [
+                sites[j].fractional.0[0] - sites[i].fractional.0[0],
+                sites[j].fractional.0[1] - sites[i].fractional.0[1],
+                sites[j].fractional.0[2] - sites[i].fractional.0[2],
+            ];
+            let mut ranges = [(0i32, 0i32); 3];
+            for axis in 0..3 {
+                let (lo, hi) = axis_bound(raw[axis], cutoff, recip_norms[axis]);
+                ranges[axis] = padded_axis_range(lo, hi);
+            }
+
+            for n0 in ranges[0].0..=ranges[0].1 {
+                for n1 in ranges[1].0..=ranges[1].1 {
+                    for n2 in ranges[2].0..=ranges[2].1 {
+                        if i == j && n0 == 0 && n1 == 0 && n2 == 0 {
+                            continue; // exclude only the trivial self-pair
+                        }
+                        let frac = [
+                            raw[0] + f64::from(n0),
+                            raw[1] + f64::from(n1),
+                            raw[2] + f64::from(n2),
+                        ];
+                        let cart = lattice.frac_to_cart(FractionalCoord::new(frac));
+                        let dist = norm3(cart.0);
+                        if dist <= cutoff {
+                            results.push(PeriodicNeighbor {
+                                center_index: i,
+                                neighbor_index: j,
+                                image: [n0, n1, n2],
+                                displacement: cart.0,
+                                distance: dist,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    results.sort_by_key(|nb| {
+        (
+            nb.center_index,
+            nb.neighbor_index,
+            nb.image[0],
+            nb.image[1],
+            nb.image[2],
+        )
+    });
+
+    Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lattice::Lattice;
+    use crate::site::{PeriodicSite, SiteSpecies};
+    use chematic_core::Element;
+    use std::collections::HashSet;
+
+    fn single_site_cubic(a: f64) -> PeriodicStructure {
+        PeriodicStructure::new(
+            Lattice::cubic(a).unwrap(),
+            vec![
+                PeriodicSite::new(
+                    vec![SiteSpecies::full(Element::AR)],
+                    FractionalCoord::new([0.0, 0.0, 0.0]),
+                    None,
+                )
+                .unwrap(),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn simple_cubic_one_site_finds_six_face_neighbors() {
+        let s = single_site_cubic(3.0);
+        let neighbors = neighbors_within(&s, 3.01).unwrap();
+        // 6 face-adjacent periodic self-images at distance exactly 3.0.
+        assert_eq!(neighbors.len(), 6);
+        for nb in &neighbors {
+            assert!((nb.distance - 3.0).abs() < 1e-9);
+            assert_eq!(nb.center_index, 0);
+            assert_eq!(nb.neighbor_index, 0);
+            assert_ne!(nb.image, [0, 0, 0]);
+        }
+    }
+
+    #[test]
+    fn periodic_self_image_neighbor_not_excluded() {
+        let s = single_site_cubic(2.0);
+        let neighbors = neighbors_within(&s, 2.5).unwrap();
+        assert!(
+            neighbors
+                .iter()
+                .all(|nb| nb.center_index == 0 && nb.neighbor_index == 0)
+        );
+        assert!(!neighbors.is_empty());
+    }
+
+    #[test]
+    fn zero_image_self_pair_always_excluded() {
+        let s = single_site_cubic(2.0);
+        // Even with a huge cutoff, (0,0,[0,0,0]) must never appear.
+        let neighbors = neighbors_within(&s, 20.0).unwrap();
+        assert!(
+            !neighbors
+                .iter()
+                .any(|nb| nb.center_index == 0 && nb.neighbor_index == 0 && nb.image == [0, 0, 0])
+        );
+    }
+
+    fn two_site_cubic(a: f64) -> PeriodicStructure {
+        PeriodicStructure::new(
+            Lattice::cubic(a).unwrap(),
+            vec![
+                PeriodicSite::new(
+                    vec![SiteSpecies::full(Element::NA)],
+                    FractionalCoord::new([0.0, 0.0, 0.0]),
+                    Some("A".to_string()),
+                )
+                .unwrap(),
+                PeriodicSite::new(
+                    vec![SiteSpecies::full(Element::CL)],
+                    FractionalCoord::new([0.5, 0.5, 0.5]),
+                    Some("B".to_string()),
+                )
+                .unwrap(),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn two_site_structure_finds_cross_neighbors() {
+        let s = two_site_cubic(4.0);
+        // Site 0 <-> site 1 body-diagonal distance = sqrt(3)*2 ~ 3.464.
+        let neighbors = neighbors_within(&s, 3.5).unwrap();
+        let cross: Vec<_> = neighbors
+            .iter()
+            .filter(|nb| nb.center_index == 0 && nb.neighbor_index == 1)
+            .collect();
+        assert!(!cross.is_empty());
+        for nb in &cross {
+            assert!((nb.distance - 3.4641016151).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn cutoff_boundary_is_inclusive() {
+        let s = single_site_cubic(3.0);
+        let exact = neighbors_within(&s, 3.0).unwrap();
+        assert_eq!(exact.len(), 6, "distance==cutoff must be included");
+
+        let below = neighbors_within(&s, 2.999).unwrap();
+        assert_eq!(below.len(), 0, "distance>cutoff must be excluded");
+
+        let above = neighbors_within(&s, 3.001).unwrap();
+        assert_eq!(above.len(), 6);
+    }
+
+    #[test]
+    fn no_duplicate_entries() {
+        let s = two_site_cubic(4.0);
+        let neighbors = neighbors_within(&s, 6.0).unwrap();
+        let mut seen = HashSet::new();
+        for nb in &neighbors {
+            let key = (nb.center_index, nb.neighbor_index, nb.image);
+            assert!(seen.insert(key), "duplicate entry: {key:?}");
+        }
+    }
+
+    #[test]
+    fn deterministic_ordering() {
+        let s = two_site_cubic(4.0);
+        let a = neighbors_within(&s, 6.0).unwrap();
+        let b = neighbors_within(&s, 6.0).unwrap();
+        assert_eq!(a, b);
+        // sorted by (center, neighbor, image) ascending
+        for w in a.windows(2) {
+            let ka = (
+                w[0].center_index,
+                w[0].neighbor_index,
+                w[0].image[0],
+                w[0].image[1],
+                w[0].image[2],
+            );
+            let kb = (
+                w[1].center_index,
+                w[1].neighbor_index,
+                w[1].image[0],
+                w[1].image[1],
+                w[1].image[2],
+            );
+            assert!(ka <= kb);
+        }
+    }
+
+    #[test]
+    fn triclinic_structure_neighbors_are_finite_and_within_cutoff() {
+        let lattice = Lattice::from_parameters(5.0, 6.0, 7.0, 75.0, 100.0, 60.0).unwrap();
+        let s = PeriodicStructure::new(
+            lattice,
+            vec![
+                PeriodicSite::new(
+                    vec![SiteSpecies::full(Element::SI)],
+                    FractionalCoord::new([0.1, 0.2, 0.3]),
+                    None,
+                )
+                .unwrap(),
+                PeriodicSite::new(
+                    vec![SiteSpecies::full(Element::O)],
+                    FractionalCoord::new([0.6, 0.4, 0.9]),
+                    None,
+                )
+                .unwrap(),
+            ],
+        )
+        .unwrap();
+        let neighbors = neighbors_within(&s, 4.0).unwrap();
+        assert!(!neighbors.is_empty());
+        for nb in &neighbors {
+            assert!(nb.distance <= 4.0 + 1e-9);
+            assert!(nb.distance.is_finite());
+        }
+    }
+
+    #[test]
+    fn invalid_cutoff_rejected() {
+        let s = single_site_cubic(3.0);
+        assert!(matches!(
+            neighbors_within(&s, 0.0),
+            Err(CrystalError::InvalidCutoff { .. })
+        ));
+        assert!(matches!(
+            neighbors_within(&s, -1.0),
+            Err(CrystalError::InvalidCutoff { .. })
+        ));
+        assert!(matches!(
+            neighbors_within(&s, f64::NAN),
+            Err(CrystalError::InvalidCutoff { .. })
+        ));
+        assert!(matches!(
+            neighbors_within(&s, f64::INFINITY),
+            Err(CrystalError::InvalidCutoff { .. })
+        ));
+    }
+
+    #[test]
+    fn absurd_cutoff_rejected_as_too_large() {
+        let s = single_site_cubic(1.0);
+        // A cutoff ~1e8x the cell edge implies an astronomically large
+        // search box.
+        let err = neighbors_within(&s, 1e8).unwrap_err();
+        assert!(matches!(err, CrystalError::NeighborSearchTooLarge { .. }));
+    }
+}

--- a/crates/chematic-crystal/src/neighbor.rs
+++ b/crates/chematic-crystal/src/neighbor.rs
@@ -1,6 +1,6 @@
 //! Cutoff-radius periodic neighbor enumeration.
 //!
-//! Reuses [`crate::periodic::axis_bound`]/[`crate::periodic::padded_axis_range`]
+//! Reuses `crate::periodic::axis_bound`/`crate::periodic::padded_axis_range`
 //! -- the same reciprocal-vector-derived search-box machinery
 //! [`crate::periodic::minimum_image`] uses, with the cutoff radius itself as
 //! the bound (no naive-round bootstrap candidate needed here, since the

--- a/crates/chematic-crystal/src/periodic.rs
+++ b/crates/chematic-crystal/src/periodic.rs
@@ -1,0 +1,197 @@
+//! Exact periodic-boundary displacement and minimum-image distance.
+//!
+//! # Why not `delta_frac -= delta_frac.round()`
+//!
+//! That one-line reduction is only guaranteed to find the *true* nearest
+//! periodic image when the cell is close to orthogonal. For a sufficiently
+//! skewed triclinic cell, "nearest per fractional axis" and "nearest in
+//! Cartesian space" diverge -- rounding each fractional component
+//! independently can miss an image that is farther in fractional space but
+//! closer in Cartesian space. This module instead derives a finite,
+//! provably sufficient search box from the lattice's own reciprocal
+//! vectors (see [`axis_bound`]) and brute-force-checks every candidate
+//! inside it, which is exact for any lattice [`Lattice::from_matrix`]
+//! accepts (validated non-singular). See
+//! `docs/rfcs/chematic_crystal_foundation.md` for the full derivation and
+//! `tests/periodicity.rs` for verification against an independent
+//! brute-force oracle, including a pinned triclinic regression fixture
+//! where naive `round()` disagrees with the exact result.
+
+use crate::lattice::{Lattice, norm3};
+use crate::site::FractionalCoord;
+
+/// A minimum-image periodic displacement between two fractional positions.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PeriodicDisplacement {
+    /// Cartesian displacement vector (Angstrom), `to`'s chosen image minus
+    /// `from`.
+    pub cartesian: [f64; 3],
+    /// The same displacement in fractional coordinates.
+    pub fractional: [f64; 3],
+    /// Which periodic image of `to` was chosen (integer lattice-vector
+    /// shift added to `to`'s fractional position).
+    pub image: [i32; 3],
+    /// Euclidean length of `cartesian`, in Angstrom.
+    pub distance: f64,
+}
+
+/// Real-valued (not yet floored/ceiled/padded) bound on the integer
+/// image-shift component along one axis: any image achieving Cartesian
+/// distance `<= bound` from a point at fractional offset `base_component`
+/// (on this axis) must have its integer shift `m` on this axis inside
+/// `[lo, hi]`.
+///
+/// Derivation (full version in the RFC): for `r = (base + m) . M` and
+/// reciprocal row `b_j` (`a_i . b_j = delta_ij`), `(base + m)_j = r . b_j`,
+/// so by Cauchy-Schwarz `|base_j + m_j| <= |r| * |b_j| <= bound * |b_j|`
+/// whenever `|r| <= bound`.
+///
+/// Shared by [`minimum_image`] (`bound` = the naive round()-based
+/// candidate's own distance) and [`crate::neighbor`] (`bound` = the
+/// cutoff radius) -- same bounding-box shape, different `bound` value and
+/// different post-processing (this module keeps only the minimum;
+/// `neighbor` keeps every candidate inside the box that also passes the
+/// cutoff after an exact distance check).
+pub(crate) fn axis_bound(base_component: f64, bound: f64, reciprocal_row_norm: f64) -> (f64, f64) {
+    let half = bound * reciprocal_row_norm;
+    (-half - base_component, half - base_component)
+}
+
+/// Convert a real-valued `axis_bound` result into an inclusive `i32` range,
+/// padded by one extra integer on each side as a defensive margin against
+/// floating-point error landing a true boundary case just outside the
+/// unpadded `floor`/`ceil` (cheap: the search box stays small either way
+/// for any lattice that passed [`Lattice`]'s own validation).
+pub(crate) fn padded_axis_range(lo: f64, hi: f64) -> (i32, i32) {
+    (lo.floor() as i32 - 1, hi.ceil() as i32 + 1)
+}
+
+/// The exact minimum-image displacement from fractional position `from` to
+/// fractional position `to` under `lattice`'s periodic boundary conditions.
+///
+/// Neither `from` nor `to` need to be pre-wrapped into `[0, 1)` -- only
+/// their difference matters. Ties (multiple images at the same minimal
+/// distance, e.g. a perfectly cubic cell's face-centered midpoint) are
+/// broken deterministically by iteration order: the first candidate
+/// encountered while enumerating image-shift components in ascending order
+/// is kept.
+pub fn minimum_image(
+    lattice: &Lattice,
+    from: FractionalCoord,
+    to: FractionalCoord,
+) -> PeriodicDisplacement {
+    let raw = [
+        to.0[0] - from.0[0],
+        to.0[1] - from.0[1],
+        to.0[2] - from.0[2],
+    ];
+    // n0 is the naive round()-based image shift; base = raw + n0 is that
+    // candidate's fractional displacement, already reduced into [-0.5, 0.5]
+    // per axis.
+    let n0 = [raw[0].round(), raw[1].round(), raw[2].round()];
+    let base = [raw[0] - n0[0], raw[1] - n0[1], raw[2] - n0[2]];
+    let image0 = [-(n0[0] as i32), -(n0[1] as i32), -(n0[2] as i32)];
+
+    let cart0 = lattice.frac_to_cart(FractionalCoord::new(base));
+    let dist0 = norm3(cart0.0);
+
+    let recip_norms = lattice.reciprocal_row_norms();
+    let mut ranges = [(0i32, 0i32); 3];
+    for axis in 0..3 {
+        let (lo, hi) = axis_bound(base[axis], dist0, recip_norms[axis]);
+        ranges[axis] = padded_axis_range(lo, hi);
+    }
+
+    let mut best = PeriodicDisplacement {
+        cartesian: cart0.0,
+        fractional: base,
+        image: image0,
+        distance: dist0,
+    };
+
+    for m0 in ranges[0].0..=ranges[0].1 {
+        for m1 in ranges[1].0..=ranges[1].1 {
+            for m2 in ranges[2].0..=ranges[2].1 {
+                let frac = [
+                    base[0] + f64::from(m0),
+                    base[1] + f64::from(m1),
+                    base[2] + f64::from(m2),
+                ];
+                let cart = lattice.frac_to_cart(FractionalCoord::new(frac));
+                let dist = norm3(cart.0);
+                if dist < best.distance {
+                    best = PeriodicDisplacement {
+                        cartesian: cart.0,
+                        fractional: frac,
+                        image: [image0[0] + m0, image0[1] + m1, image0[2] + m2],
+                        distance: dist,
+                    };
+                }
+            }
+        }
+    }
+
+    best
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lattice::Lattice;
+
+    #[test]
+    fn cubic_zero_displacement_is_zero_distance_zero_image() {
+        let l = Lattice::cubic(5.0).unwrap();
+        let f = FractionalCoord::new([0.3, 0.3, 0.3]);
+        let d = minimum_image(&l, f, f);
+        assert_eq!(d.image, [0, 0, 0]);
+        assert!(d.distance < 1e-12);
+    }
+
+    #[test]
+    fn cubic_wraps_to_nearest_image() {
+        let l = Lattice::cubic(10.0).unwrap();
+        let from = FractionalCoord::new([0.05, 0.5, 0.5]);
+        let to = FractionalCoord::new([0.95, 0.5, 0.5]);
+        // Direct distance would be 0.9*10=9; the periodic image is 0.1*10=1.
+        let d = minimum_image(&l, from, to);
+        assert!((d.distance - 1.0).abs() < 1e-9, "distance={}", d.distance);
+        assert_eq!(d.image[0], -1);
+    }
+
+    #[test]
+    fn translated_fractional_produces_same_minimum_image_distance() {
+        // Integer translation invariance: shifting `to` by a whole lattice
+        // vector must not change the minimum-image distance.
+        let l = Lattice::from_parameters(6.0, 7.0, 8.0, 85.0, 95.0, 100.0).unwrap();
+        let from = FractionalCoord::new([0.1, 0.2, 0.3]);
+        let to = FractionalCoord::new([0.6, 0.4, 0.9]);
+        let base_dist = minimum_image(&l, from, to).distance;
+        for shift in [[1, 0, 0], [0, 1, 0], [0, 0, 1], [-2, 3, -1], [5, -5, 5]] {
+            let to_shifted = to.translated(shift);
+            let shifted_dist = minimum_image(&l, from, to_shifted).distance;
+            assert!(
+                (base_dist - shifted_dist).abs() < 1e-9,
+                "shift {shift:?}: {base_dist} vs {shifted_dist}"
+            );
+        }
+    }
+
+    #[test]
+    fn origin_translation_of_both_points_does_not_change_distance() {
+        let l = Lattice::from_parameters(6.0, 7.0, 8.0, 85.0, 95.0, 100.0).unwrap();
+        let from = FractionalCoord::new([0.1, 0.2, 0.3]);
+        let to = FractionalCoord::new([0.6, 0.4, 0.9]);
+        let base_dist = minimum_image(&l, from, to).distance;
+        let shift = [0.37, -1.21, 2.05];
+        let from2 = FractionalCoord::new([
+            from.0[0] + shift[0],
+            from.0[1] + shift[1],
+            from.0[2] + shift[2],
+        ]);
+        let to2 =
+            FractionalCoord::new([to.0[0] + shift[0], to.0[1] + shift[1], to.0[2] + shift[2]]);
+        let shifted_dist = minimum_image(&l, from2, to2).distance;
+        assert!((base_dist - shifted_dist).abs() < 1e-9);
+    }
+}

--- a/crates/chematic-crystal/src/periodic.rs
+++ b/crates/chematic-crystal/src/periodic.rs
@@ -74,7 +74,9 @@ pub(crate) fn padded_axis_range(lo: f64, hi: f64) -> (i32, i32) {
 /// distance, e.g. a perfectly cubic cell's face-centered midpoint) are
 /// broken deterministically by iteration order: the first candidate
 /// encountered while enumerating image-shift components in ascending order
-/// is kept.
+/// is kept. Since `image = image0 + m` and `m` is enumerated ascending per
+/// axis (`image0` a fixed per-call offset), this is equivalent to keeping
+/// the lexicographically smallest tied `image`.
 ///
 /// # Examples
 ///
@@ -118,12 +120,12 @@ pub fn minimum_image(
         ranges[axis] = padded_axis_range(lo, hi);
     }
 
-    let mut best = PeriodicDisplacement {
-        cartesian: cart0.0,
-        fractional: base,
-        image: image0,
-        distance: dist0,
-    };
+    // Not seeded with the naive candidate: ties must be broken by ascending
+    // search order (first-found wins), not by which candidate happened to
+    // be computed first. The naive candidate (m = [0, 0, 0]) is itself
+    // always inside `ranges` (its own distance is the `bound` the ranges
+    // were derived from), so it's still considered -- just not favored.
+    let mut best: Option<PeriodicDisplacement> = None;
 
     for m0 in ranges[0].0..=ranges[0].1 {
         for m1 in ranges[1].0..=ranges[1].1 {
@@ -135,19 +137,19 @@ pub fn minimum_image(
                 ];
                 let cart = lattice.frac_to_cart(FractionalCoord::new(frac));
                 let dist = norm3(cart.0);
-                if dist < best.distance {
-                    best = PeriodicDisplacement {
+                if best.as_ref().is_none_or(|current| dist < current.distance) {
+                    best = Some(PeriodicDisplacement {
                         cartesian: cart.0,
                         fractional: frac,
                         image: [image0[0] + m0, image0[1] + m1, image0[2] + m2],
                         distance: dist,
-                    };
+                    });
                 }
             }
         }
     }
 
-    best
+    best.expect("search ranges always contain at least one candidate (m = [0, 0, 0])")
 }
 
 #[cfg(test)]
@@ -209,5 +211,43 @@ mod tests {
             FractionalCoord::new([to.0[0] + shift[0], to.0[1] + shift[1], to.0[2] + shift[2]]);
         let shifted_dist = minimum_image(&l, from2, to2).distance;
         assert!((base_dist - shifted_dist).abs() < 1e-9);
+    }
+
+    /// Regression for a tie-break bug: `best` used to be seeded with the
+    /// naive `round()`-based candidate before the search loop, so a
+    /// later candidate at the *same* distance never replaced it even
+    /// when it was lexicographically smaller. Here `from = [0.5, 0, 0]`,
+    /// `to = [0, 0, 0]` in a cubic cell: `image = [0, 0, 0]` and
+    /// `image = [1, 0, 0]` are equidistant (2.0 Angstrom), and
+    /// `round(-0.5) == -1` makes `[1, 0, 0]` the naive candidate. The
+    /// correct, ascending-search-order tie-break picks `[0, 0, 0]`.
+    #[test]
+    fn cubic_half_cell_tie_uses_lexicographically_smallest_image() {
+        let lattice = Lattice::cubic(4.0).unwrap();
+        let from = FractionalCoord::new([0.5, 0.0, 0.0]);
+        let to = FractionalCoord::new([0.0, 0.0, 0.0]);
+
+        let result = minimum_image(&lattice, from, to);
+
+        assert!((result.distance - 2.0).abs() < 1e-12);
+        assert_eq!(result.image, [0, 0, 0]);
+    }
+
+    /// Same tie, `from`/`to` swapped. The invariant is "lexicographically
+    /// smallest image wins," not "mirror the forward case": swapping
+    /// `from`/`to` shifts which two images are tied (`image` is defined
+    /// relative to `to`), so here the tied pair is `[-1, 0, 0]` /
+    /// `[0, 0, 0]` and the smaller one, `[-1, 0, 0]`, wins -- still
+    /// confirming the distance is symmetric either way.
+    #[test]
+    fn cubic_half_cell_tie_reverse_direction_also_resolves_deterministically() {
+        let lattice = Lattice::cubic(4.0).unwrap();
+        let from = FractionalCoord::new([0.0, 0.0, 0.0]);
+        let to = FractionalCoord::new([0.5, 0.0, 0.0]);
+
+        let result = minimum_image(&lattice, from, to);
+
+        assert!((result.distance - 2.0).abs() < 1e-12);
+        assert_eq!(result.image, [-1, 0, 0]);
     }
 }

--- a/crates/chematic-crystal/src/periodic.rs
+++ b/crates/chematic-crystal/src/periodic.rs
@@ -9,7 +9,7 @@
 //! independently can miss an image that is farther in fractional space but
 //! closer in Cartesian space. This module instead derives a finite,
 //! provably sufficient search box from the lattice's own reciprocal
-//! vectors (see [`axis_bound`]) and brute-force-checks every candidate
+//! vectors (see `axis_bound` below) and brute-force-checks every candidate
 //! inside it, which is exact for any lattice [`Lattice::from_matrix`]
 //! accepts (validated non-singular). See
 //! `docs/rfcs/chematic_crystal_foundation.md` for the full derivation and
@@ -75,6 +75,22 @@ pub(crate) fn padded_axis_range(lo: f64, hi: f64) -> (i32, i32) {
 /// broken deterministically by iteration order: the first candidate
 /// encountered while enumerating image-shift components in ascending order
 /// is kept.
+///
+/// # Examples
+///
+/// ```
+/// use chematic_crystal::{FractionalCoord, Lattice, minimum_image};
+///
+/// let lattice = Lattice::cubic(10.0)?;
+/// let from = FractionalCoord::new([0.05, 0.5, 0.5]);
+/// let to = FractionalCoord::new([0.95, 0.5, 0.5]);
+/// // Direct fractional difference is 0.9 (9.0 Angstrom); the periodic
+/// // image wraps around to 0.1 (1.0 Angstrom).
+/// let displacement = minimum_image(&lattice, from, to);
+/// assert!((displacement.distance - 1.0).abs() < 1e-9);
+/// assert_eq!(displacement.image, [-1, 0, 0]);
+/// # Ok::<(), chematic_crystal::CrystalError>(())
+/// ```
 pub fn minimum_image(
     lattice: &Lattice,
     from: FractionalCoord,

--- a/crates/chematic-crystal/src/site.rs
+++ b/crates/chematic-crystal/src/site.rs
@@ -200,6 +200,130 @@ impl PeriodicSite {
     }
 }
 
+/// Hand-written rather than derived throughout this module: every public
+/// type here (`FractionalCoord`, `CartesianCoord`, `Occupancy`,
+/// `SiteSpecies`, `PeriodicSite`) enforces an invariant at construction
+/// (finite components, non-negative occupancy, non-empty species,
+/// occupancy-sum tolerance), and a `#[derive(Deserialize)]` would silently
+/// skip all of them by assigning fields directly. `SiteSpecies` additionally
+/// can't derive at all: `chematic_core::Element` has no serde support (see
+/// `docs/rfcs/chematic_crystal_foundation.md`), so it round-trips through
+/// the element's existing `symbol()`/`from_symbol()` API as a string
+/// instead.
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use super::{CartesianCoord, FractionalCoord, Occupancy, PeriodicSite, SiteSpecies};
+    use crate::error::CrystalError;
+    use chematic_core::Element;
+    use serde::de::Error as _;
+    use serde::ser::SerializeStruct;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    impl Serialize for FractionalCoord {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            self.0.serialize(serializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for FractionalCoord {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let value = <[f64; 3]>::deserialize(deserializer)?;
+            if value.iter().all(|c| c.is_finite()) {
+                Ok(FractionalCoord(value))
+            } else {
+                Err(D::Error::custom(
+                    "fractional coordinate components must be finite",
+                ))
+            }
+        }
+    }
+
+    impl Serialize for CartesianCoord {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            self.0.serialize(serializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for CartesianCoord {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let value = <[f64; 3]>::deserialize(deserializer)?;
+            if value.iter().all(|c| c.is_finite()) {
+                Ok(CartesianCoord(value))
+            } else {
+                Err(D::Error::custom(
+                    "Cartesian coordinate components must be finite",
+                ))
+            }
+        }
+    }
+
+    impl Serialize for Occupancy {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            self.0.serialize(serializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Occupancy {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let value = f64::deserialize(deserializer)?;
+            Occupancy::new(value).map_err(|e: CrystalError| D::Error::custom(e.to_string()))
+        }
+    }
+
+    impl Serialize for SiteSpecies {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            let mut state = serializer.serialize_struct("SiteSpecies", 2)?;
+            state.serialize_field("element", self.element.symbol())?;
+            state.serialize_field("occupancy", &self.occupancy)?;
+            state.end()
+        }
+    }
+
+    #[derive(Deserialize)]
+    struct SiteSpeciesData {
+        element: String,
+        occupancy: Occupancy,
+    }
+
+    impl<'de> Deserialize<'de> for SiteSpecies {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let data = SiteSpeciesData::deserialize(deserializer)?;
+            let element = Element::from_symbol(&data.element).ok_or_else(|| {
+                D::Error::custom(format!("unknown element symbol {:?}", data.element))
+            })?;
+            Ok(SiteSpecies {
+                element,
+                occupancy: data.occupancy,
+            })
+        }
+    }
+
+    impl Serialize for PeriodicSite {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            let mut state = serializer.serialize_struct("PeriodicSite", 3)?;
+            state.serialize_field("species", &self.species)?;
+            state.serialize_field("fractional", &self.fractional)?;
+            state.serialize_field("label", &self.label)?;
+            state.end()
+        }
+    }
+
+    #[derive(Deserialize)]
+    struct PeriodicSiteData {
+        species: Vec<SiteSpecies>,
+        fractional: FractionalCoord,
+        label: Option<String>,
+    }
+
+    impl<'de> Deserialize<'de> for PeriodicSite {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let data = PeriodicSiteData::deserialize(deserializer)?;
+            PeriodicSite::new(data.species, data.fractional, data.label)
+                .map_err(|e: CrystalError| D::Error::custom(e.to_string()))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/chematic-crystal/src/site.rs
+++ b/crates/chematic-crystal/src/site.rs
@@ -1,0 +1,334 @@
+//! Coordinate newtypes, occupancy, and the periodic site type.
+
+use crate::error::CrystalError;
+use crate::validation::require_finite3;
+use chematic_core::Element;
+
+// ---------------------------------------------------------------------------
+// Coordinate newtypes
+// ---------------------------------------------------------------------------
+
+/// Fractional (lattice-relative, dimensionless) coordinates.
+///
+/// Not range-restricted by the type itself -- a raw fractional triple may
+/// legally sit outside `[0, 1)` (e.g. mid-calculation, before wrapping).
+/// Use [`FractionalCoord::wrapped`] to reduce into `[0, 1)`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FractionalCoord(pub [f64; 3]);
+
+impl FractionalCoord {
+    /// Construct from raw components (no validation -- see [`Self::is_finite`]).
+    #[inline]
+    pub fn new(value: [f64; 3]) -> Self {
+        Self(value)
+    }
+
+    /// `true` if every component is finite (no `NaN`, no `+-Infinity`).
+    #[inline]
+    pub fn is_finite(&self) -> bool {
+        self.0.iter().all(|c| c.is_finite())
+    }
+
+    /// Reduce each component into `[0, 1)` via `rem_euclid(1.0)`.
+    ///
+    /// `1.0` itself maps to `0.0`; negative values wrap up (e.g. `-0.25` ->
+    /// `0.75`), matching the usual crystallographic convention for "the
+    /// representative image inside the unit cell". Non-finite input yields
+    /// non-finite output (`rem_euclid` propagates `NaN`) -- callers that
+    /// need a hard guarantee should validate first via [`Self::is_finite`].
+    pub fn wrapped(&self) -> Self {
+        Self([
+            self.0[0].rem_euclid(1.0),
+            self.0[1].rem_euclid(1.0),
+            self.0[2].rem_euclid(1.0),
+        ])
+    }
+
+    /// Translate by an integer lattice-image shift `[i, j, k]`.
+    pub fn translated(&self, image: [i32; 3]) -> Self {
+        Self([
+            self.0[0] + f64::from(image[0]),
+            self.0[1] + f64::from(image[1]),
+            self.0[2] + f64::from(image[2]),
+        ])
+    }
+}
+
+/// Cartesian (orthogonal, Angstrom) coordinates.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CartesianCoord(pub [f64; 3]);
+
+impl CartesianCoord {
+    /// Construct from raw components (no validation -- see [`Self::is_finite`]).
+    #[inline]
+    pub fn new(value: [f64; 3]) -> Self {
+        Self(value)
+    }
+
+    /// `true` if every component is finite (no `NaN`, no `+-Infinity`).
+    #[inline]
+    pub fn is_finite(&self) -> bool {
+        self.0.iter().all(|c| c.is_finite())
+    }
+
+    /// Euclidean distance to another Cartesian point, in Angstrom.
+    pub fn distance(&self, other: &CartesianCoord) -> f64 {
+        let d = [
+            self.0[0] - other.0[0],
+            self.0[1] - other.0[1],
+            self.0[2] - other.0[2],
+        ];
+        (d[0] * d[0] + d[1] * d[1] + d[2] * d[2]).sqrt()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Occupancy
+// ---------------------------------------------------------------------------
+
+/// A validated site occupancy fraction: finite and `>= 0`.
+///
+/// No fixed per-value upper bound -- a single species can legitimately have
+/// a low partial occupancy (vacancy modeling); the upper bound that matters
+/// is the *sum* over all species at one [`PeriodicSite`], enforced by
+/// [`PeriodicSite::validate`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Occupancy(f64);
+
+impl Occupancy {
+    /// Tolerance (dimensionless -- occupancy is already a unitless 0..1-ish
+    /// fraction) that a site's total occupancy sum may exceed `1.0` by
+    /// before being rejected. Sized to absorb floating-point summation
+    /// error (e.g. three species at exactly 1/3 each can sum to
+    /// `0.9999999999999999` or `1.0000000000000002` depending on summation
+    /// order), not to permit genuine over-occupancy.
+    pub const SUM_TOLERANCE: f64 = 1e-6;
+
+    /// Construct a validated occupancy. Rejects non-finite and negative
+    /// values.
+    pub fn new(value: f64) -> Result<Self, CrystalError> {
+        if !value.is_finite() {
+            return Err(CrystalError::NonFiniteOccupancy);
+        }
+        if value < 0.0 {
+            return Err(CrystalError::NegativeOccupancy { value });
+        }
+        Ok(Self(value))
+    }
+
+    /// The underlying fraction.
+    #[inline]
+    pub fn value(&self) -> f64 {
+        self.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Species / site
+// ---------------------------------------------------------------------------
+
+/// One (element, occupancy) contribution at a [`PeriodicSite`].
+///
+/// Multiple `SiteSpecies` at one site model substitutional/positional
+/// disorder (e.g. a site 60% Fe / 40% Ni). `v0.1` stores this data
+/// faithfully but does not implement any disorder-aware chemistry on top of
+/// it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SiteSpecies {
+    pub element: Element,
+    pub occupancy: Occupancy,
+}
+
+impl SiteSpecies {
+    /// Convenience constructor for a fully-occupied single-element site.
+    pub fn full(element: Element) -> Self {
+        Self {
+            element,
+            // 1.0 is always finite and non-negative -- infallible.
+            occupancy: Occupancy::new(1.0).expect("1.0 is a valid occupancy"),
+        }
+    }
+}
+
+/// A periodic site: one or more species (for disorder), a fractional
+/// position, and an optional human-readable label (e.g. `"Na1"` from a CIF
+/// file).
+#[derive(Debug, Clone, PartialEq)]
+pub struct PeriodicSite {
+    pub species: Vec<SiteSpecies>,
+    pub fractional: FractionalCoord,
+    pub label: Option<String>,
+}
+
+impl PeriodicSite {
+    /// Construct and validate a site: rejects an empty species list, a
+    /// non-finite fractional position, and a species-occupancy sum above
+    /// `1.0 + `[`Occupancy::SUM_TOLERANCE`].
+    pub fn new(
+        species: Vec<SiteSpecies>,
+        fractional: FractionalCoord,
+        label: Option<String>,
+    ) -> Result<Self, CrystalError> {
+        let site = Self {
+            species,
+            fractional,
+            label,
+        };
+        site.validate()?;
+        Ok(site)
+    }
+
+    /// Re-run this site's own invariants (species non-empty, fractional
+    /// finite, occupancy sum within tolerance). Called automatically by
+    /// [`PeriodicSite::new`]; exposed for structures assembled from raw
+    /// struct-literal fields (all of `PeriodicSite`'s fields are `pub`) so
+    /// [`crate::structure::PeriodicStructure::validate`] can check them
+    /// too.
+    pub fn validate(&self) -> Result<(), CrystalError> {
+        require_finite3(self.fractional.0, "fractional")?;
+        if self.species.is_empty() {
+            return Err(CrystalError::EmptySpeciesList);
+        }
+        let sum: f64 = self.species.iter().map(|s| s.occupancy.value()).sum();
+        if sum > 1.0 + Occupancy::SUM_TOLERANCE {
+            return Err(CrystalError::OccupancySumExceeded {
+                sum,
+                tolerance: Occupancy::SUM_TOLERANCE,
+            });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fractional_wrapped_reduces_into_unit_range() {
+        let f = FractionalCoord::new([1.25, -0.25, 2.75]);
+        let w = f.wrapped();
+        assert!((w.0[0] - 0.25).abs() < 1e-12);
+        assert!((w.0[1] - 0.75).abs() < 1e-12);
+        assert!((w.0[2] - 0.75).abs() < 1e-12);
+        for c in w.0 {
+            assert!((0.0..1.0).contains(&c));
+        }
+    }
+
+    #[test]
+    fn fractional_wrapped_one_maps_to_zero() {
+        let w = FractionalCoord::new([1.0, 1.0, 1.0]).wrapped();
+        assert_eq!(w.0, [0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn fractional_translated_is_integer_shift() {
+        let f = FractionalCoord::new([0.1, 0.2, 0.3]);
+        let t = f.translated([1, -2, 0]);
+        assert!((t.0[0] - 1.1).abs() < 1e-12);
+        assert!((t.0[1] - (-1.8)).abs() < 1e-12);
+        assert!((t.0[2] - 0.3).abs() < 1e-12);
+    }
+
+    #[test]
+    fn occupancy_rejects_negative_and_non_finite() {
+        assert!(Occupancy::new(0.5).is_ok());
+        assert!(Occupancy::new(0.0).is_ok());
+        assert_eq!(
+            Occupancy::new(-0.1),
+            Err(CrystalError::NegativeOccupancy { value: -0.1 })
+        );
+        assert_eq!(
+            Occupancy::new(f64::NAN),
+            Err(CrystalError::NonFiniteOccupancy)
+        );
+        assert_eq!(
+            Occupancy::new(f64::INFINITY),
+            Err(CrystalError::NonFiniteOccupancy)
+        );
+    }
+
+    #[test]
+    fn site_rejects_empty_species() {
+        let err = PeriodicSite::new(vec![], FractionalCoord::new([0.0, 0.0, 0.0]), None)
+            .unwrap_err();
+        assert_eq!(err, CrystalError::EmptySpeciesList);
+    }
+
+    #[test]
+    fn site_rejects_non_finite_fractional() {
+        let species = vec![SiteSpecies::full(Element::NA)];
+        let err = PeriodicSite::new(species, FractionalCoord::new([f64::NAN, 0.0, 0.0]), None)
+            .unwrap_err();
+        assert_eq!(
+            err,
+            CrystalError::NonFinite {
+                field: "fractional"
+            }
+        );
+    }
+
+    #[test]
+    fn site_accepts_occupancy_sum_at_one() {
+        let species = vec![
+            SiteSpecies {
+                element: Element::FE,
+                occupancy: Occupancy::new(0.6).unwrap(),
+            },
+            SiteSpecies {
+                element: Element::NI,
+                occupancy: Occupancy::new(0.4).unwrap(),
+            },
+        ];
+        assert!(PeriodicSite::new(species, FractionalCoord::new([0.0, 0.0, 0.0]), None).is_ok());
+    }
+
+    #[test]
+    fn site_accepts_occupancy_sum_below_one_as_vacancy() {
+        let species = vec![SiteSpecies {
+            element: Element::FE,
+            occupancy: Occupancy::new(0.5).unwrap(),
+        }];
+        assert!(PeriodicSite::new(species, FractionalCoord::new([0.0, 0.0, 0.0]), None).is_ok());
+    }
+
+    #[test]
+    fn site_rejects_occupancy_sum_above_tolerance() {
+        let species = vec![
+            SiteSpecies {
+                element: Element::FE,
+                occupancy: Occupancy::new(0.7).unwrap(),
+            },
+            SiteSpecies {
+                element: Element::NI,
+                occupancy: Occupancy::new(0.5).unwrap(),
+            },
+        ];
+        let err =
+            PeriodicSite::new(species, FractionalCoord::new([0.0, 0.0, 0.0]), None).unwrap_err();
+        assert!(matches!(err, CrystalError::OccupancySumExceeded { .. }));
+    }
+
+    #[test]
+    fn site_accepts_occupancy_sum_within_float_tolerance() {
+        // Three species at 1/3 each: floating-point summation lands just
+        // above or below 1.0 depending on order, must not be rejected.
+        let third = Occupancy::new(1.0 / 3.0).unwrap();
+        let species = vec![
+            SiteSpecies {
+                element: Element::FE,
+                occupancy: third,
+            },
+            SiteSpecies {
+                element: Element::NI,
+                occupancy: third,
+            },
+            SiteSpecies {
+                element: Element::CU,
+                occupancy: third,
+            },
+        ];
+        assert!(PeriodicSite::new(species, FractionalCoord::new([0.0, 0.0, 0.0]), None).is_ok());
+    }
+}

--- a/crates/chematic-crystal/src/site.rs
+++ b/crates/chematic-crystal/src/site.rs
@@ -375,8 +375,8 @@ mod tests {
 
     #[test]
     fn site_rejects_empty_species() {
-        let err = PeriodicSite::new(vec![], FractionalCoord::new([0.0, 0.0, 0.0]), None)
-            .unwrap_err();
+        let err =
+            PeriodicSite::new(vec![], FractionalCoord::new([0.0, 0.0, 0.0]), None).unwrap_err();
         assert_eq!(err, CrystalError::EmptySpeciesList);
     }
 

--- a/crates/chematic-crystal/src/structure.rs
+++ b/crates/chematic-crystal/src/structure.rs
@@ -2,7 +2,9 @@
 
 use crate::error::CrystalError;
 use crate::lattice::Lattice;
+use crate::neighbor::{self, PeriodicNeighbor};
 use crate::site::{CartesianCoord, FractionalCoord, PeriodicSite};
+use crate::supercell;
 
 /// A periodic structure: a validated [`Lattice`] and an ordered list of
 /// [`PeriodicSite`]s.
@@ -95,6 +97,20 @@ impl PeriodicStructure {
             lattice: self.lattice.clone(),
             sites,
         }
+    }
+
+    /// Every periodic neighbor pair within `cutoff` Angstrom (inclusive).
+    /// See [`neighbor::neighbors_within`] for the full contract
+    /// (self-image handling, ordering, error conditions).
+    pub fn neighbors_within(&self, cutoff: f64) -> Result<Vec<PeriodicNeighbor>, CrystalError> {
+        neighbor::neighbors_within(self, cutoff)
+    }
+
+    /// Build a diagonal `[nx, ny, nz]` supercell. See
+    /// [`supercell::make_supercell`] for the full contract (site ordering,
+    /// error conditions).
+    pub fn make_supercell(&self, mult: [u32; 3]) -> Result<Self, CrystalError> {
+        supercell::make_supercell(self, mult)
     }
 }
 

--- a/crates/chematic-crystal/src/structure.rs
+++ b/crates/chematic-crystal/src/structure.rs
@@ -22,6 +22,35 @@ pub struct PeriodicStructure {
 impl PeriodicStructure {
     /// Construct and validate a structure: every site must independently
     /// pass [`PeriodicSite::validate`].
+    ///
+    /// # Examples
+    ///
+    /// CsCl-type structure (one cation + one anion per cubic cell, anion
+    /// at the body center -- e.g. CsCl, AlNi, beta-brass; illustrated here
+    /// with Na/Cl for familiarity, not a claim about real NaCl, which is
+    /// rock-salt-type and needs 8 sites in its conventional cubic cell):
+    ///
+    /// ```
+    /// use chematic_core::Element;
+    /// use chematic_crystal::{FractionalCoord, Lattice, PeriodicSite, PeriodicStructure, SiteSpecies};
+    ///
+    /// let lattice = Lattice::cubic(5.64)?;
+    /// let sites = vec![
+    ///     PeriodicSite::new(
+    ///         vec![SiteSpecies::full(Element::NA)],
+    ///         FractionalCoord::new([0.0, 0.0, 0.0]),
+    ///         Some("Na1".to_string()),
+    ///     )?,
+    ///     PeriodicSite::new(
+    ///         vec![SiteSpecies::full(Element::CL)],
+    ///         FractionalCoord::new([0.5, 0.5, 0.5]),
+    ///         Some("Cl1".to_string()),
+    ///     )?,
+    /// ];
+    /// let structure = PeriodicStructure::new(lattice, sites)?;
+    /// assert_eq!(structure.site_count(), 2);
+    /// # Ok::<(), chematic_crystal::CrystalError>(())
+    /// ```
     pub fn new(lattice: Lattice, sites: Vec<PeriodicSite>) -> Result<Self, CrystalError> {
         let structure = Self { lattice, sites };
         structure.validate()?;
@@ -102,6 +131,27 @@ impl PeriodicStructure {
     /// Every periodic neighbor pair within `cutoff` Angstrom (inclusive).
     /// See [`neighbor::neighbors_within`] for the full contract
     /// (self-image handling, ordering, error conditions).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use chematic_core::Element;
+    /// use chematic_crystal::{FractionalCoord, Lattice, PeriodicSite, PeriodicStructure, SiteSpecies};
+    ///
+    /// let lattice = Lattice::cubic(3.0)?;
+    /// let structure = PeriodicStructure::new(
+    ///     lattice,
+    ///     vec![PeriodicSite::new(
+    ///         vec![SiteSpecies::full(Element::AR)],
+    ///         FractionalCoord::new([0.0, 0.0, 0.0]),
+    ///         None,
+    ///     )?],
+    /// )?;
+    /// // 6 face-adjacent periodic self-images at exactly 3.0 Angstrom.
+    /// let neighbors = structure.neighbors_within(3.0)?;
+    /// assert_eq!(neighbors.len(), 6);
+    /// # Ok::<(), chematic_crystal::CrystalError>(())
+    /// ```
     pub fn neighbors_within(&self, cutoff: f64) -> Result<Vec<PeriodicNeighbor>, CrystalError> {
         neighbor::neighbors_within(self, cutoff)
     }
@@ -109,6 +159,27 @@ impl PeriodicStructure {
     /// Build a diagonal `[nx, ny, nz]` supercell. See
     /// [`supercell::make_supercell`] for the full contract (site ordering,
     /// error conditions).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use chematic_core::Element;
+    /// use chematic_crystal::{FractionalCoord, Lattice, PeriodicSite, PeriodicStructure, SiteSpecies};
+    ///
+    /// let lattice = Lattice::cubic(4.0)?;
+    /// let structure = PeriodicStructure::new(
+    ///     lattice,
+    ///     vec![PeriodicSite::new(
+    ///         vec![SiteSpecies::full(Element::C)],
+    ///         FractionalCoord::new([0.0, 0.0, 0.0]),
+    ///         None,
+    ///     )?],
+    /// )?;
+    /// let supercell = structure.make_supercell([2, 2, 2])?;
+    /// assert_eq!(supercell.site_count(), 8);
+    /// assert!((supercell.lattice().volume() - structure.lattice().volume() * 8.0).abs() < 1e-9);
+    /// # Ok::<(), chematic_crystal::CrystalError>(())
+    /// ```
     pub fn make_supercell(&self, mult: [u32; 3]) -> Result<Self, CrystalError> {
         supercell::make_supercell(self, mult)
     }

--- a/crates/chematic-crystal/src/structure.rs
+++ b/crates/chematic-crystal/src/structure.rs
@@ -1,0 +1,233 @@
+//! [`PeriodicStructure`]: a [`Lattice`] plus its [`PeriodicSite`]s.
+
+use crate::error::CrystalError;
+use crate::lattice::Lattice;
+use crate::site::{CartesianCoord, FractionalCoord, PeriodicSite};
+
+/// A periodic structure: a validated [`Lattice`] and an ordered list of
+/// [`PeriodicSite`]s.
+///
+/// Immutable by design in `v0.1` -- operations that would change geometry
+/// (wrapping, supercell expansion) return a new `PeriodicStructure` rather
+/// than mutating in place, so an already-validated instance can never be
+/// pushed into an invalid state after construction.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PeriodicStructure {
+    lattice: Lattice,
+    sites: Vec<PeriodicSite>,
+}
+
+impl PeriodicStructure {
+    /// Construct and validate a structure: every site must independently
+    /// pass [`PeriodicSite::validate`].
+    pub fn new(lattice: Lattice, sites: Vec<PeriodicSite>) -> Result<Self, CrystalError> {
+        let structure = Self { lattice, sites };
+        structure.validate()?;
+        Ok(structure)
+    }
+
+    /// The structure's lattice.
+    #[inline]
+    pub fn lattice(&self) -> &Lattice {
+        &self.lattice
+    }
+
+    /// The structure's sites, in construction order.
+    #[inline]
+    pub fn sites(&self) -> &[PeriodicSite] {
+        &self.sites
+    }
+
+    /// Number of sites.
+    #[inline]
+    pub fn site_count(&self) -> usize {
+        self.sites.len()
+    }
+
+    /// Fractional position of every site, in site order.
+    pub fn fractional_positions(&self) -> Vec<FractionalCoord> {
+        self.sites.iter().map(|s| s.fractional).collect()
+    }
+
+    /// Cartesian position of every site, in site order (`lattice.frac_to_cart`
+    /// applied to each site's fractional position).
+    pub fn cartesian_positions(&self) -> Vec<CartesianCoord> {
+        self.sites
+            .iter()
+            .map(|s| self.lattice.frac_to_cart(s.fractional))
+            .collect()
+    }
+
+    /// Re-check every site's own invariants. Called automatically by
+    /// [`Self::new`]; exposed since `sites()` is a read-only view but
+    /// structures can also be produced by other crate-internal
+    /// constructors ([`Self::wrapped`], `make_supercell`) that reuse this
+    /// check rather than re-deriving it.
+    pub fn validate(&self) -> Result<(), CrystalError> {
+        for (index, site) in self.sites.iter().enumerate() {
+            site.validate()
+                .map_err(|source| CrystalError::InvalidSite {
+                    index,
+                    source: Box::new(source),
+                })?;
+        }
+        Ok(())
+    }
+
+    /// A new structure with every site's fractional position reduced into
+    /// `[0, 1)` via [`FractionalCoord::wrapped`]. Species, occupancy, and
+    /// labels are preserved; `self` is unmodified.
+    pub fn wrapped(&self) -> Self {
+        let sites = self
+            .sites
+            .iter()
+            .map(|s| PeriodicSite {
+                species: s.species.clone(),
+                fractional: s.fractional.wrapped(),
+                label: s.label.clone(),
+            })
+            .collect();
+        // Wrapping a finite fractional coordinate (guaranteed by `self`
+        // already having passed validation) can't un-finite it, and leaves
+        // species/occupancy untouched -- constructing directly (rather than
+        // re-running `Self::new`'s Result-returning validation) is safe.
+        Self {
+            lattice: self.lattice.clone(),
+            sites,
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use super::PeriodicStructure;
+    use crate::error::CrystalError;
+    use crate::lattice::Lattice;
+    use crate::site::PeriodicSite;
+    use serde::de::Error as _;
+    use serde::ser::SerializeStruct;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    impl Serialize for PeriodicStructure {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            let mut state = serializer.serialize_struct("PeriodicStructure", 2)?;
+            state.serialize_field("lattice", &self.lattice)?;
+            state.serialize_field("sites", &self.sites)?;
+            state.end()
+        }
+    }
+
+    /// Deserializes into raw `(lattice, sites)` fields, then re-validates
+    /// through [`PeriodicStructure::new`] -- a deserialized structure can
+    /// never skip the invariants a normally-constructed one goes through.
+    #[derive(Deserialize)]
+    struct PeriodicStructureData {
+        lattice: Lattice,
+        sites: Vec<PeriodicSite>,
+    }
+
+    impl<'de> Deserialize<'de> for PeriodicStructure {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let data = PeriodicStructureData::deserialize(deserializer)?;
+            PeriodicStructure::new(data.lattice, data.sites)
+                .map_err(|e: CrystalError| D::Error::custom(e.to_string()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::site::{Occupancy, SiteSpecies};
+    use chematic_core::Element;
+
+    fn cubic_two_site() -> PeriodicStructure {
+        let lattice = Lattice::cubic(4.0).unwrap();
+        let sites = vec![
+            PeriodicSite::new(
+                vec![SiteSpecies::full(Element::NA)],
+                FractionalCoord::new([0.0, 0.0, 0.0]),
+                Some("Na1".to_string()),
+            )
+            .unwrap(),
+            PeriodicSite::new(
+                vec![SiteSpecies::full(Element::CL)],
+                FractionalCoord::new([0.5, 0.5, 0.5]),
+                Some("Cl1".to_string()),
+            )
+            .unwrap(),
+        ];
+        PeriodicStructure::new(lattice, sites).unwrap()
+    }
+
+    #[test]
+    fn new_accepts_valid_sites() {
+        let s = cubic_two_site();
+        assert_eq!(s.site_count(), 2);
+        assert_eq!(s.sites().len(), 2);
+    }
+
+    #[test]
+    fn new_rejects_invalid_site_with_index() {
+        let lattice = Lattice::cubic(4.0).unwrap();
+        let bad_site = PeriodicSite {
+            species: vec![],
+            fractional: FractionalCoord::new([0.0, 0.0, 0.0]),
+            label: None,
+        };
+        let err = PeriodicStructure::new(lattice, vec![bad_site]).unwrap_err();
+        match err {
+            CrystalError::InvalidSite { index, source } => {
+                assert_eq!(index, 0);
+                assert_eq!(*source, CrystalError::EmptySpeciesList);
+            }
+            other => panic!("expected InvalidSite, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fractional_and_cartesian_positions_match_site_order() {
+        let s = cubic_two_site();
+        let frac = s.fractional_positions();
+        let cart = s.cartesian_positions();
+        assert_eq!(frac.len(), 2);
+        assert_eq!(cart.len(), 2);
+        assert_eq!(frac[0].0, [0.0, 0.0, 0.0]);
+        assert_eq!(cart[0].0, [0.0, 0.0, 0.0]);
+        // second site at (0.5,0.5,0.5) in a cubic(4.0) cell -> (2,2,2) Cartesian.
+        for c in cart[1].0 {
+            assert!((c - 2.0).abs() < 1e-9);
+        }
+    }
+
+    #[test]
+    fn wrapped_reduces_out_of_cell_fractional_and_preserves_species() {
+        let lattice = Lattice::cubic(4.0).unwrap();
+        let site = PeriodicSite::new(
+            vec![SiteSpecies {
+                element: Element::FE,
+                occupancy: Occupancy::new(0.6).unwrap(),
+            }],
+            FractionalCoord::new([1.25, -0.5, 3.0]),
+            Some("Fe1".to_string()),
+        )
+        .unwrap();
+        let s = PeriodicStructure::new(lattice, vec![site]).unwrap();
+        let w = s.wrapped();
+        let wf = w.sites()[0].fractional.0;
+        assert!((wf[0] - 0.25).abs() < 1e-12);
+        assert!((wf[1] - 0.5).abs() < 1e-12);
+        assert!((wf[2] - 0.0).abs() < 1e-12);
+        assert_eq!(w.sites()[0].species, s.sites()[0].species);
+        assert_eq!(w.sites()[0].label, s.sites()[0].label);
+        // original unchanged
+        assert_eq!(s.sites()[0].fractional.0, [1.25, -0.5, 3.0]);
+    }
+
+    #[test]
+    fn site_order_is_preserved_not_reordered() {
+        let s = cubic_two_site();
+        assert_eq!(s.sites()[0].label.as_deref(), Some("Na1"));
+        assert_eq!(s.sites()[1].label.as_deref(), Some("Cl1"));
+    }
+}

--- a/crates/chematic-crystal/src/supercell.rs
+++ b/crates/chematic-crystal/src/supercell.rs
@@ -1,0 +1,233 @@
+//! Diagonal supercell generation.
+//!
+//! `v0.1` supports only diagonal `[nx, ny, nz]` expansion, each `>= 1`.
+//! Arbitrary 3x3 integer supercell transforms are out of scope (see
+//! `docs/crystal_scope.md`).
+
+use crate::error::CrystalError;
+use crate::lattice::{Lattice, scale3};
+use crate::site::{FractionalCoord, PeriodicSite};
+use crate::structure::PeriodicStructure;
+
+/// Build a diagonal supercell: lattice vectors scaled by `[nx, ny, nz]`,
+/// sites replicated across every translated cell and re-normalized into
+/// the new (larger) cell's fractional frame.
+///
+/// Site order is deterministic: outer loop over `i in 0..nx`, then `j in
+/// 0..ny`, then `k in 0..nz`, then the original sites in their existing
+/// order -- so site `((i*ny + j)*nz + k) * original_site_count +
+/// original_index` in the result corresponds to translated-cell `(i, j,
+/// k)`'s copy of `original_index`. Species, occupancy, and labels are
+/// copied unchanged. `structure` itself is not modified.
+///
+/// # Errors
+///
+/// [`CrystalError::NonPositiveSupercellMultiplier`] if any of `nx, ny, nz`
+/// is `0`.
+pub fn make_supercell(
+    structure: &PeriodicStructure,
+    mult: [u32; 3],
+) -> Result<PeriodicStructure, CrystalError> {
+    for (axis, &m) in mult.iter().enumerate() {
+        if m < 1 {
+            return Err(CrystalError::NonPositiveSupercellMultiplier { axis, value: m });
+        }
+    }
+    let [nx, ny, nz] = mult;
+
+    let old_matrix = structure.lattice().matrix();
+    let new_matrix = [
+        scale3(old_matrix[0], f64::from(nx)),
+        scale3(old_matrix[1], f64::from(ny)),
+        scale3(old_matrix[2], f64::from(nz)),
+    ];
+    // Scaling each row independently by a positive factor can't introduce
+    // a singularity or change the (scale-invariant) condition indicator --
+    // see supercell_never_fails_lattice_validation_when_original_is_valid
+    // below -- but the Result is still propagated rather than unwrapped,
+    // matching this crate's pattern of never asserting away a fallible
+    // constructor's own check.
+    let new_lattice = Lattice::from_matrix(new_matrix)?;
+
+    let orig_sites = structure.sites();
+    let mut new_sites = Vec::new();
+    for i in 0..nx {
+        for j in 0..ny {
+            for k in 0..nz {
+                for site in orig_sites {
+                    let f = site.fractional.0;
+                    let new_frac = FractionalCoord::new([
+                        (f[0] + f64::from(i)) / f64::from(nx),
+                        (f[1] + f64::from(j)) / f64::from(ny),
+                        (f[2] + f64::from(k)) / f64::from(nz),
+                    ]);
+                    new_sites.push(PeriodicSite {
+                        species: site.species.clone(),
+                        fractional: new_frac,
+                        label: site.label.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    PeriodicStructure::new(new_lattice, new_sites)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::periodic::minimum_image;
+    use crate::site::SiteSpecies;
+    use chematic_core::Element;
+
+    fn two_site_cubic(a: f64) -> PeriodicStructure {
+        PeriodicStructure::new(
+            Lattice::cubic(a).unwrap(),
+            vec![
+                PeriodicSite::new(
+                    vec![SiteSpecies::full(Element::NA)],
+                    FractionalCoord::new([0.0, 0.0, 0.0]),
+                    Some("A".to_string()),
+                )
+                .unwrap(),
+                PeriodicSite::new(
+                    vec![SiteSpecies::full(Element::CL)],
+                    FractionalCoord::new([0.5, 0.5, 0.5]),
+                    Some("B".to_string()),
+                )
+                .unwrap(),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn identity_supercell_is_equivalent() {
+        let s = two_site_cubic(4.0);
+        let sc = make_supercell(&s, [1, 1, 1]).unwrap();
+        assert_eq!(sc.site_count(), s.site_count());
+        assert_eq!(sc.lattice().matrix(), s.lattice().matrix());
+        for (a, b) in sc.sites().iter().zip(s.sites()) {
+            assert_eq!(a, b);
+        }
+    }
+
+    #[test]
+    fn supercell_2_1_1_doubles_a_axis_and_site_count() {
+        let s = two_site_cubic(4.0);
+        let sc = make_supercell(&s, [2, 1, 1]).unwrap();
+        assert_eq!(sc.site_count(), 4);
+        let m = sc.lattice().matrix();
+        assert!((m[0][0] - 8.0).abs() < 1e-9);
+        assert!((m[1][1] - 4.0).abs() < 1e-9);
+        assert!((m[2][2] - 4.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn supercell_2_2_2_site_count_is_original_times_multiplier_product() {
+        let s = two_site_cubic(4.0);
+        let sc = make_supercell(&s, [2, 2, 2]).unwrap();
+        assert_eq!(sc.site_count(), s.site_count() * 8);
+    }
+
+    #[test]
+    fn supercell_volume_scales_by_multiplier_product() {
+        let s = two_site_cubic(4.0);
+        for mult in [[1, 1, 1], [2, 1, 1], [2, 2, 2], [3, 1, 2]] {
+            let sc = make_supercell(&s, mult).unwrap();
+            let expected = s.lattice().volume() * f64::from(mult[0] * mult[1] * mult[2]);
+            assert!(
+                (sc.lattice().volume() - expected).abs() < 1e-6,
+                "mult={mult:?} got={} expected={expected}",
+                sc.lattice().volume()
+            );
+        }
+    }
+
+    #[test]
+    fn supercell_preserves_species_and_occupancy() {
+        let s = two_site_cubic(4.0);
+        let sc = make_supercell(&s, [2, 2, 2]).unwrap();
+        let orig_species: Vec<_> = s.sites().iter().map(|site| &site.species).collect();
+        for site in sc.sites() {
+            assert!(orig_species.contains(&&site.species));
+        }
+    }
+
+    #[test]
+    fn supercell_site_order_is_deterministic_across_calls() {
+        let s = two_site_cubic(4.0);
+        let a = make_supercell(&s, [2, 1, 2]).unwrap();
+        let b = make_supercell(&s, [2, 1, 2]).unwrap();
+        assert_eq!(a.sites(), b.sites());
+    }
+
+    #[test]
+    fn supercell_preserves_nearest_neighbor_geometry() {
+        // The nearest-neighbor distance from a site to its periodic images
+        // must be identical before and after supercell expansion (the
+        // physical structure hasn't changed, only how many periodic copies
+        // are stored explicitly).
+        let s = two_site_cubic(4.0);
+        let sc = make_supercell(&s, [2, 2, 2]).unwrap();
+        let orig_dist = minimum_image(
+            s.lattice(),
+            s.sites()[0].fractional,
+            s.sites()[1].fractional,
+        )
+        .distance;
+        let sc_dist = minimum_image(
+            sc.lattice(),
+            sc.sites()[0].fractional,
+            sc.sites()[1].fractional,
+        )
+        .distance;
+        assert!(
+            (orig_dist - sc_dist).abs() < 1e-9,
+            "orig={orig_dist} supercell={sc_dist}"
+        );
+    }
+
+    #[test]
+    fn original_structure_is_not_modified() {
+        let s = two_site_cubic(4.0);
+        let before = s.clone();
+        let _ = make_supercell(&s, [3, 2, 1]).unwrap();
+        assert_eq!(s, before);
+    }
+
+    #[test]
+    fn rejects_zero_multiplier() {
+        let s = two_site_cubic(4.0);
+        let err = make_supercell(&s, [0, 1, 1]).unwrap_err();
+        assert!(matches!(
+            err,
+            CrystalError::NonPositiveSupercellMultiplier { axis: 0, value: 0 }
+        ));
+    }
+
+    #[test]
+    fn supercell_never_fails_lattice_validation_when_original_is_valid() {
+        // Anisotropic diagonal scaling preserves the condition indicator
+        // (volume and bounding-box both scale by the same nx*ny*nz
+        // factor), so a supercell of any validated lattice must itself
+        // validate, for any positive integer multiplier triple.
+        let l = Lattice::from_parameters(5.0, 6.0, 7.0, 75.0, 100.0, 60.0).unwrap();
+        let s = PeriodicStructure::new(
+            l,
+            vec![
+                PeriodicSite::new(
+                    vec![SiteSpecies::full(Element::C)],
+                    FractionalCoord::new([0.1, 0.2, 0.3]),
+                    None,
+                )
+                .unwrap(),
+            ],
+        )
+        .unwrap();
+        for mult in [[1, 1, 1], [5, 1, 1], [1, 5, 1], [3, 4, 2]] {
+            assert!(make_supercell(&s, mult).is_ok(), "mult={mult:?}");
+        }
+    }
+}

--- a/crates/chematic-crystal/src/validation.rs
+++ b/crates/chematic-crystal/src/validation.rs
@@ -1,0 +1,62 @@
+//! Shared, crate-internal validation helpers.
+//!
+//! Every module that accepts raw `f64`/`[f64; 3]` values from a caller
+//! (rather than deriving them from an already-validated value) routes them
+//! through here, so "reject NaN/Infinity before it enters a public type" is
+//! enforced in one place instead of re-implemented per module.
+
+use crate::error::CrystalError;
+
+/// Reject a non-finite scalar.
+pub(crate) fn require_finite(value: f64, field: &'static str) -> Result<(), CrystalError> {
+    if value.is_finite() {
+        Ok(())
+    } else {
+        Err(CrystalError::NonFinite { field })
+    }
+}
+
+/// Reject a non-finite 3-vector (any component `NaN`/`Infinity`).
+pub(crate) fn require_finite3(value: [f64; 3], field: &'static str) -> Result<(), CrystalError> {
+    if value.iter().all(|c| c.is_finite()) {
+        Ok(())
+    } else {
+        Err(CrystalError::NonFinite { field })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn require_finite_accepts_finite() {
+        assert!(require_finite(1.5, "x").is_ok());
+        assert!(require_finite(0.0, "x").is_ok());
+        assert!(require_finite(-3.0, "x").is_ok());
+    }
+
+    #[test]
+    fn require_finite_rejects_nan_and_infinity() {
+        assert_eq!(
+            require_finite(f64::NAN, "x"),
+            Err(CrystalError::NonFinite { field: "x" })
+        );
+        assert_eq!(
+            require_finite(f64::INFINITY, "x"),
+            Err(CrystalError::NonFinite { field: "x" })
+        );
+        assert_eq!(
+            require_finite(f64::NEG_INFINITY, "x"),
+            Err(CrystalError::NonFinite { field: "x" })
+        );
+    }
+
+    #[test]
+    fn require_finite3_rejects_any_bad_component() {
+        assert!(require_finite3([1.0, 2.0, 3.0], "v").is_ok());
+        assert!(require_finite3([f64::NAN, 2.0, 3.0], "v").is_err());
+        assert!(require_finite3([1.0, f64::INFINITY, 3.0], "v").is_err());
+        assert!(require_finite3([1.0, 2.0, f64::NEG_INFINITY], "v").is_err());
+    }
+}

--- a/crates/chematic-crystal/tests/neighbor.rs
+++ b/crates/chematic-crystal/tests/neighbor.rs
@@ -1,0 +1,174 @@
+//! Neighbor-enumeration integration tests, including comparison against an
+//! independent brute-force oracle (hardcoded fixed-range triple loop per
+//! pair, no shared code with `chematic_crystal::neighbor`'s search-box
+//! logic).
+
+use chematic_core::Element;
+use chematic_crystal::{FractionalCoord, Lattice, PeriodicSite, PeriodicStructure, SiteSpecies};
+use std::collections::HashSet;
+
+fn brute_force_neighbors_within(
+    structure: &PeriodicStructure,
+    cutoff: f64,
+    half: i32,
+) -> HashSet<(usize, usize, [i32; 3])> {
+    let lattice = structure.lattice();
+    let sites = structure.sites();
+    let n = sites.len();
+    let mut found = HashSet::new();
+    for i in 0..n {
+        for j in 0..n {
+            // Computed as (to - from) + n, matching the natural additive
+            // decomposition the RFC's derivation itself uses (base + n) --
+            // not "(to + n) - from", which for i == j (from == to exactly)
+            // can lose the `x - x == 0.0` exactness IEEE754 guarantees and
+            // land a boundary case (e.g. an image whose true distance is
+            // exactly the cutoff) on the other side of `<=` purely from
+            // summation-order rounding, unrelated to the search-box logic
+            // this oracle exists to check.
+            let raw = [
+                sites[j].fractional.0[0] - sites[i].fractional.0[0],
+                sites[j].fractional.0[1] - sites[i].fractional.0[1],
+                sites[j].fractional.0[2] - sites[i].fractional.0[2],
+            ];
+            for a in -half..=half {
+                for b in -half..=half {
+                    for c in -half..=half {
+                        if i == j && a == 0 && b == 0 && c == 0 {
+                            continue;
+                        }
+                        let frac = [
+                            raw[0] + f64::from(a),
+                            raw[1] + f64::from(b),
+                            raw[2] + f64::from(c),
+                        ];
+                        let cart = lattice.frac_to_cart(FractionalCoord::new(frac));
+                        let dist =
+                            (cart.0[0].powi(2) + cart.0[1].powi(2) + cart.0[2].powi(2)).sqrt();
+                        if dist <= cutoff {
+                            found.insert((i, j, [a, b, c]));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    found
+}
+
+fn assert_matches_oracle(structure: &PeriodicStructure, cutoff: f64, half: i32) {
+    let got: HashSet<_> = structure
+        .neighbors_within(cutoff)
+        .unwrap()
+        .into_iter()
+        .map(|nb| (nb.center_index, nb.neighbor_index, nb.image))
+        .collect();
+    let oracle = brute_force_neighbors_within(structure, cutoff, half);
+    assert_eq!(got, oracle, "cutoff={cutoff} half={half}");
+}
+
+fn two_site_cubic(a: f64) -> PeriodicStructure {
+    PeriodicStructure::new(
+        Lattice::cubic(a).unwrap(),
+        vec![
+            PeriodicSite::new(
+                vec![SiteSpecies::full(Element::NA)],
+                FractionalCoord::new([0.0, 0.0, 0.0]),
+                Some("A".to_string()),
+            )
+            .unwrap(),
+            PeriodicSite::new(
+                vec![SiteSpecies::full(Element::CL)],
+                FractionalCoord::new([0.5, 0.5, 0.5]),
+                Some("B".to_string()),
+            )
+            .unwrap(),
+        ],
+    )
+    .unwrap()
+}
+
+#[test]
+fn cubic_matches_brute_force_oracle() {
+    let s = two_site_cubic(4.0);
+    for cutoff in [1.0, 3.5, 4.0, 6.0] {
+        assert_matches_oracle(&s, cutoff, 4);
+    }
+}
+
+#[test]
+fn triclinic_matches_brute_force_oracle() {
+    let lattice = Lattice::from_parameters(5.0, 6.0, 7.0, 75.0, 100.0, 60.0).unwrap();
+    let s = PeriodicStructure::new(
+        lattice,
+        vec![
+            PeriodicSite::new(
+                vec![SiteSpecies::full(Element::SI)],
+                FractionalCoord::new([0.1, 0.2, 0.3]),
+                None,
+            )
+            .unwrap(),
+            PeriodicSite::new(
+                vec![SiteSpecies::full(Element::O)],
+                FractionalCoord::new([0.6, 0.4, 0.9]),
+                None,
+            )
+            .unwrap(),
+        ],
+    )
+    .unwrap();
+    for cutoff in [2.0, 4.0, 6.0] {
+        assert_matches_oracle(&s, cutoff, 4);
+    }
+}
+
+#[test]
+fn site_order_change_does_not_change_the_physical_neighbor_set() {
+    // Permute the two sites' insertion order; the *set* of physically
+    // distinct (unordered pair + image, up to relabeling) neighbor facts
+    // must be identical, only the index labels swap.
+    let lattice = Lattice::cubic(4.0).unwrap();
+    let site_a = PeriodicSite::new(
+        vec![SiteSpecies::full(Element::NA)],
+        FractionalCoord::new([0.0, 0.0, 0.0]),
+        None,
+    )
+    .unwrap();
+    let site_b = PeriodicSite::new(
+        vec![SiteSpecies::full(Element::CL)],
+        FractionalCoord::new([0.5, 0.5, 0.5]),
+        None,
+    )
+    .unwrap();
+
+    let s1 = PeriodicStructure::new(lattice.clone(), vec![site_a.clone(), site_b.clone()]).unwrap();
+    let s2 = PeriodicStructure::new(lattice, vec![site_b, site_a]).unwrap();
+
+    let n1 = s1.neighbors_within(6.0).unwrap();
+    let n2 = s2.neighbors_within(6.0).unwrap();
+    assert_eq!(n1.len(), n2.len());
+
+    // Relabel s2's indices back to s1's labeling (0<->1 swap) and compare
+    // as sets.
+    let relabeled: HashSet<_> = n2
+        .iter()
+        .map(|nb| (1 - nb.center_index, 1 - nb.neighbor_index, nb.image))
+        .collect();
+    let original: HashSet<_> = n1
+        .iter()
+        .map(|nb| (nb.center_index, nb.neighbor_index, nb.image))
+        .collect();
+    assert_eq!(relabeled, original);
+}
+
+#[test]
+fn no_duplicates_across_a_wider_cutoff_sweep() {
+    let s = two_site_cubic(4.0);
+    for cutoff in [1.0, 2.0, 3.0, 5.0, 8.0] {
+        let neighbors = s.neighbors_within(cutoff).unwrap();
+        let mut seen = HashSet::new();
+        for nb in &neighbors {
+            assert!(seen.insert((nb.center_index, nb.neighbor_index, nb.image)));
+        }
+    }
+}

--- a/crates/chematic-crystal/tests/periodicity.rs
+++ b/crates/chematic-crystal/tests/periodicity.rs
@@ -17,15 +17,23 @@ fn brute_force_minimum_image(
     to: FractionalCoord,
     half: i32,
 ) -> (f64, [i32; 3]) {
+    // (to - from) + n, not "(to + n) - from" -- see the comment on the
+    // analogous oracle in tests/neighbor.rs for why the order matters at
+    // exact-distance boundaries.
+    let raw = [
+        to.0[0] - from.0[0],
+        to.0[1] - from.0[1],
+        to.0[2] - from.0[2],
+    ];
     let mut best_dist = f64::INFINITY;
     let mut best_image = [0i32; 3];
     for i in -half..=half {
         for j in -half..=half {
             for k in -half..=half {
                 let frac = [
-                    to.0[0] + f64::from(i) - from.0[0],
-                    to.0[1] + f64::from(j) - from.0[1],
-                    to.0[2] + f64::from(k) - from.0[2],
+                    raw[0] + f64::from(i),
+                    raw[1] + f64::from(j),
+                    raw[2] + f64::from(k),
                 ];
                 let cart = lattice.frac_to_cart(FractionalCoord::new(frac));
                 let dist = (cart.0[0].powi(2) + cart.0[1].powi(2) + cart.0[2].powi(2)).sqrt();
@@ -54,15 +62,20 @@ fn assert_matches_oracle(lattice: &Lattice, from: FractionalCoord, to: Fractiona
     // Multiple images can tie at the same minimal distance (e.g. a face
     // midpoint in a cubic cell); only assert the image matches when the
     // oracle's own best isn't tied with a neighboring candidate.
+    let raw = [
+        to.0[0] - from.0[0],
+        to.0[1] - from.0[1],
+        to.0[2] - from.0[2],
+    ];
     let tie_free = {
         let mut count = 0;
         for i in -half..=half {
             for j in -half..=half {
                 for k in -half..=half {
                     let frac = [
-                        to.0[0] + f64::from(i) - from.0[0],
-                        to.0[1] + f64::from(j) - from.0[1],
-                        to.0[2] + f64::from(k) - from.0[2],
+                        raw[0] + f64::from(i),
+                        raw[1] + f64::from(j),
+                        raw[2] + f64::from(k),
                     ];
                     let cart = lattice.frac_to_cart(FractionalCoord::new(frac));
                     let dist = (cart.0[0].powi(2) + cart.0[1].powi(2) + cart.0[2].powi(2)).sqrt();

--- a/crates/chematic-crystal/tests/periodicity.rs
+++ b/crates/chematic-crystal/tests/periodicity.rs
@@ -1,0 +1,364 @@
+//! Periodicity integration tests: verify `chematic_crystal::minimum_image`
+//! against an independent, from-scratch brute-force oracle (no shared code
+//! with the production bounded-search implementation, other than the
+//! `Lattice::frac_to_cart` primitive both necessarily use to turn a
+//! fractional candidate into a Cartesian distance -- the property under
+//! test is the *image search strategy*, not that primitive).
+
+use chematic_crystal::{FractionalCoord, Lattice, minimum_image};
+
+/// Independent brute-force minimum-image oracle: enumerate every integer
+/// image shift in `-half..=half` per axis directly, keep the closest.
+/// Deliberately hardcoded rather than calling any of `chematic_crystal`'s
+/// own search-bound derivation.
+fn brute_force_minimum_image(
+    lattice: &Lattice,
+    from: FractionalCoord,
+    to: FractionalCoord,
+    half: i32,
+) -> (f64, [i32; 3]) {
+    let mut best_dist = f64::INFINITY;
+    let mut best_image = [0i32; 3];
+    for i in -half..=half {
+        for j in -half..=half {
+            for k in -half..=half {
+                let frac = [
+                    to.0[0] + f64::from(i) - from.0[0],
+                    to.0[1] + f64::from(j) - from.0[1],
+                    to.0[2] + f64::from(k) - from.0[2],
+                ];
+                let cart = lattice.frac_to_cart(FractionalCoord::new(frac));
+                let dist = (cart.0[0].powi(2) + cart.0[1].powi(2) + cart.0[2].powi(2)).sqrt();
+                if dist < best_dist {
+                    best_dist = dist;
+                    best_image = [i, j, k];
+                }
+            }
+        }
+    }
+    (best_dist, best_image)
+}
+
+fn assert_matches_oracle(lattice: &Lattice, from: FractionalCoord, to: FractionalCoord, half: i32) {
+    let (oracle_dist, oracle_image) = brute_force_minimum_image(lattice, from, to, half);
+    let got = minimum_image(lattice, from, to);
+    assert!(
+        (got.distance - oracle_dist).abs() < 1e-7,
+        "distance mismatch: impl={} oracle={} (lattice={:?} from={:?} to={:?})",
+        got.distance,
+        oracle_dist,
+        lattice.matrix(),
+        from.0,
+        to.0
+    );
+    // Multiple images can tie at the same minimal distance (e.g. a face
+    // midpoint in a cubic cell); only assert the image matches when the
+    // oracle's own best isn't tied with a neighboring candidate.
+    let tie_free = {
+        let mut count = 0;
+        for i in -half..=half {
+            for j in -half..=half {
+                for k in -half..=half {
+                    let frac = [
+                        to.0[0] + f64::from(i) - from.0[0],
+                        to.0[1] + f64::from(j) - from.0[1],
+                        to.0[2] + f64::from(k) - from.0[2],
+                    ];
+                    let cart = lattice.frac_to_cart(FractionalCoord::new(frac));
+                    let dist = (cart.0[0].powi(2) + cart.0[1].powi(2) + cart.0[2].powi(2)).sqrt();
+                    if (dist - oracle_dist).abs() < 1e-9 {
+                        count += 1;
+                    }
+                }
+            }
+        }
+        count == 1
+    };
+    if tie_free {
+        assert_eq!(
+            got.image,
+            oracle_image,
+            "image mismatch (untied): lattice={:?} from={:?} to={:?}",
+            lattice.matrix(),
+            from.0,
+            to.0
+        );
+    }
+}
+
+// -- fixed-shape oracle comparisons --------------------------------------
+
+#[test]
+fn cubic_minimum_image_matches_brute_force() {
+    let l = Lattice::cubic(5.0).unwrap();
+    let pairs = [
+        ([0.05, 0.5, 0.5], [0.95, 0.5, 0.5]),
+        ([0.0, 0.0, 0.0], [0.5, 0.5, 0.5]),
+        ([0.1, 0.2, 0.3], [0.9, 0.8, 0.7]),
+        ([0.0, 0.0, 0.0], [0.0, 0.0, 0.0]),
+    ];
+    for (from, to) in pairs {
+        assert_matches_oracle(&l, FractionalCoord::new(from), FractionalCoord::new(to), 4);
+    }
+}
+
+#[test]
+fn orthorhombic_minimum_image_matches_brute_force() {
+    let l = Lattice::orthorhombic(4.0, 9.0, 15.0).unwrap();
+    let pairs = [
+        ([0.02, 0.02, 0.02], [0.98, 0.98, 0.98]),
+        ([0.3, 0.6, 0.1], [0.7, 0.1, 0.95]),
+    ];
+    for (from, to) in pairs {
+        assert_matches_oracle(&l, FractionalCoord::new(from), FractionalCoord::new(to), 4);
+    }
+}
+
+#[test]
+fn triclinic_minimum_image_matches_brute_force() {
+    let l = Lattice::from_parameters(5.0, 6.0, 7.0, 75.0, 100.0, 60.0).unwrap();
+    let pairs = [
+        ([0.02, 0.02, 0.02], [0.98, 0.98, 0.98]),
+        ([0.1, 0.9, 0.4], [0.85, 0.05, 0.6]),
+        ([0.0, 0.0, 0.0], [0.5, 0.5, 0.5]),
+    ];
+    for (from, to) in pairs {
+        assert_matches_oracle(&l, FractionalCoord::new(from), FractionalCoord::new(to), 4);
+    }
+}
+
+// -- pinned regression fixture: naive round() disagrees with the exact
+// answer, exact answer independently confirmed against the brute-force
+// oracle above (half=8) --------------------------------------------------
+
+#[test]
+fn skewed_triclinic_naive_round_disagrees_with_exact_minimum_image() {
+    // Found by randomized search (fixed seed, see
+    // randomized_triclinic_matches_brute_force_oracle below for the
+    // generator shape) and pinned here as a permanent regression fixture:
+    // naive `delta_frac -= delta_frac.round()` reports distance ~8.92
+    // Angstrom for this pair, but the true nearest periodic image (image
+    // [1, 0, 1]) is ~1.73 Angstrom away -- confirmed independently against
+    // a hardcoded brute-force oracle over -8..=8 per axis (see this
+    // module's search history; reproduced directly below via
+    // brute_force_minimum_image with half=8).
+    let l = Lattice::from_parameters(
+        7.987030736455244,
+        7.905173387101117,
+        6.17331345211384,
+        40.620511882721246,
+        63.965671339359986,
+        29.95313760584825,
+    )
+    .unwrap();
+    let from = FractionalCoord::new([0.79075334224289, 0.8185506937359817, 0.9768055390549911]);
+    let to = FractionalCoord::new([0.2902896769377683, 0.3139302234302791, 0.2814707286846695]);
+
+    // Naive round()-only "minimum image" (the rejected approach).
+    let raw = [
+        to.0[0] - from.0[0],
+        to.0[1] - from.0[1],
+        to.0[2] - from.0[2],
+    ];
+    let naive_frac = [
+        raw[0] - raw[0].round(),
+        raw[1] - raw[1].round(),
+        raw[2] - raw[2].round(),
+    ];
+    let naive_cart = l.frac_to_cart(FractionalCoord::new(naive_frac));
+    let naive_dist =
+        (naive_cart.0[0].powi(2) + naive_cart.0[1].powi(2) + naive_cart.0[2].powi(2)).sqrt();
+    assert!(
+        (naive_dist - 8.923828466561345).abs() < 1e-6,
+        "naive_dist={naive_dist}"
+    );
+
+    let got = minimum_image(&l, from, to);
+    assert!(
+        (got.distance - 1.7281501267279693).abs() < 1e-6,
+        "distance={}",
+        got.distance
+    );
+    assert_eq!(got.image, [1, 0, 1]);
+
+    // The whole point: naive and exact must disagree by a wide margin, not
+    // a rounding-noise-sized amount.
+    assert!(naive_dist - got.distance > 5.0);
+
+    // Independent oracle confirmation, same fixture.
+    let (oracle_dist, oracle_image) = brute_force_minimum_image(&l, from, to, 8);
+    assert!((oracle_dist - got.distance).abs() < 1e-7);
+    assert_eq!(oracle_image, got.image);
+}
+
+#[test]
+fn near_singular_triclinic_requires_large_image_shift() {
+    // The randomized-search draw that motivated widening the property
+    // test's oracle half-width (see the comment there): a cell with
+    // condition_indicator ~0.02 (near, but above, the RFC's 1e-3 rejection
+    // floor) whose true nearest periodic image has magnitude 11 on two
+    // axes. Independently reconfirmed with a hardcoded brute force up to
+    // half=30 (converges to the same answer from half=15 onward) --
+    // pinned here as a permanent regression fixture for "the bounded
+    // search box must actually grow to cover cells this skewed, not just
+    // a few units either way".
+    let matrix = [
+        [4.059173556199132, 0.0, 0.0],
+        [-3.500362048473072, 3.554383756790896, 0.0],
+        [1.602131464217347, 7.317385649094703, 0.21424309247456755],
+    ];
+    let l = Lattice::from_matrix(matrix).unwrap();
+    assert!(l.condition_indicator() < 0.03);
+    let from = FractionalCoord::new([0.6289642968793616, 0.7796459005054238, 0.1371601305857918]);
+    let to = FractionalCoord::new([0.7690665050911141, 0.2146789376436573, 0.09206061526606202]);
+
+    let got = minimum_image(&l, from, to);
+    assert!(
+        (got.distance - 1.253297300461551).abs() < 1e-6,
+        "distance={}",
+        got.distance
+    );
+    assert_eq!(got.image, [11, 11, -5]);
+
+    let (oracle_dist, oracle_image) = brute_force_minimum_image(&l, from, to, 15);
+    assert!((oracle_dist - got.distance).abs() < 1e-7);
+    assert_eq!(oracle_image, got.image);
+}
+
+// -- translation invariance / wrapping -----------------------------------
+
+#[test]
+fn fractional_integer_translation_invariance() {
+    let l = Lattice::from_parameters(6.0, 7.0, 8.0, 70.0, 100.0, 110.0).unwrap();
+    let from = FractionalCoord::new([0.15, 0.25, 0.35]);
+    let to = FractionalCoord::new([0.65, 0.85, 0.05]);
+    let base = minimum_image(&l, from, to).distance;
+    for shift in [[3, -2, 1], [-1, -1, -1], [7, 0, -4]] {
+        let shifted = minimum_image(&l, from, to.translated(shift)).distance;
+        assert!((base - shifted).abs() < 1e-9, "shift={shift:?}");
+    }
+}
+
+#[test]
+fn wrapped_fractional_coordinates_land_in_unit_range() {
+    let coords = [
+        FractionalCoord::new([1.7, -0.3, 4.999999]),
+        FractionalCoord::new([-3.2, 2.4, -0.0001]),
+        FractionalCoord::new([0.0, 1.0, 0.5]),
+    ];
+    for c in coords {
+        let w = c.wrapped();
+        for component in w.0 {
+            assert!(
+                (0.0..1.0).contains(&component),
+                "component {component} out of [0,1) for input {c:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn lattice_origin_translation_invariance() {
+    let l = Lattice::from_parameters(6.0, 7.0, 8.0, 70.0, 100.0, 110.0).unwrap();
+    let from = FractionalCoord::new([0.15, 0.25, 0.35]);
+    let to = FractionalCoord::new([0.65, 0.85, 0.05]);
+    let base = minimum_image(&l, from, to).distance;
+    let origin_shift = [1.37, -2.81, 0.44];
+    let from2 = FractionalCoord::new([
+        from.0[0] + origin_shift[0],
+        from.0[1] + origin_shift[1],
+        from.0[2] + origin_shift[2],
+    ]);
+    let to2 = FractionalCoord::new([
+        to.0[0] + origin_shift[0],
+        to.0[1] + origin_shift[1],
+        to.0[2] + origin_shift[2],
+    ]);
+    let shifted = minimum_image(&l, from2, to2).distance;
+    assert!((base - shifted).abs() < 1e-9);
+}
+
+// -- property-based / randomized (fixed seed, no external RNG dependency) --
+
+/// Minimal SplitMix64 PRNG -- avoids adding a `rand` dependency (not used
+/// anywhere else in this workspace either) for a handful of fixed-seed
+/// property tests. Not cryptographic; fine for test-fixture generation.
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    fn f64_in(&mut self, lo: f64, hi: f64) -> f64 {
+        let unit = (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64;
+        lo + unit * (hi - lo)
+    }
+}
+
+#[test]
+fn randomized_triclinic_matches_brute_force_oracle() {
+    // Fixed seed -> fully reproducible. Deliberately the same generator
+    // shape used to originally discover the pinned regression fixture
+    // above, so this test is the reason to trust that fixture's "exact"
+    // value wasn't cherry-picked from a broken implementation: every one of
+    // these 500 random triclinic cells is independently checked against
+    // the brute-force oracle too.
+    //
+    // condition_indicator floor is 0.15, not the RFC's validation floor of
+    // 1e-3: a *fixed*-half-width brute-force oracle (needed here so the
+    // oracle stays independent of `chematic_crystal`'s own reciprocal-
+    // vector-derived search-box logic) is only trustworthy when it's wide
+    // enough to contain the true minimum. An earlier version of this test
+    // used condition_indicator >= 0.02 and half=6, and hit a real draw
+    // (condition_indicator ~0.0204) whose true nearest image was [11, 11,
+    // -5] -- half=6 (and even half=10) missed it entirely, while
+    // `chematic_crystal::minimum_image` found it correctly (independently
+    // reconfirmed with a half=30 brute force). That was the oracle being
+    // too narrow, not a production bug -- but it means a *fixed*-half
+    // oracle can't safely cover cells that close to singular. The
+    // near-threshold regime is covered separately by the pinned regression
+    // fixture above, whose "exact" distance was independently reconfirmed
+    // up to half=8 (that fixture's true image only had magnitude 1, so
+    // half=8 was already generous there).
+    let mut rng = Rng::new(0x00C0_FFEE_1234_5678);
+    let mut checked = 0;
+    for _ in 0..500 {
+        let a = rng.f64_in(2.0, 8.0);
+        let b = rng.f64_in(2.0, 8.0);
+        let c = rng.f64_in(2.0, 8.0);
+        let alpha = rng.f64_in(25.0, 155.0);
+        let beta = rng.f64_in(25.0, 155.0);
+        let gamma = rng.f64_in(25.0, 155.0);
+        let Ok(l) = Lattice::from_parameters(a, b, c, alpha, beta, gamma) else {
+            continue;
+        };
+        if l.condition_indicator() < 0.15 {
+            continue; // skip near-degenerate draws -- a fixed-half brute-force oracle isn't trustworthy there, see comment above
+        }
+        let from = FractionalCoord::new([
+            rng.f64_in(0.0, 1.0),
+            rng.f64_in(0.0, 1.0),
+            rng.f64_in(0.0, 1.0),
+        ]);
+        let to = FractionalCoord::new([
+            rng.f64_in(0.0, 1.0),
+            rng.f64_in(0.0, 1.0),
+            rng.f64_in(0.0, 1.0),
+        ]);
+        assert_matches_oracle(&l, from, to, 8);
+        checked += 1;
+    }
+    assert!(
+        checked > 300,
+        "too many draws skipped as near-degenerate: {checked}/500"
+    );
+}

--- a/crates/chematic-crystal/tests/serde_roundtrip.rs
+++ b/crates/chematic-crystal/tests/serde_roundtrip.rs
@@ -1,0 +1,164 @@
+//! Serde round-trip tests. Only compiled when the `serde` feature is on
+//! (see `Cargo.toml`'s `[[test]] required-features`).
+
+use chematic_core::Element;
+use chematic_crystal::{
+    CartesianCoord, FractionalCoord, Lattice, Occupancy, PeriodicSite, PeriodicStructure,
+    SiteSpecies,
+};
+
+fn nacl_structure() -> PeriodicStructure {
+    let lattice = Lattice::from_parameters(5.64, 5.64, 5.64, 90.0, 90.0, 90.0).unwrap();
+    let sites = vec![
+        PeriodicSite::new(
+            vec![SiteSpecies::full(Element::NA)],
+            FractionalCoord::new([0.0, 0.0, 0.0]),
+            Some("Na1".to_string()),
+        )
+        .unwrap(),
+        PeriodicSite::new(
+            vec![SiteSpecies::full(Element::CL)],
+            FractionalCoord::new([0.5, 0.5, 0.5]),
+            Some("Cl1".to_string()),
+        )
+        .unwrap(),
+    ];
+    PeriodicStructure::new(lattice, sites).unwrap()
+}
+
+#[test]
+fn lattice_json_round_trip() {
+    let l = Lattice::from_parameters(5.0, 6.0, 7.0, 80.0, 95.0, 110.0).unwrap();
+    let json = serde_json::to_string(&l).unwrap();
+    let back: Lattice = serde_json::from_str(&json).unwrap();
+    assert_eq!(l, back);
+}
+
+#[test]
+fn periodic_structure_json_round_trip() {
+    let s = nacl_structure();
+    let json = serde_json::to_string(&s).unwrap();
+    let back: PeriodicStructure = serde_json::from_str(&json).unwrap();
+    assert_eq!(s, back);
+}
+
+#[test]
+fn fractional_and_cartesian_coord_round_trip() {
+    let f = FractionalCoord::new([0.1, 0.2, 0.3]);
+    let json = serde_json::to_string(&f).unwrap();
+    let back: FractionalCoord = serde_json::from_str(&json).unwrap();
+    assert_eq!(f, back);
+
+    let c = CartesianCoord::new([1.5, -2.5, 3.5]);
+    let json = serde_json::to_string(&c).unwrap();
+    let back: CartesianCoord = serde_json::from_str(&json).unwrap();
+    assert_eq!(c, back);
+}
+
+#[test]
+fn occupancy_round_trip() {
+    let o = Occupancy::new(0.75).unwrap();
+    let json = serde_json::to_string(&o).unwrap();
+    assert_eq!(json, "0.75");
+    let back: Occupancy = serde_json::from_str(&json).unwrap();
+    assert_eq!(o.value(), back.value());
+}
+
+#[test]
+fn site_species_round_trips_through_element_symbol() {
+    let s = SiteSpecies::full(Element::PT);
+    let json = serde_json::to_string(&s).unwrap();
+    assert!(
+        json.contains("\"Pt\""),
+        "expected element symbol in JSON, got {json}"
+    );
+    let back: SiteSpecies = serde_json::from_str(&json).unwrap();
+    assert_eq!(s, back);
+}
+
+// -- invalid numeric rejection ------------------------------------------
+
+#[test]
+fn lattice_deserialize_rejects_nan() {
+    let json = r#"{"matrix":[[1.0,0.0,0.0],[0.0,1.0,0.0],[0.0,0.0,"NaN"]]}"#;
+    // serde_json has no NaN literal token in valid JSON at all, so a raw
+    // NaN can't even parse as a number here -- the more realistic "invalid
+    // numeric value" case is a matrix that parses fine but fails Lattice's
+    // own singular/near-singular checks, exercised below. This test
+    // confirms serde_json itself rejects the malformed literal.
+    assert!(serde_json::from_str::<Lattice>(json).is_err());
+}
+
+#[test]
+fn lattice_deserialize_rejects_singular_matrix() {
+    let json = r#"{"matrix":[[1.0,0.0,0.0],[0.0,1.0,0.0],[1.0,1.0,0.0]]}"#;
+    let err = serde_json::from_str::<Lattice>(json).unwrap_err();
+    assert!(err.to_string().contains("singular"));
+}
+
+#[test]
+fn occupancy_deserialize_rejects_negative() {
+    let err = serde_json::from_str::<Occupancy>("-0.5").unwrap_err();
+    assert!(err.to_string().contains("occupancy"));
+}
+
+#[test]
+fn fractional_coord_deserialize_rejects_infinity_via_serde_json_null() {
+    // serde_json serializes non-finite f64 as `null`; deserializing that
+    // back must fail (not silently produce Infinity/NaN), whether it fails
+    // at the array-of-f64 stage or a hypothetical finite check.
+    let json = "[1.0, null, 2.0]";
+    assert!(serde_json::from_str::<FractionalCoord>(json).is_err());
+}
+
+#[test]
+fn site_species_deserialize_rejects_unknown_element_symbol() {
+    let json = r#"{"element":"Zz","occupancy":1.0}"#;
+    let err = serde_json::from_str::<SiteSpecies>(json).unwrap_err();
+    assert!(err.to_string().contains("Zz"));
+}
+
+#[test]
+fn periodic_site_deserialize_rejects_occupancy_sum_over_tolerance() {
+    let json = r#"{"species":[{"element":"Fe","occupancy":0.7},{"element":"Ni","occupancy":0.5}],"fractional":[0.0,0.0,0.0],"label":null}"#;
+    let err = serde_json::from_str::<PeriodicSite>(json).unwrap_err();
+    assert!(err.to_string().contains("occupanc"));
+}
+
+// -- field-name stability -------------------------------------------------
+
+#[test]
+fn periodic_structure_field_names_are_lattice_and_sites() {
+    let s = nacl_structure();
+    let json = serde_json::to_value(&s).unwrap();
+    let obj = json.as_object().unwrap();
+    assert!(obj.contains_key("lattice"));
+    assert!(obj.contains_key("sites"));
+    assert_eq!(obj.len(), 2);
+}
+
+#[test]
+fn periodic_site_field_names_are_species_fractional_label() {
+    let site = PeriodicSite::new(
+        vec![SiteSpecies::full(Element::NA)],
+        FractionalCoord::new([0.0, 0.0, 0.0]),
+        Some("Na1".to_string()),
+    )
+    .unwrap();
+    let json = serde_json::to_value(&site).unwrap();
+    let obj = json.as_object().unwrap();
+    assert!(obj.contains_key("species"));
+    assert!(obj.contains_key("fractional"));
+    assert!(obj.contains_key("label"));
+    assert_eq!(obj.len(), 3);
+}
+
+#[test]
+fn lattice_field_name_is_matrix_only_no_inverse() {
+    let l = Lattice::cubic(4.0).unwrap();
+    let json = serde_json::to_value(&l).unwrap();
+    let obj = json.as_object().unwrap();
+    assert_eq!(obj.len(), 1);
+    assert!(obj.contains_key("matrix"));
+    assert!(!obj.contains_key("inverse"));
+}

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -25,6 +25,13 @@ rxn         = ["smiles", "dep:chematic-rxn"]
 threed      = ["perception", "dep:chematic-3d"]
 inchi       = ["chem", "dep:chematic-inchi"]
 iupac       = ["dep:chematic-iupac"]
+# Deliberately NOT added to `full` in this PR -- see docs/rfcs/
+# chematic_crystal_foundation.md's facade-feature section and the task's
+# final report: `full` is what --all-features/docs.rs build, and whether
+# a brand-new, architecturally separate (no Molecule dependency) crate
+# should join that aggregate is left for explicit human confirmation
+# rather than assumed from precedent.
+crystal     = ["dep:chematic-crystal"]
 full        = ["smiles", "perception", "mol", "depict", "fp", "chem", "smarts", "rxn", "threed", "inchi", "iupac"]
 
 [package.metadata.docs.rs]
@@ -45,3 +52,4 @@ chematic-rxn        = { path = "../chematic-rxn",        version = "0.14.1", opt
 chematic-3d         = { path = "../chematic-3d",         version = "0.14.1", optional = true }
 chematic-inchi      = { path = "../chematic-inchi",      version = "0.14.1", optional = true }
 chematic-iupac      = { path = "../chematic-iupac",      version = "0.14.1", optional = true }
+chematic-crystal    = { path = "../chematic-crystal",    version = "0.14.1", optional = true }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -25,16 +25,16 @@ rxn         = ["smiles", "dep:chematic-rxn"]
 threed      = ["perception", "dep:chematic-3d"]
 inchi       = ["chem", "dep:chematic-inchi"]
 iupac       = ["dep:chematic-iupac"]
-# Deliberately NOT added to `full` in this PR -- see docs/rfcs/
-# chematic_crystal_foundation.md's facade-feature section. `--all-features`
-# and docs.rs (which sets `all-features = true` above) both build
-# `crystal` regardless of `full` membership, so leaving it out of `full`
-# only affects users who opt in via that one aggregate feature. Whether a
-# brand-new, architecturally separate (no Molecule dependency) crate
-# should join `full` is left for explicit human confirmation rather than
-# assumed from precedent.
 crystal     = ["dep:chematic-crystal"]
-full        = ["smiles", "perception", "mol", "depict", "fp", "chem", "smarts", "rxn", "threed", "inchi", "iupac"]
+# `full` is the aggregate of every optional facade capability (not scoped
+# to Molecule-only features) -- a user who writes `features = ["full"]`
+# expects everything, `crystal` included. `chematic-crystal`'s
+# architectural independence from `Molecule` is why it's its own crate,
+# not a reason to exclude it from this aggregate. New optional facade
+# features should default to joining `full` too unless there's a specific
+# reason not to (see docs/rfcs/chematic_crystal_foundation.md's
+# facade-feature section for the crystal-specific decision record).
+full        = ["smiles", "perception", "mol", "depict", "fp", "chem", "smarts", "rxn", "threed", "inchi", "iupac", "crystal"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -26,11 +26,13 @@ threed      = ["perception", "dep:chematic-3d"]
 inchi       = ["chem", "dep:chematic-inchi"]
 iupac       = ["dep:chematic-iupac"]
 # Deliberately NOT added to `full` in this PR -- see docs/rfcs/
-# chematic_crystal_foundation.md's facade-feature section and the task's
-# final report: `full` is what --all-features/docs.rs build, and whether
-# a brand-new, architecturally separate (no Molecule dependency) crate
-# should join that aggregate is left for explicit human confirmation
-# rather than assumed from precedent.
+# chematic_crystal_foundation.md's facade-feature section. `--all-features`
+# and docs.rs (which sets `all-features = true` above) both build
+# `crystal` regardless of `full` membership, so leaving it out of `full`
+# only affects users who opt in via that one aggregate feature. Whether a
+# brand-new, architecturally separate (no Molecule dependency) crate
+# should join `full` is left for explicit human confirmation rather than
+# assumed from precedent.
 crystal     = ["dep:chematic-crystal"]
 full        = ["smiles", "perception", "mol", "depict", "fp", "chem", "smarts", "rxn", "threed", "inchi", "iupac"]
 

--- a/crates/chematic/src/lib.rs
+++ b/crates/chematic/src/lib.rs
@@ -69,8 +69,8 @@
 //! | `inchi` | InChI and InChIKey generation |
 //! | `threed` | 3D coordinates, UFF minimization, XYZ/PDB I/O |
 //! | `iupac` | IUPAC nomenclature for simple molecules |
-//! | `crystal` | Periodic crystal structures (lattice, PBC, neighbors, supercells) -- **not** included in `full`, see `chematic-crystal`'s README |
-//! | `full` | All of the above except `crystal` |
+//! | `crystal` | Periodic crystal structures (lattice, PBC, neighbors, supercells) -- see `chematic-crystal`'s README |
+//! | `full` | All of the above |
 
 #[cfg(feature = "threed")]
 pub use chematic_3d as threed;

--- a/crates/chematic/src/lib.rs
+++ b/crates/chematic/src/lib.rs
@@ -69,7 +69,8 @@
 //! | `inchi` | InChI and InChIKey generation |
 //! | `threed` | 3D coordinates, UFF minimization, XYZ/PDB I/O |
 //! | `iupac` | IUPAC nomenclature for simple molecules |
-//! | `full` | All of the above |
+//! | `crystal` | Periodic crystal structures (lattice, PBC, neighbors, supercells) -- **not** included in `full`, see `chematic-crystal`'s README |
+//! | `full` | All of the above except `crystal` |
 
 #[cfg(feature = "threed")]
 pub use chematic_3d as threed;
@@ -77,6 +78,8 @@ pub use chematic_3d as threed;
 pub use chematic_chem as chem;
 #[cfg(feature = "smiles")]
 pub use chematic_core as core;
+#[cfg(feature = "crystal")]
+pub use chematic_crystal as crystal;
 #[cfg(feature = "depict")]
 pub use chematic_depict as depict;
 #[cfg(feature = "fp")]

--- a/docs/crystal_scope.md
+++ b/docs/crystal_scope.md
@@ -1,0 +1,61 @@
+# `chematic-crystal` scope
+
+`chematic-crystal` is a structural/geometric foundation for periodic
+(crystalline) materials, meant to be consumed by future higher-level
+projects (`mikiwame` for explainable materials diagnostics, `gugen` for
+synthesis/process planning) without those projects, or their concerns,
+living in this crate.
+
+## In scope (v0.1)
+
+- `Lattice`: 3x3 matrix + inverse, cell-parameter constructors, volume,
+  reciprocal vectors, fractional<->Cartesian conversion, validation
+  (rejects `NaN`/`Infinity`/non-positive lengths/degenerate angles/singular
+  and near-singular matrices).
+- `FractionalCoord` / `CartesianCoord`: distinct newtypes so the two spaces
+  can't be silently mixed up at a call site.
+- `PeriodicSite` / `SiteSpecies` / `Occupancy`: one or more (element,
+  occupancy) pairs per site, occupancy-sum validation, room for future
+  disorder without a breaking change.
+- `PeriodicStructure`: lattice + sites, `validate()`, coordinate wrapping,
+  periodic-neighbor enumeration, diagonal supercell generation.
+- Exact PBC displacement/minimum-image (bounded exhaustive search derived
+  from reciprocal vectors -- see `docs/rfcs/chematic_crystal_foundation.md`),
+  verified against a from-scratch brute-force oracle, including triclinic
+  cells.
+- Diagonal supercells (`[nx, ny, nz]`, each `>= 1`).
+- Optional `serde` feature (JSON round-trip through validated constructors,
+  not raw field derives).
+- `wasm32-unknown-unknown` build target.
+
+## Out of scope (v0.1) -- do not assume these exist
+
+- Symmetry: no space-group determination, no symmetry-operation search, no
+  Wyckoff positions, no primitive/conventional cell conversion, no Niggli
+  reduction, no spglib (or any) FFI.
+- No CIF parser rewrite. `chematic_mol::cif::{parse_cif, write_cif,
+  UnitCell}` are untouched; a future `parse_cif_structure() ->
+  PeriodicStructure` adapter is sketched (not implemented) in
+  `docs/rfcs/chematic_crystal_foundation.md`.
+- No POSCAR/VASP I/O, no XRD simulation, no crystal fingerprinting.
+- No oxidation-state inference, no coordination-geometry classification.
+- No DFT, no formation-energy or phase-diagram computation, no band
+  structure, no phonons.
+- No defect generation, no surface/slab construction.
+- No materials-ML models.
+- No prediction of stability, synthesizability, or any other materials
+  property -- this crate stores and computes pure geometry, nothing more.
+- No `mikiwame` diagnostics, no `gugen` synthesis planning -- those are
+  separate crates/projects layered on top, not part of this repository's
+  scope in this PR.
+- No Python (`chematic-py`), WASM (`chematic-wasm`), or MCP
+  (`chematic-mcp`) bindings.
+- No arbitrary 3x3 integer supercell transform, only diagonal
+  `[nx, ny, nz]`.
+- No spatial-partitioning / cell-list neighbor-search optimization --
+  correctness first, the baseline neighbor search is an exact bounded
+  enumeration, not necessarily the fastest one possible.
+
+If a task or PR touching `chematic-crystal` starts to need any of the above,
+that is a signal to stop and open a new RFC rather than grow this crate's
+scope inline.

--- a/docs/rfcs/chematic_crystal_foundation.md
+++ b/docs/rfcs/chematic_crystal_foundation.md
@@ -219,24 +219,26 @@ out).
   (each describes a different center's neighbor shell), not duplicates of
   each other.
 
-## Facade feature: `crystal` added, but **not** to `full` (open question, not decided here)
+## Facade feature: `crystal` added, and included in `full` (decided)
 
 `crates/chematic/Cargo.toml` gains an optional `crystal =
 ["dep:chematic-crystal"]` feature and a `pub use chematic_crystal as
 crystal` re-export gated on it, following the exact shape every other
-facade feature already uses (`smiles`, `mol`, `chem`, ...). Whether
-`crystal` also joins the `full`
-aggregate feature (which today lists every other optional feature) is
-**not decided in this PR** -- left for explicit human confirmation. The
-precedent ("every feature is in `full`") argues for inclusion; the
-project's convention of not assuming when unclear ("不明確ならfullへ含めず
-stop-and-report") argues for leaving it out until a human confirms, since
-`crystal` is architecturally separate from every other facade feature (no
-`Molecule` dependency) in a way `full`'s existing members are not. Note
-that `--all-features` and docs.rs (which sets `all-features = true`) both
-build `crystal` regardless of `full` membership -- leaving it out of `full`
-only affects users who opt in via that one aggregate feature, not
-exhaustive-build tooling. This PR leaves `crystal` out of `full`.
+facade feature already uses (`smiles`, `mol`, `chem`, ...).
+
+Whether `crystal` also joins the `full` aggregate feature was initially
+left open in this PR pending explicit human confirmation -- the project
+owner has since decided **yes**: `full` is operated as the aggregate of
+*every* optional facade capability, not scoped to `Molecule`-only
+features, and a user who writes `features = ["full"]` expects everything,
+`crystal` included. `chematic-crystal`'s architectural independence from
+`Molecule` (see above) is why it's its own crate, not a reason to exclude
+it from `full`. This does **not** change the facade's `default` feature
+(still `[]`) -- only explicit `--features full` (or `--all-features`,
+which already built `crystal` regardless of `full` membership either way)
+users are affected. Convention going forward: a new optional facade
+feature should default to joining `full` too, unless there's a specific
+reason not to.
 
 ## WASM constraint
 

--- a/docs/rfcs/chematic_crystal_foundation.md
+++ b/docs/rfcs/chematic_crystal_foundation.md
@@ -222,9 +222,10 @@ out).
 ## Facade feature: `crystal` added, but **not** to `full` (open question, not decided here)
 
 `crates/chematic/Cargo.toml` gains an optional `crystal =
-["dep:chematic-crystal"]` feature and a `pub mod crystal` re-export gated on
-it, following the exact shape every other facade feature already uses
-(`smiles`, `mol`, `chem`, ...). Whether `crystal` also joins the `full`
+["dep:chematic-crystal"]` feature and a `pub use chematic_crystal as
+crystal` re-export gated on it, following the exact shape every other
+facade feature already uses (`smiles`, `mol`, `chem`, ...). Whether
+`crystal` also joins the `full`
 aggregate feature (which today lists every other optional feature) is
 **not decided in this PR** -- left for explicit human confirmation. The
 precedent ("every feature is in `full`") argues for inclusion; the

--- a/docs/rfcs/chematic_crystal_foundation.md
+++ b/docs/rfcs/chematic_crystal_foundation.md
@@ -226,12 +226,16 @@ out).
 it, following the exact shape every other facade feature already uses
 (`smiles`, `mol`, `chem`, ...). Whether `crystal` also joins the `full`
 aggregate feature (which today lists every other optional feature) is
-**not decided in this PR** -- see the Stop-and-report section of the final
-task report. The precedent ("every feature is in `full`") argues for
-inclusion; the spec's explicit instruction ("不明確ならfullへ含めず
+**not decided in this PR** -- left for explicit human confirmation. The
+precedent ("every feature is in `full`") argues for inclusion; the
+project's convention of not assuming when unclear ("不明確ならfullへ含めず
 stop-and-report") argues for leaving it out until a human confirms, since
-`full` is what `--all-features` and docs.rs builds exercise project-wide.
-This PR leaves `crystal` out of `full`.
+`crystal` is architecturally separate from every other facade feature (no
+`Molecule` dependency) in a way `full`'s existing members are not. Note
+that `--all-features` and docs.rs (which sets `all-features = true`) both
+build `crystal` regardless of `full` membership -- leaving it out of `full`
+only affects users who opt in via that one aggregate feature, not
+exhaustive-build tooling. This PR leaves `crystal` out of `full`.
 
 ## WASM constraint
 

--- a/docs/rfcs/chematic_crystal_foundation.md
+++ b/docs/rfcs/chematic_crystal_foundation.md
@@ -1,0 +1,323 @@
+# chematic-crystal foundation
+
+Branch: `feat/chematic-crystal-foundation`. Scope: a new crate providing pure
+structural/geometric representation of periodic (crystal) materials --
+lattice, fractional/Cartesian coordinates, periodic sites, PBC displacement,
+periodic neighbor enumeration, diagonal supercells. No symmetry, no CIF
+rewrite, no `Molecule` changes. This document is the Phase 0 audit +
+design record the implementation phases (1-5) build against.
+
+## Why a new crate, not new `Molecule` fields
+
+`chematic_core::Molecule` is a bond graph: atoms + typed edges, with
+aromaticity, implicit-hydrogen inference, and stereo perception all defined
+in terms of that graph. A crystal's "neighbors" are a function of geometry
+and a periodic lattice, not chemical bonding -- two atoms 3.2 Angstrom apart
+across a cell boundary are a coordination-sphere fact, not evidence of a
+`Bond`. Encoding periodicity onto `Molecule` would force every consumer of
+`Molecule` (SMILES, aromaticity, CIP, fingerprints, depiction -- the entire
+existing crate graph) to reason about a periodicity dimension that is
+meaningless to them, and would tempt future code into auto-deriving `Bond`
+edges from periodic proximity, silently smuggling molecular semantics into
+what should stay a geometry fact.
+
+`PeriodicStructure` is therefore a distinct first-class type: lattice +
+sites (element/occupancy + fractional position), no bond graph at all. It
+depends on `chematic-core` only for `Element` (and, per audit below, cannot
+depend on it for anything else without adding an unwanted dependency).
+`Molecule` is untouched by this work -- no new fields, no new variants.
+
+## Type ownership
+
+| Type | Crate | Concept |
+|---|---|---|
+| `Molecule` | `chematic-core` | bond graph, chemistry semantics |
+| `Element` | `chematic-core` | shared, reused as-is |
+| `Coords3D`/`Point3` | `chematic-core` | atom-indexed 3D storage for `Molecule` conformers -- **not** reused here (see below) |
+| `Lattice`, `PeriodicSite`, `PeriodicStructure`, `FractionalCoord`, `CartesianCoord`, `Occupancy` | `chematic-crystal` (new) | periodic structure |
+| `UnitCell` (existing) | `chematic-mol::cif` | legacy CIF-parser-local cell parameters; unchanged (see CIF section) |
+| `BoxVectors` | `chematic-ewald` | MD-simulation periodic box; unchanged, no dependency edge to/from `chematic-crystal` |
+
+**`chematic_core::coords3d::Coords3D` was audited and deliberately not
+reused.** It stores one `Point3` per atom indexed by `AtomIdx` (insertion
+order into a `Molecule`) -- its own doc comment states it exists so
+`chematic-mol` doesn't have to pull in `chematic-3d`'s heavier dependency
+chain for a plain per-atom Cartesian point. `PeriodicStructure` has no
+`Molecule`/`AtomIdx` in the picture at all, and needs **fractional**
+coordinates as the primary representation (Cartesian is derived), plus a
+type-level distinction between the two coordinate spaces that `Point3` does
+not carry. Reusing it would mean either (a) storing fractional coordinates
+in a type named/shaped for Cartesian atom storage, confusing readers, or (b)
+depending on `chematic-core::coords3d` for a type whose invariants don't
+match this crate's needs. Writing `FractionalCoord`/`CartesianCoord` as
+small local newtypes costs a few lines and keeps the distinction the spec
+requires (never take a fractional value where Cartesian is expected, or vice
+versa) enforceable by the type checker.
+
+## Dependency direction
+
+```
+chematic-core  <---  chematic-crystal  <---  chematic (facade, optional feature)
+chematic-core  <---  chematic-mol      (existing CIF parser, unchanged)
+```
+
+`chematic-crystal` depends on `chematic-core` only (plus optional `serde`).
+It does **not** depend on `chematic-mol`, `chematic-ewald`, or any other
+domain crate. `chematic-mol` does not depend on `chematic-crystal` in this
+PR either -- see "CIF migration" below for why the natural
+`chematic-mol -> chematic-crystal` adapter direction is deferred to RFC-only
+this round.
+
+## Matrix convention (binding for all of `chematic-crystal`)
+
+`Lattice::matrix()` is `[[f64; 3]; 3]` with **rows = lattice vectors a, b,
+c** (`matrix[0]` = a, `matrix[1]` = b, `matrix[2]` = c). A Cartesian point is
+obtained from fractional coordinates by **row-vector x matrix**:
+
+```
+cartesian = fractional . matrix          (fractional treated as a row vector)
+cartesian_k = sum_j fractional_j * matrix[j][k]
+```
+
+This is the same row-vector convention `chematic_ewald::BoxVectors` already
+uses (`BoxVectors(pub [[f64; 3]; 3])`, rows = box vectors, audited in
+`crates/chematic-ewald/src/lib.rs`) -- chosen deliberately so a future
+`Lattice <-> BoxVectors` conversion helper (not implemented in this PR, out
+of scope) is a straight field copy, no transpose. `chematic-crystal` does
+**not** depend on `chematic-ewald` to get this; the convention is just kept
+compatible in case a bridge is written later, by either side, without a
+breaking transpose.
+
+It's also the convention `chematic_mol::cif::UnitCell::frac_to_cart` already
+implements algebraically (`X = a.fx + b.cos(gamma).fy + c.cos(beta).fz`,
+i.e. `fx * a_vec + fy * b_vec + fz * c_vec`) -- `Lattice::from_parameters`
+reproduces the same IUCr formula, so a CIF-parsed cell and a
+`Lattice::from_parameters` cell built from the same six numbers agree
+bit-for-bit-modulo-fp on Cartesian output.
+
+**Reciprocal vectors** use the crystallographic (no `2*pi`) convention:
+`a_i . b_j = delta_ij`. Under the row convention above, `matrix . inverse =
+I`, so `b_j` (row `j` of the reciprocal matrix) is **column `j` of
+`inverse`**, not row `j` -- this is a real transposition, not a naming
+choice, and is asserted directly in `lattice.rs`'s test suite
+(`a_i . b_j == delta_ij` for all 9 pairs) rather than trusted by inspection.
+
+## Coordinate convention
+
+- `FractionalCoord([f64; 3])`: dimensionless, lattice-relative. Not
+  range-restricted by the type itself (a raw fractional value can legally
+  fall outside `[0, 1)` -- e.g. mid-calculation before wrapping); `.wrapped()`
+  reduces each component into `[0, 1)` via `rem_euclid(1.0)`.
+- `CartesianCoord([f64; 3])`: Angstrom, same units as the rest of chematic
+  (`chematic_core::coords3d::Point3`, MOL/SDF, PDB all use Angstrom).
+- Constructors and structure-level `validate()`/`new()` reject non-finite
+  (`NaN`/`Infinity`) components; the newtypes' fields stay `pub` per the
+  spec sketch; unwrapped direct field construction is possible but every
+  *validated* entry point (`Lattice::from_matrix`, `PeriodicSite::new`,
+  `PeriodicStructure::new`) runs a finiteness check, and `validate()` is
+  callable on-demand for structures assembled by hand.
+
+## PBC displacement / minimum-image algorithm
+
+**Decision: exact bounded enumeration, not `round()`-only minimum image.**
+`delta_frac -= delta_frac.round()` is only exact for cells close to
+orthogonal; for a sufficiently skewed triclinic cell the true nearest
+periodic image is not the one obtained by rounding each fractional
+component independently, because "nearest in fractional space per axis"
+and "nearest in Cartesian space" diverge once lattice vectors are not close
+to mutually perpendicular. The chosen algorithm derives a *provably
+sufficient* finite search box from the lattice's own reciprocal vectors, so
+it is exact for every valid (non-singular, `condition_indicator` above
+threshold) lattice, not an approximation:
+
+1. Reduce the raw fractional delta component-wise into `[-0.5, 0.5]`:
+   `base = delta_frac - round(delta_frac)`. This is one legitimate periodic
+   image (the "naive" one) with Cartesian distance `D0`.
+2. For a displacement `r = (base + n) . M` (row convention) and reciprocal
+   rows `b_j` (`a_i . b_j = delta_ij`), the identity `(base + n)_j = r . b_j`
+   plus Cauchy-Schwarz gives `|base_j + n_j| <= |r| * |b_j|`. Any image
+   at least as good as the naive one (`|r| <= D0`) must therefore have
+   `n_j` inside `[-D0*|b_j| - base_j, D0*|b_j| - base_j]` for every axis `j`
+   -- a finite, explicitly computed integer box.
+3. Enumerate every integer point in that box (small for any well-conditioned
+   cell -- a handful of candidates per axis), evaluate the true Cartesian
+   distance for each, keep the minimum. Ties broken by lexicographically
+   smallest image vector for determinism.
+
+This is the spec's "recommended" option (derive a safe search range
+mathematically, verify against a brute-force oracle) rather than the
+"reduced-cell-only, fallback elsewhere" alternative -- the bound holds for
+any non-singular lattice, so there is no fallback branch to maintain.
+`neighbors_within` reuses the same bound with `D = cutoff` instead of `D0`
+(a cutoff-radius neighbor search needs every image within the cutoff, not
+just the closest one; the box-then-filter shape is identical).
+
+Verification: `tests/periodicity.rs` and `tests/neighbor.rs` compare this
+algorithm against a **from-scratch** brute-force oracle (hardcoded
+`-4..=4` per-axis triple loop, sharing no code with the production path) on
+cubic, orthorhombic, and randomized triclinic cells (fixed-seed PRNG, no new
+dependency -- see "Property-based tests" in the crate's test files), plus a
+pinned regression fixture: a specific skewed triclinic cell where naive
+`round()`-only minimum image disagrees with the true nearest image, found by
+randomized search and committed so the exact-vs-naive distinction is
+regression-tested, not just asserted in prose.
+
+## Occupancy model
+
+`Occupancy(f64)`, finite, `>= 0`, no fixed upper bound on a single value
+(placeholder/vacancy modeling can have a single low-occupancy species). Site
+validity is a **sum** constraint: `SiteSpecies` occupancies at one
+`PeriodicSite` must sum to `<= 1.0 + OCCUPANCY_SUM_TOLERANCE`. Summing to
+less than 1.0 is legal (vacancy). An empty `species: Vec<SiteSpecies>` is
+rejected as a construction error (`CrystalError::EmptySpeciesList`) rather
+than silently treated as a vacant/ghost site, per the spec's requirement to
+either forbid or explicitly define the empty case. `v0.1` does not implement
+any disorder-aware chemistry on top of multi-species sites (no averaged
+scattering, no partial-occupancy energetics) -- the type only guarantees the
+data model won't need a breaking change when that lands.
+
+## serde design note: `chematic-core::Element` has no serde support
+
+`chematic-core` is an intentionally zero-external-dependency crate (its own
+`lib.rs` doc: "Zero external dependencies: compiles to wasm32-unknown-unknown
+without modification") and `Element` does not derive `Serialize`/
+`Deserialize`. Adding a `serde` feature to `chematic-core` to support this
+one new downstream crate would be a real change to a foundational,
+widely-depended-on crate -- out of the declared scope ("Moleculeを拡張し
+ない" extends in spirit to "don't touch chematic-core's dependency profile
+either", and the task brief lists only `chematic-crystal`'s own files as
+in-scope). Instead, `SiteSpecies` (the only type holding an `Element`
+directly) implements `Serialize`/`Deserialize` **by hand**, round-tripping
+through the element's existing public `symbol()`/`from_symbol()` API as a
+string (`"Na"`, `"Cl"`, ...) rather than deriving through `Element`. Every
+other `chematic-crystal` type with private/derived-state fields (`Lattice`
+stores a redundant `inverse` alongside `matrix`; `PeriodicStructure`'s
+constructor is where validation lives) also gets a hand-written
+`Deserialize` that round-trips through the crate's own validated
+constructors (`Lattice::from_matrix`, `PeriodicStructure::new`) rather than
+a field-literal derive, so a deserialized value can never skip validation
+that a normally-constructed one goes through. `Occupancy`,
+`FractionalCoord`, `CartesianCoord` do the same for the same reason
+(reject non-finite / out-of-range values on the way in, not just on the way
+out).
+
+## Neighbor semantics
+
+- `(same site, image [0,0,0])` excluded (trivial self-pair).
+- `(same site, nonzero image)` **not** auto-excluded -- physically valid for
+  small cells (an atom interacting with its own periodic image).
+- Distance `0` or near-`0` for *distinct* sites/images is kept, not filtered
+  -- e.g. two disorder-split sites at the same fractional position.
+- Cutoff comparison is `distance <= cutoff` (inclusive boundary).
+- Output order is sorted by `(center_index, neighbor_index, image[0],
+  image[1], image[2])` -- integers only, no float comparison, so the order
+  is deterministic independent of platform/optimization-level float
+  rounding differences.
+- The neighbor list is a **full** (not half/bonded) list: for two distinct
+  sites `i != j` within cutoff, both `(center=i, neighbor=j, image=n)` and
+  `(center=j, neighbor=i, image=-n)` are legitimate, independent entries
+  (each describes a different center's neighbor shell), not duplicates of
+  each other.
+
+## Facade feature: `crystal` added, but **not** to `full` (open question, not decided here)
+
+`crates/chematic/Cargo.toml` gains an optional `crystal =
+["dep:chematic-crystal"]` feature and a `pub mod crystal` re-export gated on
+it, following the exact shape every other facade feature already uses
+(`smiles`, `mol`, `chem`, ...). Whether `crystal` also joins the `full`
+aggregate feature (which today lists every other optional feature) is
+**not decided in this PR** -- see the Stop-and-report section of the final
+task report. The precedent ("every feature is in `full`") argues for
+inclusion; the spec's explicit instruction ("不明確ならfullへ含めず
+stop-and-report") argues for leaving it out until a human confirms, since
+`full` is what `--all-features` and docs.rs builds exercise project-wide.
+This PR leaves `crystal` out of `full`.
+
+## WASM constraint
+
+`chematic-crystal`'s only dependency is `chematic-core` (zero-dependency,
+WASM-clean) plus optional `serde` (also WASM-clean, used elsewhere in this
+workspace's WASM build already via `chematic-wasm`). `cargo check -p
+chematic-crystal --target wasm32-unknown-unknown` is part of this PR's
+quality gates (Phase 5). `chematic-wasm`/`chematic-py`/`chematic-mcp` are
+not touched -- no bindings are added in this PR.
+
+## CIF migration (RFC only -- no code change to `chematic-mol` in this PR)
+
+`chematic_mol::cif` today:
+
+- Parses `_atom_site_*` loops into a flat `Molecule` (atoms only, no bonds)
+  plus a `Vec<(f64, f64, f64)>` of orthogonal Cartesian coordinates and an
+  optional `UnitCell { a, b, c, alpha, beta, gamma }`.
+- Performs no symmetry expansion -- effectively P1 (every atom in the file
+  is taken literally; symmetry-equivalent positions implied by a space group
+  are not generated).
+- `UnitCell` carries only the six cell parameters (no matrix, no inverse, no
+  reciprocal vectors) and exposes `volume()`/`frac_to_cart()` computed
+  ad hoc from those six numbers each call.
+- Does not preserve occupancy (`_atom_site_occupancy` is not read) or model
+  disorder.
+- Returns a `Molecule`, not a periodic-aware first-class type -- a
+  CIF-parsed structure today has no distinction between "this is a periodic
+  crystal" and "this is a normal isolated molecule with 3D coordinates
+  attached", other than the caller happening to also have an `Option
+  <UnitCell>` in hand.
+
+**Semantic difference from the new `Lattice`/`PeriodicStructure`:**
+`UnitCell` is parameters-only (recomputes derived quantities every call,
+no reciprocal-vector API, no validation beyond what `parse_cif` itself
+enforces at parse time); `Lattice` is a validated matrix + cached inverse
+with reciprocal vectors, condition-number rejection, and the exact
+minimum-image machinery above. They are not drop-in replacements for each
+other today.
+
+**Future API shape (not implemented, sketch only):**
+
+```rust
+// crates/chematic-mol/src/cif.rs -- future, not in this PR
+pub fn parse_cif_structure(input: &str) -> Result<PeriodicStructureResult, CifError>;
+
+pub struct PeriodicStructureResult {
+    pub structure: chematic_crystal::PeriodicStructure,
+    pub labels: Vec<String>,           // _atom_site_label, if present
+    // occupancy would come from _atom_site_occupancy, read but currently discarded
+}
+```
+
+This would require `chematic-mol` to depend on `chematic-crystal` (the
+correct direction per this RFC's dependency-direction section -- never the
+reverse). `chematic-mol` currently has **no `[features]` table at all** and
+is a direct, unconditional dependency of `chematic-wasm`,
+`chematic-fp`/`chematic-chem`/`chematic-3d` (via their own dep chains), and
+`chematic-py` -- adding a new unconditional dependency (or introducing
+`chematic-mol`'s first-ever optional feature, purely to gate this one
+addition) is a structural change to a widely-depended-on crate's dependency
+graph and build surface, which the task brief calls out explicitly as a
+case to leave as RFC-only rather than implement
+("この追加で既存feature graphやWASM buildへ影響が出る場合は、実装せずRFC
+だけに留めて報告"). **Not implemented in this PR.** `parse_cif`/`write_cif`/
+`UnitCell` are unchanged, not deprecated, not touched.
+
+## Future symmetry boundary (non-goal, noted for later RFCs)
+
+Space-group determination, symmetry-operation search, Wyckoff positions,
+primitive/conventional cell reduction, Niggli reduction, and any spglib FFI
+are explicitly out of scope for `chematic-crystal` v0.1 and are not stubbed
+or scaffolded here. A future symmetry layer would most naturally sit
+*above* `PeriodicStructure` (consuming it, producing symmetry metadata
+alongside it or a reduced structure) rather than inside this crate, to keep
+`chematic-crystal` a stable, dependency-light base that `mikiwame`/`gugen`
+and a future symmetry crate can all build on independently. No interface for
+that layer is designed in this PR.
+
+## Non-goals (this PR)
+
+space group / symmetry operations / Wyckoff positions / primitive-conventional
+cell conversion / Niggli reduction / spglib FFI / CIF parser rewrite / POSCAR
+parser / XRD / crystal fingerprinting / oxidation-state inference /
+coordination-geometry classification / DFT / formation energy / phase
+diagrams / band structure / phonons / defect generation / surfaces & slabs /
+materials ML / `mikiwame` diagnostics / `gugen` synthesis planning /
+Python/WASM/MCP bindings / arbitrary 3x3 integer supercell transforms
+(diagonal only) / spatial-partitioning neighbor-search optimization
+(baseline is a correct, not necessarily fast, exact search).


### PR DESCRIPTION
## Summary

`chematic-crystal` foundation, Phases 0-5: a new crate for periodic
(crystal) structure representation and geometry -- `Lattice`
(triclinic-capable), `FractionalCoord`/`CartesianCoord`, `PeriodicSite`/
`SiteSpecies`/`Occupancy` (disorder-ready), and `PeriodicStructure` with
exact periodic minimum-image distance, cutoff neighbor enumeration, and
diagonal supercells. Deliberately **not** an extension of
`chematic_core::Molecule` -- see `docs/rfcs/chematic_crystal_foundation.md`
for the rationale.

This PR (Phase 5) is docs/wiring on top of the already-committed Phases
1-4 (lattice, `PeriodicStructure`, minimum-image, neighbor search +
supercells + benchmarks):

- Wires `chematic-crystal` into the `chematic` facade behind an opt-in
  `crystal` feature (`crates/chematic/Cargo.toml`,
  `crates/chematic/src/lib.rs`), **included in `full`** -- see the
  resolved decision below. `default` is unchanged (still `[]`).
- Adds a runnable example (`crates/chematic-crystal/examples/basic_structure.rs`):
  CsCl-type cell -> lattice inspection -> periodic neighbors -> supercell.
- Documents Phase 4 benchmark numbers in `crates/chematic-crystal/README.md`,
  with a corrected O(n^2) scaling note (an earlier draft's "~100x
  pair-count increase" estimate didn't match the actual 125->1000 site
  ratio; fixed to the correct 64x, with the observed 49.5x/64.9x
  cubic/triclinic slowdowns bracketing it).
- CHANGELOG entry under `[Unreleased]`.

## Bug fix: `minimum_image()` tie-break contract violation

Found in spot-review. `minimum_image` seeded its running `best` with the
naive `round()`-based candidate *before* the search loop, then only
replaced it on strict `<`. The RFC's own spec (`docs/rfcs/
chematic_crystal_foundation.md`, "Ties broken by lexicographically
smallest image vector for determinism") was already correct -- the
implementation just didn't match it: a later candidate at the *same*
distance never overwrote the naive seed, even when it was
lexicographically smaller. The distance itself was always correct (why
the existing brute-force-oracle test didn't catch it), and the existing
integration tests deliberately skip image comparison on ties
(`tests/periodicity.rs`'s `tie_free` gate), so this had zero test
coverage before now.

Fix (`crates/chematic-crystal/src/periodic.rs`): `best` now starts as
`None`; the first candidate found in ascending search order wins ties
naturally, since `image = image0 + m` and `m` is enumerated ascending
per axis. `m = [0, 0, 0]` (the naive candidate) is still always inside
the search box by construction, so it's still considered, just not
favored anymore. Two new regression tests pin a concrete tie (`Lattice::
cubic(4.0)`, `from = [0.5, 0, 0]`, `to = [0, 0, 0]`: images `[0,0,0]` and
`[1,0,0]` tie at distance 2.0, correct answer `[0,0,0]`) plus the
`from`/`to`-swapped case (tied pair becomes `[-1,0,0]`/`[0,0,0]`,
correct answer `[-1,0,0]` -- same "smallest wins" invariant, different
tied pair since `image` is defined relative to `to`).

Checked for the same seed-with-naive-first shape elsewhere in the crate
(`grep -rn 'dist0\|best.distance\|let mut best' crates/chematic-crystal/
src/*.rs`): only this one site. Checked callers of `minimum_image`
outside `periodic.rs`: `supercell.rs`'s own test only reads `.distance`
(unaffected), and `neighbor.rs` has an independent box-then-filter
search that keeps every in-cutoff candidate rather than tracking a
single running minimum, so it doesn't share this bug shape.

No CHANGELOG entry added for this fix -- `chematic-crystal` is
unreleased in this same PR, so a "fixed" note for code that never
shipped would be noise.

## Decision: `crystal` included in `full` (resolved by the project owner)

Whether `crystal` should join the `full` aggregate feature was originally
left open pending explicit human confirmation. Resolved: **yes**, `full`
is operated as the aggregate of *every* optional facade capability (not
scoped to `Molecule`-only features), and a user who writes
`features = ["full"]` expects everything, `crystal` included.
`chematic-crystal`'s architectural independence from `Molecule` is why
it's its own crate, not a reason to exclude it from `full`. This does
**not** change `default` (still `[]`) -- only explicit `--features full`
users are affected (`--all-features` and docs.rs, which sets
`all-features = true`, already built `crystal` regardless of `full`
membership either way). Convention going forward: a new optional facade
feature should default to joining `full` too, unless there's a specific
reason not to.

## Quality gates run this session

`chematic-crystal`-specific:
- `cargo fmt -p chematic-crystal -- --check`
- `cargo clippy -p chematic-crystal --all-features --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p chematic-crystal --all-features --no-deps`
- `cargo test -p chematic-crystal --all-features` -- 61 unit (+2 tie-break regression tests) + 27 integration + 6 doctest, all passing
- `cargo check -p chematic-crystal --all-features --target wasm32-unknown-unknown`
- `cargo run -p chematic-crystal --example basic_structure`

Facade-specific (re-verified after adding `crystal` to `full`):
- `cargo check -p chematic --features full` -- clean
- `cargo test -p chematic --features full` -- 1 unit test + 1 ignored doctest, 0 failures
- `cargo check -p chematic --features crystal` -- clean
- `cargo check -p chematic --no-default-features` -- clean

Workspace-wide:
- `cargo test --workspace --all-features` -- 77/77 `test result: ok` blocks, 0 failures
- `cargo test --workspace --no-default-features` -- 76/76 `test result: ok` blocks, 0 failures (`serde_roundtrip` correctly skipped via `required-features`)

CI-exact commands (matching `.github/workflows/ci.yml` / `security.yml`):
- `cargo clippy --workspace -- -D warnings` -- clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` -- clean
- `cargo test --workspace --lib --quiet` -- 20/20 `test result: ok` blocks, 0 failures
- `cargo test --workspace --tests --quiet` -- 56/56 `test result: ok` blocks, 0 failures
- `cargo fmt --all -- --check` -- clean

(The CI-exact pair and default-features clippy were already green before this
round; re-run here because `Cargo.toml` changed, not newly added.)

All green. Containment check: `grep -rn '"full"' --include=Cargo.toml`
repo-wide matches only `crates/chematic/Cargo.toml` itself (the comment),
and a separate grep over `.github/workflows/` for `--features full`
returns nothing -- so this change's blast radius is the facade crate
alone.

## Known pre-existing gap (not introduced by this PR, not fixed here)

`RUSTDOCFLAGS="-D warnings" cargo doc -p chematic --all-features --no-deps`
fails on ambiguous/unresolved intra-doc links at `crates/chematic/src/lib.rs:25`
and `:32` (`chem::standardize`, `threed::minimize`). Confirmed via
`git diff fa63822 HEAD -- crates/chematic/src/lib.rs` that those two
lines are byte-identical to the pre-Phase-5 state -- this predates this
branch's work entirely. There is no CI doc-warnings gate today, so it
isn't currently failing anything, but it's a real gap worth its own
follow-up.

## Scope / non-goals

No symmetry, no CIF parser changes, no Python/WASM/MCP bindings in this
PR. Not published, not version-bumped, not registered in release tooling.

## Test plan

- [x] `chematic-crystal` fmt/clippy/doc/test gates (see above)
- [x] Workspace `--all-features` / `--no-default-features` both clean
- [x] CI-exact clippy/test/fmt commands all clean
- [x] WASM target check clean
- [x] Example runs and produces sane output

