### PR TITLE
release: v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added — chematic-crystal (new crate, draft)
+## [0.15.0] — 2026-08-14
+
+New crate `chematic-crystal` (periodic/crystal structure foundation), plus
+a substantial MMFF94 Bond/Angle accuracy fix (issue #227): 265-molecule
+corpus strict-policy success 178/265 → 248/265, zero regressions. Purely
+additive at the Rust API level for existing crates -- no breaking changes.
+
+### Fixed — `chematic-ff` (MMFF94 Bond/Angle empirical-rule fallback, issue #227)
+
+- Ported Halgren's MMFF.V eq. 18-20 empirical Bond-stretch/Angle-bend rule
+  (`mmff94_bond_energy_resolved`/`mmff94_angle_energy_resolved`, new
+  additive functions -- the existing `mmff94_bond_energy`/
+  `mmff94_angle_energy` keep their original `Option<Params>` signatures
+  unchanged), tried strictly *after* the existing exact-table/`eqLevel`-
+  ladder lookup so it never overrides a real table hit. New
+  `Mmff94Resolution` enum (`DirectTable`/`EquivalentType`/
+  `GenericAngleTypeFallback`/`EmpiricalBond`/`EmpiricalAngle`) reports
+  which mechanism resolved a given lookup, for diagnostics/tests.
+- Along the way, discovered and fixed a real data gap in the Angle table
+  itself: 97 rows present in RDKit's real `defaultMMFFAngleData` (generic,
+  central-atom-type-only `theta0` defaults) were missing from chematic's
+  port (2245 → 2342 rows) -- restored with a guard so the existing
+  `mmff94_angle_energy` contract is provably unchanged for every
+  pre-existing input.
+- One triple, `(angle_type=0, N-type=43, S-type=18, C-type=63)`, is
+  deliberately left unresolved (fails closed) rather than guessed: the
+  outer atom type has no equivalence-class table entry, RDKit's own real
+  C++ dereferences that unchecked (undefined behavior), and the live
+  RDKit oracle's answer for it could not be attributed to any well-defined
+  resolution mechanism.
+- Also fixed 5 pre-existing MMFF94 atom-typing gaps (nitrile/isocyanide N,
+  sulfonamide/sulfonate N, nitro N, azide/diazo N, charged-sulfoxide S)
+  and ported RDKit's `eqLevel` atom-type-equivalence ladder for Angle
+  table lookup (both prerequisites for the empirical-rule work above).
+- **Net effect**, measured on the 265-molecule Wave 1 corpus via the
+  production minimization path: `ForceFieldPolicy::Mmff94BondAngleStrict`
+  now succeeds on 248/265 molecules, up from 178/265 before this work
+  (107 → 17 failing), with zero regressions (verified by a full
+  per-molecule comparison, not just aggregate counts).
+
+### Added — chematic-crystal (new crate)
 
 - `crates/chematic-crystal`: periodic (crystal) structure representation
   and geometry -- `Lattice` (triclinic-capable, validated matrix/inverse/
   reciprocal vectors), `FractionalCoord`/`CartesianCoord`, `PeriodicSite`/
   `SiteSpecies`/`Occupancy` (multi-species disorder-ready), and
   `PeriodicStructure` with exact (not `round()`-approximate) periodic
-  minimum-image distance, cutoff neighbor enumeration, and diagonal
-  supercells. Deliberately **not** an extension of `chematic_core::Molecule`
-  -- see `docs/rfcs/chematic_crystal_foundation.md`. Optional `serde`
-  feature; optional `crystal` feature on the `chematic` facade, included
-  in `full` (does not change `default`, which stays empty). No symmetry,
-  no CIF parser changes, no Python/WASM/MCP bindings in this PR.
+  minimum-image distance (deterministic tie-break: equidistant periodic
+  images resolve to the lexicographically smallest image), cutoff
+  neighbor enumeration, and diagonal supercells. Deliberately **not** an
+  extension of `chematic_core::Molecule` -- see
+  `docs/rfcs/chematic_crystal_foundation.md`. Optional `serde` feature;
+  optional `crystal` feature on the `chematic` facade, included in `full`
+  (does not change `default`, which stays empty). No symmetry, no CIF
+  parser changes, no Python/WASM/MCP bindings in this release.
 
 ## [0.14.1] — 2026-08-12
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,5 +23,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.14.1
+version: 0.15.0
 date-released: "2026-08-12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.14.1"
