### PR TITLE
Square-planar stereo (@SP1/@SP2/@SP3) in MOL/SDF: V2000 + V3000 (roadmap step 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,14 +37,22 @@ conformer writers, building on the generalized stereo geometry foundation
   real coordinates before writing — never fabricating a conformer from
   nothing, never silently trusting a mismatch — and fail closed with a
   typed `MolStereoWriteError` otherwise. The pre-existing, more commonly
-  used writers (`write_mol`, `write_mol_with_coords`,
-  `write_mol_with_conformer`, `write_mol_v3000`,
-  `write_mol_v3000_with_conformer`, and the whole `write_sdf*` family)
-  are **unchanged and still silently drop `Chirality::SquarePlanar`** —
-  each now carries a Rustdoc warning saying so and pointing at its
+  used writers are unchanged, but fall into two different gaps — each now
+  carries a Rustdoc warning naming its specific one and pointing at its
   `_checked` counterpart where one exists. Do not describe MOL/SDF
   writing in general as "square-planar supported"; only the three
   `_checked` functions above are.
+  - **2D-only, so they drop the tag outright**: `write_mol`,
+    `write_mol_with_coords`, `write_mol_v3000`, and the whole `write_sdf*`
+    family (`write_sdf`, `write_sdf_with_charges`, `write_sdf_record`,
+    `write_sdf_record_v3000`) — none of these has a z coordinate to write
+    a square-planar tag against in the first place.
+  - **3D-capable but unvalidated**: `write_mol_with_conformer`,
+    `write_mol_v3000_with_conformer`, and `write_sdf_record_with_conformer`
+    write whatever conformer they're handed and so *do* preserve the tag
+    when the conformer actually matches it — but they trust the caller and
+    never check, so a mismatched or flat conformer is written silently
+    self-inconsistent with no error.
   Explicitly out of scope: pure-2D wedge-only square-planar encoding (no
   such MDL mechanism exists), 3-heavy + implicit-H square-planar centers,
   and a chematic-specific lossless SDF extension (Tier 3, not built).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Roadmap step 2: square-planar stereo (`@SP1`/`@SP2`/`@SP3`-equivalent)
-MOL/SDF (V2000 + V3000) support, building on the generalized stereo
-geometry foundation (PR #326).
+Roadmap step 2: square-planar stereo (`@SP1`/`@SP2`/`@SP3`-equivalent),
+read on every MOL/SDF (V2000 + V3000) reader and write via new checked
+conformer writers, building on the generalized stereo geometry foundation
+(PR #326).
 
-### Added — `chematic-mol` (square-planar stereo in MOL/SDF)
+### Added — `chematic-mol` (square-planar stereo read everywhere; write via new checked conformer writers only)
 
 - MDL/CTfile has no symbolic field for a non-tetrahedral stereo tag
   (confirmed against RDKit 2026.03.4 as a live oracle, and consistent
@@ -22,15 +23,28 @@ geometry foundation (PR #326).
   3D-coordinate-derived reperception: given a real (non-flat) 3D
   conformer, a coplanar 4-coordinate center whose neighbor pair angles
   unambiguously resolve to one of SP1/SP2/SP3 is reperceived directly
-  from geometry on read (`perceive_square_planar_from_3d`, wired into
-  both `read_mol_with_diagnostics` and `read_mol_v3000_with_diagnostics`)
-  and validated against the declared tag before writing (new
-  `write_mol_with_conformer_checked`/`write_mol_v3000_with_conformer_checked`,
-  backed by the public `validate_square_planar_for_write`) — never
-  fabricated from nothing, and never silently trusted to match. Element
-  eligibility reuses `Element::normal_valences().is_empty()` (transition
-  metals and similar), matching an RDKit oracle observation for every
-  element tested (one documented Na/Mg/Al divergence, see the RFC).
+  from geometry **on every read** (`perceive_square_planar_from_3d`,
+  wired into both `read_mol_with_diagnostics` and
+  `read_mol_v3000_with_diagnostics` — this applies regardless of which
+  writer produced the file). Element eligibility reuses
+  `Element::normal_valences().is_empty()` (transition metals and
+  similar), matching an RDKit oracle observation for every element
+  tested (one documented Na/Mg/Al divergence, see the RFC).
+- **Write support is opt-in, via three new `_checked` functions only**:
+  `write_mol_with_conformer_checked`, `write_mol_v3000_with_conformer_checked`,
+  and `write_sdf_record_with_conformer_checked` (backed by the public
+  `validate_square_planar_for_write`) validate the declared tag against
+  real coordinates before writing — never fabricating a conformer from
+  nothing, never silently trusting a mismatch — and fail closed with a
+  typed `MolStereoWriteError` otherwise. The pre-existing, more commonly
+  used writers (`write_mol`, `write_mol_with_coords`,
+  `write_mol_with_conformer`, `write_mol_v3000`,
+  `write_mol_v3000_with_conformer`, and the whole `write_sdf*` family)
+  are **unchanged and still silently drop `Chirality::SquarePlanar`** —
+  each now carries a Rustdoc warning saying so and pointing at its
+  `_checked` counterpart where one exists. Do not describe MOL/SDF
+  writing in general as "square-planar supported"; only the three
+  `_checked` functions above are.
   Explicitly out of scope: pure-2D wedge-only square-planar encoding (no
   such MDL mechanism exists), 3-heavy + implicit-H square-planar centers,
   and a chematic-specific lossless SDF extension (Tier 3, not built).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Roadmap step 2: square-planar stereo (`@SP1`/`@SP2`/`@SP3`-equivalent)
+MOL/SDF (V2000 + V3000) support, building on the generalized stereo
+geometry foundation (PR #326).
+
+### Added — `chematic-mol` (square-planar stereo in MOL/SDF)
+
+- MDL/CTfile has no symbolic field for a non-tetrahedral stereo tag
+  (confirmed against RDKit 2026.03.4 as a live oracle, and consistent
+  with public RDKit documentation/source — see
+  `docs/rfcs/square_planar_mol_io_rfc.md`). The only real mechanism is
+  3D-coordinate-derived reperception: given a real (non-flat) 3D
+  conformer, a coplanar 4-coordinate center whose neighbor pair angles
+  unambiguously resolve to one of SP1/SP2/SP3 is reperceived directly
+  from geometry on read (`perceive_square_planar_from_3d`, wired into
+  both `read_mol_with_diagnostics` and `read_mol_v3000_with_diagnostics`)
+  and validated against the declared tag before writing (new
+  `write_mol_with_conformer_checked`/`write_mol_v3000_with_conformer_checked`,
+  backed by the public `validate_square_planar_for_write`) — never
+  fabricated from nothing, and never silently trusted to match. Element
+  eligibility reuses `Element::normal_valences().is_empty()` (transition
+  metals and similar), matching an RDKit oracle observation for every
+  element tested (one documented Na/Mg/Al divergence, see the RFC).
+  Explicitly out of scope: pure-2D wedge-only square-planar encoding (no
+  such MDL mechanism exists), 3-heavy + implicit-H square-planar centers,
+  and a chematic-specific lossless SDF extension (Tier 3, not built).
+- New public types: `MolFormat`, `UnsupportedStereoReason`,
+  `MolStereoWriteError`, `SquarePlanarRejectionReason`,
+  `SquarePlanarPerceptionDiagnostic`; `MolReadReport` gained a new
+  `square_planar_diagnostics` field.
+
+### Fixed — `chematic-mol` (`wedge_vs_3d_conflicts` tetrahedral-only gate)
+
+- `wedge_vs_3d_conflicts` gated on `atom.chirality == Chirality::None`,
+  so any non-`None`, non-tetrahedral chirality fell through into a
+  computation that assumes a tetrahedral shape — latent until this PR,
+  since no MOL/SDF reader ever produced `Chirality::SquarePlanar` before
+  now. Fixed by switching to `!atom.chirality.is_tetrahedral()`, an
+  exhaustive-match-safe allowlist gate (same fix shape as two prior
+  instances of this bug class in `chematic-3d`/`chematic-chem`).
+
 Issue #227 Phase 2: MMFF94 BCI (bond-charge-increment) partial-charge bug,
 investigated per Phase 1's own flagged follow-up and fixed. Also adds a
 full `embed_pipeline_v2` 3-state quality re-measurement (State 1: v0.16.0

--- a/crates/chematic-mol/src/lib.rs
+++ b/crates/chematic-mol/src/lib.rs
@@ -70,7 +70,7 @@ pub use mol2000::{
     read_mol_with_diagnostics, read_sdf_with_diagnostics, validate_square_planar_for_write,
     write_mol, write_mol_with_conformer, write_mol_with_conformer_checked, write_mol_with_coords,
     write_sdf, write_sdf_record, write_sdf_record_v3000, write_sdf_record_with_conformer,
-    write_sdf_with_charges,
+    write_sdf_record_with_conformer_checked, write_sdf_with_charges,
 };
 pub use mol3000::{
     parse_mol_v3000, parse_mol_v3000_with_coords, read_mol_v3000_with_diagnostics, write_mol_v3000,

--- a/crates/chematic-mol/src/lib.rs
+++ b/crates/chematic-mol/src/lib.rs
@@ -64,15 +64,17 @@ pub use mmcif::{
 };
 pub use mol2_tripos::{Mol2Error, parse_mol2, write_mol2};
 pub use mol2000::{
-    CoordinateDimension, GeometryRank, MolMetadata, MolReadReport, Stereo3DDiagnostic, parse_mol,
-    parse_mol_with_coords, parse_sdf_with_coords, read_mol_with_diagnostics,
-    read_sdf_with_diagnostics, write_mol, write_mol_with_conformer, write_mol_with_coords,
+    CoordinateDimension, GeometryRank, MolFormat, MolMetadata, MolReadReport, MolStereoWriteError,
+    SquarePlanarPerceptionDiagnostic, SquarePlanarRejectionReason, Stereo3DDiagnostic,
+    UnsupportedStereoReason, parse_mol, parse_mol_with_coords, parse_sdf_with_coords,
+    read_mol_with_diagnostics, read_sdf_with_diagnostics, validate_square_planar_for_write,
+    write_mol, write_mol_with_conformer, write_mol_with_conformer_checked, write_mol_with_coords,
     write_sdf, write_sdf_record, write_sdf_record_v3000, write_sdf_record_with_conformer,
     write_sdf_with_charges,
 };
 pub use mol3000::{
     parse_mol_v3000, parse_mol_v3000_with_coords, read_mol_v3000_with_diagnostics, write_mol_v3000,
-    write_mol_v3000_with_conformer,
+    write_mol_v3000_with_conformer, write_mol_v3000_with_conformer_checked,
 };
 pub use moljson::{MolJsonError, parse_moljson, write_moljson};
 pub use mrv::{

--- a/crates/chematic-mol/src/mol2000.rs
+++ b/crates/chematic-mol/src/mol2000.rs
@@ -231,9 +231,26 @@ fn signed_volume3(p1: Point3, p2: Point3, p3: Point3, p4: Point3) -> f64 {
 /// synthetic H position needed -- the triple product of the 3 real bond
 /// vectors from the center already carries full parity) for a 3-heavy +
 /// implicit-H center. Only ever consulted when a wedge/hash bond was
-/// actually present (`atom.chirality != Chirality::None`), so this never
+/// actually present (`atom.chirality.is_tetrahedral()`), so this never
 /// fires on the common case of a real 3D SDF record with no wedge notation
 /// at all.
+///
+/// Gated on [`chematic_core::Chirality::is_tetrahedral`], not `!=
+/// Chirality::None`: the computation below assumes a tetrahedral shape (it
+/// only ever produces `Chirality::Clockwise`/`CounterClockwise` and compares
+/// that against `atom.chirality`), so any non-tetrahedral-but-non-`None`
+/// chirality (e.g. `Chirality::SquarePlanar`, produced by this crate's own
+/// MOL/SDF readers as of this file's `perceive_square_planar_from_3d`) must
+/// be excluded up front rather than coerced through a check that can only
+/// ever disagree with it. `is_tetrahedral()` is an allowlist (`true` only
+/// for the two known-tetrahedral variants), which makes this fix
+/// exhaustive-match safe by construction: any future non-tetrahedral
+/// geometry this crate adds later (trigonal-bipyramidal, octahedral --
+/// sketched but unimplemented in `chematic_core::stereo_geometry`) is
+/// automatically excluded too, without a new arm here. Same
+/// equality-vs-exhaustive-match bug shape fixed twice before in this
+/// project's history (`chematic-3d/src/stereo_constraints.rs`,
+/// `chematic-chem/src/cip.rs`).
 pub(crate) fn wedge_vs_3d_conflicts(
     mol: &Molecule,
     conformer: &Coords3D,
@@ -242,7 +259,7 @@ pub(crate) fn wedge_vs_3d_conflicts(
     let get = |a: u32| conformer.points.get(a as usize).copied();
 
     for (idx, atom) in mol.atoms() {
-        if atom.chirality == Chirality::None {
+        if !atom.chirality.is_tetrahedral() {
             continue;
         }
         let Some(order) = mol.stereo_neighbor_order(idx) else {

--- a/crates/chematic-mol/src/mol2000.rs
+++ b/crates/chematic-mol/src/mol2000.rs
@@ -11,7 +11,7 @@
 
 use chematic_core::{
     Atom, AtomIdx, BondIdx, BondOrder, Chirality, Coords3D, Element, Molecule, MoleculeBuilder,
-    Point3, STEREO_H_SENTINEL,
+    Point3, STEREO_H_SENTINEL, SquarePlanarPermutation, StereoGeometry,
 };
 use chematic_perception::{
     EzDirectionDiagnostic, StereoDiagnostic, apply_ez_directions_from_2d_ex,
@@ -105,6 +105,30 @@ const COLLINEAR_EPS: f64 = 1e-6;
 /// Minimum |signed volume| (Angstrom^3) treated as a reliable, non-degenerate
 /// tetrahedral sign in [`wedge_vs_3d_conflicts`].
 const VOLUME_EPS: f64 = 1e-6;
+/// Minimum bond-vector norm (Angstrom) accepted as non-degenerate by
+/// [`classify_square_planar_geometry`] -- below this, a neighbor's position
+/// coincides with (or is implausibly close to) the center's own position,
+/// which can never be a real bond length for any element. Many orders of
+/// magnitude below any real M-L bond (~1.5-2.5 Angstrom for a transition
+/// metal): a pure corrupt-data guard, not a chemistry judgment call.
+const SQUARE_PLANAR_MIN_BOND_NORM: f64 = 1e-3;
+/// `cos(135 degrees)` -- the geometric midpoint between an ideal
+/// square-planar cis angle (90 degrees) and trans angle (180 degrees), used
+/// by [`classify_square_planar_geometry`] to decide whether a neighbor pair
+/// (viewed from the center) is "trans-like". Self-justifying: over 45
+/// degrees of distortion from either ideal is required to misclassify,
+/// comfortably covering real (non-idealized) square-planar geometry while
+/// still rejecting a tetrahedral center's ~109.5 degree angles outright
+/// (already excluded earlier by the coplanarity check, since a real
+/// tetrahedral center's 4 substituents are never coplanar with it -- this
+/// threshold only has to disambiguate *which* pairing is trans for input
+/// that already passed that gate). Chosen the same way `COPLANAR_EPS`/
+/// `VOLUME_EPS` were: a deliberately-derived, stated-reasoning constant, not
+/// a copied or guessed one. See `docs/rfcs/square_planar_mol_io_rfc.md` §7,
+/// which also cites an RDKit 2026.03.4 oracle observation (empirical cutoff
+/// between 30 and 40 degrees of distortion) in the same family as this
+/// value, without copying RDKit's number.
+const SQUARE_PLANAR_TRANS_COS_MAX: f64 = -std::f64::consts::FRAC_1_SQRT_2;
 
 /// Classify a point cloud's [`GeometryRank`]. See that type's docs for the
 /// four cases.
@@ -309,6 +333,206 @@ pub(crate) fn wedge_vs_3d_conflicts(
     out
 }
 
+// ---------------------------------------------------------------------------
+// Square-planar stereo: 3D-coordinate-derived reperception (read) and
+// pre-write validation (write) -- see
+// `docs/rfcs/square_planar_mol_io_rfc.md` for the full design and RDKit
+// oracle provenance. MDL/CTfile has no symbolic field for a non-tetrahedral
+// stereo tag (RFC §2); this is the *only* mechanism that can represent it.
+// ---------------------------------------------------------------------------
+
+/// Why a coplanar, undefined-valence, 4-coordinate center's neighbor
+/// arrangement failed to resolve to exactly one of SP1/SP2/SP3 in
+/// [`classify_square_planar_geometry`]. Used both as a read-side diagnostic
+/// reason ([`SquarePlanarPerceptionDiagnostic`]) and, wrapped, as a write-side
+/// error reason ([`UnsupportedStereoReason::GeometryRejected`]) -- one
+/// classifier, one reason vocabulary, shared by both directions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SquarePlanarRejectionReason {
+    /// A neighbor's position coincides with (or is implausibly close to) the
+    /// center's own position -- see [`SQUARE_PLANAR_MIN_BOND_NORM`].
+    DegenerateBondVector,
+    /// The center and its 4 neighbors are not coplanar within tolerance --
+    /// the common case for a genuinely tetrahedral/octahedral/other-shaped
+    /// 4-coordinate center. Never surfaced as a read-side diagnostic (see
+    /// [`perceive_square_planar_from_3d`]'s doc comment) since it is the
+    /// expected, non-noteworthy outcome for the vast majority of real
+    /// undefined-valence-element 4-coordinate centers.
+    NotCoplanar,
+    /// Coplanar, but no single pairing of neighbors had *both* its pairs at
+    /// a trans-like angle (see [`SQUARE_PLANAR_TRANS_COS_MAX`]) -- or more
+    /// than one pairing did, which can only happen for near-degenerate
+    /// input. Either way, the arrangement does not unambiguously name one
+    /// of SP1/SP2/SP3.
+    AmbiguousTransPairing,
+}
+
+impl core::fmt::Display for SquarePlanarRejectionReason {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::DegenerateBondVector => write!(
+                f,
+                "a neighbor position coincides with the center (degenerate bond vector)"
+            ),
+            Self::NotCoplanar => write!(f, "center and neighbors are not coplanar"),
+            Self::AmbiguousTransPairing => {
+                write!(f, "no single trans-pairing of neighbors was unambiguous")
+            }
+        }
+    }
+}
+
+/// Classify a candidate square-planar center's local geometry: `center` plus
+/// its 4 neighbor positions, in [`Molecule::neighbors`]/`stereo_neighbor_order`
+/// order (position `i` of the returned tag's
+/// [`SquarePlanarPermutation::trans_pairs`] refers to `neighbors[i]`).
+///
+/// The single shared implementation used by both
+/// [`perceive_square_planar_from_3d`] (read) and
+/// [`validate_square_planar_for_write`] (write) -- see
+/// `docs/rfcs/square_planar_mol_io_rfc.md` §7 for the full derivation of each
+/// step's tolerance.
+pub(crate) fn classify_square_planar_geometry(
+    center: Point3,
+    neighbors: [Point3; 4],
+) -> Result<SquarePlanarPermutation, SquarePlanarRejectionReason> {
+    let vecs: [Point3; 4] = [
+        neighbors[0].sub(&center),
+        neighbors[1].sub(&center),
+        neighbors[2].sub(&center),
+        neighbors[3].sub(&center),
+    ];
+    let norms: [f64; 4] = [
+        vecs[0].norm(),
+        vecs[1].norm(),
+        vecs[2].norm(),
+        vecs[3].norm(),
+    ];
+    if norms.iter().any(|&n| n < SQUARE_PLANAR_MIN_BOND_NORM) {
+        return Err(SquarePlanarRejectionReason::DegenerateBondVector);
+    }
+
+    // Coplanarity of center + 4 neighbors, reusing `classify_geometry_rank`
+    // directly rather than a second plane-fit implementation. `FlatZero` is
+    // accepted here (it is the *local* 5-point subset that may legitimately
+    // sit at z=0 even inside a molecule whose overall conformer is real 3D
+    // data -- the whole-molecule flat/indeterminate case is rejected
+    // separately, by the caller checking `conformer.is_some()` on read and
+    // by `validate_square_planar_for_write` on write).
+    let five = [
+        center,
+        neighbors[0],
+        neighbors[1],
+        neighbors[2],
+        neighbors[3],
+    ];
+    match classify_geometry_rank(&five) {
+        GeometryRank::Coplanar | GeometryRank::FlatZero => {}
+        GeometryRank::ThreeD | GeometryRank::Indeterminate => {
+            return Err(SquarePlanarRejectionReason::NotCoplanar);
+        }
+    }
+
+    let cos_angle = |i: usize, j: usize| vecs[i].dot(&vecs[j]) / (norms[i] * norms[j]);
+    let is_trans = |i: u8, j: u8| cos_angle(i as usize, j as usize) <= SQUARE_PLANAR_TRANS_COS_MAX;
+
+    let mut matched: Option<SquarePlanarPermutation> = None;
+    for tag in [
+        SquarePlanarPermutation::SP1,
+        SquarePlanarPermutation::SP2,
+        SquarePlanarPermutation::SP3,
+    ] {
+        let [(a, b), (c, d)] = tag.trans_pairs();
+        if is_trans(a, b) && is_trans(c, d) {
+            if matched.is_some() {
+                return Err(SquarePlanarRejectionReason::AmbiguousTransPairing);
+            }
+            matched = Some(tag);
+        }
+    }
+    matched.ok_or(SquarePlanarRejectionReason::AmbiguousTransPairing)
+}
+
+/// One candidate square-planar center whose geometry looked plausible
+/// (coplanar) but did not unambiguously resolve to SP1/SP2/SP3 -- surfaced
+/// instead of silently leaving `Chirality::None`, matching this crate's
+/// existing "explain why, don't guess" diagnostic discipline
+/// (`StereoDiagnostic`/`Stereo3DDiagnostic`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SquarePlanarPerceptionDiagnostic {
+    pub atom: AtomIdx,
+    pub reason: SquarePlanarRejectionReason,
+}
+
+/// Scan `mol` for undefined-valence-element, 4-coordinate, not-already-tagged
+/// atoms and, using `conformer`'s real 3D positions, reperceive
+/// `Chirality::SquarePlanar` directly from geometry -- see
+/// `docs/rfcs/square_planar_mol_io_rfc.md` for why this (not a symbolic MOL
+/// field, which does not exist) is the mechanism.
+///
+/// Element eligibility reuses `Element::normal_valences().is_empty()`
+/// (transition metals and other elements this crate already treats as
+/// "valence undefined") -- reproduces an RDKit 2026.03.4 oracle observation
+/// for every element tested, with one documented divergence (RFC §6).
+///
+/// Only [`SquarePlanarRejectionReason::DegenerateBondVector`]/
+/// `AmbiguousTransPairing` are surfaced as diagnostics.
+/// `NotCoplanar` is silently skipped -- it is the expected, non-noteworthy
+/// outcome for the overwhelming majority of real 4-coordinate
+/// undefined-valence-element centers (genuinely tetrahedral or octahedral,
+/// not square-planar), mirroring `StereoDiagnostic`'s own "no wedge present
+/// -> nothing to say" precedent rather than warning on every ordinary
+/// tetrahedral transition-metal complex in a 3D SDF file.
+pub(crate) fn perceive_square_planar_from_3d(
+    mol: &mut Molecule,
+    conformer: &Coords3D,
+) -> Vec<SquarePlanarPerceptionDiagnostic> {
+    let mut out = Vec::new();
+
+    // Collect candidates first (immutable borrow of `mol`) before mutating.
+    let candidates: Vec<(AtomIdx, [AtomIdx; 4])> = mol
+        .atoms()
+        .filter(|(_, atom)| {
+            atom.chirality == Chirality::None && atom.element.normal_valences().is_empty()
+        })
+        .filter_map(|(idx, _)| {
+            let nbs: Vec<AtomIdx> = mol.neighbors(idx).map(|(n, _)| n).collect();
+            (nbs.len() == 4).then(|| (idx, [nbs[0], nbs[1], nbs[2], nbs[3]]))
+        })
+        .collect();
+
+    for (idx, nbs) in candidates {
+        let Some(center) = conformer.points.get(idx.0 as usize).copied() else {
+            continue;
+        };
+        let mut pts = [Point3::zero(); 4];
+        let mut all_present = true;
+        for (slot, n) in nbs.iter().enumerate() {
+            match conformer.points.get(n.0 as usize).copied() {
+                Some(p) => pts[slot] = p,
+                None => {
+                    all_present = false;
+                    break;
+                }
+            }
+        }
+        if !all_present {
+            continue;
+        }
+
+        match classify_square_planar_geometry(center, pts) {
+            Ok(tag) => {
+                mol.set_chirality(idx, Chirality::SquarePlanar(tag));
+                mol.set_stereo_neighbor_order(idx, nbs.iter().map(|a| a.0).collect());
+            }
+            Err(SquarePlanarRejectionReason::NotCoplanar) => {}
+            Err(reason) => out.push(SquarePlanarPerceptionDiagnostic { atom: idx, reason }),
+        }
+    }
+
+    out
+}
+
 /// Result of parsing a MOL/SDF record with stereo-perception diagnostics.
 ///
 /// `stereo_diagnostics` is empty unless a wedge/hash bond was actually
@@ -331,6 +555,14 @@ pub(crate) fn wedge_vs_3d_conflicts(
 /// `geometry_rank` are always populated; `stereo3d_diagnostics` cross-checks
 /// the two and checks any wedge/hash-declared stereo against real geometry
 /// -- see [`Stereo3DDiagnostic`].
+///
+/// `square_planar_diagnostics` is populated only when `conformer` is `Some`
+/// (square-planar reperception never runs against a flat/absent conformer --
+/// see `docs/rfcs/square_planar_mol_io_rfc.md`), and even then only for a
+/// candidate center whose geometry looked plausible but didn't
+/// unambiguously resolve to SP1/SP2/SP3; a successfully-perceived center is
+/// reflected directly in `mol`'s `Atom.chirality`/`stereo_neighbor_order`,
+/// not listed here.
 #[derive(Clone)]
 pub struct MolReadReport {
     pub mol: Molecule,
@@ -342,6 +574,7 @@ pub struct MolReadReport {
     pub coordinate_dimension: CoordinateDimension,
     pub geometry_rank: GeometryRank,
     pub stereo3d_diagnostics: Vec<Stereo3DDiagnostic>,
+    pub square_planar_diagnostics: Vec<SquarePlanarPerceptionDiagnostic>,
 }
 
 // ---------------------------------------------------------------------------
@@ -691,7 +924,13 @@ pub fn read_mol_with_diagnostics(input: &str) -> Result<MolReadReport, MolParseE
         }
         _ => {}
     }
+    // Square-planar reperception BEFORE `wedge_vs_3d_conflicts`: it may set
+    // `Chirality::SquarePlanar` on some atoms, and that function's own
+    // `is_tetrahedral()` gate (see its doc comment) must see the final
+    // chirality to correctly skip them.
+    let mut square_planar_diagnostics = Vec::new();
     if let Some(ref conf) = conformer {
+        square_planar_diagnostics = perceive_square_planar_from_3d(&mut mol, conf);
         stereo3d_diagnostics.extend(wedge_vs_3d_conflicts(&mol, conf));
     }
 
@@ -705,6 +944,7 @@ pub fn read_mol_with_diagnostics(input: &str) -> Result<MolReadReport, MolParseE
         coordinate_dimension,
         geometry_rank,
         stereo3d_diagnostics,
+        square_planar_diagnostics,
     })
 }
 
@@ -947,6 +1187,253 @@ pub fn write_mol_with_conformer(
 
     out.push_str("M  END\n");
     out
+}
+
+// ---------------------------------------------------------------------------
+// Square-planar write-side validation -- see the read-side section above
+// and `docs/rfcs/square_planar_mol_io_rfc.md` §8-9 for the design (no
+// coordinate fabrication, ever; existing coordinates are validated against
+// the declared tag, never trusted silently).
+// ---------------------------------------------------------------------------
+
+/// Which MOL/SDF variant a [`MolStereoWriteError`] was raised against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MolFormat {
+    V2000,
+    V3000,
+}
+
+impl core::fmt::Display for MolFormat {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::V2000 => write!(f, "V2000"),
+            Self::V3000 => write!(f, "V3000"),
+        }
+    }
+}
+
+/// Why [`validate_square_planar_for_write`] refused to write a molecule
+/// carrying `Chirality::SquarePlanar`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnsupportedStereoReason {
+    /// No 3D conformer was supplied at all. MDL/CTfile has no symbolic field
+    /// for a non-tetrahedral stereo tag (RFC §2) -- geometry is the only
+    /// mechanism, and there is none to write here. The writer never
+    /// fabricates one (RFC §8).
+    NoConformerSupplied,
+    /// A conformer was supplied, but this atom has no recorded
+    /// `stereo_neighbor_order` to validate/write positions against.
+    MissingNeighborOrder,
+    /// This atom's `stereo_neighbor_order` contains the implicit-hydrogen
+    /// sentinel -- there is no real spatial position for an implicit H to
+    /// validate or write against (RFC §11).
+    ImplicitHydrogenNeighbor,
+    /// A conformer was supplied, but it has no real position for the center
+    /// or one of its declared neighbors.
+    MissingConformerPosition,
+    /// The whole-molecule conformer is flat (`GeometryRank::FlatZero`) or
+    /// indeterminate -- indistinguishable from an ordinary 2D depiction with
+    /// no 3D data at all (RFC §10); this crate's own reader would never
+    /// reperceive a tag from it, so writing one out would silently produce
+    /// an unrecoverable file.
+    WholeMoleculeConformerFlat,
+    /// The conformer's local geometry around this atom does not
+    /// unambiguously resolve to *any* square-planar permutation.
+    GeometryRejected(SquarePlanarRejectionReason),
+    /// The conformer's local geometry resolves to a *different* permutation
+    /// than the one declared on the atom.
+    GeometryTagMismatch { computed: SquarePlanarPermutation },
+}
+
+impl core::fmt::Display for UnsupportedStereoReason {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::NoConformerSupplied => write!(f, "no 3D conformer supplied"),
+            Self::MissingNeighborOrder => write!(f, "atom has no recorded stereo_neighbor_order"),
+            Self::ImplicitHydrogenNeighbor => write!(
+                f,
+                "stereo_neighbor_order contains an implicit-hydrogen slot"
+            ),
+            Self::MissingConformerPosition => {
+                write!(
+                    f,
+                    "conformer is missing a position for this center or a neighbor"
+                )
+            }
+            Self::WholeMoleculeConformerFlat => {
+                write!(f, "whole-molecule conformer is flat/indeterminate")
+            }
+            Self::GeometryRejected(reason) => write!(f, "geometry rejected: {reason}"),
+            Self::GeometryTagMismatch { computed } => write!(
+                f,
+                "conformer geometry encodes {computed:?}, which does not match the declared tag"
+            ),
+        }
+    }
+}
+
+/// A MOL/SDF write was refused because `atom`'s declared
+/// `chematic_core::StereoGeometry` could not be represented in `format` --
+/// see [`UnsupportedStereoReason`] for why. Never raised for tetrahedral
+/// chirality (which round-trips via wedge/hash bonds, already written
+/// faithfully by every writer in this file).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MolStereoWriteError {
+    pub atom: AtomIdx,
+    pub geometry: StereoGeometry,
+    pub format: MolFormat,
+    pub reason: UnsupportedStereoReason,
+}
+
+impl core::fmt::Display for MolStereoWriteError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "cannot write atom {} ({:?} stereo) to MOL {}: {}",
+            self.atom.0, self.geometry, self.format, self.reason
+        )
+    }
+}
+
+impl std::error::Error for MolStereoWriteError {}
+
+/// Validate every `Chirality::SquarePlanar` atom in `mol` against `conformer`
+/// before writing `format`. `Ok(())` when `mol` has no square-planar atom at
+/// all (the common case -- this is a no-op for every existing caller), or
+/// when every square-planar atom's declared tag matches what its
+/// `conformer` positions actually encode. `pub`, not `pub(crate)`: callers
+/// building their own write pipeline can use this as a pre-flight check
+/// even without going through this crate's `*_checked` writer wrappers.
+///
+/// `conformer: None` means "the 2D-only writer path was used" -- always an
+/// error (`NoConformerSupplied`) when `mol` has any square-planar atom, since
+/// no 2D-only writer in this crate has a z channel to encode one (RFC §2).
+pub fn validate_square_planar_for_write(
+    mol: &Molecule,
+    conformer: Option<&Coords3D>,
+    format: MolFormat,
+) -> Result<(), MolStereoWriteError> {
+    // Whole-molecule flatness check once, up front: if ANY square-planar
+    // atom exists and the conformer is flat/indeterminate, every one of them
+    // fails the same way (RFC §10) -- report the first by atom order for a
+    // deterministic, non-HashMap-dependent error.
+    let whole_mol_flat_or_missing = match conformer {
+        None => true,
+        Some(conf) => matches!(
+            classify_geometry_rank(&conf.points),
+            GeometryRank::FlatZero | GeometryRank::Indeterminate
+        ),
+    };
+
+    for (idx, atom) in mol.atoms() {
+        let Chirality::SquarePlanar(declared) = atom.chirality else {
+            continue;
+        };
+        let geometry = StereoGeometry::SquarePlanar;
+
+        let Some(conf) = conformer else {
+            return Err(MolStereoWriteError {
+                atom: idx,
+                geometry,
+                format,
+                reason: UnsupportedStereoReason::NoConformerSupplied,
+            });
+        };
+        if whole_mol_flat_or_missing {
+            return Err(MolStereoWriteError {
+                atom: idx,
+                geometry,
+                format,
+                reason: UnsupportedStereoReason::WholeMoleculeConformerFlat,
+            });
+        }
+
+        let Some(order) = mol.stereo_neighbor_order(idx) else {
+            return Err(MolStereoWriteError {
+                atom: idx,
+                geometry,
+                format,
+                reason: UnsupportedStereoReason::MissingNeighborOrder,
+            });
+        };
+        if order.len() != 4 {
+            return Err(MolStereoWriteError {
+                atom: idx,
+                geometry,
+                format,
+                reason: UnsupportedStereoReason::MissingNeighborOrder,
+            });
+        }
+        if order.contains(&STEREO_H_SENTINEL) {
+            return Err(MolStereoWriteError {
+                atom: idx,
+                geometry,
+                format,
+                reason: UnsupportedStereoReason::ImplicitHydrogenNeighbor,
+            });
+        }
+
+        let Some(center) = conf.points.get(idx.0 as usize).copied() else {
+            return Err(MolStereoWriteError {
+                atom: idx,
+                geometry,
+                format,
+                reason: UnsupportedStereoReason::MissingConformerPosition,
+            });
+        };
+        let mut pts = [Point3::zero(); 4];
+        for (slot, &n) in order.iter().enumerate() {
+            match conf.points.get(n as usize).copied() {
+                Some(p) => pts[slot] = p,
+                None => {
+                    return Err(MolStereoWriteError {
+                        atom: idx,
+                        geometry,
+                        format,
+                        reason: UnsupportedStereoReason::MissingConformerPosition,
+                    });
+                }
+            }
+        }
+
+        match classify_square_planar_geometry(center, pts) {
+            Ok(computed) if computed == declared => {}
+            Ok(computed) => {
+                return Err(MolStereoWriteError {
+                    atom: idx,
+                    geometry,
+                    format,
+                    reason: UnsupportedStereoReason::GeometryTagMismatch { computed },
+                });
+            }
+            Err(reason) => {
+                return Err(MolStereoWriteError {
+                    atom: idx,
+                    geometry,
+                    format,
+                    reason: UnsupportedStereoReason::GeometryRejected(reason),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// [`write_mol_with_conformer`], but fails closed with a typed
+/// [`MolStereoWriteError`] instead of silently writing coordinates that
+/// don't actually match a molecule's declared square-planar stereo (or
+/// don't exist at all). See [`validate_square_planar_for_write`].
+///
+/// For a molecule with no `Chirality::SquarePlanar` atom, this is exactly
+/// [`write_mol_with_conformer`] wrapped in `Ok`.
+pub fn write_mol_with_conformer_checked(
+    mol: &Molecule,
+    metadata: &MolMetadata,
+    conformer: &Coords3D,
+) -> Result<String, MolStereoWriteError> {
+    validate_square_planar_for_write(mol, Some(conformer), MolFormat::V2000)?;
+    Ok(write_mol_with_conformer(mol, metadata, conformer))
 }
 
 // ---------------------------------------------------------------------------
@@ -1539,5 +2026,319 @@ many_bonds
         // confirming the blank-line-skip removal didn't loosen error recovery.
         let bad_sdf = format!("{ETHANOL_MOL}$$$$\nbad\n  prog\n\n  X  Y\nM  END\n$$$$\n");
         assert!(read_sdf_with_diagnostics(&bad_sdf).is_err());
+    }
+}
+
+/// Square-planar 3D-coordinate-derived stereo: classification, perception,
+/// and write-side validation. See `docs/rfcs/square_planar_mol_io_rfc.md`
+/// for the design and `tests/square_planar_mol_io.rs` for the
+/// reader/writer/renumbering integration tests.
+#[cfg(test)]
+mod square_planar_tests {
+    use super::*;
+
+    /// Build the 4 neighbor positions (in trans_pairs() slot order) for an
+    /// ideal, undistorted square-planar arrangement matching `tag` -- reuses
+    /// `trans_pairs()` (not a hand-picked per-tag layout) so this generator
+    /// and `classify_square_planar_geometry` agree by construction on what
+    /// "matches the tag" means. All points share z = 1.5 (nonzero, to avoid
+    /// the FlatZero ambiguity -- see RFC §10).
+    fn ideal_square_planar_neighbors(tag: SquarePlanarPermutation) -> [Point3; 4] {
+        let [(a, b), (c, d)] = tag.trans_pairs();
+        let mut pts = [Point3::zero(); 4];
+        let at = |deg: f64| -> Point3 {
+            let r = deg.to_radians();
+            Point3::new(1.5 * r.cos(), 1.5 * r.sin(), 1.5)
+        };
+        pts[a as usize] = at(45.0);
+        pts[b as usize] = at(225.0); // trans to a
+        pts[c as usize] = at(135.0);
+        pts[d as usize] = at(315.0); // trans to c
+        pts
+    }
+
+    #[test]
+    fn classify_recovers_all_three_tags_from_ideal_geometry() {
+        // Center must share the neighbors' z=1.5 plane (see
+        // `ideal_square_planar_neighbors`) -- coplanarity is center-relative.
+        let center = Point3::new(0.0, 0.0, 1.5);
+        for tag in [
+            SquarePlanarPermutation::SP1,
+            SquarePlanarPermutation::SP2,
+            SquarePlanarPermutation::SP3,
+        ] {
+            let neighbors = ideal_square_planar_neighbors(tag);
+            assert_eq!(
+                classify_square_planar_geometry(center, neighbors),
+                Ok(tag),
+                "failed to recover {tag:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_rejects_genuinely_tetrahedral_geometry_as_not_coplanar() {
+        // Ideal tetrahedral directions (unit vectors), scaled -- never
+        // coplanar with the center.
+        let center = Point3::zero();
+        let neighbors = [
+            Point3::new(1.0, 1.0, 1.0),
+            Point3::new(1.0, -1.0, -1.0),
+            Point3::new(-1.0, 1.0, -1.0),
+            Point3::new(-1.0, -1.0, 1.0),
+        ];
+        assert_eq!(
+            classify_square_planar_geometry(center, neighbors),
+            Err(SquarePlanarRejectionReason::NotCoplanar)
+        );
+    }
+
+    #[test]
+    fn classify_rejects_degenerate_coincident_neighbor() {
+        let center = Point3::zero();
+        let mut neighbors = ideal_square_planar_neighbors(SquarePlanarPermutation::SP1);
+        neighbors[0] = center; // coincides with the center itself
+        assert_eq!(
+            classify_square_planar_geometry(center, neighbors),
+            Err(SquarePlanarRejectionReason::DegenerateBondVector)
+        );
+    }
+
+    #[test]
+    fn classify_rejects_ambiguous_geometry_with_no_trans_pair() {
+        // All 4 neighbors clustered within one 90-degree quadrant -- coplanar,
+        // but no two are ever close to trans (180 degrees) apart.
+        let center = Point3::new(0.0, 0.0, 1.5);
+        let at = |deg: f64| -> Point3 {
+            let r = deg.to_radians();
+            Point3::new(1.5 * r.cos(), 1.5 * r.sin(), 1.5)
+        };
+        let neighbors = [at(0.0), at(20.0), at(40.0), at(60.0)];
+        assert_eq!(
+            classify_square_planar_geometry(center, neighbors),
+            Err(SquarePlanarRejectionReason::AmbiguousTransPairing)
+        );
+    }
+
+    /// Build a 5-atom (center + 4 ligand) molecule plus a matching `Coords3D`
+    /// conformer encoding `tag`'s ideal geometry. `center_element` lets
+    /// callers probe the element-eligibility gate (RFC §6).
+    fn square_planar_fixture(
+        center_element: Element,
+        tag: SquarePlanarPermutation,
+    ) -> (Molecule, Coords3D) {
+        let mut b = MoleculeBuilder::new();
+        let center = b.add_atom(Atom::new(center_element));
+        let cl1 = b.add_atom(Atom::new(Element::CL));
+        let cl2 = b.add_atom(Atom::new(Element::CL));
+        let n1 = b.add_atom(Atom::new(Element::N));
+        let n2 = b.add_atom(Atom::new(Element::N));
+        b.add_bond(center, cl1, BondOrder::Single).unwrap();
+        b.add_bond(center, cl2, BondOrder::Single).unwrap();
+        b.add_bond(center, n1, BondOrder::Single).unwrap();
+        b.add_bond(center, n2, BondOrder::Single).unwrap();
+        let mol = b.build();
+
+        let neighbor_pts = ideal_square_planar_neighbors(tag);
+        let points = vec![
+            Point3::new(0.0, 0.0, 1.5), // center
+            neighbor_pts[0],
+            neighbor_pts[1],
+            neighbor_pts[2],
+            neighbor_pts[3],
+        ];
+        (mol, Coords3D { points })
+    }
+
+    #[test]
+    fn perceive_assigns_all_three_tags_for_an_undefined_valence_element() {
+        for tag in [
+            SquarePlanarPermutation::SP1,
+            SquarePlanarPermutation::SP2,
+            SquarePlanarPermutation::SP3,
+        ] {
+            let (mut mol, conformer) = square_planar_fixture(Element::PT, tag);
+            let diagnostics = perceive_square_planar_from_3d(&mut mol, &conformer);
+            assert!(
+                diagnostics.is_empty(),
+                "{tag:?}: unexpected {diagnostics:?}"
+            );
+            assert_eq!(mol.atom(AtomIdx(0)).chirality, Chirality::SquarePlanar(tag));
+            assert_eq!(
+                mol.stereo_neighbor_order(AtomIdx(0)),
+                Some([1u32, 2, 3, 4].as_slice())
+            );
+        }
+    }
+
+    #[test]
+    fn perceive_never_tags_an_element_with_a_defined_valence() {
+        // Identical coplanar-square coordinates, but Carbon has a defined
+        // (organic-subset) valence list -- RDKit itself does not perceive
+        // non-tetrahedral chirality for such elements either (RFC §4/§6),
+        // even from geometrically-square coordinates.
+        let (mut mol, conformer) = square_planar_fixture(Element::C, SquarePlanarPermutation::SP1);
+        let diagnostics = perceive_square_planar_from_3d(&mut mol, &conformer);
+        assert!(diagnostics.is_empty());
+        assert_eq!(mol.atom(AtomIdx(0)).chirality, Chirality::None);
+    }
+
+    #[test]
+    fn perceive_reports_a_diagnostic_for_coplanar_but_ambiguous_geometry() {
+        let mut b = MoleculeBuilder::new();
+        let center = b.add_atom(Atom::new(Element::PT));
+        let cl1 = b.add_atom(Atom::new(Element::CL));
+        let cl2 = b.add_atom(Atom::new(Element::CL));
+        let n1 = b.add_atom(Atom::new(Element::N));
+        let n2 = b.add_atom(Atom::new(Element::N));
+        b.add_bond(center, cl1, BondOrder::Single).unwrap();
+        b.add_bond(center, cl2, BondOrder::Single).unwrap();
+        b.add_bond(center, n1, BondOrder::Single).unwrap();
+        b.add_bond(center, n2, BondOrder::Single).unwrap();
+        let mut mol = b.build();
+
+        let at = |deg: f64| -> Point3 {
+            let r = deg.to_radians();
+            Point3::new(1.5 * r.cos(), 1.5 * r.sin(), 1.5)
+        };
+        let points = vec![
+            Point3::new(0.0, 0.0, 1.5),
+            at(0.0),
+            at(20.0),
+            at(40.0),
+            at(60.0),
+        ];
+        let conformer = Coords3D { points };
+
+        let diagnostics = perceive_square_planar_from_3d(&mut mol, &conformer);
+        assert_eq!(
+            diagnostics,
+            vec![SquarePlanarPerceptionDiagnostic {
+                atom: AtomIdx(0),
+                reason: SquarePlanarRejectionReason::AmbiguousTransPairing,
+            }]
+        );
+        assert_eq!(mol.atom(AtomIdx(0)).chirality, Chirality::None);
+    }
+
+    #[test]
+    fn validate_is_a_no_op_for_a_molecule_with_no_square_planar_atom() {
+        let (mol, _conformer) = square_planar_fixture(Element::PT, SquarePlanarPermutation::SP1);
+        // No chirality was set on this fixture yet (perceive was never
+        // called) -- validate must be Ok regardless of conformer presence.
+        assert!(validate_square_planar_for_write(&mol, None, MolFormat::V2000).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_no_conformer_supplied() {
+        let (mut mol, _conformer) =
+            square_planar_fixture(Element::PT, SquarePlanarPermutation::SP1);
+        mol.set_chirality(
+            AtomIdx(0),
+            Chirality::SquarePlanar(SquarePlanarPermutation::SP1),
+        );
+        mol.set_stereo_neighbor_order(AtomIdx(0), vec![1, 2, 3, 4]);
+        let err = validate_square_planar_for_write(&mol, None, MolFormat::V2000).unwrap_err();
+        assert_eq!(err.reason, UnsupportedStereoReason::NoConformerSupplied);
+        assert_eq!(err.format, MolFormat::V2000);
+        assert_eq!(err.geometry, StereoGeometry::SquarePlanar);
+    }
+
+    #[test]
+    fn validate_rejects_whole_molecule_flat_conformer() {
+        let (mut mol, mut conformer) =
+            square_planar_fixture(Element::PT, SquarePlanarPermutation::SP1);
+        mol.set_chirality(
+            AtomIdx(0),
+            Chirality::SquarePlanar(SquarePlanarPermutation::SP1),
+        );
+        mol.set_stereo_neighbor_order(AtomIdx(0), vec![1, 2, 3, 4]);
+        // Flatten every z to exactly 0 -- the ordinary "2D depiction, no
+        // real 3D data" case (RFC §10), indistinguishable from wedge-only
+        // MOL input by this crate's own reader.
+        for p in &mut conformer.points {
+            p.z = 0.0;
+        }
+        let err =
+            validate_square_planar_for_write(&mol, Some(&conformer), MolFormat::V3000).unwrap_err();
+        assert_eq!(
+            err.reason,
+            UnsupportedStereoReason::WholeMoleculeConformerFlat
+        );
+    }
+
+    #[test]
+    fn validate_rejects_geometry_tag_mismatch() {
+        // Declare SP1 but supply SP2-shaped coordinates.
+        let (mut mol, conformer) = square_planar_fixture(Element::PT, SquarePlanarPermutation::SP2);
+        mol.set_chirality(
+            AtomIdx(0),
+            Chirality::SquarePlanar(SquarePlanarPermutation::SP1),
+        );
+        mol.set_stereo_neighbor_order(AtomIdx(0), vec![1, 2, 3, 4]);
+        let err =
+            validate_square_planar_for_write(&mol, Some(&conformer), MolFormat::V2000).unwrap_err();
+        assert_eq!(
+            err.reason,
+            UnsupportedStereoReason::GeometryTagMismatch {
+                computed: SquarePlanarPermutation::SP2
+            }
+        );
+    }
+
+    #[test]
+    fn validate_rejects_implicit_hydrogen_neighbor_slot() {
+        let (mut mol, conformer) = square_planar_fixture(Element::PT, SquarePlanarPermutation::SP1);
+        mol.set_chirality(
+            AtomIdx(0),
+            Chirality::SquarePlanar(SquarePlanarPermutation::SP1),
+        );
+        mol.set_stereo_neighbor_order(AtomIdx(0), vec![1, 2, 3, STEREO_H_SENTINEL]);
+        let err =
+            validate_square_planar_for_write(&mol, Some(&conformer), MolFormat::V2000).unwrap_err();
+        assert_eq!(
+            err.reason,
+            UnsupportedStereoReason::ImplicitHydrogenNeighbor
+        );
+    }
+
+    #[test]
+    fn validate_accepts_matching_geometry_and_checked_writer_produces_output() {
+        let (mut mol, conformer) = square_planar_fixture(Element::PT, SquarePlanarPermutation::SP1);
+        mol.set_chirality(
+            AtomIdx(0),
+            Chirality::SquarePlanar(SquarePlanarPermutation::SP1),
+        );
+        mol.set_stereo_neighbor_order(AtomIdx(0), vec![1, 2, 3, 4]);
+        assert!(validate_square_planar_for_write(&mol, Some(&conformer), MolFormat::V2000).is_ok());
+
+        let block = write_mol_with_conformer_checked(&mol, &MolMetadata::default(), &conformer)
+            .expect("matching geometry must write successfully");
+        assert!(block.contains("V2000"));
+        assert!(block.contains("Pt"));
+    }
+
+    /// The `wedge_vs_3d_conflicts` regression this PR fixes: before the
+    /// `is_tetrahedral()` gate, ANY non-`None` chirality (not just
+    /// `Chirality::None`) fell through into a computation that only ever
+    /// produces `Chirality::Clockwise`/`CounterClockwise` and compares that
+    /// against `atom.chirality` -- which can never equal
+    /// `Chirality::SquarePlanar`, so every square-planar-tagged atom with a
+    /// real conformer would have been flagged as a spurious
+    /// `WedgeVs3DParityConflict`, regardless of whether its geometry was
+    /// actually self-consistent.
+    #[test]
+    fn wedge_vs_3d_conflicts_skips_square_planar_chirality() {
+        let (mut mol, conformer) = square_planar_fixture(Element::PT, SquarePlanarPermutation::SP1);
+        mol.set_chirality(
+            AtomIdx(0),
+            Chirality::SquarePlanar(SquarePlanarPermutation::SP1),
+        );
+        mol.set_stereo_neighbor_order(AtomIdx(0), vec![1, 2, 3, 4]);
+        let diagnostics = wedge_vs_3d_conflicts(&mol, &conformer);
+        assert!(
+            diagnostics.is_empty(),
+            "square-planar chirality must never reach the tetrahedral-only conflict check: {diagnostics:?}"
+        );
     }
 }

--- a/crates/chematic-mol/src/mol2000.rs
+++ b/crates/chematic-mol/src/mol2000.rs
@@ -1043,6 +1043,15 @@ pub fn parse_sdf_with_coords(
 /// Coordinates are written as 0.0 because the core `Molecule` type does not
 /// store 2D/3D coordinates.  All other atom and bond fields are derived from
 /// the molecule graph.
+///
+/// **Does not preserve `Chirality::SquarePlanar` stereo.** This is a 2D-only
+/// writer with no z channel; MOL/CTfile has no other field for a
+/// non-tetrahedral stereo tag either (see
+/// `docs/rfcs/square_planar_mol_io_rfc.md`). A square-planar-tagged atom is
+/// written with no indication anything was dropped. If `mol` may carry
+/// `Chirality::SquarePlanar`, use [`write_mol_with_conformer_checked`]
+/// instead, which fails closed with a typed error rather than silently
+/// discarding the tag.
 pub fn write_mol(mol: &Molecule, metadata: &MolMetadata) -> String {
     write_mol_with_coords(mol, metadata, &[])
 }
@@ -1051,6 +1060,10 @@ pub fn write_mol(mol: &Molecule, metadata: &MolMetadata) -> String {
 ///
 /// `coords[i]` is the `(x, y)` position in Ångström for atom index `i`.
 /// Atoms beyond `coords.len()` receive `(0.0, 0.0, 0.0)`.
+///
+/// **Does not preserve `Chirality::SquarePlanar` stereo** -- see
+/// [`write_mol`]'s doc comment; the same 2D-only limitation applies here.
+/// Use [`write_mol_with_conformer_checked`] if `mol` may carry it.
 pub fn write_mol_with_coords(
     mol: &Molecule,
     metadata: &MolMetadata,
@@ -1129,6 +1142,15 @@ pub fn write_mol_with_coords(
 /// contradictory at worst -- see [`write_mol_with_coords`] (unchanged, still
 /// the 2D writer) for the wedge-preserving counterpart. Atoms beyond
 /// `conformer.atom_count()` receive `(0.0, 0.0, 0.0)`.
+///
+/// **Does not validate `Chirality::SquarePlanar` stereo against
+/// `conformer`** -- it writes whatever coordinates it is given, trusting the
+/// caller (the same "trust the caller" posture this crate's writers have
+/// always had for tetrahedral wedge bonds). If `conformer`'s geometry
+/// doesn't actually match a declared square-planar tag, this will silently
+/// write a self-inconsistent file. Use
+/// [`write_mol_with_conformer_checked`] instead to fail closed on that
+/// mismatch (or on a missing/flat conformer) rather than trusting it.
 pub fn write_mol_with_conformer(
     mol: &Molecule,
     metadata: &MolMetadata,
@@ -1445,6 +1467,12 @@ pub fn write_mol_with_conformer_checked(
 /// `records` — slice of `(molecule, metadata, coords)` tuples.
 /// `coords` is optional; pass an empty slice to write zero coordinates.
 /// Each molecule block is terminated with `$$$$`.
+///
+/// **Does not preserve `Chirality::SquarePlanar` stereo** -- see
+/// [`write_mol`]'s doc comment; this delegates to [`write_mol_with_coords`]
+/// per record. There is no `_checked` SDF-multi-record entry point today;
+/// call [`write_sdf_record_with_conformer_checked`] once per record and
+/// concatenate if `records` may carry it.
 #[allow(clippy::type_complexity)]
 pub fn write_sdf(records: &[(&Molecule, &MolMetadata, &[(f64, f64)])]) -> String {
     let mut out = String::new();
@@ -1469,6 +1497,10 @@ pub fn write_sdf(records: &[(&Molecule, &MolMetadata, &[(f64, f64)])]) -> String
 ///
 /// $$$$
 /// ```
+///
+/// **Does not preserve `Chirality::SquarePlanar` stereo** -- see
+/// [`write_mol`]'s doc comment; this delegates to [`write_mol_with_coords`]
+/// per record.
 #[allow(clippy::type_complexity)]
 pub fn write_sdf_with_charges(
     records: &[(&Molecule, &MolMetadata, &[(f64, f64)], &[f64])],
@@ -1492,6 +1524,10 @@ pub fn write_sdf_with_charges(
 /// Keys starting with `_` are treated as internal/computed properties and are
 /// omitted from the SD block (e.g. `_Name` is written into the MOL header, not
 /// as an SD field).  The record is terminated with `$$$$`.
+///
+/// **Does not preserve `Chirality::SquarePlanar` stereo** -- see
+/// [`write_mol`]'s doc comment; this delegates to [`write_mol_with_coords`].
+/// Use [`write_sdf_record_with_conformer_checked`] if `mol` may carry it.
 pub fn write_sdf_record(
     mol: &Molecule,
     meta: &MolMetadata,
@@ -1511,6 +1547,10 @@ pub fn write_sdf_record(
 /// Like [`write_sdf_record`] but emits a MOL V3000 (Extended Ctab) block
 /// instead of V2000 — required for molecules with more than 999 atoms or
 /// bonds, which don't fit V2000's fixed-width count fields.
+///
+/// **Does not preserve `Chirality::SquarePlanar` stereo** -- see
+/// [`write_mol`]'s doc comment; this delegates to [`crate::mol3000::write_mol_v3000`],
+/// itself 2D-only.
 pub fn write_sdf_record_v3000(
     mol: &Molecule,
     meta: &MolMetadata,
@@ -1534,6 +1574,12 @@ pub fn write_sdf_record_v3000(
 /// back as one [`crate::sdf::ConformerEnsemble`] by
 /// [`crate::sdf::read_sdf_conformer_ensembles`]), call this once per
 /// conformer and concatenate the results.
+///
+/// **Does not validate `Chirality::SquarePlanar` stereo against
+/// `conformer`** -- see [`write_mol_with_conformer`]'s doc comment for why.
+/// Use [`write_sdf_record_with_conformer_checked`] instead to fail closed on
+/// a geometry/tag mismatch (or a missing/flat conformer) rather than
+/// trusting it.
 pub fn write_sdf_record_with_conformer(
     mol: &Molecule,
     meta: &MolMetadata,
@@ -1548,6 +1594,29 @@ pub fn write_sdf_record_with_conformer(
     }
     out.push_str("$$$$\n");
     out
+}
+
+/// [`write_sdf_record_with_conformer`], but fails closed with a typed
+/// [`MolStereoWriteError`] instead of silently writing coordinates that
+/// don't actually match a molecule's declared square-planar stereo (or
+/// don't exist at all) -- the SDF-record counterpart of
+/// [`write_mol_with_conformer_checked`]. See
+/// [`validate_square_planar_for_write`].
+///
+/// For a molecule with no `Chirality::SquarePlanar` atom, this is exactly
+/// [`write_sdf_record_with_conformer`] wrapped in `Ok`. To write a
+/// multi-record SDF (e.g. several distinct molecules, or several conformers
+/// of the same one), call this once per record and concatenate the
+/// results -- there is no separate multi-record entry point, matching
+/// [`write_sdf`]'s own per-record-call convention.
+pub fn write_sdf_record_with_conformer_checked(
+    mol: &Molecule,
+    meta: &MolMetadata,
+    conformer: &Coords3D,
+    props: &std::collections::HashMap<String, String>,
+) -> Result<String, MolStereoWriteError> {
+    validate_square_planar_for_write(mol, Some(conformer), MolFormat::V2000)?;
+    Ok(write_sdf_record_with_conformer(mol, meta, conformer, props))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/chematic-mol/src/mol3000.rs
+++ b/crates/chematic-mol/src/mol3000.rs
@@ -1119,6 +1119,15 @@ M  END
 ///
 /// `coords[i]` is the `(x, y)` position for atom `i`.  Atoms beyond
 /// `coords.len()` receive `(0.0, 0.0, 0.0)`.
+///
+/// **Does not preserve `Chirality::SquarePlanar` stereo.** This is a
+/// 2D-only writer with no z channel; MOL/CTfile has no other field for a
+/// non-tetrahedral stereo tag either (see
+/// `docs/rfcs/square_planar_mol_io_rfc.md`). A square-planar-tagged atom is
+/// written with no indication anything was dropped. If `mol` may carry
+/// `Chirality::SquarePlanar`, use
+/// [`write_mol_v3000_with_conformer_checked`] instead, which fails closed
+/// with a typed error rather than silently discarding the tag.
 pub fn write_mol_v3000(mol: &Molecule, metadata: &MolMetadata, coords: &[(f64, f64)]) -> String {
     let natoms = mol.atom_count();
     let nbonds = mol.bond_count();
@@ -1236,6 +1245,13 @@ pub fn write_mol_v3000(mol: &Molecule, metadata: &MolMetadata, coords: &[(f64, f
 /// its own output. Enhanced stereo groups (`COLLECTION`/`STEABS`/`STEOR`/
 /// `STEAND`) are unaffected -- they label which atoms form a stereo group,
 /// not a direction, and remain meaningful for a 3D record.
+///
+/// **Does not validate `Chirality::SquarePlanar` stereo against
+/// `conformer`** -- it writes whatever coordinates it is given, trusting the
+/// caller. If `conformer`'s geometry doesn't actually match a declared
+/// square-planar tag, this will silently write a self-inconsistent file.
+/// Use [`write_mol_v3000_with_conformer_checked`] instead to fail closed on
+/// that mismatch (or on a missing/flat conformer) rather than trusting it.
 pub fn write_mol_v3000_with_conformer(
     mol: &Molecule,
     metadata: &MolMetadata,

--- a/crates/chematic-mol/src/mol3000.rs
+++ b/crates/chematic-mol/src/mol3000.rs
@@ -565,7 +565,13 @@ pub fn read_mol_v3000_with_diagnostics(input: &str) -> Result<MolReadReport, Mol
         }
         _ => {}
     }
+    // Same ordering rationale as `mol2000.rs::read_mol_with_diagnostics`:
+    // square-planar reperception first (may set `Chirality::SquarePlanar`),
+    // then `wedge_vs_3d_conflicts` (whose `is_tetrahedral()` gate must see
+    // the final chirality).
+    let mut square_planar_diagnostics = Vec::new();
     if let Some(ref conf) = conformer {
+        square_planar_diagnostics = crate::mol2000::perceive_square_planar_from_3d(&mut mol, conf);
         stereo3d_diagnostics.extend(crate::mol2000::wedge_vs_3d_conflicts(&mol, conf));
     }
 
@@ -579,6 +585,7 @@ pub fn read_mol_v3000_with_diagnostics(input: &str) -> Result<MolReadReport, Mol
         coordinate_dimension,
         geometry_rank,
         stereo3d_diagnostics,
+        square_planar_diagnostics,
     })
 }
 
@@ -1334,6 +1341,25 @@ pub fn write_mol_v3000_with_conformer(
     out.push_str("M  END\n");
 
     out
+}
+
+/// [`write_mol_v3000_with_conformer`], but fails closed with a typed
+/// [`crate::mol2000::MolStereoWriteError`] instead of silently writing
+/// coordinates that don't actually match a molecule's declared
+/// square-planar stereo (or don't exist at all) -- the V3000 counterpart of
+/// [`crate::mol2000::write_mol_with_conformer_checked`]. See
+/// [`crate::mol2000::validate_square_planar_for_write`].
+pub fn write_mol_v3000_with_conformer_checked(
+    mol: &Molecule,
+    metadata: &MolMetadata,
+    conformer: &Coords3D,
+) -> Result<String, crate::mol2000::MolStereoWriteError> {
+    crate::mol2000::validate_square_planar_for_write(
+        mol,
+        Some(conformer),
+        crate::mol2000::MolFormat::V3000,
+    )?;
+    Ok(write_mol_v3000_with_conformer(mol, metadata, conformer))
 }
 
 #[cfg(test)]

--- a/crates/chematic-mol/tests/square_planar_mol_io.rs
+++ b/crates/chematic-mol/tests/square_planar_mol_io.rs
@@ -1,0 +1,513 @@
+//! Square-planar stereo (`@SP1`/`@SP2`/`@SP3`) MOL/SDF I/O integration
+//! tests: read/write across V2000 and V3000, atom-renumbering invariance,
+//! and the FlatZero round-trip limitation this design accepts.
+//!
+//! Design and RDKit oracle provenance:
+//! `docs/rfcs/square_planar_mol_io_rfc.md`. Unit-level coverage of the
+//! classifier/validator themselves lives in `mol2000.rs`'s own
+//! `square_planar_tests` module; these tests cover the cross-cutting,
+//! full-pipeline invariants that only exist once a real reader/writer round
+//! trip is in the loop -- mirroring `stereo_reader_integration.rs`'s own
+//! split between unit-level parity math and integration-level round trips.
+//!
+//! Every fixture here places the whole molecule off the z=0 plane (nonzero,
+//! constant z) -- see the RFC §10 for why: a literal z=0 conformer is this
+//! crate's pre-existing, load-bearing signal for "no real 3D data", and
+//! using it here would produce a fixture whose tag silently fails to
+//! round-trip, not a fixture that demonstrates round-tripping.
+
+use chematic_core::{
+    AtomIdx, Chirality, Coords3D, Point3, SquarePlanarPermutation, remap_square_planar_tag,
+};
+use chematic_mol::mol2000::{
+    MolFormat, MolMetadata, UnsupportedStereoReason, read_mol_with_diagnostics,
+    validate_square_planar_for_write, write_mol_with_conformer_checked,
+};
+use chematic_mol::mol3000::{
+    read_mol_v3000_with_diagnostics, write_mol_v3000_with_conformer_checked,
+};
+use chematic_smiles::{canonical_smiles, parse};
+
+/// Ideal (undistorted) neighbor positions for `tag`, in `trans_pairs()` slot
+/// order, all sharing `z` (nonzero -- see module docs). Reuses
+/// `trans_pairs()` (the same oracle-verified source of truth
+/// `chematic_core::remap_square_planar_tag` uses) rather than a hand-picked
+/// per-tag layout, and applies `distortion_deg` symmetrically to both
+/// members of each trans pair so the pair's angle moves off 180 degrees by
+/// `2 * distortion_deg` -- used by the near-degenerate robustness test.
+fn ideal_neighbor_positions(
+    tag: SquarePlanarPermutation,
+    z: f64,
+    distortion_deg: f64,
+) -> [Point3; 4] {
+    let [(a, b), (c, d)] = tag.trans_pairs();
+    let mut pts = [Point3::new(0.0, 0.0, z); 4];
+    let at = |deg: f64| -> Point3 {
+        let r = deg.to_radians();
+        Point3::new(1.5 * r.cos(), 1.5 * r.sin(), z)
+    };
+    pts[a as usize] = at(45.0 + distortion_deg);
+    pts[b as usize] = at(225.0 - distortion_deg);
+    pts[c as usize] = at(135.0 - distortion_deg);
+    pts[d as usize] = at(315.0 + distortion_deg);
+    pts
+}
+
+/// One SMILES-declared square-planar fixture: the parsed molecule, a
+/// synthetic `Coords3D` conformer whose real coordinates geometrically
+/// encode the declared tag (using the parser's own `stereo_neighbor_order`,
+/// not an assumed atom order), the declared tag itself, and its declared
+/// neighbor order -- the latter is what makes the differential check below
+/// frame-explicit rather than assuming the MOL round trip preserves
+/// neighbor-listing order. The center atom's index is re-derived on demand
+/// via `pt_atom_idx` rather than stored (this fixture family only ever has
+/// one Pt-like center).
+struct SquarePlanarFixture {
+    mol: chematic_core::Molecule,
+    conformer: Coords3D,
+    tag: SquarePlanarPermutation,
+    order: [u32; 4],
+}
+
+/// Panics (test setup, not the code under test) if `smiles` isn't a
+/// square-planar center with exactly 4 explicit neighbors.
+fn smiles_to_square_planar_mol_fixture(smiles: &str, z: f64) -> SquarePlanarFixture {
+    let mol = parse(smiles).unwrap_or_else(|e| panic!("{smiles} must parse: {e}"));
+    let (center, tag) = mol
+        .atoms()
+        .find_map(|(idx, atom)| match atom.chirality {
+            Chirality::SquarePlanar(tag) => Some((idx, tag)),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("{smiles} must declare a square-planar center"));
+    let order_vec = mol
+        .stereo_neighbor_order(center)
+        .unwrap_or_else(|| panic!("{smiles}'s center must have a stereo_neighbor_order"))
+        .to_vec();
+    let order: [u32; 4] = order_vec
+        .try_into()
+        .unwrap_or_else(|v: Vec<u32>| panic!("fixture must have 4 explicit neighbors, got {v:?}"));
+
+    let neighbor_pts = ideal_neighbor_positions(tag, z, 0.0);
+    let mut points = vec![Point3::new(0.0, 0.0, z); mol.atom_count()];
+    for (slot, &atom_id) in order.iter().enumerate() {
+        points[atom_id as usize] = neighbor_pts[slot];
+    }
+    SquarePlanarFixture {
+        mol,
+        conformer: Coords3D { points },
+        tag,
+        order,
+    }
+}
+
+fn pt_atom_idx(mol: &chematic_core::Molecule) -> AtomIdx {
+    mol.atoms()
+        .find(|(_, a)| a.element == chematic_core::Element::PT)
+        .map(|(idx, _)| idx)
+        .expect("fixture must contain Pt")
+}
+
+/// The physical-arrangement-aware differential check the task asks for: not
+/// "does the recovered tag's spelling match", but "does the recovered
+/// `(tag, neighbor_order)` pair describe the *same physical arrangement* as
+/// the original SMILES-declared `(tag, neighbor_order)` pair" -- computed via
+/// `chematic_core::remap_square_planar_tag`, the same oracle-validated
+/// (144-case table) function `chematic-smiles`'s own canonicalizer uses, not
+/// a raw tag equality that would silently assume the MOL round trip
+/// preserves `stereo_neighbor_order`'s exact listing order (it need not:
+/// `perceive_square_planar_from_3d` derives its order from
+/// `Molecule::neighbors`/bond-block order, which is not guaranteed to match
+/// the original SMILES parser's branch-encounter order).
+fn assert_same_physical_arrangement(
+    original: &SquarePlanarFixture,
+    read_mol: &chematic_core::Molecule,
+    label: &str,
+) {
+    let read_center = pt_atom_idx(read_mol);
+    let recovered_tag = match read_mol.atom(read_center).chirality {
+        Chirality::SquarePlanar(tag) => tag,
+        other => panic!("{label}: expected SquarePlanar, got {other:?}"),
+    };
+    let recovered_order: [u32; 4] = read_mol
+        .stereo_neighbor_order(read_center)
+        .unwrap_or_else(|| panic!("{label}: recovered center has no stereo_neighbor_order"))
+        .to_vec()
+        .try_into()
+        .unwrap_or_else(|v: Vec<u32>| panic!("{label}: expected 4 neighbors, got {v:?}"));
+
+    assert_eq!(
+        remap_square_planar_tag(recovered_tag, recovered_order, original.order),
+        Some(original.tag),
+        "{label}: recovered ({recovered_tag:?}, {recovered_order:?}) does not describe the same \
+         physical arrangement as the original ({:?}, {:?})",
+        original.tag,
+        original.order
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cisplatin/transplatin differential test (V2000 + V3000)
+// ---------------------------------------------------------------------------
+
+/// The same structures and tags as `chematic-smiles/tests/square_planar_stereo.rs`'s
+/// `cisplatin_and_transplatin_have_distinct_canonical_identity` -- source of
+/// truth for which tag means cis vs trans, reused here rather than
+/// re-derived, exactly as the task requires: a differential test against the
+/// already-oracle-validated SMILES path.
+const CISPLATIN_SMILES: &str = "N->[Pt@SP1](<-N)(Cl)Cl";
+const TRANSPLATIN_SMILES: &str = "N->[Pt@SP2](<-N)(Cl)Cl";
+
+#[test]
+fn cisplatin_transplatin_v2000_round_trip_recovers_distinct_tags() {
+    let cis = smiles_to_square_planar_mol_fixture(CISPLATIN_SMILES, 1.5);
+    let trans = smiles_to_square_planar_mol_fixture(TRANSPLATIN_SMILES, 1.5);
+    assert_ne!(cis.tag, trans.tag, "fixture setup sanity check");
+
+    let cis_block =
+        write_mol_with_conformer_checked(&cis.mol, &MolMetadata::default(), &cis.conformer)
+            .expect("cisplatin-shaped geometry must be representable");
+    let trans_block =
+        write_mol_with_conformer_checked(&trans.mol, &MolMetadata::default(), &trans.conformer)
+            .expect("transplatin-shaped geometry must be representable");
+
+    let cis_read = read_mol_with_diagnostics(&cis_block).expect("cisplatin V2000 parses");
+    let trans_read = read_mol_with_diagnostics(&trans_block).expect("transplatin V2000 parses");
+
+    // Differential check against the SMILES oracle -- frame-explicit via
+    // `remap_square_planar_tag`, not a raw tag comparison (see the helper's
+    // doc comment for why that would be unsound).
+    assert_same_physical_arrangement(&cis, &cis_read.mol, "cisplatin V2000");
+    assert_same_physical_arrangement(&trans, &trans_read.mol, "transplatin V2000");
+
+    assert_ne!(
+        cis_read.mol.atom(pt_atom_idx(&cis_read.mol)).chirality,
+        trans_read.mol.atom(pt_atom_idx(&trans_read.mol)).chirality,
+        "cisplatin and transplatin must stay distinct after a MOL round trip"
+    );
+    assert!(cis_read.square_planar_diagnostics.is_empty());
+    assert!(trans_read.square_planar_diagnostics.is_empty());
+}
+
+#[test]
+fn cisplatin_transplatin_v3000_round_trip_recovers_distinct_tags() {
+    let cis = smiles_to_square_planar_mol_fixture(CISPLATIN_SMILES, 1.5);
+    let trans = smiles_to_square_planar_mol_fixture(TRANSPLATIN_SMILES, 1.5);
+
+    let cis_block =
+        write_mol_v3000_with_conformer_checked(&cis.mol, &MolMetadata::default(), &cis.conformer)
+            .expect("cisplatin-shaped geometry must be representable in V3000");
+    let trans_block = write_mol_v3000_with_conformer_checked(
+        &trans.mol,
+        &MolMetadata::default(),
+        &trans.conformer,
+    )
+    .expect("transplatin-shaped geometry must be representable in V3000");
+
+    let cis_read = read_mol_v3000_with_diagnostics(&cis_block).expect("cisplatin V3000 parses");
+    let trans_read =
+        read_mol_v3000_with_diagnostics(&trans_block).expect("transplatin V3000 parses");
+
+    assert_same_physical_arrangement(&cis, &cis_read.mol, "cisplatin V3000");
+    assert_same_physical_arrangement(&trans, &trans_read.mol, "transplatin V3000");
+    assert_ne!(
+        cis_read.mol.atom(pt_atom_idx(&cis_read.mol)).chirality,
+        trans_read.mol.atom(pt_atom_idx(&trans_read.mol)).chirality
+    );
+
+    // Both formats behave identically for this mechanism (checked, not
+    // assumed -- RFC §5): the V2000 test above and this V3000 test recover
+    // the same physical tags from the same source SMILES.
+
+    // Full SMILES -> MOL -> SMILES closure (V3000 only -- V2000 collapses
+    // Dative bonds to plain Single, which would perturb the canonical
+    // string for reasons unrelated to stereo; see RFC/module docs).
+    assert_eq!(
+        canonical_smiles(&cis_read.mol),
+        canonical_smiles(&cis.mol),
+        "cisplatin: canonical SMILES must survive a V3000 MOL round trip"
+    );
+    assert_eq!(
+        canonical_smiles(&trans_read.mol),
+        canonical_smiles(&trans.mol),
+        "transplatin: canonical SMILES must survive a V3000 MOL round trip"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Atom-renumbering invariance
+// ---------------------------------------------------------------------------
+
+/// Renumbering must preserve the recovered physical configuration. Per the
+/// RFC (§ design notes) and this project's `stereo_geometry.rs`, a pure
+/// atom relabeling does not require an explicit `remap_square_planar_tag`
+/// call here: `Molecule`'s `stereo_neighbor_order` is itself defined
+/// relative to atom ids, so renumbering the atoms and the conformer
+/// together (the same ids used consistently on both sides) reproduces an
+/// equivalent physical arrangement by construction -- `remap_square_planar_tag`
+/// is exercised end to end via `canonical_smiles`'s own canonicalization
+/// pipeline in the assertion below, not called directly by this test.
+#[test]
+fn atom_renumbering_preserves_square_planar_configuration() {
+    let SquarePlanarFixture {
+        mol,
+        conformer: conf,
+        tag,
+        ..
+    } = smiles_to_square_planar_mol_fixture(CISPLATIN_SMILES, 1.5);
+    let n = mol.atom_count();
+
+    // Reverse atom order: id `i` in the original becomes id `n-1-i`.
+    let mut builder = chematic_core::MoleculeBuilder::new();
+    let mut old_to_new = vec![0u32; n];
+    for old in (0..n).rev() {
+        let new_idx = builder.add_atom(mol.atom(AtomIdx(old as u32)).clone());
+        old_to_new[old] = new_idx.0;
+    }
+    for (_, bond) in mol.bonds() {
+        let a = AtomIdx(old_to_new[bond.atom1.0 as usize]);
+        let b = AtomIdx(old_to_new[bond.atom2.0 as usize]);
+        builder.add_bond(a, b, bond.order).unwrap();
+    }
+    // Remap stereo_neighbor_order (side channel, not carried by `add_atom`/
+    // `Atom` itself) using the same old->new table.
+    for (old_idx, atom) in mol.atoms() {
+        if let Chirality::SquarePlanar(_) = atom.chirality
+            && let Some(order) = mol.stereo_neighbor_order(old_idx)
+        {
+            let new_order: Vec<u32> = order.iter().map(|&v| old_to_new[v as usize]).collect();
+            builder.set_stereo_neighbor_order(AtomIdx(old_to_new[old_idx.0 as usize]), new_order);
+        }
+    }
+    let renumbered = builder.build();
+
+    // Permute the conformer the same way.
+    let mut renumbered_points = vec![Point3::new(0.0, 0.0, 0.0); n];
+    for old in 0..n {
+        renumbered_points[old_to_new[old] as usize] = conf.points[old];
+    }
+    let renumbered_conf = Coords3D {
+        points: renumbered_points,
+    };
+
+    // Both orderings must write successfully and read back to the SAME
+    // physical arrangement.
+    let block_original = write_mol_with_conformer_checked(&mol, &MolMetadata::default(), &conf)
+        .expect("original order writes");
+    let block_renumbered =
+        write_mol_with_conformer_checked(&renumbered, &MolMetadata::default(), &renumbered_conf)
+            .expect("reversed order writes");
+
+    let read_original = read_mol_with_diagnostics(&block_original).unwrap();
+    let read_renumbered = read_mol_with_diagnostics(&block_renumbered).unwrap();
+
+    assert_eq!(
+        read_original
+            .mol
+            .atom(pt_atom_idx(&read_original.mol))
+            .chirality,
+        Chirality::SquarePlanar(tag)
+    );
+    assert_eq!(
+        read_renumbered
+            .mol
+            .atom(pt_atom_idx(&read_renumbered.mol))
+            .chirality,
+        Chirality::SquarePlanar(tag),
+        "atom-reversed molecule must recover the same tag as the original"
+    );
+
+    // Exercise `remap_square_planar_tag` end to end: canonical SMILES of
+    // both orderings' read-back molecules must agree (same physical
+    // identity), not merely "both happen to say SP1/SP2 in their own local
+    // stereo_neighbor_order frame".
+    assert_eq!(
+        canonical_smiles(&read_original.mol),
+        canonical_smiles(&read_renumbered.mol),
+        "renumbering must not change canonical identity"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Near-degenerate / distorted geometry robustness
+// ---------------------------------------------------------------------------
+
+#[test]
+fn moderately_distorted_geometry_still_recovers_the_correct_tag() {
+    // 15 degrees of symmetric distortion per trans pair (well inside the
+    // ~35-45 degree ambiguity band derived in the RFC/mol2000.rs comments).
+    let mol = parse(CISPLATIN_SMILES).unwrap();
+    let center_idx = mol
+        .atoms()
+        .find(|(_, a)| a.element == chematic_core::Element::PT)
+        .unwrap()
+        .0;
+    let tag = match mol.atom(center_idx).chirality {
+        Chirality::SquarePlanar(tag) => tag,
+        other => panic!("expected square-planar, got {other:?}"),
+    };
+    let order = mol.stereo_neighbor_order(center_idx).unwrap().to_vec();
+
+    let neighbor_pts = ideal_neighbor_positions(tag, 1.5, 15.0);
+    let mut points = vec![Point3::new(0.0, 0.0, 1.5); mol.atom_count()];
+    for (slot, &atom_id) in order.iter().enumerate() {
+        points[atom_id as usize] = neighbor_pts[slot];
+    }
+    let conf = Coords3D { points };
+
+    let block = write_mol_with_conformer_checked(&mol, &MolMetadata::default(), &conf)
+        .expect("distorted-but-valid geometry must still be representable");
+    let read = read_mol_with_diagnostics(&block).unwrap();
+    assert_eq!(
+        read.mol.atom(pt_atom_idx(&read.mol)).chirality,
+        Chirality::SquarePlanar(tag),
+        "15-degree distortion must not prevent tag recovery"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FlatZero: documented round-trip limitation (RFC §10)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn flat_z_conformer_is_a_documented_round_trip_limitation() {
+    let SquarePlanarFixture {
+        mol,
+        conformer: mut conf,
+        ..
+    } = smiles_to_square_planar_mol_fixture(CISPLATIN_SMILES, 1.5);
+    for p in &mut conf.points {
+        p.z = 0.0;
+    }
+
+    // The checked writer must refuse (this is exactly the "writer says
+    // encoded, reader says nothing" failure this design exists to prevent).
+    let err = write_mol_with_conformer_checked(&mol, &MolMetadata::default(), &conf).unwrap_err();
+    assert_eq!(
+        err.reason,
+        UnsupportedStereoReason::WholeMoleculeConformerFlat
+    );
+    assert!(matches!(
+        validate_square_planar_for_write(&mol, Some(&conf), MolFormat::V2000),
+        Err(e) if e.reason == UnsupportedStereoReason::WholeMoleculeConformerFlat
+    ));
+
+    // And even a hand-built, flat-z MOL block bypassing this crate's own
+    // writer entirely (simulating an externally-produced file) does not
+    // recover a tag on read -- documenting, not silently mishandling, the
+    // limitation.
+    let center = pt_atom_idx(&mol);
+    let order = mol.stereo_neighbor_order(center).unwrap().to_vec();
+    let neighbor_pts = ideal_neighbor_positions(
+        match mol.atom(center).chirality {
+            Chirality::SquarePlanar(t) => t,
+            other => panic!("expected square-planar, got {other:?}"),
+        },
+        0.0,
+        0.0,
+    );
+    let natoms = mol.atom_count();
+    let mut lines = vec![
+        String::new(),
+        "     hand    3D".to_string(),
+        String::new(),
+        format!(
+            "{:>3}{:>3}  0  0  0  0  0  0  0  0999 V2000",
+            natoms,
+            mol.bond_count()
+        ),
+    ];
+    let mut xyz = vec![(0.0, 0.0, 0.0); natoms];
+    for (slot, &atom_id) in order.iter().enumerate() {
+        let p = neighbor_pts[slot];
+        xyz[atom_id as usize] = (p.x, p.y, p.z);
+    }
+    for (idx, atom) in mol.atoms() {
+        let (x, y, z) = xyz[idx.0 as usize];
+        lines.push(format!(
+            "{:>10.4}{:>10.4}{:>10.4} {:<3} 0  0  0  0  0  0  0  0  0  0  0  0",
+            x,
+            y,
+            z,
+            atom.element.symbol()
+        ));
+    }
+    for (_, bond) in mol.bonds() {
+        lines.push(format!(
+            "{:>3}{:>3}{:>3}{:>3}",
+            bond.atom1.0 + 1,
+            bond.atom2.0 + 1,
+            1,
+            0
+        ));
+    }
+    lines.push("M  END".to_string());
+    let hand_block = lines.join("\n") + "\n";
+
+    let read = read_mol_with_diagnostics(&hand_block).expect("hand-built flat block still parses");
+    assert_eq!(
+        read.mol.atom(pt_atom_idx(&read.mol)).chirality,
+        Chirality::None,
+        "flat-z (z=0) square-planar geometry is a known, documented non-recoverable case"
+    );
+    assert!(read.conformer.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Malformed / adversarial input never panics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn degenerate_and_truncated_conformers_never_panic() {
+    let SquarePlanarFixture {
+        mol,
+        conformer: mut conf,
+        ..
+    } = smiles_to_square_planar_mol_fixture(CISPLATIN_SMILES, 1.5);
+
+    // Every atom coincident at the same point (degenerate bond vectors).
+    let center_pt = conf.points[pt_atom_idx(&mol).0 as usize];
+    for p in &mut conf.points {
+        *p = center_pt;
+    }
+    let _ = write_mol_with_conformer_checked(&mol, &MolMetadata::default(), &conf);
+    let _ = validate_square_planar_for_write(&mol, Some(&conf), MolFormat::V3000);
+
+    // Truncated conformer (fewer points than atoms) -- must fail closed via
+    // `MissingConformerPosition`, never index-panic.
+    let short_conf = Coords3D {
+        points: vec![Point3::new(0.0, 0.0, 1.5)],
+    };
+    let err =
+        write_mol_with_conformer_checked(&mol, &MolMetadata::default(), &short_conf).unwrap_err();
+    assert_eq!(
+        err.reason,
+        UnsupportedStereoReason::MissingConformerPosition
+    );
+
+    // Empty conformer entirely.
+    let empty_conf = Coords3D { points: vec![] };
+    let _ = write_mol_with_conformer_checked(&mol, &MolMetadata::default(), &empty_conf);
+
+    // A MOL block whose Pt-adjacent atom coordinates are all identical
+    // (degenerate) must parse and never panic, regardless of what stereo
+    // (if any) gets perceived.
+    let degenerate_block = "\
+degenerate
+  chematic          3D
+
+  5  4  0  0  0  0  0  0  0  0999 V2000
+    0.0000    0.0000    1.5000 Pt  0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    0.0000    1.5000 Cl  0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    0.0000    1.5000 Cl  0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    0.0000    1.5000 N   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    0.0000    1.5000 N   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  1  3  1  0
+  1  4  1  0
+  1  5  1  0
+M  END
+";
+    let read = read_mol_with_diagnostics(degenerate_block).expect("degenerate block still parses");
+    assert_eq!(read.mol.atom(AtomIdx(0)).chirality, Chirality::None);
+}

--- a/crates/chematic-mol/tests/square_planar_mol_io.rs
+++ b/crates/chematic-mol/tests/square_planar_mol_io.rs
@@ -17,15 +17,18 @@
 //! round-trip, not a fixture that demonstrates round-tripping.
 
 use chematic_core::{
-    AtomIdx, Chirality, Coords3D, Point3, SquarePlanarPermutation, remap_square_planar_tag,
+    Atom, AtomIdx, BondOrder, Chirality, Coords3D, Element, MoleculeBuilder, Point3,
+    SquarePlanarPermutation, remap_square_planar_tag,
 };
 use chematic_mol::mol2000::{
     MolFormat, MolMetadata, UnsupportedStereoReason, read_mol_with_diagnostics,
-    validate_square_planar_for_write, write_mol_with_conformer_checked,
+    validate_square_planar_for_write, write_mol_with_conformer, write_mol_with_conformer_checked,
+    write_sdf_record_with_conformer_checked,
 };
 use chematic_mol::mol3000::{
     read_mol_v3000_with_diagnostics, write_mol_v3000_with_conformer_checked,
 };
+use chematic_mol::sdf::SdfRecordReader;
 use chematic_smiles::{canonical_smiles, parse};
 
 /// Ideal (undistorted) neighbor positions for `tag`, in `trans_pairs()` slot
@@ -510,4 +513,330 @@ M  END
 ";
     let read = read_mol_with_diagnostics(degenerate_block).expect("degenerate block still parses");
     assert_eq!(read.mol.atom(AtomIdx(0)).chirality, Chirality::None);
+}
+
+// ---------------------------------------------------------------------------
+// Additional fixture coverage (per human-reviewer follow-up on this PR):
+// SP3 + all-distinct ligands, a duplicate-ligand composition, degree-3/5
+// negative controls, a malformed V3000 coordinate block, write-read-write
+// stability, and the real (`$$$$`-terminated) SDF multi-record path.
+// ---------------------------------------------------------------------------
+
+/// Build a Pt-centered molecule with `ligand_elements.len()` explicit
+/// single-bonded neighbors, no SMILES involved -- lets these tests probe
+/// coordination numbers (3, 5) SMILES parsing wouldn't naturally produce,
+/// and ligand compositions (4 distinct elements, 3+1 duplicate) SMILES
+/// fixtures wouldn't cleanly express either.
+fn build_pt_with_ligands(
+    ligand_elements: &[Element],
+) -> (chematic_core::Molecule, AtomIdx, Vec<AtomIdx>) {
+    let mut b = MoleculeBuilder::new();
+    let center = b.add_atom(Atom::new(Element::PT));
+    let mut ligands = Vec::new();
+    for &el in ligand_elements {
+        let l = b.add_atom(Atom::new(el));
+        b.add_bond(center, l, BondOrder::Single).unwrap();
+        ligands.push(l);
+    }
+    (b.build(), center, ligands)
+}
+
+/// Declare `tag` on `center` with `ligands` as its neighbor order, and build
+/// a matching `Coords3D` conformer (nonzero z -- see module docs).
+fn declare_and_place(
+    mol: &mut chematic_core::Molecule,
+    center: AtomIdx,
+    ligands: &[AtomIdx],
+    tag: SquarePlanarPermutation,
+) -> ([u32; 4], Coords3D) {
+    let order: [u32; 4] = ligands
+        .iter()
+        .map(|a| a.0)
+        .collect::<Vec<_>>()
+        .try_into()
+        .expect("exactly 4 ligands");
+    mol.set_chirality(center, Chirality::SquarePlanar(tag));
+    mol.set_stereo_neighbor_order(center, order.to_vec());
+
+    let neighbor_pts = ideal_neighbor_positions(tag, 1.5, 0.0);
+    let mut points = vec![Point3::new(0.0, 0.0, 1.5); mol.atom_count()];
+    for (slot, &atom_id) in order.iter().enumerate() {
+        points[atom_id as usize] = neighbor_pts[slot];
+    }
+    (order, Coords3D { points })
+}
+
+#[test]
+fn all_four_ligands_distinct_round_trips_all_three_tags() {
+    for tag in [
+        SquarePlanarPermutation::SP1,
+        SquarePlanarPermutation::SP2,
+        SquarePlanarPermutation::SP3,
+    ] {
+        let (mut mol, center, ligands) =
+            build_pt_with_ligands(&[Element::F, Element::CL, Element::BR, Element::I]);
+        let (order, conf) = declare_and_place(&mut mol, center, &ligands, tag);
+
+        let block = write_mol_with_conformer_checked(&mol, &MolMetadata::default(), &conf)
+            .unwrap_or_else(|e| panic!("{tag:?}: must write: {e}"));
+        let read = read_mol_with_diagnostics(&block).unwrap_or_else(|e| panic!("{tag:?}: {e}"));
+        let read_center = pt_atom_idx(&read.mol);
+        let recovered_tag = match read.mol.atom(read_center).chirality {
+            Chirality::SquarePlanar(t) => t,
+            other => panic!("{tag:?}: expected SquarePlanar, got {other:?}"),
+        };
+        let recovered_order: [u32; 4] = read
+            .mol
+            .stereo_neighbor_order(read_center)
+            .unwrap()
+            .to_vec()
+            .try_into()
+            .unwrap();
+        assert_eq!(
+            remap_square_planar_tag(recovered_tag, recovered_order, order),
+            Some(tag),
+            "{tag:?}: round trip must recover the same physical arrangement"
+        );
+    }
+
+    // The 3 tags, applied to the SAME distinct-ligand composition, must
+    // remain pairwise distinct after a round trip (not just individually
+    // "recoverable") -- this is what makes them 3 genuinely different
+    // stereoisomers for a 4-distinct-ligand square-planar complex, unlike
+    // cisplatin/transplatin's 2xCl+2xN composition where SP1 and SP3
+    // collapse to the same physical species (see
+    // `chematic-core/src/stereo_geometry.rs`'s own duplicate-ligand note).
+    let mut recovered_tags = Vec::new();
+    for tag in [
+        SquarePlanarPermutation::SP1,
+        SquarePlanarPermutation::SP2,
+        SquarePlanarPermutation::SP3,
+    ] {
+        let (mut mol, center, ligands) =
+            build_pt_with_ligands(&[Element::F, Element::CL, Element::BR, Element::I]);
+        let (_order, conf) = declare_and_place(&mut mol, center, &ligands, tag);
+        let block = write_mol_with_conformer_checked(&mol, &MolMetadata::default(), &conf).unwrap();
+        let read = read_mol_with_diagnostics(&block).unwrap();
+        recovered_tags.push(canonical_smiles(&read.mol));
+    }
+    assert_ne!(recovered_tags[0], recovered_tags[1]);
+    assert_ne!(recovered_tags[0], recovered_tags[2]);
+    assert_ne!(recovered_tags[1], recovered_tags[2]);
+}
+
+#[test]
+fn three_plus_one_duplicate_ligand_composition_round_trips() {
+    // 3xCl + 1xN -- not itself a stereogenic arrangement chemically (no
+    // isomerism when 3 of 4 ligands are identical), but the reader/writer
+    // machinery must still round-trip whatever tag is declared without
+    // crashing or silently corrupting it, the same "duplicate chemistry,
+    // distinct ids" property `chematic-core`'s own unit tests check at the
+    // geometry-module level.
+    let (mut mol, center, ligands) =
+        build_pt_with_ligands(&[Element::CL, Element::CL, Element::CL, Element::N]);
+    let (order, conf) = declare_and_place(&mut mol, center, &ligands, SquarePlanarPermutation::SP1);
+
+    let block = write_mol_with_conformer_checked(&mol, &MolMetadata::default(), &conf)
+        .expect("duplicate-ligand geometry must still be representable");
+    let read = read_mol_with_diagnostics(&block).expect("parses");
+    let read_center = pt_atom_idx(&read.mol);
+    let recovered_tag = match read.mol.atom(read_center).chirality {
+        Chirality::SquarePlanar(t) => t,
+        other => panic!("expected SquarePlanar, got {other:?}"),
+    };
+    let recovered_order: [u32; 4] = read
+        .mol
+        .stereo_neighbor_order(read_center)
+        .unwrap()
+        .to_vec()
+        .try_into()
+        .unwrap();
+    assert_eq!(
+        remap_square_planar_tag(recovered_tag, recovered_order, order),
+        Some(SquarePlanarPermutation::SP1)
+    );
+}
+
+#[test]
+fn three_coordinate_center_is_never_perceived_as_square_planar() {
+    let (mol, center, ligands) = build_pt_with_ligands(&[Element::CL, Element::CL, Element::N]);
+    // Coplanar (real, nonzero-z, 3-around-a-center) positions -- the
+    // perception candidate filter requires exactly 4 neighbors, so this
+    // must never even be classified, regardless of how planar it looks.
+    let mut points = vec![Point3::new(0.0, 0.0, 1.5); mol.atom_count()];
+    let at = |deg: f64| -> Point3 {
+        let r = deg.to_radians();
+        Point3::new(1.5 * r.cos(), 1.5 * r.sin(), 1.5)
+    };
+    for (i, &l) in ligands.iter().enumerate() {
+        points[l.0 as usize] = at(120.0 * i as f64);
+    }
+    let conf = Coords3D { points };
+
+    let block = write_mol_with_conformer(&mol, &MolMetadata::default(), &conf);
+    let read = read_mol_with_diagnostics(&block).expect("parses");
+    assert_eq!(read.mol.atom(center).chirality, Chirality::None);
+    assert!(read.square_planar_diagnostics.is_empty());
+}
+
+#[test]
+fn five_coordinate_center_is_never_perceived_as_square_planar() {
+    let (mol, center, ligands) = build_pt_with_ligands(&[
+        Element::CL,
+        Element::CL,
+        Element::N,
+        Element::N,
+        Element::BR,
+    ]);
+    let mut points = vec![Point3::new(0.0, 0.0, 1.5); mol.atom_count()];
+    let at = |deg: f64| -> Point3 {
+        let r = deg.to_radians();
+        Point3::new(1.5 * r.cos(), 1.5 * r.sin(), 1.5)
+    };
+    for (i, &l) in ligands.iter().enumerate() {
+        points[l.0 as usize] = at(72.0 * i as f64);
+    }
+    let conf = Coords3D { points };
+
+    let block = write_mol_with_conformer(&mol, &MolMetadata::default(), &conf);
+    let read = read_mol_with_diagnostics(&block).expect("parses");
+    assert_eq!(read.mol.atom(center).chirality, Chirality::None);
+    assert!(read.square_planar_diagnostics.is_empty());
+}
+
+#[test]
+fn truncated_v3000_coordinate_block_is_a_typed_error_not_a_panic() {
+    // Same shape as `conformer_3d_io.rs`'s own `v3000_garbled_z_is_a_typed_error`,
+    // applied to a square-planar-eligible (undefined-valence) center: the
+    // malformed z field must fail during ordinary V3000 atom-line parsing,
+    // before this PR's perception code ever runs -- confirming that new
+    // code path doesn't need its own defense here, and that the existing
+    // one still holds for this element class.
+    let bad = "\
+bad
+  chematic
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 4 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 Pt 0.0 0.0 0.0 0
+M  V30 2 Cl -1.0607 -1.0607 garbage 0
+M  V30 3 Cl -1.0607 1.0607 1.5 0
+M  V30 4 N 1.0607 1.0607 1.5 0
+M  V30 5 N 1.0607 -1.0607 1.5 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 1 3
+M  V30 3 1 1 4
+M  V30 4 1 1 5
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+";
+    let result = read_mol_v3000_with_diagnostics(bad);
+    assert!(matches!(
+        result,
+        Err(chematic_mol::MolParseError::InvalidAtomLine { .. })
+    ));
+}
+
+#[test]
+fn write_read_write_is_stable() {
+    let cis = smiles_to_square_planar_mol_fixture(CISPLATIN_SMILES, 1.5);
+    let block1 =
+        write_mol_with_conformer_checked(&cis.mol, &MolMetadata::default(), &cis.conformer)
+            .expect("first write");
+    let read1 = read_mol_with_diagnostics(&block1).expect("first read");
+    let conformer1 = read1.conformer.clone().expect("first read has a conformer");
+    let block2 = write_mol_with_conformer_checked(&read1.mol, &MolMetadata::default(), &conformer1)
+        .expect("second write");
+
+    assert_eq!(
+        block1, block2,
+        "writing, reading back, and writing again must reproduce byte-identical output"
+    );
+}
+
+#[test]
+fn sdf_multi_record_round_trip_no_cross_contamination() {
+    let cis = smiles_to_square_planar_mol_fixture(CISPLATIN_SMILES, 1.5);
+    let trans = smiles_to_square_planar_mol_fixture(TRANSPLATIN_SMILES, 1.5);
+
+    let mut cis_props = std::collections::HashMap::new();
+    cis_props.insert("Name".to_string(), "cisplatin".to_string());
+    let mut trans_props = std::collections::HashMap::new();
+    trans_props.insert("Name".to_string(), "transplatin".to_string());
+
+    let cis_record = write_sdf_record_with_conformer_checked(
+        &cis.mol,
+        &MolMetadata::default(),
+        &cis.conformer,
+        &cis_props,
+    )
+    .expect("cisplatin SD record must write");
+    let trans_record = write_sdf_record_with_conformer_checked(
+        &trans.mol,
+        &MolMetadata::default(),
+        &trans.conformer,
+        &trans_props,
+    )
+    .expect("transplatin SD record must write");
+
+    let sdf = format!("{cis_record}{trans_record}");
+    let records: Vec<_> = SdfRecordReader::new(&sdf)
+        .collect::<Result<Vec<_>, _>>()
+        .expect("both records must parse");
+    assert_eq!(
+        records.len(),
+        2,
+        "must be exactly 2 records, not merged/split"
+    );
+
+    let rec0_tag = match records[0].mol.atom(pt_atom_idx(&records[0].mol)).chirality {
+        Chirality::SquarePlanar(t) => t,
+        other => panic!("record 0: expected SquarePlanar, got {other:?}"),
+    };
+    let rec1_tag = match records[1].mol.atom(pt_atom_idx(&records[1].mol)).chirality {
+        Chirality::SquarePlanar(t) => t,
+        other => panic!("record 1: expected SquarePlanar, got {other:?}"),
+    };
+
+    // Physical-arrangement-aware check, same as the top-level differential
+    // tests -- not a raw tag comparison.
+    let rec0_order: [u32; 4] = records[0]
+        .mol
+        .stereo_neighbor_order(pt_atom_idx(&records[0].mol))
+        .unwrap()
+        .to_vec()
+        .try_into()
+        .unwrap();
+    let rec1_order: [u32; 4] = records[1]
+        .mol
+        .stereo_neighbor_order(pt_atom_idx(&records[1].mol))
+        .unwrap()
+        .to_vec()
+        .try_into()
+        .unwrap();
+    assert_eq!(
+        remap_square_planar_tag(rec0_tag, rec0_order, cis.order),
+        Some(cis.tag),
+        "record 0 must be cisplatin's arrangement"
+    );
+    assert_eq!(
+        remap_square_planar_tag(rec1_tag, rec1_order, trans.order),
+        Some(trans.tag),
+        "record 1 must be transplatin's arrangement, not cisplatin's"
+    );
+
+    // Properties must attach to the correct record, not cross-contaminate.
+    assert_eq!(
+        records[0].properties.get("Name").map(|s| s.as_str()),
+        Some("cisplatin")
+    );
+    assert_eq!(
+        records[1].properties.get("Name").map(|s| s.as_str()),
+        Some("transplatin")
+    );
 }

--- a/docs/rfcs/square_planar_mol_io_rfc.md
+++ b/docs/rfcs/square_planar_mol_io_rfc.md
@@ -1,0 +1,376 @@
+# Square-planar stereo in MOL/SDF (V2000 + V3000)
+
+## 1. The question
+
+`Chirality::SquarePlanar(SquarePlanarPermutation)` (PR #313/#326) already round-trips
+through SMILES's `@SP1`/`@SP2`/`@SP3` tags. MOL/SDF (V2000 and V3000) has no
+such symbolic tag at all. Before writing any code, this RFC answers: is there
+*any* way to preserve a declared square-planar configuration through a MOL/SDF
+round trip, and if so, what is it?
+
+## 2. What the MDL/CTfile format actually has
+
+Neither V2000 nor V3000 has a field that stores a permutation value
+(1/2/3, or any other discrete SP-class marker) for a stereocenter:
+
+- **V2000's atom-line "stereo parity" field** exists in the spec, but this
+  codebase never reads it for *any* geometry (see `mol2000.rs`'s atom-block
+  parser — the field is skipped entirely), matching RDKit's own primary
+  `MolFromMolBlock` path. It has no permutation-value semantics regardless
+  (0/1/2/3 = none/odd/even/either, a 2-state-plus-unknown tetrahedral parity
+  flag, not a 3-way class selector).
+- **V3000's atom-line `CFG`** is likewise unread today (explicitly out of
+  scope, `mol3000.rs`'s own comment). Its defined values (0/1/2/3) are again
+  a tetrahedral-shaped parity/either encoding, not a permutation-class field.
+- **V3000's `COLLECTION`/`STEABS`/`STEOR`/`STEAND` block** groups atoms into
+  absolute/OR/AND *certainty* classes for already-defined tetrahedral
+  centers. It carries no per-atom geometry-class or permutation information
+  and cannot be repurposed for this without inventing semantics MDL never
+  defined.
+
+**Conclusion: there is no lossless, standard, symbolic MOL/CTfile field for
+`@SPn`.** This is Tier 1 in the design space below, and it is a dead end —
+confirmed independently against RDKit 2026.03.4 (see §4) and consistent with
+public RDKit documentation/source.
+
+## 3. What DOES exist: 3D-coordinate-derived reperception
+
+Square-planar geometry, unlike tetrahedral parity, is a real physical shape a
+3D conformer can encode directly: 4 ligands and a center, coplanar, with two
+ligand pairs at ~180° (trans) and the rest at ~90° (cis). A MOL/SDF atom
+block already carries real `(x, y, z)` coordinates. If those coordinates
+geometrically encode a square-planar arrangement, the SP1/SP2/SP3 class can
+be **reperceived from geometry**, the same way this crate's existing 2D
+wedge/hash pathway reperceives tetrahedral parity from a drawing rather than
+storing it symbolically.
+
+## 4. RDKit oracle findings (2026.03.4, empirical, this session)
+
+RDKit was available locally (`.venv`, `rdkit==2026.03.4`) and used as a live
+oracle, matching this repo's established methodology (PR #313's own square
+planar RFC used the same approach).
+
+**Finding 1 — no symbolic round trip.** A molecule built with
+`ChiralType.CHI_SQUAREPLANAR` + `_chiralPermutation`, written via
+`Chem.MolToMolBlock` with **no existing 3D conformer**, gets *auto-generated
+2D coordinates* that geometrically encode the correct trans-pairing (verified
+by hand: the emitted `(x, y)` layout puts SP1's declared trans-pairs at
+antipodal positions around the center). But reading that exact block back
+with plain `Chem.MolFromMolBlock` (default arguments) returns
+`CHI_UNSPECIFIED` — the tag is **not** recovered automatically, from either
+V2000 or V3000, from a 2D-declared or a flat-z record.
+
+**Finding 2 — 3D reperception is real.** Calling
+`Chem.AssignStereochemistryFrom3D(mol)` explicitly, on a parsed molecule
+whose real 3D coordinates encode a square-planar shape, *does* recover
+`CHI_SQUAREPLANAR` with the correct `_chiralPermutation`, for **both** V2000
+(`forceV3000=False`, confirmed with a hand-built RWMol using plain covalent
+bonds, no dative bonds involved) and V3000. Round-tripping that block again
+through `MolToMolBlock` reproduces the identical coordinates. This holds even
+when every z is exactly `0.0` (a genuinely planar 3D structure is
+legitimately flat) — RDKit's own `MolFromMolBlock`/`AssignStereochemistryFrom3D`
+split treats "is this really 3D data" as a question of *which function the
+caller invokes*, not a geometry heuristic on z-values.
+
+**Finding 3 — element gating, not pure geometry.** The exact same coplanar
+`(F, Cl, Br, I)` square arrangement around a center is perceived as
+`CHI_SQUAREPLANAR` for Pt/Pd/Ni/Cu/Au/Fe/Xe/K/Ca/Zn/Ga/Ge/Sn/Pb/Bi, but
+**not** for C/Si/Na/Mg/Al — RDKit does not assign non-tetrahedral chirality
+to an element whose periodic table entry carries a small, fixed default
+valence. Pure coordinate geometry is not the only signal; element identity
+gates eligibility too (§6).
+
+**Finding 4 — angle tolerance is real but bounded.** Distorting a square
+arrangement's trans-pair angle away from 180° (equivalently, the cis angle
+away from 90°) by up to ~30° still perceives correctly; by 40° it fails
+(`CHI_UNSPECIFIED`). RDKit's own cutoff sits strictly between those two
+values.
+
+These four findings settle the design question: **Tier 2 (3D-coordinate-derived
+reperception) is real, RDKit-precedented, and implementable** — not a
+hypothetical.
+
+## 5. Design decision: Tier 2, read + write, both formats
+
+**Read**: for every atom whose element has no fixed default valence (§6) and
+exactly 4 heavy-atom neighbors, when the record has genuine (non-flat, i.e.
+not all-`z≈0`) 3D coordinates, classify the local 5-point geometry (center +
+4 neighbors). If it resolves unambiguously to one of SP1/SP2/SP3 (coplanar,
+within tolerance, with exactly one of the three trans-pairings both
+≥135°), set `Chirality::SquarePlanar` and `stereo_neighbor_order`. If the
+center is coplanar-*ish* but the classification is ambiguous or degenerate,
+surface a typed diagnostic (`SquarePlanarPerceptionDiagnostic`) rather than
+silently leaving `Chirality::None` — the same "explain why, don't guess"
+discipline `StereoDiagnostic`/`Stereo3DDiagnostic` already use elsewhere in
+this crate. If the center simply isn't coplanar (the overwhelmingly common
+case — most 4-coordinate transition-metal centers are tetrahedral or
+octahedral, not square-planar), nothing is reported: this mirrors
+`StereoDiagnostic`'s existing "no wedge present -> nothing to say" precedent.
+
+**Write**: only permitted when a 3D conformer already exists, and the
+existing coordinates are validated against the declared `@SPn` tag before
+writing — never fabricated from nothing, and never silently trusted to
+match. See §8 for why fabricating coordinates was considered and rejected.
+
+**Both formats, verified not assumed**: V2000 and V3000 atom lines both
+carry independent `(x, y, z)` fields at the same fixed columns, and both
+formats share this crate's existing `classify_geometry_rank`/`parse_dimension_code`
+(mol3000.rs already calls into mol2000.rs's implementations directly — see
+that file's existing `wedge_vs_3d_conflicts` reuse). The new perception and
+validation logic is added once, in `mol2000.rs`, and reused by `mol3000.rs`
+the same way. This was confirmed, not assumed: RDKit finding 2 above was
+independently reproduced against *both* a V2000 block (hand-built,
+`forceV3000=False`, plain covalent bonds) and a V3000 block.
+
+## 6. Element eligibility gate: reusing `Element::normal_valences()`
+
+RDKit's oracle behavior (§4, finding 3) shows non-tetrahedral perception is
+gated by element, not geometry alone: a real sp3 carbon is never square
+planar even if handed adversarial/synthetic coordinates that happen to look
+that way. This project already has a fitting primitive:
+`Element::normal_valences() -> &'static [u8]`, documented as "Empty =
+undefined (transition metals, etc.)". The new geometric classifier only
+considers atoms whose element has `normal_valences().is_empty()`.
+
+This was RDKit-tested directly (same coplanar-square coordinate fixture, per
+element, `AssignStereochemistryFrom3D`) for two groups: elements this
+crate's `normal_valences()` gives a defined list for and therefore *excludes*
+(**C, Si** — both correctly rejected by RDKit too, `CHI_UNSPECIFIED`), and
+elements it returns empty (undefined) for and therefore *includes*
+(**Pt, Pd, Ni, Cu, Au, Fe, Xe, K, Ca, Zn, Ga, Ge, Sn, Pb, Bi** — all correctly
+perceived by RDKit as `CHI_SQUAREPLANAR`). The remaining entries in this
+crate's 15-element `normal_valences()` table (H, B, N, O, F, P, S, Cl, As,
+Se, Br, Te, I) were **not** individually RDKit-tested; they are assumed, not
+verified, to follow the same defined-valence-excludes-them rule by the same
+logic as C/Si (all are ordinary main-group organic-subset elements with
+small, fixed valences in RDKit's own periodic table too), consistent with
+this project's policy against unverified "fixed"/"matches" claims.
+
+**One confirmed, honest divergence**: RDKit's periodic table also assigns
+Na/Mg/Al a small fixed valence and excludes them (RDKit-tested directly,
+§4 finding 3), but this crate's `normal_valences()` table has no entry for
+Na/Mg/Al and returns empty for them too, so this crate's gate is *more
+permissive* than RDKit's for those 3 specific, RDKit-confirmed-divergent
+elements. In practice this divergence is very unlikely to matter: it can
+only be reached by real (or adversarially-constructed) coordinates in which
+an Na/Mg/Al center is genuinely coplanar with 4 ligands at square angles —
+chemically implausible for these elements' actual bonding, so the
+coplanarity gate (§7) would almost always exclude them anyway even without
+the element check. Replicating RDKit's full internal default-valence table
+for every element was judged out of scope for this PR; this is recorded
+here as a known,
+low-risk, documented gap rather than silently overclaiming exact parity.
+
+## 7. Geometry classification: coplanarity + trans-pair angle
+
+Given a candidate center (`Point3`) and its 4 neighbor positions
+(`[Point3; 4]`, ordered per `Molecule::neighbors()`/`stereo_neighbor_order`):
+
+1. **Degenerate-bond-vector check first**: reject (typed reason
+   `DegenerateBondVector`) if any neighbor's distance from the center is
+   below `1e-3` Å — many orders of magnitude below any real bond length,
+   purely a corrupt-data guard. Checked before coplanarity so a coincident
+   point doesn't trivially "pass" a plane fit.
+2. **Coplanarity**: reuse `mol2000.rs::classify_geometry_rank` directly
+   (not reimplemented) on the 5-point set `{center, n0, n1, n2, n3}`. Only
+   `Coplanar`/`FlatZero` pass; `ThreeD` is rejected (`NotCoplanar`) — this is
+   the check that makes a real tetrahedral center's ~109.5° angles
+   self-reject: 4 tetrahedral substituents plus their center are never
+   coplanar within `COPLANAR_EPS` (`1e-2` Å), so no separate "is this
+   tetrahedral-shaped" check is needed. Reuses `COPLANAR_EPS`, explicitly
+   **not** `VOLUME_EPS` — `VOLUME_EPS` is a signed-tetrahedral-volume
+   epsilon from a different check with different failure semantics; using it
+   here was the RFC's own stated anti-pattern to avoid (matching PR #326's
+   deferred-scope note).
+3. **Trans-pair angle**: for each of the 3 candidate tags (SP1/SP2/SP3),
+   read its `trans_pairs()` (existing, oracle-verified — not
+   reimplemented) and test whether *both* pairs have
+   `cos(angle) <= -1/sqrt(2)` (i.e. angle ≥ 135°) as measured from the
+   center. 135° is the geometric midpoint between an ideal cis angle (90°)
+   and an ideal trans angle (180°) — a self-justifying threshold requiring
+   over 45° of distortion from either ideal to misclassify, in the same
+   family as RDKit's own empirically-observed tolerance (finding 4: real
+   cutoff between 30° and 40°) without copying RDKit's number. Exactly one
+   tag matching resolves the class; zero or more than one is
+   `AmbiguousTransPairing` (typed, surfaced, never guessed).
+
+This function (`classify_square_planar_geometry`) is the single shared
+implementation used by both the reader (candidate scan) and the writer
+(pre-write validation) — not two independent copies.
+
+## 8. Why the writer never fabricates coordinates
+
+An earlier draft of this design considered having the writer synthesize a
+fresh coordinate layout (mirroring RDKit's `MolToMolBlock` auto-2D-layout
+behavior, §4 finding 1) whenever a `Chirality::SquarePlanar` atom had no
+existing conformer, so that e.g. a SMILES-parsed (coordinate-less) cisplatin
+molecule could still be written to MOL. This was rejected: a writer that
+invents geometry to satisfy its own serialization is exactly the kind of
+silent, unverifiable behavior this project's fail-closed policy exists to
+prevent — nothing downstream could distinguish "these coordinates are real
+structural data" from "these coordinates are a fabrication that happens to
+decode back to the right tag". If the caller has no conformer, that is a
+**Tier 1** situation (no lossless standard encoding exists) and must return
+a typed error, not trigger geometry fabrication. Round-trip test fixtures in
+this PR therefore construct their own explicit `Coords3D` (the same way
+existing tetrahedral wedge/hash round-trip tests in
+`stereo_reader_integration.rs` construct explicit 2D `coords` rather than
+having the writer invent a layout) — see `docs/rfcs/square_planar_stereo_rfc.md`'s
+sibling precedent.
+
+## 9. Write-side validation, not silent trust
+
+Because MOL/SDF's only mechanism for this is geometry, a caller could in
+principle hand the writer a `Chirality::SquarePlanar(SP1)` atom next to a
+conformer whose real coordinates encode SP2 — writing that out verbatim
+would silently manufacture a file that reperceives as the *wrong* tag on the
+next read. The writer path added by this PR
+(`write_mol_with_conformer_checked` / `write_mol_v3000_with_conformer_checked`,
+backed by the shared, `pub` `validate_square_planar_for_write`) runs the
+exact same `classify_square_planar_geometry` classifier used on read against
+every `Chirality::SquarePlanar` atom's `stereo_neighbor_order` positions
+before emitting anything, and fails closed with a typed
+`MolStereoWriteError` (carrying the offending atom, the declared
+`chematic_core::StereoGeometry`, the target `MolFormat`, and one of:
+no conformer supplied; missing `stereo_neighbor_order`; an implicit-H slot in
+that order (§11); a missing conformer position; geometry that classifies to
+a *different* tag than declared; or geometry that doesn't classify at all)
+on any mismatch, missing data, or ambiguity — never a silent overwrite.
+
+It also rejects a whole-molecule-flat (`GeometryRank::FlatZero`/
+`Indeterminate`) conformer outright, for the same reason the reader's
+`conformer` field is `None` in that case (§10) — a conformer this function
+would happily validate as geometrically SP1-shaped at z≈0 exactly would be
+silently unrecoverable by this crate's own reader, which is precisely the
+"writer says encoded, reader says nothing" failure this design exists to
+prevent.
+
+## 10. The z=0 ambiguity, and why fixtures use a nonzero z
+
+`GeometryRank::FlatZero` (every atom's z within `1e-4` of exactly 0) is this
+crate's existing, pre-PR#326-vintage signal for "this all-zero-z record is
+indistinguishable from an ordinary 2D wedge-only depiction" — the existing
+`conformer: Option<Coords3D>` field is already `None` in that case (see
+`mol2000.rs`'s `read_mol_with_diagnostics`), and this PR's square-planar
+perception is gated on `conformer.is_some()`, i.e. it **never runs** against
+a flat-z record. This is deliberate, not an oversight: it is the direct
+implementation of §2's conclusion that a pure-2D, wedge-only MOL block has
+no way to encode square-planar stereo at all — flat z=0 coordinates are
+exactly what a 2D depiction looks like, indistinguishable from "no 3D data
+was ever provided". A genuinely-planar real 3D square-planar structure whose
+plane happens to coincide with z=0 exactly is an unavoidable, accepted
+false-negative of this same ambiguity (documented limitation, not fixed by
+this PR — matches this file's own `GeometryRank::Coplanar` doc comment,
+which already states a flat real molecule "legitimately lands" in the
+zero-evidence bucket).
+
+Because of this, every round-trip fixture in this PR's test suite places its
+whole molecule off the z=0 plane (e.g. z=1.5 for every atom) — this is not a
+workaround for a test-only quirk, it is what *any* real embedded 3D
+conformer looks like in practice (an embedder essentially never lands a
+structure exactly on z=0), and it is exactly the geometry the write-side
+validator (§9) now also requires.
+
+## 11. Explicitly out of scope
+
+- **Pure-2D, wedge-only square-planar encoding.** No such mechanism exists
+  in MDL/CTfile (§2); not invented here.
+- **3-heavy-neighbor + implicit-H square-planar centers.** SMILES syntax
+  permits `@SPn` with `STEREO_H_SENTINEL` in `stereo_neighbor_order` (no
+  geometry-specific restriction in the parser), but there is no real spatial
+  position for an implicit hydrogen to validate or write against, and this
+  shape is chemically unusual for the d8 transition-metal chemistry
+  square-planar stereo describes. The writer returns a typed
+  `MolStereoWriteError` (reason: implicit-H slot present) rather than
+  attempting anything; the reader's candidate scan requires exactly 4
+  explicit heavy neighbors and never considers implicit-H centers.
+- **Full RDKit-parity element eligibility table** (§6) — Na/Mg/Al divergence
+  accepted and documented, not closed.
+- **A chematic-specific lossless SDF property-block extension** (Tier 3 —
+  e.g. a `<CHEMATIC_NONTETRAHEDRAL_STEREO>` SD field). Not built: Tier 2
+  already gives genuine, real-3D-data round-tripping for the realistic case
+  (a molecule that actually has a conformer), and this PR's scope is
+  intentionally kept to the light-gate policy in effect for this work (no
+  new SD-property-block format to design, document, and test). Left for
+  future work if a pure-2D or coordinate-free use case is ever prioritized.
+- **Retrofitting every pre-existing 2D-only MOL/SDF writer
+  (`write_mol`/`write_mol_with_coords`/`write_mol_v3000`/the `write_sdf*`
+  family) to a fallible signature.** These functions have never consulted
+  `Atom.chirality` for *any* geometry (tetrahedral round-trips via the
+  wedge/hash `BondOrder`, which they do write faithfully; only
+  square-planar has no such always-written channel). Changing their return
+  type ripples through `chematic-py`, `chematic-wasm`, and every existing
+  example/test in this crate for a class of molecule vanishingly rare in
+  those call sites today. Instead, this PR adds new, additive, fully
+  fail-closed entry points (`*_checked`) for the one path that can actually
+  represent this stereo class (the conformer-aware writers), and leaves the
+  pre-existing infallible 2D writers' documented behavior as "does not
+  encode non-tetrahedral stereo, use the checked conformer writer instead" —
+  an explicit scope decision, flagged here for the maintainer to overrule if
+  a broader breaking change is actually wanted.
+- **`write_sdf_record_with_conformer` has no `_checked` sibling.** Unlike
+  the 2D-only writers above, this one *does* carry a real `Coords3D`
+  conformer, so the gap here is narrower: a caller can still get fail-closed
+  behavior for it today via `validate_square_planar_for_write(mol,
+  Some(conformer), MolFormat::V2000)` before calling it (the function is
+  `pub` precisely so this composes), just not through a single wrapped call.
+  Not added because no fixture or test in this PR needed the SDF-record
+  (`$$$$`-terminated) framing specifically — every round-trip test operates
+  at the plain MOL-block level, which the `*_checked` writers already
+  cover.
+
+## 12. `wedge_vs_3d_conflicts` fix
+
+`wedge_vs_3d_conflicts` (`mol2000.rs`) gated on `atom.chirality ==
+Chirality::None`, i.e. it ran its tetrahedral-signed-volume comparison
+against *any* non-`None` chirality. Before this PR, `Chirality::SquarePlanar`
+was never produced by a MOL/SDF reader, so the bug was latent — this PR makes
+it reachable. Fixed by switching the gate to `!atom.chirality.is_tetrahedral()`,
+using the existing allowlist-shaped `Chirality::is_tetrahedral()` (`atom.rs`,
+PR #326) rather than enumerating known non-tetrahedral variants by name. This
+is the same "positive match on the known-good case, not negative match on the
+known-bad case" fix shape as the two prior instances of this exact bug class
+in this project's history (`chematic-3d/src/stereo_constraints.rs` and
+`chematic-chem/src/cip.rs`, per project history) — the fix is
+exhaustive-match-safe by construction: any future non-tetrahedral geometry
+(trigonal-bipyramidal, octahedral, sketched but unimplemented in
+`stereo_geometry.rs`) is automatically excluded by this same gate without
+requiring a new match arm here, because `is_tetrahedral()` only ever returns
+`true` for the two known-tetrahedral variants.
+
+## 13. Sibling-gate audit (not fixed, and why)
+
+A grep for `Chirality::None ==`-shaped gates elsewhere in `chematic-mol`/
+`chematic-perception` found two more production sites
+(`chematic-perception/src/stereo_validation.rs`, `validate_stereo` and
+`stereo_centers`). Both were checked for the same false-positive shape
+`wedge_vs_3d_conflicts` had (a downstream computation that assumes
+tetrahedral geometry and produces a *wrong* answer for a non-`None`,
+non-tetrahedral chirality). Neither does: both are generic
+neighbor-count/Morgan-rank distinctness checks that do not depend on which
+concrete tetrahedral-vs-square-planar shape is present, so a
+`Chirality::SquarePlanar` atom passing through them does not produce an
+incorrect `StereoError`/`stereo_centers` entry. `stereo_centers`'s doc
+comment labels its output "tetrahedral candidates", which is a
+pre-existing, orthogonal naming/scope-accuracy gap (a square-planar center
+with 4 distinct neighbors would be counted there too) rather than a
+correctness bug, and duplicating this PR's new element-eligibility gate into
+that module to fix the label would be scope creep beyond the one bug PR #326
+named as deferred. Recorded here rather than silently left unmentioned.
+
+## 14. Verification
+
+- RDKit 2026.03.4 oracle (`.venv`), used interactively this session — not a
+  pre-existing script, since this is a narrow point-confirmation, not a
+  corpus measurement (matches this PR's light-gate scope).
+- Cisplatin/transplatin MOL/SDF round-trip differential test against the
+  existing, independently oracle-verified SMILES fixtures in
+  `chematic-smiles/tests/square_planar_stereo.rs` (source of truth for which
+  tag means cis vs trans for this specific structure) — not re-derived from
+  scratch.
+- Atom-renumbering invariance, coordinate rounding, and near-degenerate
+  (distorted-but-still-valid) geometry — see `chematic-mol/tests/`.
+- `cargo test -p chematic-mol` run immediately after wiring the reader (before
+  writing new tests) to check for regressions in existing 4-coordinate
+  fixtures (`platinum_benchmark.rs`, `conformer_3d_io.rs`) that might newly
+  acquire a tag.

--- a/docs/rfcs/square_planar_mol_io_rfc.md
+++ b/docs/rfcs/square_planar_mol_io_rfc.md
@@ -302,22 +302,23 @@ validator (§9) now also requires.
   type ripples through `chematic-py`, `chematic-wasm`, and every existing
   example/test in this crate for a class of molecule vanishingly rare in
   those call sites today. Instead, this PR adds new, additive, fully
-  fail-closed entry points (`*_checked`) for the one path that can actually
-  represent this stereo class (the conformer-aware writers), and leaves the
-  pre-existing infallible 2D writers' documented behavior as "does not
-  encode non-tetrahedral stereo, use the checked conformer writer instead" —
-  an explicit scope decision, flagged here for the maintainer to overrule if
-  a broader breaking change is actually wanted.
-- **`write_sdf_record_with_conformer` has no `_checked` sibling.** Unlike
-  the 2D-only writers above, this one *does* carry a real `Coords3D`
-  conformer, so the gap here is narrower: a caller can still get fail-closed
-  behavior for it today via `validate_square_planar_for_write(mol,
-  Some(conformer), MolFormat::V2000)` before calling it (the function is
-  `pub` precisely so this composes), just not through a single wrapped call.
-  Not added because no fixture or test in this PR needed the SDF-record
-  (`$$$$`-terminated) framing specifically — every round-trip test operates
-  at the plain MOL-block level, which the `*_checked` writers already
-  cover.
+  fail-closed entry points (`*_checked`) for every conformer-aware writer
+  that can actually represent this stereo class
+  (`write_mol_with_conformer_checked`,
+  `write_mol_v3000_with_conformer_checked`,
+  `write_sdf_record_with_conformer_checked`), and leaves the pre-existing
+  infallible 2D writers unchanged but now carrying an explicit Rustdoc
+  warning on each one ("does not preserve `Chirality::SquarePlanar`
+  stereo... use `write_..._checked` instead") so a caller reading the docs
+  for any of them is steered to the right one rather than silently losing
+  data with zero indication anything happened — an explicit scope decision
+  (fail-closed-by-default via new entry points + documented steering, not a
+  breaking signature change to the existing ones), flagged here for the
+  maintainer to overrule if a broader breaking change is actually wanted.
+  There is no V3000 SDF-record-with-conformer writer at all today (only the
+  V2000 `write_sdf_record_with_conformer`/`_checked` pair exists), so
+  nothing was left un-checked there — it simply doesn't exist as a
+  capability yet, checked or not.
 
 ## 12. `wedge_vs_3d_conflicts` fix
 


### PR DESCRIPTION
## Summary

Roadmap step 2 (v0.17.0): square-planar stereo (`@SP1`/`@SP2`/`@SP3`-equivalent) round-trip support for MOL/SDF (V2000 + V3000), building on the generalized stereo geometry foundation shipped in PR #326.

**Phase A finding (design doc: `docs/rfcs/square_planar_mol_io_rfc.md`)**: MDL/CTfile has no standard, symbolic field for a non-tetrahedral stereo tag — confirmed against a live RDKit 2026.03.4 oracle this session (not assumed). The only real mechanism is **3D-coordinate-derived reperception**, which is exactly what RDKit itself does (`AssignStereochemistryFrom3D`, opt-in, never automatic from `MolFromMolBlock`). This PR implements that mechanism (Tier 2 in the RFC's design space):

- **Read (universal, every reader)**: `perceive_square_planar_from_3d` scans undefined-valence-element (`Element::normal_valences().is_empty()`, reused not reinvented), 4-coordinate, untagged atoms; classifies local geometry (degenerate-bond-vector check -> coplanarity via the existing `classify_geometry_rank`/`COPLANAR_EPS` -> trans-pair angle via a derived `cos(135deg)` threshold) against the 3 tags via their existing, oracle-verified `trans_pairs()`. Wired into both V2000 and V3000 readers, gated on a real (non-flat) 3D conformer being present. Ambiguous-but-plausible geometry is surfaced as a new typed diagnostic, never silently dropped.
- **Write (opt-in, exactly three functions)**: `write_mol_with_conformer_checked` (V2000 MOL block), `write_mol_v3000_with_conformer_checked` (V3000 MOL block), and `write_sdf_record_with_conformer_checked` (V2000 SDF record, `$$$$`-terminated) — all backed by `pub validate_square_planar_for_write` — validate every `Chirality::SquarePlanar` atom's real coordinates against its declared tag before writing, never fabricating coordinates from nothing, never silently trusting a mismatch, and fail closed with a typed `MolStereoWriteError` otherwise. These are the only three conformer-carrying writers that exist in the codebase today, so this covers all of them; there is no V3000 SDF-record-with-conformer writer at all (checked or unchecked), so nothing was skipped there — it's an absent capability, not an unguarded one.
- **Every pre-existing writer is unchanged, but falls into one of two different gaps**, each now carrying an explicit Rustdoc warning naming its specific one and pointing at its `_checked` counterpart where one exists:
  - **2D-only, drops the tag outright**: `write_mol`, `write_mol_with_coords`, `write_mol_v3000`, and the whole `write_sdf*` family (`write_sdf`, `write_sdf_with_charges`, `write_sdf_record`, `write_sdf_record_v3000`) — none has a z coordinate to write a square-planar tag against.
  - **3D-capable but unvalidated**: `write_mol_with_conformer`, `write_mol_v3000_with_conformer`, `write_sdf_record_with_conformer` — these *do* write whatever conformer they're handed, so the tag survives when the conformer actually matches it, but they trust the caller and never check, so a mismatched or flat conformer is written silently self-inconsistent with no error.
  
  Do not describe MOL/SDF writing in general as "square-planar supported"; only the three `_checked` functions above validate before writing.
- **Bug fix**: `wedge_vs_3d_conflicts` gated on `atom.chirality == Chirality::None` (denylist), which would spuriously flag every square-planar-tagged atom as a false conflict once this PR shipped. Fixed to `!atom.chirality.is_tetrahedral()` (an exhaustive-match-safe allowlist) -- deferred from PR #326 pending this exact scoping.

## Review follow-up (both blockers closed)

A human reviewer examined an earlier head of this PR and approved the core design, but flagged 2 blockers before mergeable — both are now closed:

- **Blocker 1 (no real SDF round trip)**: added `write_sdf_record_with_conformer_checked` plus a real `$$$$`-terminated 2-record SDF round trip (cisplatin + transplatin, via `SdfRecordReader`) proving no cross-contamination between records.
- **Blocker 2 (silent data loss in unchecked writers)**: added Rustdoc warnings to every unchecked writer that can carry a conformer or that delegates to one that can, and rewrote the CHANGELOG to precisely scope the claim (read is universal; write is exactly the three `_checked` functions). No breaking signature change, per the reviewer's own guidance.
- Also closed ~10 requested fixture gaps (see Testing below).
- `#[must_use]` was considered and skipped: it can't be conditional on whether a molecule actually carries square-planar stereo, so it would fire on every ignored return across `chematic-py`/`chematic-wasm`/examples under `-D warnings` for writers that mostly never touch this stereo class. The Rustdoc warning is the actual steering mechanism.

## What's explicitly out of scope (see RFC Sec 11)

- Pure-2D, wedge-only square-planar encoding (no such MDL mechanism exists).
- 3-heavy-neighbor + implicit-H square-planar centers (no spatial position to validate against).
- Full RDKit-parity element-eligibility table (one documented Na/Mg/Al divergence, low practical risk -- see RFC Sec 6).
- A chematic-specific lossless SDF extension (Tier 3) -- not needed since Tier 2 already gives genuine round-tripping for the realistic (has-a-conformer) case.
- Retrofitting the pre-existing infallible 2D-only writers (`write_mol`/`write_mol_with_coords`/`write_mol_v3000`/`write_sdf*`) to a *breaking, fallible* signature -- blast radius would ripple into `chematic-py`/`chematic-wasm`/every existing example for a stereo class those call sites essentially never carry today. Addressed additively instead (see above), not by breaking the existing signatures.

## Testing (light-gate scope, no corpus/benchmark)

- 14 unit tests (classifier, perceiver, validator, `wedge_vs_3d_conflicts` regression) in `mol2000.rs`.
- 13 integration tests in `crates/chematic-mol/tests/square_planar_mol_io.rs`: cisplatin/transplatin V2000+V3000 round trip (differential against the existing oracle-validated SMILES fixtures via `remap_square_planar_tag`, frame-explicit -- not a raw tag comparison), atom-renumbering invariance, 15-degree-distorted-geometry robustness, the documented z=0 FlatZero round-trip limitation, degenerate/truncated-conformer panic-safety, all-4-distinct-ligands (SP1/SP2/SP3, pairwise-distinct canonical SMILES), a 3+1 duplicate-ligand composition, degree-3 and degree-5 negative controls, a truncated/malformed V3000 coordinate block (typed error, not a panic), write->read->write stability (byte-identical on the second write, stronger than required), and the real SDF multi-record round trip closing Blocker 1.
- Canonical SMILES output is unaffected -- confirmed by the full `chematic-smiles` test suite passing unchanged in the full-workspace run.

## Gate results

- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo test --workspace --all-features`: 0 failures (full workspace)
- `cargo test --workspace --no-default-features`: 0 failures
- `cargo check -p chematic-wasm --target wasm32-unknown-unknown`: clean
- `python scripts/check_publish_graph.py`: OK, 19 publishable crates
- `cargo deny check`: advisories/bans/licenses/sources all OK (pre-existing, unrelated duplicate-dependency warnings only)

## Test plan

- [x] All gate commands above run and pass
- [x] No regression in existing MOL/SDF fixtures (ran `cargo test -p chematic-mol` immediately after wiring the reader, before adding new tests)
- [x] chematic-core's public API is unchanged (`StereoGeometry` was already `pub`; `remap_square_planar_tag`/`SquarePlanarPermutation::trans_pairs()` reused, not reimplemented)
- [x] Both reviewer blockers closed and re-verified against the full local gate

Draft PR -- not merging, not bumping version, not tagging.
