### PR TITLE
fix(chematic): forward chematic-mol's crystal feature through the facade

### DIFF
--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -25,7 +25,7 @@ rxn         = ["smiles", "dep:chematic-rxn"]
 threed      = ["perception", "dep:chematic-3d"]
 inchi       = ["chem", "dep:chematic-inchi"]
 iupac       = ["dep:chematic-iupac"]
-crystal     = ["dep:chematic-crystal"]
+crystal     = ["dep:chematic-crystal", "chematic-mol?/crystal"]
 # `full` is the aggregate of every optional facade capability (not scoped
 # to Molecule-only features) -- a user who writes `features = ["full"]`
 # expects everything, `crystal` included. `chematic-crystal`'s
@@ -34,6 +34,17 @@ crystal     = ["dep:chematic-crystal"]
 # features should default to joining `full` too unless there's a specific
 # reason not to (see docs/rfcs/chematic_crystal_foundation.md's
 # facade-feature section for the crystal-specific decision record).
+#
+# `crystal`'s weak-dependency forward (`chematic-mol?/crystal`) activates
+# chematic-mol's own `crystal` feature (the CIF <-> PeriodicStructure
+# adapter, `parse_cif_periodic_structure`/`write_cif_periodic_structure`)
+# whenever `chematic-mol` is *also* already a dependency (i.e. `mol` is
+# enabled too) -- a no-op otherwise, per Cargo's `?` weak-feature syntax.
+# Found and fixed as a release-readiness check: `full` previously enabled
+# both `mol` and `crystal` without this forward, so a `full` user got
+# `chematic::crystal` and `chematic::mol` but never the adapter bridging
+# them -- exactly the "enabled full but one thing doesn't work" surprise
+# this facade's own `full` contract is meant to rule out.
 full        = ["smiles", "perception", "mol", "depict", "fp", "chem", "smarts", "rxn", "threed", "inchi", "iupac", "crystal"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
## Summary

Found during the v0.16.0 release-readiness audit: the `chematic` facade's `crystal` feature only enabled `dep:chematic-crystal`, never forwarding to `chematic-mol`'s own `crystal` feature (the CIF ↔ `PeriodicStructure` adapter added in PR #323). Since `full = [..., "mol", ..., "crystal", ...]` enables both facade features independently, a `full` user got both `chematic::crystal` and `chematic::mol` but the bridging adapter functions (`parse_cif_periodic_structure`/`write_cif_periodic_structure`) were never actually reachable — exactly the "enabled `full` but one thing doesn't work" surprise `full`'s own contract (see `docs/rfcs/chematic_crystal_foundation.md`) is meant to rule out.

## Fix

```toml
crystal = ["dep:chematic-crystal", "chematic-mol?/crystal"]
```

Cargo's weak-dependency-feature syntax (`dep-name?/feature-name`): a no-op when `mol` isn't enabled (the `?` means "only if this optional dependency is already active for some other reason"), activates `chematic-mol`'s own `crystal` feature when it is.

## Verification

- `cargo build -p chematic --features crystal --no-default-features` (mol off): still builds fine, confirming the forward is a true no-op when `mol` isn't active.
- `cargo build -p chematic --features full`: builds fine.
- Standalone smoke-test crate confirming `chematic::mol::parse_cif_periodic_structure` is genuinely reachable (not just "compiles" — took the function's address) under `features = ["full"]`. `chematic`'s own `lib.rs` re-exports the whole `chematic_mol` crate as a module (`pub use chematic_mol as mol;`) gated on `#[cfg(feature = "mol")]`, so no separate re-export line was needed — only the Cargo.toml feature-graph wiring was missing.
- Full local release-readiness gate (`scripts/check.sh`) re-run after this change: fmt/clippy/tests (537 passed, 0 failed)/deny/publish-graph/version-consistency all pass.

No functional/library behavior change beyond exposing the already-implemented, already-tested CIF adapter through the facade as intended.