+version = "0.15.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.14.1
+# chematic v0.15.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-07-17, v0.4.29 vs RDKit 2026.03.3 --
@@ -419,6 +419,11 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +1
 
 ## Recent Development
 
+**v0.15.0** (2026-08-14): **`chematic-crystal` — periodic (crystal) structure foundation crate, MMFF94 Bond/Angle empirical-rule fallback (issue #227)**
+- New crate `chematic-crystal`: periodic (crystal) structure representation and geometry — `Lattice` (triclinic-capable, validated matrix/inverse/reciprocal vectors), `FractionalCoord`/`CartesianCoord`, `PeriodicSite`/`SiteSpecies`/`Occupancy` (multi-species disorder-ready), and `PeriodicStructure` with exact (not `round()`-approximate) periodic minimum-image distance — equidistant periodic images resolve deterministically to the lexicographically smallest image — cutoff neighbor enumeration, and diagonal supercells. Deliberately **not** an extension of `chematic_core::Molecule` (a bond graph); see `docs/rfcs/chematic_crystal_foundation.md`. Optional `serde` feature; optional `crystal` feature on the `chematic` facade, included in `full` (does not change `default`, which stays empty). No symmetry, no CIF parser changes, no Python/WASM/MCP bindings yet
+- `chematic-ff`: ported Halgren's MMFF.V eq. 18-20 empirical Bond-stretch/Angle-bend rule (`mmff94_bond_energy_resolved`/`mmff94_angle_energy_resolved`, new additive functions — the existing `mmff94_bond_energy`/`mmff94_angle_energy` keep their original signatures), tried strictly after the existing exact-table/`eqLevel`-ladder lookup so it never overrides a real table hit. Along the way, found and fixed a real data gap: 97 rows present in RDKit's real Angle table (generic central-atom-type-only `theta0` defaults) were missing from chematic's port. One triple is deliberately left unresolved (fails closed) rather than guessed — the outer atom type has no equivalence-class entry and RDKit's own real code dereferences that unchecked (undefined behavior), so its live-oracle answer couldn't be attributed to any well-defined mechanism. Also fixed 5 pre-existing MMFF94 atom-typing gaps and ported RDKit's `eqLevel` atom-type-equivalence ladder for Angle lookup. Net effect on the 265-molecule Wave 1 corpus (production minimization path): `Mmff94BondAngleStrict` success 178/265 → 248/265 (107 → 17 failing), zero regressions
+- Full details in `CHANGELOG.md`'s `[0.15.0]` section
+
 **v0.14.1** (2026-08-12): **Anticancer platinum coordination-chemistry compatibility fixes, Extended XYZ (extxyz) read/write**
 - `chematic-core`: `valence_inferred_hcount` treated a `BondOrder::Dative` bond's donor side exactly like a covalent single bond when computing implicit hydrogen count — an un-bracketed dative donor like `N->[Pt]Cl` computed as `NH2` instead of the chemically correct `NH3`. Donor-side dative bonds now contribute 0 to the valence sum; found via a platinum coordination-chemistry benchmark but general (verified against Fe/Co/Pd/Ru acceptors too), not platinum-specific
 - `chematic-mol`: MDL bond type 9 (dative/coordinate — RDKit's own V3000 convention for `Bond::BondType.DATIVE`) silently mapped to `BondOrder::Single` in both V2000 and V3000 readers, quietly discarding coordination-bond semantics on read. Both readers now map code 9 to `BondOrder::Dative`; V3000's writer now emits code 9 instead of collapsing to plain single
@@ -541,7 +546,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v0.14.1)
+├── Cargo.toml                    workspace root (v0.15.0)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)
@@ -595,7 +600,7 @@ If you use chematic in academic or research work, please cite:
   author    = {kent-tokyo},
   title     = {chematic: A pure-Rust cheminformatics toolkit},
   url       = {https://github.com/kent-tokyo/chematic},
-  version   = {0.14.1},
+  version   = {0.15.0},
   year      = {2026},
 }
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -106,7 +106,7 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.14.1
+# chematic v0.15.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-06, v0.4.22 vs RDKit 2026.03.3 --
@@ -282,6 +282,11 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi      
 ---
 
 ## 最近の開発
