### PR TITLE
ci: add crates.io publish workflow

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,49 @@
+name: Publish to crates.io
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish crates to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify publish graph
+        run: python3 scripts/check_publish_graph.py
+
+      - name: Publish crates in dependency order
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -e
+          CRATES=$(python3 scripts/check_publish_graph.py | awk '/Safe publish order:/{found=1; next} found {print $1}')
+          echo "Publish order:"
+          echo "$CRATES"
+          for crate in $CRATES; do
+            echo "=== Publishing $crate ==="
+            if OUTPUT=$(cargo publish -p "$crate" --locked 2>&1); then
+              echo "$OUTPUT"
+              echo "Published $crate"
+            elif echo "$OUTPUT" | grep -qi "already uploaded\|already exists"; then
+              echo "$OUTPUT"
+              echo "$crate already published at this version, skipping"
+            else
+              echo "$OUTPUT"
+              echo "::error::Failed to publish $crate"
+              exit 1
+            fi
+            # ponytail: fixed sleep so crates.io has indexed this crate before
+            # the next dependent tries to resolve it -- replace with a poll
+            # against the registry API if this starts flaking under load.
+            sleep 20
+          done


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish-crates.yml` -- the missing piece in the release automation. `release.yml`/`publish-pypi.yml`/`publish-npm.yml` already handle the GitHub Release, PyPI, and npm targets on tag push, but no workflow ran `cargo publish` for the 19 workspace crates themselves. Found this gap while verifying v0.15.0's actual publish status: the tag/release/PyPI/npm all succeeded, but crates.io still showed `chematic-core` at `0.14.1` -- the crates.io side of past releases was apparently done manually.

## What it does

- Triggers on `push: tags: v*` (same pattern as the other publish workflows) plus `workflow_dispatch` for manual/backfill runs.
- Gets the publish order from `scripts/check_publish_graph.py`'s own "Safe publish order" output (the same dependency-ordered list already used for manual releases), so the workflow can't drift out of sync with that script.
- `cargo publish -p <crate> --locked` per crate, using the `CARGO_REGISTRY_TOKEN` secret. Treats an "already uploaded" error as a soft-skip so re-running after a partial failure is safe/idempotent.
- Fixed 20s sleep between publishes for crates.io indexing propagation (marked as a known shortcut in a code comment -- replace with a registry-availability poll if this starts flaking under real load).

## Why `workflow_dispatch` too

v0.15.0's tag was already pushed before this workflow existed, so the tag-push trigger won't retroactively fire for it. Once this merges, it can be triggered manually against `main`'s current state (which already has all `Cargo.toml`s at `0.15.0` from #319) to backfill that specific release's crates.io publish.

## Test plan

- [x] `scripts/check_publish_graph.py` already run as part of `scripts/check.sh` in the v0.15.0 release prep -- confirms the publish graph itself is valid (19 publishable crates, no cycles).
- [ ] First real run (tag push or manual dispatch) will be the actual test of the publish steps themselves -- not something a CI check can simulate without actually publishing.