+
+**v0.15.0**（2026-08-14）: **`chematic-crystal`——周期（結晶）構造の基盤crate新設、MMFF94 Bond/Angle empirical rule対応（issue #227）**
+- 新規crate `chematic-crystal`：周期（結晶）構造の表現とジオメトリ計算——`Lattice`（三斜晶系対応、行列/逆行列/逆格子ベクトルをvalidation済み）、`FractionalCoord`/`CartesianCoord`、`PeriodicSite`/`SiteSpecies`/`Occupancy`（disorder対応可能な複数species設計）、`PeriodicStructure`は近似（`round()`）ではなく厳密な周期最小像距離計算（等距離の周期像が複数ある場合は辞書順最小のimageへ決定論的に解決）、cutoff近傍探索、diagonal supercellを提供。`chematic_core::Molecule`（結合グラフ）の拡張ではなく意図的に独立した型——詳細は`docs/rfcs/chematic_crystal_foundation.md`参照。optionalな`serde` feature、facadeの`crystal` featureは`full`に含まれる（`default`は空のまま変更なし）。symmetry・CIF parser変更・Python/WASM/MCPバインディングは今回未対応
+- `chematic-ff`：HalgrenのMMFF.V eq. 18-20 empirical Bond-stretch/Angle-bend ruleを移植（`mmff94_bond_energy_resolved`/`mmff94_angle_energy_resolved`——既存の`mmff94_bond_energy`/`mmff94_angle_energy`のシグネチャは変更なし）。既存の完全一致テーブル/`eqLevel`ラダー探索の後にのみ試行するため、実データテーブルのヒットを上書きすることはない。この過程で、RDKit実データのAngleテーブルにある97行（中心原子タイプのみで決まる汎用`theta0`デフォルト値）がchematicの移植版に欠落していたことを発見・復元。1タプルのみ意図的に未解決（fail-closed）のまま——外側原子タイプに等価クラステーブルのエントリがなく、RDKit実装のC++コード自体が未定義動作（nullチェックなし参照）を起こす箇所であり、live oracleの返り値を明確な解決メカニズムに帰属させられなかったため。既存の5件のMMFF94原子タイプ判定ギャップも修正し、RDKitの`eqLevel`原子タイプ等価ラダーをAngleテーブル探索へ移植（いずれも今回のempirical rule対応の前提作業）。265分子Wave 1コーパスでの実測（本番の最小化パス経由）：`Mmff94BondAngleStrict`の成功数が178/265→248/265（失敗107→17）、regressionはゼロ
+- 詳細は`CHANGELOG.md`の`[0.15.0]`セクション参照
 
 **v0.14.1**（2026-08-12）: **抗がん白金配位化学の互換性修正、Extended XYZ（extxyz）読み書き対応**
 - `chematic-core`: `valence_inferred_hcount`が`BondOrder::Dative`結合のdonor側を通常の共有結合と同じに扱っていたため、implicit水素数計算が誤っていた——`N->[Pt]Cl`のような括弧なしdative donorが`NH3`ではなく`NH2`と計算されていた。donor側dative結合はvalence合計に0を寄与するよう修正。白金配位化学ベンチマークで発見したが、Fe/Co/Pd/Ruのacceptorでも検証済みの一般的な修正（白金固有ではない）
@@ -477,6 +482,7 @@ chematic/
 │   ├── chematic-smarts/     SMARTS パーサー + VF2 部分構造一致（再帰 SMARTS）
 │   ├── chematic-3d/         3D 座標生成、ConformerEnsemble、PDB/XYZ 形式
 │   ├── chematic-rxn/        反応 SMILES/SMIRKS
+│   ├── chematic-crystal/    周期結晶構造: 格子、PBC、近傍探索、supercell（Molecule非依存）
 │   └── chematic/            フィーチャーフラグ付きアンブレラクレート（統合クレート）
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -238,6 +238,7 @@ const picks = JSON.parse(maxmin_picks_ecfp4_json('["CC","c1ccccc1","CCO","CCCC"]
 | `chematic-wasm`       | **130+ WASM 导出** — npm：`@kent-tokyo/chematic`（已发布 `0.7.0`，与 crates.io/PyPI 同步）；**pKa/ADMET/BBB/Caco-2/hERG/CYP3A4** WASM API | 211    |
 | `chematic-iupac`      | 本地 IUPAC 命名（纯 Rust·离线）— **25+ 化合物类**：烷烃、环烷烃、醇、胺、卤代烃、酮、酸、酯、酰胺、**哌啶、吗啉、哌嗪、萘、硫醚** | 47     |
 | `chematic-mcp`        | **MCP（模型上下文协议）服务器** — AI 代理集成；**20 个工具**：parse_smiles, calc_properties, ecfp4, tanimoto, smarts_match, canonical_smiles, find_mcs, generate_3d, pains_check, brenk_check, sa_score, admet_profile, boiled_egg, lipinski_check, name_to_smiles, retrosynthesis, smiles_to_moljson, moljson_to_smiles, representation_router, molecule_context_pack；dual-era 协议（旧版 `2024-11-05` + 现代 `2026-07-28` 无状态方言）、全部 20 个工具均支持 `structuredContent`/`outputSchema` | 82     |
+| `chematic-crystal`    | 周期（晶体）结构基础 crate——`Lattice`（三斜晶系）、`PeriodicSite`/`Occupancy`、精确周期最小像距离、近邻枚举、supercell；有意与 `chematic-core::Molecule`（键图）保持独立 | 92     |
 | `chematic`            | 带功能标志的伞形 crate                                                                                   | 1      |
 
 ```
@@ -248,6 +249,11 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi      
 ---
 
 ## 近期开发
+
+**v0.15.0**（2026-08-14）：**新增 `chematic-crystal`——周期（晶体）结构基础 crate；MMFF94 Bond/Angle empirical rule 支持（issue #227）**
+- 新增 crate `chematic-crystal`：周期（晶体）结构表示与几何计算——`Lattice`（支持三斜晶系，矩阵/逆矩阵/倒易晶格矢量均经过校验）、`FractionalCoord`/`CartesianCoord`、`PeriodicSite`/`SiteSpecies`/`Occupancy`（支持多 species 占位、为无序结构预留设计空间）、`PeriodicStructure` 提供精确（而非 `round()` 近似）的周期最小像距离计算——等距的多个周期像会确定性地解析为字典序最小的 image——以及 cutoff 近邻枚举与对角 supercell。刻意**不**作为 `chematic_core::Molecule`（键图）的扩展，设计说明见 `docs/rfcs/chematic_crystal_foundation.md`。可选 `serde` feature；facade 的 `crystal` feature 已纳入 `full`（`default` 保持为空，未变更）。本次未包含对称性判定、CIF parser 改动、Python/WASM/MCP 绑定
+- `chematic-ff`：移植 Halgren MMFF.V eq. 18-20 经验 Bond-stretch/Angle-bend 规则（`mmff94_bond_energy_resolved`/`mmff94_angle_energy_resolved`，新增函数，不改变既有 `mmff94_bond_energy`/`mmff94_angle_energy` 的签名），仅在既有精确表/`eqLevel` 阶梯查找均未命中后才会触发，不会覆盖真实表数据的命中结果。过程中发现并修复了一个真实的数据缺口：RDKit 真实 Angle 表中 97 行（仅按中心原子类型给出通用 `theta0` 默认值的行）此前在 chematic 的移植版本中缺失。其中 1 个三元组被有意保留为未解析（fail-closed）而非猜测性填补——该三元组外侧原子类型没有等价类表条目，RDKit 自身真实 C++ 实现在此处存在未加 null 检查的解引用（未定义行为），其 live oracle 返回值无法归因于任何良定义的解析机制。同时修复了 5 个已知的 MMFF94 原子类型判定缺口，并移植了 RDKit 的 `eqLevel` 原子类型等价阶梯用于 Angle 表查找（均为本次 empirical rule 工作的前置条件）。在 265 分子 Wave 1 语料库上的实测（经生产环境最小化路径）：`Mmff94BondAngleStrict` 成功率从 178/265 提升到 248/265（失败数 107 → 17），零回归
+- 详见 `CHANGELOG.md` 的 `[0.15.0]` 部分
 
 **v0.13.0**（2026-08-10）：**MMFF94 stretch-bend + 扭转参数选取一致性（均为破坏性变更）、逐原子立体中心 API、E/Z 完整性、大环检测、记法无关的阻转异构检测/判定、XYZ I/O**
 - `chematic-ff`：`mmff94_stbn`/`mmff94_stbn_type_only` 现在依据 RDKit 真实的、更细粒度的 "stretch-bend type"（`getMMFFStretchBendType`，0-11）来索引 `MMFF94_STBN` 表，取代此前用作替代的粗粒度 angle type（0-8）（issue #227）——265 分子 Wave 1 语料库上 427 个 stretch-bend 路由候选中的 220 个，从 RDKit 通用的 Dfsb 周期表行默认值改为正确的专用参数；`angle_type_for` 的环偏移公式也已修正，以匹配 RDKit 真实的 `getMMFFAngleType`。**破坏性变更**：`mmff94_stbn`/`mmff94_stbn_type_only` 的首个 `u8` 参数现在是 `stretch_bend_type`，而非 `angle_type`——形状不变，但要求的取值不同；使用新增的 `pub stretch_bend_type_for` 计算该值
@@ -452,6 +458,7 @@ chematic/
 │   ├── chematic-smarts/     SMARTS 解析器 + VF2 子图同构，MCS
 │   ├── chematic-3d/         3D 坐标生成、ConformerEnsemble、PDB/XYZ 格式
 │   ├── chematic-rxn/        反应 SMILES/SMIRKS
+│   ├── chematic-crystal/    周期晶体结构：晶格、PBC、近邻、supercell（不依赖 Molecule）
 │   └── chematic/            带功能标志的伞形 crate
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.14.1 | Yes | Current release — active support |
+| v0.15.0 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.14.1) receives all security updates.  
+**Active Support**: Latest release (v0.15.0) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -16,12 +16,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.14.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.14.1" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.14.1" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.14.1" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.15.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.15.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.15.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.15.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.15.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.15.0" }
 serde_json          = "1.0"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #219); web-time

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -16,14 +16,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.14.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.15.0" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.1" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.1" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.14.1" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.14.1" }
-chematic-cip        = { path = "../chematic-cip",        version = "0.14.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.15.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.15.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.15.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.15.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.15.0" }
+chematic-cip        = { path = "../chematic-cip",        version = "0.15.0" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.14.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.15.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.15.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-crystal/Cargo.toml
+++ b/crates/chematic-crystal/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 serde = ["dep:serde"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.14.1" }
+chematic-core = { path = "../chematic-core", version = "0.15.0" }
 serde         = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -22,10 +22,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.14.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.14.1" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.14.1" }
+chematic-core = { path = "../chematic-core", version = "0.15.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.15.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.15.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.15.0" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.14.1" }
+chematic-core = { path = "../chematic-core", version = "0.15.0" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.14.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.15.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.15.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -22,13 +22,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.14.1" }
+chematic-core = { path = "../chematic-core", version = "0.15.0" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.14.1" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.14.1" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.14.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.15.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.15.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.15.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.15.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -18,10 +18,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.14.1", path = "../chematic-core" }
-chematic-smiles = { version = "0.14.1", path = "../chematic-smiles" }
-chematic-chem = { version = "0.14.1", path = "../chematic-chem" }
-chematic-rxn = { version = "0.14.1", path = "../chematic-rxn" }
+chematic-core = { version = "0.15.0", path = "../chematic-core" }
+chematic-smiles = { version = "0.15.0", path = "../chematic-smiles" }
+chematic-chem = { version = "0.15.0", path = "../chematic-chem" }
+chematic-rxn = { version = "0.15.0", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.14.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.15.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.15.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -17,15 +17,15 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.14.1" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.1" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.14.1", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.14.1" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.1" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.14.1" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.14.1" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.14.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.15.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.15.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.15.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.15.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.15.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.15.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.15.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.15.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.15.0" }
 
 [dev-dependencies]
 # Real JSON Schema 2020-12 validator, used only in tests to independently

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -16,10 +16,10 @@ documentation = "https://docs.rs/chematic-mol"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.14.1" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.14.1" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.14.1" }
-chematic-smiles      = { path = "../chematic-smiles",      version = "0.14.1" }
+chematic-core        = { path = "../chematic-core",        version = "0.15.0" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.15.0" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.15.0" }
+chematic-smiles      = { path = "../chematic-smiles",      version = "0.15.0" }
 serde_json           = "1.0"
 
 [dev-dependencies]

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.14.1" }
+chematic-core = { path = "../chematic-core", version = "0.15.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,16 +25,16 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.14.1" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.14.1" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.14.1" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.14.1", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.14.1" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.1" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.14.1" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.14.1" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.14.1" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.14.1" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.14.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.15.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.15.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.15.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.15.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.15.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.15.0", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.15.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.15.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.15.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.15.0" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.15.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.15.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.15.0" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -22,9 +22,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 perf-instrumentation = []
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.14.1" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.14.1" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.14.1" }
+chematic-core   = { path = "../chematic-core",   version = "0.15.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.15.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.15.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -16,8 +16,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.14.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
+chematic-core = { path = "../chematic-core", version = "0.15.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.15.0" }
 rustc-hash = "2"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #221); web-time

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.14.1" }
+chematic-core = { path = "../chematic-core", version = "0.15.0" }
 
 [features]
 # Feature-gated internal work counters for the orbit-pruning canonical

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -26,16 +26,16 @@ wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["console"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.14.1" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.14.1" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.14.1", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.14.1" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.14.1", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.14.1" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.1" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.14.1" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.14.1" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.14.1" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.14.1" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.14.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.15.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.15.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.15.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.15.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.15.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.15.0", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.15.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.15.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.15.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.15.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.15.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.15.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.15.0" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -42,16 +42,16 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.14.1", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.14.1", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.14.1", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.14.1", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.14.1", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.14.1", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.14.1", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.14.1", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.14.1", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.14.1", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.14.1", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.14.1", optional = true }
-chematic-crystal    = { path = "../chematic-crystal",    version = "0.14.1", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.15.0", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.15.0", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.15.0", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.15.0", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.15.0", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.15.0", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.15.0", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.15.0", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.15.0", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.15.0", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.15.0", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.15.0", optional = true }
+chematic-crystal    = { path = "../chematic-crystal",    version = "0.15.0", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Version bump for v0.15.0, following this repo's `release/*` branch convention.

**Headline changes** (both already reviewed/merged to main individually):
- New crate `chematic-crystal` (#318): periodic/crystal structure foundation -- `Lattice`, `PeriodicSite`/`Occupancy`, exact minimum-image PBC distance, cutoff neighbor enumeration, diagonal supercells. Independent from `chematic_core::Molecule` by design. Optional `crystal` facade feature, included in `full` (does not change `default`).
- MMFF94 Bond/Angle empirical-rule fallback, issue #227 (#314-317): Halgren MMFF.V eq. 18-20 empirical rule, plus a real data-gap fix (97 missing table rows) and 5 atom-typing fixes. 265-molecule corpus: `Mmff94BondAngleStrict` success 178/265 → 248/265 (107 → 17 failing), zero regressions.

Purely additive at the Rust API level -- no breaking changes in this release.

## What this PR does

- `Cargo.toml` workspace version 0.14.1 → 0.15.0, propagated via `scripts/bump_version.py` to all crate `Cargo.toml`s, `README.md`/`README_ja.md`/`README_zh.md`, `CITATION.cff`, `SECURITY.md`, `demo/pkg/package.json`.
- `CHANGELOG.md`: cuts `[Unreleased]` into a new `[0.15.0]` section (also backfilled the issue #227 entry, which was missing from `[Unreleased]` before this PR).
- Adds v0.15.0 release-notes entries to all three README variants (English/Japanese/Chinese), plus `chematic-crystal` rows in each README's repository-structure/crate-list section.

## Test plan

- [x] `bash scripts/check.sh` -- fmt, clippy (`-D warnings`), `cargo test --workspace --lib/--tests --quiet`, `cargo deny check`, publish-graph check (19 publishable crates, `chematic-crystal` correctly included), version-consistency check across README/CITATION.cff/SECURITY.md/demo package/path-dependency pins -- all green.

## Next steps (not part of this PR)

Once merged, tag `v0.15.0` at the merge commit and push the tag -- this triggers `release.yml` (GitHub Release), `publish-pypi.yml`, and `publish-npm.yml` automatically. That's a separate, explicit step after this PR merges, not done here.