### PR TITLE
feat(mol): LAMMPS data file + dump/trajectory read/write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -620,6 +620,126 @@ subset) read/write support.
   future entry point: VASP's CHGCAR/LOCPOT volumetric formats, which
   would build on this same `VolumetricGrid` type.
 
+### Added — `chematic-mol` (LAMMPS data file + dump/trajectory file)
+
+Issue #227 format-expansion Wave 2, continued: LAMMPS `read_data`-format
+data files and `dump`-command text-style trajectory files, explicitly
+promised in this same Unreleased block's earlier mmCIF/PQR/QCSchema/ORCA
+entry ("LAMMPS data/dump ... are scoped for a later Wave 2, not this
+PR"). Both new modules (`lammps_data`, `lammps_dump`) are **standalone
+document types**, deliberately not integrated with `chematic_core::Molecule`
+-- LAMMPS bonds/angles/etc. are raw atom-index topology, not chemically
+perceived bonds, and an MD atom under some `atom_style`s is not
+necessarily even a chemical element. Verified independently against
+LAMMPS's own official manual (<https://docs.lammps.org/read_data.html>,
+<https://docs.lammps.org/dump.html>, <https://docs.lammps.org/Howto_triclinic.html>)
+before implementation, not taken from memory; nothing in this brief's
+format spec needed correcting -- every detail below was confirmed rather
+than assumed, including the triclinic bounding-box formula (see below).
+
+- **LAMMPS data file** (`chematic_mol::lammps_data`):
+  `parse_lammps_data(text, atom_style)` / `write_lammps_data(data)`. The
+  data-file format does not declare `atom_style` in-file and LAMMPS's own
+  docs state it must be defined before reading -- it is genuinely not
+  always recoverable from column count alone (`atom_style charge`'s
+  `atom-ID atom-type q x y z` and `atom_style molecular`'s `atom-ID
+  molecule-ID atom-type x y z` are both 6 fields). `atom_style` is
+  therefore a required `LammpsAtomStyle` parameter, not inferred; there
+  is no "guess from column count" fallback. Supports exactly 4 styles --
+  `Atomic`/`Charge`/`Molecular`/`Full`, each with optional trailing `ix
+  iy iz` image flags -- typed via `LammpsMass`/`LammpsAtom`/
+  `LammpsVelocity`/`LammpsBond` for the `Masses`/`Atoms`/`Velocities`/
+  `Bonds` sections and the `LammpsBox` (`lo`/`hi`/optional `tilt`) box.
+  Any other `atom_style` (`LammpsAtomStyle::Other`) fails closed with a
+  typed `LammpsDataError::UnsupportedAtomStyle`.
+- Every other section (`Angles`, `Dihedrals`, `Impropers`, `Pair Coeffs`,
+  `Bond Coeffs`, `Angle Coeffs`, `Dihedral Coeffs`, `Improper Coeffs`,
+  and any unrecognized name) is preserved opaquely, byte-for-byte,
+  in an ordered `Vec<(String, String)>` (`LammpsData::unparsed_sections`
+  -- not a `HashMap`), never interpreted. This is safe specifically
+  because this module is read/write/round-trip only in v1 (no
+  atom-removal/renumbering API yet) -- documented on `LammpsData` as a
+  constraint on any future PR that adds atom mutation, since renumbering
+  would need to also remap these opaque sections' raw atom-index
+  references or reject the operation.
+- LAMMPS's separate type-label framework (`Atom Type Labels`/`Bond Type
+  Labels`/...), under which `Masses`/`Atoms`/`Bonds` rows can key off a
+  string label instead of a numeric type/ID, is fail-closed rejected
+  (`LammpsDataError::TypeLabelsUnsupported`) as soon as such a section
+  name is seen, rather than silently mis-splitting/dropping data: this
+  module's section-boundary detection is numeric-ID-only and cannot
+  safely distinguish a label-keyed row from a new section header.
+- No unit conversion or inference anywhere: LAMMPS data files don't
+  declare a unit system in-file (`units` is a separate input-script
+  command), so every numeric value is stored exactly as read,
+  unit-agnostic -- a deliberate non-goal, matching this project's
+  Cube/OpenDX unit-handling discipline.
+- **LAMMPS dump/trajectory file** (`chematic_mol::lammps_dump`):
+  `parse_lammps_dump_frame` (single frame), the streaming
+  `LammpsDumpReader<R: BufRead>` (`Iterator<Item = Result<LammpsDumpFrame,
+  LammpsDumpError>>`, following this crate's `SdfFileReader` precedent
+  rather than `CubeFileReader`'s one-shot shape, since a trajectory is
+  inherently multi-record), `write_lammps_dump_frame`, and
+  `write_lammps_trajectory`. The `ITEM: ATOMS` column list is arbitrary
+  and self-declared per dump command; `LammpsDumpFrame` stores it as
+  index-parallel `column_names`/`rows` (row-major), not a
+  `HashMap<String, Vec<f64>>`, exactly preserving original column names
+  and order -- confirmed by a round-trip test using unusual real-world
+  column names (`c_myCompute[1]`, `f_myFix`).
+- Reuses `LammpsBox` from `lammps_data` for the box shape -- LAMMPS data
+  files give the true box directly, but dump files instead give an
+  axis-aligned *bounding* box around the (possibly tilted) true box
+  (`xlo_bound`/`xhi_bound`/...), needed because some visualization tools
+  expect an axis-aligned rendering box. The triclinic bound<->true
+  conversion formula was independently confirmed against
+  <https://docs.lammps.org/Howto_triclinic.html> in **both directions**
+  (the page states the true-box-to-bound formula explicitly, `xlo_bound
+  = xlo + MIN(0.0,xy,xz,xy+xz)` etc., and gives the inverse explicitly
+  too, `xlo = xlo_bound - MIN(0.0,xy,xz,xy+xz)`) -- new `box_bounds_to_true`/
+  `true_to_box_bounds`, tested both via a bound->true->bound identity
+  check over several tilt fixtures *and* (since the identity check alone
+  can't catch a self-consistently-wrong `MIN`/`MAX` term) a
+  hand-computed-absolute-value check.
+- `LammpsDumpFrame::cartesian_positions()` resolves `x y z` (pass
+  through) or `xs ys zs` (box-scaled, including the triclinic shear
+  terms -- **not** simply independent per-axis scaling) into real
+  Cartesian positions; `column()`/`column_index()` give raw access to
+  any column by name. `xu yu zu` ("unwrapped": not passed through
+  periodic-boundary wrapping, a materially different quantity from a
+  wrapped position) are deliberately not resolved by
+  `cartesian_positions()` -- use `column("xu")` etc. directly. The
+  scaled-coordinate transform's box-origin term is this module's own
+  derivation (LAMMPS's own docs sentence, "the actual unscaled
+  coordinate is `xs*A + ys*B + zs*C`", omits the origin but cannot be
+  correct without it, since `xs=ys=zs=0` must map to the box's own
+  corner) -- flagged medium-confidence in the module docs per this
+  project's citation-confidence convention, verified against a
+  hand-computed example.
+- Note on `column()`'s signature: returns `Option<Vec<f64>>` (owned), not
+  `Option<&[f64]>` -- `LammpsDumpFrame::rows` is row-major, so a single
+  column is not stored contiguously and cannot be borrowed without a
+  copy; documented as a deliberate deviation.
+- Zero-atom frames, custom/unrecognized dump columns, and orthogonal vs.
+  triclinic boxes in either format all round-trip correctly (see test
+  suite).
+
+**Not supported, by design**: any `atom_style` outside
+Atomic/Charge/Molecular/Full (typed `UnsupportedAtomStyle` error);
+semantic parsing of `Angles`/`Dihedrals`/`Impropers`/any `*Coeffs`
+section (opaquely preserved instead); LAMMPS's type-label framework
+(typed `TypeLabelsUnsupported` error); any unit conversion or inference;
+binary dump formats (only the default text `dump` style is supported);
+any `Molecule`/bond-perception integration (both types are standalone,
+see above); atom removal/renumbering (read/write/round-trip only in
+v1); exact preservation of the *interleaving* order between typed and
+opaque sections in a data file on write (each section's own content is
+preserved exactly; `write_lammps_data` always emits the 4 typed sections
+first in a fixed order, then opaque sections in their original relative
+order -- LAMMPS itself doesn't require a specific section order either).
+No Python or WASM bindings this step (consistent with every other
+format module added in this Wave -- that remains a separate, later
+concern).
+
 ---
 
 ## [0.16.0] — 2026-08-15

--- a/crates/chematic-mol/src/lammps_data.rs
+++ b/crates/chematic-mol/src/lammps_data.rs
@@ -1,0 +1,1491 @@
+//! LAMMPS data file (`read_data` command format) reader and writer.
+//!
+//! ## Provenance
+//!
+//! Implemented independently from LAMMPS's own official manual
+//! (<https://docs.lammps.org/read_data.html>, fetched and confirmed
+//! directly against the live page -- not from memory). No source code,
+//! comments, or tables were copied from LAMMPS itself, VMD, OVITO,
+//! MDAnalysis, or any other tool.
+//!
+//! ## Structure
+//!
+//! A data file has: an unconditionally ignored first comment line; a
+//! header block of `<count> <label>` lines (e.g. `120 atoms`,
+//! `4 atom types`) and box-bounds lines (`xlo xhi`, `ylo yhi`, `zlo zhi`,
+//! plus an optional `xy xz yz` triclinic-tilt line); then a sequence of
+//! named sections, each introduced by a bare section-name line, a
+//! mandatory skipped line (per read_data.html: "the next line is always
+//! skipped" after a section keyword -- conventionally blank, but this
+//! reader discards whatever is there unconditionally, matching LAMMPS's
+//! own actual behavior), then the section's data rows, ending at the next
+//! section-name line or EOF. Section order in the file is not fixed.
+//!
+//! `#` trailing comments are permitted by read_data.html on header lines,
+//! section-keyword lines, and individual data rows ("There must be at
+//! least one blank between valid content and the comment") -- stripped
+//! here for header lines, section-name lines, and the 4 typed sections'
+//! rows below. **Not** stripped for opaque (`unparsed_sections`) rows,
+//! which are preserved byte-for-byte including any such comment -- see
+//! "Sections not semantically parsed" below.
+//!
+//! ## `atom_style` is not inferable from the file -- do not guess it
+//!
+//! read_data.html states plainly that the atom style must be defined
+//! before reading a data file; it is genuinely not always recoverable
+//! from the `Atoms` section's column count alone. For example,
+//! `atom_style charge` rows (`atom-ID atom-type q x y z`) and
+//! `atom_style molecular` rows (`atom-ID molecule-ID atom-type x y z`)
+//! are both 6 fields -- same column count, different meaning, genuinely
+//! ambiguous by shape alone. [`parse_lammps_data`] therefore takes
+//! `atom_style: LammpsAtomStyle` as a required parameter rather than a
+//! "guess from column count" fallback, which would silently mis-parse
+//! that ambiguous case.
+//!
+//! ## Supported atom styles
+//!
+//! Exactly 4, matching read_data.html's documented column layouts
+//! verbatim:
+//! - [`LammpsAtomStyle::Atomic`]: `atom-ID atom-type x y z`
+//! - [`LammpsAtomStyle::Charge`]: `atom-ID atom-type q x y z`
+//! - [`LammpsAtomStyle::Molecular`]: `atom-ID molecule-ID atom-type x y z`
+//! - [`LammpsAtomStyle::Full`]: `atom-ID molecule-ID atom-type q x y z`
+//!
+//! All 4 optionally carry 3 trailing image flags `ix iy iz`
+//! (read_data.html: "atom lines (all lines or none of them) can
+//! optionally list 3 trailing integer values (nx,ny,nz)"), detected per
+//! row from whether it has exactly 3 more whitespace-delimited fields
+//! than the style's base count.
+//!
+//! Any `atom_style` outside this set of 4 -- passed as
+//! [`LammpsAtomStyle::Other`] -- is rejected with a typed
+//! [`LammpsDataError::UnsupportedAtomStyle`]; there is no best-effort
+//! fallback parse.
+//!
+//! ## Sections fully parsed (typed)
+//!
+//! `Masses` (`atom-type mass` pairs), `Atoms` (per `atom_style` above),
+//! `Velocities` (`atom-ID vx vy vz`), `Bonds`
+//! (`bond-ID bond-type atom1-ID atom2-ID`).
+//!
+//! ## Sections preserved but not semantically parsed
+//!
+//! `Angles`, `Dihedrals`, `Impropers`, `Pair Coeffs`, `Bond Coeffs`,
+//! `Angle Coeffs`, `Dihedral Coeffs`, `Improper Coeffs`, and any other
+//! section name not listed above: captured verbatim (name + raw row
+//! text, byte-for-byte, including any inline `#` comment) into
+//! [`LammpsData::unparsed_sections`], an ordered `Vec<(String, String)>`
+//! (not a `HashMap` -- this project's standing determinism rule; order is
+//! the sections' original relative order among themselves, and matters).
+//! [`write_lammps_data`] always writes the 4 typed sections first (in a
+//! fixed canonical order: Masses, Atoms, Velocities, Bonds), followed by
+//! the opaque sections in their original relative order. The exact
+//! *interleaving* of typed and opaque sections in the source file is
+//! therefore not preserved -- only each section's own content is. Real
+//! LAMMPS itself does not require or preserve a specific section order
+//! either, and `parse(write(parse(text)))` is still a fixed point of
+//! `parse(text)` under this scheme.
+//!
+//! ## Why opaque preservation is safe *right now* -- and a constraint on future work
+//!
+//! See the "Mutation safety" note on [`LammpsData`] below: this module is
+//! read/write/round-trip only in v1 (no atom-removal or atom-renumbering
+//! API), which is exactly why treating `Angles`/`Dihedrals`/etc. as
+//! opaque byte blobs is safe rather than merely convenient.
+//!
+//! ## LAMMPS's type-label framework: unsupported, fails closed
+//!
+//! LAMMPS also supports an `Atom Type Labels` / `Bond Type Labels` /
+//! `Angle Type Labels` / `Dihedral Type Labels` / `Improper Type Labels`
+//! extension under which `Masses`/`Atoms`/`Bonds`/etc. rows can key off a
+//! string label (e.g. a `Masses` row `C 12.011` instead of `1 12.011`)
+//! rather than a numeric type/ID. This module's section-boundary
+//! detection (see below) and typed-row parsing are numeric-ID-only and
+//! cannot safely distinguish a label-keyed data row from the start of a
+//! new section -- silently misreading such a file would drop or
+//! mis-split real data rather than failing loudly. Rather than attempt
+//! that, any section whose name ends in `"Type Labels"` causes the whole
+//! parse to fail closed with [`LammpsDataError::TypeLabelsUnsupported`]
+//! as soon as it's seen, since its presence signals the rest of the file
+//! may use the same string-keyed convention this module cannot safely
+//! interpret.
+//!
+//! ## Units: not tracked, by design
+//!
+//! LAMMPS data files do not declare their unit system in-file (`units` is
+//! a separate *input-script* command, never present in the data file
+//! itself). This module performs **no** unit conversion or inference:
+//! every numeric value is stored exactly as read, unit-agnostic. This is
+//! a deliberate, disclosed non-goal -- matching this project's own
+//! Cube/OpenDX lesson about never silently assuming a unit system -- not
+//! an oversight.
+//!
+//! ## Section-boundary detection
+//!
+//! After a section-name line and its mandatory skipped line, this reader
+//! consumes data rows until either EOF or a line whose first
+//! whitespace-delimited token (after stripping any `#` comment) fails to
+//! parse as a number -- every documented LAMMPS section-name line begins
+//! with a non-numeric word (`Masses`, `Atoms`, `Pair Coeffs`, ...) while
+//! every documented data row begins with a numeric ID/type index, so this
+//! is a safe, generic boundary heuristic *given* the type-label framework
+//! is rejected up front (see above) -- without that guard, a label-keyed
+//! row (`C 12.011`) would look exactly like a new section header to this
+//! heuristic.
+//!
+//! ## Box: a new type, not `chematic_crystal::Lattice`
+//!
+//! See [`LammpsBox`]'s own doc comment.
+
+// ---------------------------------------------------------------------------
+// LammpsBox
+// ---------------------------------------------------------------------------
+
+/// The simulation box shape shared by LAMMPS data files (this module) and
+/// dump files ([`crate::lammps_dump`]).
+///
+/// Deliberately **not** `chematic_crystal::Lattice`: a `Lattice` is a
+/// crystallographic unit-cell matrix (row-vector fractional/Cartesian
+/// convention, positive-length/non-degenerate-angle validation, a cached
+/// inverse) built for periodic *crystal* structures. LAMMPS's lo/hi/tilt
+/// convention is a different, simpler shape -- an axis-aligned box plus 3
+/// shear/tilt components -- and forcing that mapping is unnecessary
+/// coupling for no benefit. `chematic-mol` only depends on
+/// `chematic-crystal` behind its optional `crystal` feature (for the CIF
+/// adapter); this type must work without it, same reasoning as
+/// [`crate::volumetric::VolumetricGrid`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LammpsBox {
+    /// `[xlo, ylo, zlo]`.
+    pub lo: [f64; 3],
+    /// `[xhi, yhi, zhi]`.
+    pub hi: [f64; 3],
+    /// `(xy, xz, yz)` tilt factors. `None` for an orthogonal box.
+    pub tilt: Option<[f64; 3]>,
+}
+
+impl LammpsBox {
+    /// Validate structural invariants: every `hi[i] > lo[i]`, and every
+    /// `lo`/`hi`/`tilt` component is finite. Returns a plain `String`
+    /// reason rather than a format-specific error type, so both
+    /// [`LammpsDataError::InvalidBox`] (this module) and
+    /// `LammpsDumpError::InvalidBox` ([`crate::lammps_dump`]) can wrap it
+    /// without this type depending on either error enum.
+    pub fn validate(&self) -> Result<(), String> {
+        for i in 0..3 {
+            if !self.lo[i].is_finite() {
+                return Err(format!("lo[{i}] = {} is not finite", self.lo[i]));
+            }
+            if !self.hi[i].is_finite() {
+                return Err(format!("hi[{i}] = {} is not finite", self.hi[i]));
+            }
+            if self.hi[i] <= self.lo[i] {
+                return Err(format!(
+                    "axis {i}: hi ({}) must be greater than lo ({})",
+                    self.hi[i], self.lo[i]
+                ));
+            }
+        }
+        if let Some(t) = self.tilt {
+            for (i, v) in t.iter().enumerate() {
+                if !v.is_finite() {
+                    return Err(format!("tilt[{i}] = {v} is not finite"));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LammpsAtomStyle
+// ---------------------------------------------------------------------------
+
+/// Which `atom_style` a data file's `Atoms` section rows follow. See
+/// module docs for why this must be supplied by the caller rather than
+/// inferred.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LammpsAtomStyle {
+    /// `atom-ID atom-type x y z`.
+    Atomic,
+    /// `atom-ID atom-type q x y z`.
+    Charge,
+    /// `atom-ID molecule-ID atom-type x y z`.
+    Molecular,
+    /// `atom-ID molecule-ID atom-type q x y z`.
+    Full,
+    /// Any style name other than the 4 above (e.g. `"sphere"`, `"bond"`,
+    /// `"granular"`, `"full/omp"`, ...). Carried as the raw style name so
+    /// [`parse_lammps_data`] can fail closed with a typed
+    /// [`LammpsDataError::UnsupportedAtomStyle`] rather than requiring
+    /// every caller to pre-filter before calling in -- see module docs.
+    Other(String),
+}
+
+impl LammpsAtomStyle {
+    /// The literal LAMMPS keyword for this style, used for the
+    /// `Atoms # <style>` comment [`write_lammps_data`] emits (matching
+    /// real `write_data` output convention; purely cosmetic -- readers of
+    /// this module strip and ignore it, see module docs on comments).
+    fn keyword(&self) -> &str {
+        match self {
+            Self::Atomic => "atomic",
+            Self::Charge => "charge",
+            Self::Molecular => "molecular",
+            Self::Full => "full",
+            Self::Other(s) => s,
+        }
+    }
+
+    /// Number of whitespace-delimited fields an `Atoms` row has for this
+    /// style, *not* counting optional trailing image flags. `None` for
+    /// [`Self::Other`] (out of scope; see module docs).
+    fn base_field_count(&self) -> Option<usize> {
+        match self {
+            Self::Atomic => Some(5),    // id type x y z
+            Self::Charge => Some(6),    // id type q x y z
+            Self::Molecular => Some(6), // id mol-id type x y z
+            Self::Full => Some(7),      // id mol-id type q x y z
+            Self::Other(_) => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+/// One `Masses` section row: `atom-type mass`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LammpsMass {
+    pub atom_type: i64,
+    pub mass: f64,
+}
+
+/// One `Atoms` section row. Which of `molecule_id`/`charge` are `Some`
+/// depends on the file's [`LammpsAtomStyle`] (stored once on
+/// [`LammpsData::atom_style`], not per-atom, since one file has exactly
+/// one atom style).
+#[derive(Debug, Clone, PartialEq)]
+pub struct LammpsAtom {
+    pub id: i64,
+    /// `Some` for [`LammpsAtomStyle::Molecular`]/[`LammpsAtomStyle::Full`].
+    pub molecule_id: Option<i64>,
+    pub atom_type: i64,
+    /// `Some` for [`LammpsAtomStyle::Charge`]/[`LammpsAtomStyle::Full`].
+    pub charge: Option<f64>,
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+    /// Trailing `ix iy iz` periodic-image flags, if present on this row.
+    pub image: Option<[i32; 3]>,
+}
+
+/// One `Velocities` section row: `atom-ID vx vy vz`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LammpsVelocity {
+    pub atom_id: i64,
+    pub vx: f64,
+    pub vy: f64,
+    pub vz: f64,
+}
+
+/// One `Bonds` section row: `bond-ID bond-type atom1-ID atom2-ID`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LammpsBond {
+    pub id: i64,
+    pub bond_type: i64,
+    pub atom1: i64,
+    pub atom2: i64,
+}
+
+// ---------------------------------------------------------------------------
+// LammpsData
+// ---------------------------------------------------------------------------
+
+/// A parsed LAMMPS data file. This is a **standalone document type**, not
+/// integrated with [`chematic_core::Molecule`] -- LAMMPS bonds/angles/etc.
+/// are raw atom-index topology, not chemically perceived bonds, and an MD
+/// atom under some `atom_style`s is not necessarily even a chemical
+/// element. Callers needing a `Molecule` should build one themselves from
+/// [`LammpsData::atoms`]/[`LammpsData::bonds`] plus whatever
+/// element-inference or bond-perception policy fits their use case; this
+/// module does not attempt that.
+///
+/// ## Mutation safety (read this before adding an atom-removal/renumbering API)
+///
+/// This module is **read/write/round-trip only in v1** -- there is no
+/// atom-removal or atom-renumbering operation. That is deliberate, not an
+/// oversight, and it is exactly what makes opaque preservation of
+/// `Angles`/`Dihedrals`/`Impropers`/`*Coeffs`/etc. (see
+/// [`Self::unparsed_sections`]) safe: those sections reference atom/type
+/// indices by raw integer, which this module never interprets. If a
+/// future PR adds an API that removes or renumbers atoms, it **must**
+/// also either remap every opaque section's atom-index references or
+/// reject the operation outright -- otherwise renumbering would silently
+/// corrupt `unparsed_sections` into referencing atoms that no longer
+/// exist (or the wrong ones). Since no such mutation API exists yet, that
+/// staleness trap is unreachable today; it becomes reachable the moment
+/// one is added. The same reasoning applies to [`Self::counts`]: it is
+/// preserved and written back verbatim as parsed, so a mutation API would
+/// also need to keep it consistent with the mutated sections' actual row
+/// counts.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LammpsData {
+    /// Header `<count> <label>` lines, in file order, exactly as declared
+    /// (e.g. `[("atoms", 120), ("bonds", 60), ("atom types", 4), ...]`).
+    /// Looked up via [`Self::count`] rather than a fixed field per
+    /// topology kind, since LAMMPS data files declare an open-ended set
+    /// of these. [`write_lammps_data`] writes this back verbatim -- it is
+    /// never recomputed from e.g. `atoms.len()`, so a hand-mutated
+    /// `LammpsData` whose `atoms` no longer matches its stored `"atoms"`
+    /// count will silently write an inconsistent file (see "Mutation
+    /// safety" above).
+    pub counts: Vec<(String, i64)>,
+    pub atom_style: LammpsAtomStyle,
+    pub simulation_box: LammpsBox,
+    pub masses: Vec<LammpsMass>,
+    pub atoms: Vec<LammpsAtom>,
+    pub velocities: Vec<LammpsVelocity>,
+    pub bonds: Vec<LammpsBond>,
+    /// `(section_name, raw_row_text)` for every section this module does
+    /// not semantically parse, in the sections' original relative order.
+    /// `raw_row_text` is every data row of that section joined by `\n`
+    /// (no trailing newline), byte-for-byte as read -- `#` comments and
+    /// all. See module docs.
+    pub unparsed_sections: Vec<(String, String)>,
+}
+
+impl LammpsData {
+    /// Look up a header count by its exact label (e.g. `"atoms"`,
+    /// `"atom types"`). `None` if the header never declared that label.
+    pub fn count(&self, label: &str) -> Option<i64> {
+        self.counts
+            .iter()
+            .find(|(k, _)| k == label)
+            .map(|(_, v)| *v)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors from [`parse_lammps_data`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum LammpsDataError {
+    /// The requested [`LammpsAtomStyle`] is [`LammpsAtomStyle::Other`] --
+    /// outside this module's 4 supported styles. See module docs.
+    UnsupportedAtomStyle { style: String },
+    /// A header line (count or box-bounds) did not match any recognized
+    /// shape.
+    MalformedHeader { line: usize, detail: String },
+    /// [`LammpsBox::validate`] failed -- missing bound line(s), or a
+    /// non-finite/non-increasing bound.
+    InvalidBox { reason: String },
+    /// A numeric field parsed but was NaN/Infinite.
+    NonFiniteValue {
+        section: String,
+        line: usize,
+        raw: String,
+    },
+    /// The header's declared `"atoms"` count did not match the number of
+    /// rows actually found in the `Atoms` section.
+    AtomCountMismatch { declared: i64, actual: usize },
+    /// Two `Atoms` rows declared the same `atom-ID`.
+    DuplicateAtomId {
+        id: i64,
+        first_line: usize,
+        line: usize,
+    },
+    /// A `Bonds` row referenced an `atom-ID` not present in `Atoms`.
+    BondReferencesUnknownAtom { bond_id: i64, atom_id: i64 },
+    /// The input ended before a required section/field was fully read.
+    TruncatedInput { context: &'static str },
+    /// A row in one of the 4 typed sections (`Masses`/`Atoms`/
+    /// `Velocities`/`Bonds`) did not have the expected field count or
+    /// shape for that section.
+    MalformedRow {
+        section: String,
+        line: usize,
+        detail: String,
+    },
+    /// A section name ending in `"Type Labels"` was found -- LAMMPS's
+    /// type-label framework, which this module cannot safely parse. See
+    /// module docs.
+    TypeLabelsUnsupported { section: String },
+}
+
+impl std::fmt::Display for LammpsDataError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedAtomStyle { style } => {
+                write!(f, "unsupported LAMMPS atom_style '{style}'")
+            }
+            Self::MalformedHeader { line, detail } => {
+                write!(f, "malformed header line at line {line}: '{detail}'")
+            }
+            Self::InvalidBox { reason } => write!(f, "invalid LAMMPS box: {reason}"),
+            Self::NonFiniteValue { section, line, raw } => write!(
+                f,
+                "non-finite value '{raw}' in section '{section}' at line {line}"
+            ),
+            Self::AtomCountMismatch { declared, actual } => write!(
+                f,
+                "header declares {declared} atoms but Atoms section has {actual} rows"
+            ),
+            Self::DuplicateAtomId {
+                id,
+                first_line,
+                line,
+            } => write!(
+                f,
+                "duplicate atom-ID {id} at line {line} (first seen at line {first_line})"
+            ),
+            Self::BondReferencesUnknownAtom { bond_id, atom_id } => {
+                write!(f, "bond {bond_id} references unknown atom-ID {atom_id}")
+            }
+            Self::TruncatedInput { context } => {
+                write!(f, "unexpected end of input while reading {context}")
+            }
+            Self::MalformedRow {
+                section,
+                line,
+                detail,
+            } => write!(
+                f,
+                "malformed row in section '{section}' at line {line}: '{detail}'"
+            ),
+            Self::TypeLabelsUnsupported { section } => write!(
+                f,
+                "section '{section}' uses LAMMPS's type-label framework, which is not supported"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LammpsDataError {}
+
+// ---------------------------------------------------------------------------
+// Parsing helpers
+// ---------------------------------------------------------------------------
+
+/// Strip a trailing `#` comment (read_data.html: permitted on any line,
+/// with at least one blank before `#`) and trailing whitespace.
+fn strip_comment(line: &str) -> &str {
+    match line.find('#') {
+        Some(i) => line[..i].trim_end(),
+        None => line.trim_end(),
+    }
+}
+
+/// Whether `tok` parses as a number at all (int or float) -- used only for
+/// the section-boundary heuristic (see module docs), never to decide a
+/// value's actual type.
+fn looks_numeric(tok: &str) -> bool {
+    tok.parse::<f64>().is_ok()
+}
+
+struct LineCursor<'a> {
+    lines: Vec<&'a str>,
+    idx: usize,
+}
+
+impl<'a> LineCursor<'a> {
+    fn new(input: &'a str) -> Self {
+        Self {
+            lines: input.lines().collect(),
+            idx: 0,
+        }
+    }
+
+    /// 1-based line number of the line `peek()`/`next()` would return.
+    fn line_no(&self) -> usize {
+        self.idx + 1
+    }
+
+    fn peek(&self) -> Option<&'a str> {
+        self.lines.get(self.idx).copied()
+    }
+
+    fn next(&mut self) -> Option<&'a str> {
+        let l = self.peek();
+        if l.is_some() {
+            self.idx += 1;
+        }
+        l
+    }
+}
+
+fn parse_finite(
+    tok: &str,
+    section: &str,
+    line: usize,
+    raw_line: &str,
+) -> Result<f64, LammpsDataError> {
+    let v: f64 = tok.parse().map_err(|_| LammpsDataError::MalformedRow {
+        section: section.to_string(),
+        line,
+        detail: raw_line.to_string(),
+    })?;
+    if !v.is_finite() {
+        return Err(LammpsDataError::NonFiniteValue {
+            section: section.to_string(),
+            line,
+            raw: tok.to_string(),
+        });
+    }
+    Ok(v)
+}
+
+fn parse_int(
+    tok: &str,
+    section: &str,
+    line: usize,
+    raw_line: &str,
+) -> Result<i64, LammpsDataError> {
+    tok.parse::<i64>()
+        .map_err(|_| LammpsDataError::MalformedRow {
+            section: section.to_string(),
+            line,
+            detail: raw_line.to_string(),
+        })
+}
+
+// ---------------------------------------------------------------------------
+// Header parsing
+// ---------------------------------------------------------------------------
+
+enum HeaderLine {
+    Count { label: String, value: i64 },
+    BoxPair { axis: usize, lo: f64, hi: f64 },
+    Tilt { xy: f64, xz: f64, yz: f64 },
+}
+
+/// Classify one header-block line. `Ok(None)` means `raw` is not a header
+/// line at all (blank, or the first section-name line) -- the caller
+/// decides what to do next.
+fn classify_header_line(raw: &str, line_no: usize) -> Result<Option<HeaderLine>, LammpsDataError> {
+    let content = strip_comment(raw);
+    let toks: Vec<&str> = content.split_whitespace().collect();
+    if toks.is_empty() {
+        // Blank (post-comment-stripping) line: not a header line, but not
+        // a section header either -- caller skips it.
+        return Ok(None);
+    }
+
+    // Tilt line: 3 leading floats + literal "xy xz yz" keywords.
+    if toks.len() == 6 && toks[3] == "xy" && toks[4] == "xz" && toks[5] == "yz" {
+        let xy = parse_finite(toks[0], "header", line_no, raw)?;
+        let xz = parse_finite(toks[1], "header", line_no, raw)?;
+        let yz = parse_finite(toks[2], "header", line_no, raw)?;
+        return Ok(Some(HeaderLine::Tilt { xy, xz, yz }));
+    }
+
+    // Box-bound pair line: 2 leading floats + a known keyword pair.
+    if toks.len() == 4 {
+        let axis = match (toks[2], toks[3]) {
+            ("xlo", "xhi") => Some(0),
+            ("ylo", "yhi") => Some(1),
+            ("zlo", "zhi") => Some(2),
+            _ => None,
+        };
+        if let Some(axis) = axis {
+            let lo = parse_finite(toks[0], "header", line_no, raw)?;
+            let hi = parse_finite(toks[1], "header", line_no, raw)?;
+            return Ok(Some(HeaderLine::BoxPair { axis, lo, hi }));
+        }
+    }
+
+    // Count line: leading integer + a non-numeric label (>= 1 word).
+    if let Ok(value) = toks[0].parse::<i64>()
+        && toks.len() >= 2
+        && !looks_numeric(toks[1])
+    {
+        let label = toks[1..].join(" ");
+        return Ok(Some(HeaderLine::Count { label, value }));
+    }
+
+    if looks_numeric(toks[0]) {
+        // Starts with a number but matches none of the known header
+        // shapes -- genuinely malformed, not "end of header".
+        return Err(LammpsDataError::MalformedHeader {
+            line: line_no,
+            detail: raw.to_string(),
+        });
+    }
+
+    // Non-numeric leading token that isn't blank: this is the first
+    // section-name line, not a header line.
+    Ok(None)
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+/// Parse a LAMMPS data file. `atom_style` must be supplied by the caller
+/// (see module docs -- it cannot be recovered from the file alone).
+pub fn parse_lammps_data(
+    text: &str,
+    atom_style: LammpsAtomStyle,
+) -> Result<LammpsData, LammpsDataError> {
+    if let LammpsAtomStyle::Other(style) = &atom_style {
+        return Err(LammpsDataError::UnsupportedAtomStyle {
+            style: style.clone(),
+        });
+    }
+
+    let mut cur = LineCursor::new(text);
+    // Line 1: unconditionally ignored comment line.
+    cur.next();
+
+    let mut counts: Vec<(String, i64)> = Vec::new();
+    let mut lo = [0.0f64; 3];
+    let mut hi = [0.0f64; 3];
+    let mut have_axis = [false; 3];
+    let mut tilt: Option<[f64; 3]> = None;
+
+    // Header block: classify lines until we hit the first section-name
+    // line (classify_header_line returns Ok(None) for both blanks and
+    // that boundary; blanks are skipped, the boundary line is left
+    // un-consumed for the section loop below).
+    loop {
+        let Some(raw) = cur.peek() else {
+            return Err(LammpsDataError::TruncatedInput {
+                context: "header block (no sections found)",
+            });
+        };
+        let line_no = cur.line_no();
+        match classify_header_line(raw, line_no)? {
+            Some(HeaderLine::Count { label, value }) => {
+                counts.push((label, value));
+                cur.next();
+            }
+            Some(HeaderLine::BoxPair { axis, lo: l, hi: h }) => {
+                lo[axis] = l;
+                hi[axis] = h;
+                have_axis[axis] = true;
+                cur.next();
+            }
+            Some(HeaderLine::Tilt { xy, xz, yz }) => {
+                tilt = Some([xy, xz, yz]);
+                cur.next();
+            }
+            None => {
+                if strip_comment(raw).split_whitespace().next().is_none() {
+                    // Blank line -- skip and keep scanning the header.
+                    cur.next();
+                    continue;
+                }
+                // First section-name line -- stop, leave it for the
+                // section loop.
+                break;
+            }
+        }
+    }
+
+    if !have_axis.iter().all(|&a| a) {
+        return Err(LammpsDataError::InvalidBox {
+            reason: "missing one or more of xlo/xhi, ylo/yhi, zlo/zhi bound lines".to_string(),
+        });
+    }
+    let simulation_box = LammpsBox { lo, hi, tilt };
+    simulation_box
+        .validate()
+        .map_err(|reason| LammpsDataError::InvalidBox { reason })?;
+
+    let mut masses: Vec<LammpsMass> = Vec::new();
+    let mut atoms: Vec<LammpsAtom> = Vec::new();
+    // Source line number for each `atoms[i]`, index-parallel -- used only
+    // for the `DuplicateAtomId` diagnostic below (not retained on
+    // `LammpsData` itself, which has no line-number fields).
+    let mut atom_lines: Vec<usize> = Vec::new();
+    let mut velocities: Vec<LammpsVelocity> = Vec::new();
+    let mut bonds: Vec<LammpsBond> = Vec::new();
+    let mut unparsed_sections: Vec<(String, String)> = Vec::new();
+
+    // Body: sequence of sections.
+    while let Some(raw) = cur.peek() {
+        let name = strip_comment(raw)
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        if name.is_empty() {
+            // Blank line between sections.
+            cur.next();
+            continue;
+        }
+        cur.next(); // consume the section-name line
+
+        if name.ends_with("Type Labels") {
+            return Err(LammpsDataError::TypeLabelsUnsupported { section: name });
+        }
+
+        // Mandatory "next line is always skipped" per read_data.html.
+        if cur.next().is_none() {
+            return Err(LammpsDataError::TruncatedInput {
+                context: "line after section header",
+            });
+        }
+
+        // Collect this section's data rows: everything up to (but not
+        // including) the next line whose first token isn't numeric, or
+        // EOF. Blank lines within a section are skipped, not counted as
+        // rows or as section boundaries.
+        let mut rows: Vec<(usize, &str)> = Vec::new();
+        while let Some(row_raw) = cur.peek() {
+            let stripped = strip_comment(row_raw);
+            let Some(first_tok) = stripped.split_whitespace().next() else {
+                cur.next(); // blank line inside a section
+                continue;
+            };
+            if !looks_numeric(first_tok) {
+                break; // next section header
+            }
+            rows.push((cur.line_no(), row_raw));
+            cur.next();
+        }
+
+        match name.as_str() {
+            "Masses" => {
+                for (line_no, row_raw) in rows {
+                    let content = strip_comment(row_raw);
+                    let toks: Vec<&str> = content.split_whitespace().collect();
+                    if toks.len() != 2 {
+                        return Err(LammpsDataError::MalformedRow {
+                            section: name.clone(),
+                            line: line_no,
+                            detail: row_raw.to_string(),
+                        });
+                    }
+                    let atom_type = parse_int(toks[0], &name, line_no, row_raw)?;
+                    let mass = parse_finite(toks[1], &name, line_no, row_raw)?;
+                    masses.push(LammpsMass { atom_type, mass });
+                }
+            }
+            "Atoms" => {
+                let base = atom_style.base_field_count().expect(
+                    "atom_style is one of the 4 supported styles here -- Other was rejected above",
+                );
+                for (line_no, row_raw) in rows {
+                    let content = strip_comment(row_raw);
+                    let toks: Vec<&str> = content.split_whitespace().collect();
+                    let (fields, image) = if toks.len() == base {
+                        (&toks[..], None)
+                    } else if toks.len() == base + 3 {
+                        let mut img = [0i32; 3];
+                        for (k, slot) in img.iter_mut().enumerate() {
+                            *slot = toks[base + k].parse().map_err(|_| {
+                                LammpsDataError::MalformedRow {
+                                    section: name.clone(),
+                                    line: line_no,
+                                    detail: row_raw.to_string(),
+                                }
+                            })?;
+                        }
+                        (&toks[..base], Some(img))
+                    } else {
+                        return Err(LammpsDataError::MalformedRow {
+                            section: name.clone(),
+                            line: line_no,
+                            detail: row_raw.to_string(),
+                        });
+                    };
+
+                    let id = parse_int(fields[0], &name, line_no, row_raw)?;
+                    let (molecule_id, type_idx) = match atom_style {
+                        LammpsAtomStyle::Molecular | LammpsAtomStyle::Full => {
+                            (Some(parse_int(fields[1], &name, line_no, row_raw)?), 2)
+                        }
+                        _ => (None, 1),
+                    };
+                    let atom_type = parse_int(fields[type_idx], &name, line_no, row_raw)?;
+                    let mut next = type_idx + 1;
+                    let charge = match atom_style {
+                        LammpsAtomStyle::Charge | LammpsAtomStyle::Full => {
+                            let q = parse_finite(fields[next], &name, line_no, row_raw)?;
+                            next += 1;
+                            Some(q)
+                        }
+                        _ => None,
+                    };
+                    let x = parse_finite(fields[next], &name, line_no, row_raw)?;
+                    let y = parse_finite(fields[next + 1], &name, line_no, row_raw)?;
+                    let z = parse_finite(fields[next + 2], &name, line_no, row_raw)?;
+
+                    atoms.push(LammpsAtom {
+                        id,
+                        molecule_id,
+                        atom_type,
+                        charge,
+                        x,
+                        y,
+                        z,
+                        image,
+                    });
+                    atom_lines.push(line_no);
+                }
+            }
+            "Velocities" => {
+                for (line_no, row_raw) in rows {
+                    let content = strip_comment(row_raw);
+                    let toks: Vec<&str> = content.split_whitespace().collect();
+                    if toks.len() != 4 {
+                        return Err(LammpsDataError::MalformedRow {
+                            section: name.clone(),
+                            line: line_no,
+                            detail: row_raw.to_string(),
+                        });
+                    }
+                    velocities.push(LammpsVelocity {
+                        atom_id: parse_int(toks[0], &name, line_no, row_raw)?,
+                        vx: parse_finite(toks[1], &name, line_no, row_raw)?,
+                        vy: parse_finite(toks[2], &name, line_no, row_raw)?,
+                        vz: parse_finite(toks[3], &name, line_no, row_raw)?,
+                    });
+                }
+            }
+            "Bonds" => {
+                for (line_no, row_raw) in rows {
+                    let content = strip_comment(row_raw);
+                    let toks: Vec<&str> = content.split_whitespace().collect();
+                    if toks.len() != 4 {
+                        return Err(LammpsDataError::MalformedRow {
+                            section: name.clone(),
+                            line: line_no,
+                            detail: row_raw.to_string(),
+                        });
+                    }
+                    bonds.push(LammpsBond {
+                        id: parse_int(toks[0], &name, line_no, row_raw)?,
+                        bond_type: parse_int(toks[1], &name, line_no, row_raw)?,
+                        atom1: parse_int(toks[2], &name, line_no, row_raw)?,
+                        atom2: parse_int(toks[3], &name, line_no, row_raw)?,
+                    });
+                }
+            }
+            _ => {
+                let raw_text = rows.iter().map(|(_, r)| *r).collect::<Vec<_>>().join("\n");
+                unparsed_sections.push((name.clone(), raw_text));
+            }
+        }
+    }
+
+    // Cross-checks.
+    if let Some(declared) = counts.iter().find(|(k, _)| k == "atoms").map(|(_, v)| *v) {
+        if declared != atoms.len() as i64 {
+            return Err(LammpsDataError::AtomCountMismatch {
+                declared,
+                actual: atoms.len(),
+            });
+        }
+    } else {
+        return Err(LammpsDataError::MalformedHeader {
+            line: 0,
+            detail: "missing required 'N atoms' header count line".to_string(),
+        });
+    }
+
+    // Duplicate atom-ID check: O(n log n) via a sorted (id, source line)
+    // copy -- no hash container anywhere in this module (project
+    // determinism rule). Uses `atom_lines` (the real source line each
+    // `atoms[i]` was parsed from), not the atom's position in `atoms`, so
+    // the reported line numbers are genuinely useful for locating the
+    // offending rows in the original file.
+    let mut by_id: Vec<(i64, usize)> = atoms
+        .iter()
+        .zip(&atom_lines)
+        .map(|(a, &line)| (a.id, line))
+        .collect();
+    by_id.sort_unstable_by_key(|(id, _)| *id);
+    for w in by_id.windows(2) {
+        if w[0].0 == w[1].0 {
+            // `sort_unstable_by_key` doesn't preserve original relative
+            // order for equal ids, so recover chronological order via
+            // min/max rather than assuming `w[0]` was read first.
+            let (first_line, line) = (w[0].1.min(w[1].1), w[0].1.max(w[1].1));
+            return Err(LammpsDataError::DuplicateAtomId {
+                id: w[0].0,
+                first_line,
+                line,
+            });
+        }
+    }
+
+    let mut sorted_ids: Vec<i64> = atoms.iter().map(|a| a.id).collect();
+    sorted_ids.sort_unstable();
+    for bond in &bonds {
+        if sorted_ids.binary_search(&bond.atom1).is_err() {
+            return Err(LammpsDataError::BondReferencesUnknownAtom {
+                bond_id: bond.id,
+                atom_id: bond.atom1,
+            });
+        }
+        if sorted_ids.binary_search(&bond.atom2).is_err() {
+            return Err(LammpsDataError::BondReferencesUnknownAtom {
+                bond_id: bond.id,
+                atom_id: bond.atom2,
+            });
+        }
+    }
+
+    Ok(LammpsData {
+        counts,
+        atom_style,
+        simulation_box,
+        masses,
+        atoms,
+        velocities,
+        bonds,
+        unparsed_sections,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Writer
+// ---------------------------------------------------------------------------
+
+/// Write a [`LammpsData`] back out as a LAMMPS data file. Writes
+/// [`LammpsData::counts`] verbatim (never recomputed from the typed
+/// sections' actual lengths -- see [`LammpsData::counts`]'s doc comment),
+/// then the box-bounds lines, then the 4 typed sections in a fixed
+/// canonical order (`Masses`, `Atoms`, `Velocities`, `Bonds` -- each
+/// omitted entirely when empty), then [`LammpsData::unparsed_sections`]
+/// in their original relative order. See module docs on why section
+/// *order* is not treated as significant round-trip content.
+pub fn write_lammps_data(data: &LammpsData) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let _ = writeln!(out, "LAMMPS data file written by chematic");
+    out.push('\n');
+
+    for (label, value) in &data.counts {
+        let _ = writeln!(out, "{value} {label}");
+    }
+    out.push('\n');
+
+    let b = &data.simulation_box;
+    let _ = writeln!(out, "{} {} xlo xhi", b.lo[0], b.hi[0]);
+    let _ = writeln!(out, "{} {} ylo yhi", b.lo[1], b.hi[1]);
+    let _ = writeln!(out, "{} {} zlo zhi", b.lo[2], b.hi[2]);
+    if let Some([xy, xz, yz]) = b.tilt {
+        let _ = writeln!(out, "{xy} {xz} {yz} xy xz yz");
+    }
+    out.push('\n');
+
+    if !data.masses.is_empty() {
+        out.push_str("Masses\n\n");
+        for m in &data.masses {
+            let _ = writeln!(out, "{} {}", m.atom_type, m.mass);
+        }
+        out.push('\n');
+    }
+
+    if !data.atoms.is_empty() {
+        let _ = writeln!(out, "Atoms # {}", data.atom_style.keyword());
+        out.push('\n');
+        for a in &data.atoms {
+            let mut line = a.id.to_string();
+            if let Some(mol) = a.molecule_id {
+                let _ = write!(line, " {mol}");
+            }
+            let _ = write!(line, " {}", a.atom_type);
+            if let Some(q) = a.charge {
+                let _ = write!(line, " {q}");
+            }
+            let _ = write!(line, " {} {} {}", a.x, a.y, a.z);
+            if let Some([ix, iy, iz]) = a.image {
+                let _ = write!(line, " {ix} {iy} {iz}");
+            }
+            out.push_str(&line);
+            out.push('\n');
+        }
+        out.push('\n');
+    }
+
+    if !data.velocities.is_empty() {
+        out.push_str("Velocities\n\n");
+        for v in &data.velocities {
+            let _ = writeln!(out, "{} {} {} {}", v.atom_id, v.vx, v.vy, v.vz);
+        }
+        out.push('\n');
+    }
+
+    if !data.bonds.is_empty() {
+        out.push_str("Bonds\n\n");
+        for bd in &data.bonds {
+            let _ = writeln!(out, "{} {} {} {}", bd.id, bd.bond_type, bd.atom1, bd.atom2);
+        }
+        out.push('\n');
+    }
+
+    for (name, raw) in &data.unparsed_sections {
+        out.push_str(name);
+        out.push_str("\n\n");
+        if !raw.is_empty() {
+            out.push_str(raw);
+            out.push('\n');
+        }
+        out.push('\n');
+    }
+
+    out
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn atomic_fixture() -> &'static str {
+        "comment line, ignored\n\
+\n\
+3 atoms\n\
+1 atom types\n\
+2 bonds\n\
+1 bond types\n\
+\n\
+0.0 10.0 xlo xhi\n\
+0.0 10.0 ylo yhi\n\
+0.0 10.0 zlo zhi\n\
+\n\
+Masses\n\
+\n\
+1 12.011\n\
+\n\
+Atoms # atomic\n\
+\n\
+1 1 0.0 0.0 0.0\n\
+2 1 1.5 0.0 0.0\n\
+3 1 3.0 0.0 0.0\n\
+\n\
+Bonds\n\
+\n\
+1 1 1 2\n\
+2 1 2 3\n\
+"
+    }
+
+    #[test]
+    fn parses_atomic_fixture() {
+        let d = parse_lammps_data(atomic_fixture(), LammpsAtomStyle::Atomic).unwrap();
+        assert_eq!(d.atoms.len(), 3);
+        assert_eq!(d.bonds.len(), 2);
+        assert_eq!(d.masses.len(), 1);
+        assert_eq!(d.atoms[0].molecule_id, None);
+        assert_eq!(d.atoms[0].charge, None);
+        assert_eq!(d.count("atoms"), Some(3));
+        assert_eq!(d.count("bond types"), Some(1));
+    }
+
+    #[test]
+    fn round_trip_atomic_style() {
+        let d = parse_lammps_data(atomic_fixture(), LammpsAtomStyle::Atomic).unwrap();
+        let written = write_lammps_data(&d);
+        let d2 = parse_lammps_data(&written, LammpsAtomStyle::Atomic).unwrap();
+        assert_eq!(d, d2);
+    }
+
+    fn charge_fixture() -> String {
+        "comment\n\
+\n\
+2 atoms\n\
+1 atom types\n\
+\n\
+-5.0 5.0 xlo xhi\n\
+-5.0 5.0 ylo yhi\n\
+-5.0 5.0 zlo zhi\n\
+\n\
+Atoms # charge\n\
+\n\
+1 1 -0.5 0.0 0.0 0.0\n\
+2 1 0.5 1.0 0.0 0.0\n\
+"
+        .to_string()
+    }
+
+    #[test]
+    fn round_trip_charge_style() {
+        let d = parse_lammps_data(&charge_fixture(), LammpsAtomStyle::Charge).unwrap();
+        assert_eq!(d.atoms[0].charge, Some(-0.5));
+        assert_eq!(d.atoms[0].molecule_id, None);
+        let written = write_lammps_data(&d);
+        let d2 = parse_lammps_data(&written, LammpsAtomStyle::Charge).unwrap();
+        assert_eq!(d, d2);
+    }
+
+    fn molecular_fixture() -> String {
+        "comment\n\
+\n\
+2 atoms\n\
+1 atom types\n\
+\n\
+0.0 10.0 xlo xhi\n\
+0.0 10.0 ylo yhi\n\
+0.0 10.0 zlo zhi\n\
+\n\
+Atoms # molecular\n\
+\n\
+1 1 1 0.0 0.0 0.0\n\
+2 1 1 1.0 0.0 0.0\n\
+"
+        .to_string()
+    }
+
+    #[test]
+    fn round_trip_molecular_style() {
+        let d = parse_lammps_data(&molecular_fixture(), LammpsAtomStyle::Molecular).unwrap();
+        assert_eq!(d.atoms[0].molecule_id, Some(1));
+        assert_eq!(d.atoms[0].charge, None);
+        let written = write_lammps_data(&d);
+        let d2 = parse_lammps_data(&written, LammpsAtomStyle::Molecular).unwrap();
+        assert_eq!(d, d2);
+    }
+
+    fn full_fixture_with_images() -> String {
+        "comment\n\
+\n\
+2 atoms\n\
+1 atom types\n\
+\n\
+0.0 10.0 xlo xhi\n\
+0.0 10.0 ylo yhi\n\
+0.0 10.0 zlo zhi\n\
+\n\
+Atoms # full\n\
+\n\
+1 1 1 -0.834 0.0 0.0 0.0 1 0 0\n\
+2 1 1 0.417 1.0 0.0 0.0 0 -1 2\n\
+"
+        .to_string()
+    }
+
+    #[test]
+    fn round_trip_full_style_with_image_flags() {
+        let d = parse_lammps_data(&full_fixture_with_images(), LammpsAtomStyle::Full).unwrap();
+        assert_eq!(d.atoms[0].molecule_id, Some(1));
+        assert_eq!(d.atoms[0].charge, Some(-0.834));
+        assert_eq!(d.atoms[0].image, Some([1, 0, 0]));
+        assert_eq!(d.atoms[1].image, Some([0, -1, 2]));
+        let written = write_lammps_data(&d);
+        let d2 = parse_lammps_data(&written, LammpsAtomStyle::Full).unwrap();
+        assert_eq!(d, d2);
+    }
+
+    #[test]
+    fn round_trip_triclinic_box() {
+        let text = "comment\n\
+\n\
+1 atoms\n\
+1 atom types\n\
+\n\
+0.0 10.0 xlo xhi\n\
+0.0 10.0 ylo yhi\n\
+0.0 10.0 zlo zhi\n\
+1.0 2.0 0.5 xy xz yz\n\
+\n\
+Atoms # atomic\n\
+\n\
+1 1 5.0 5.0 5.0\n\
+";
+        let d = parse_lammps_data(text, LammpsAtomStyle::Atomic).unwrap();
+        assert_eq!(d.simulation_box.tilt, Some([1.0, 2.0, 0.5]));
+        let written = write_lammps_data(&d);
+        let d2 = parse_lammps_data(&written, LammpsAtomStyle::Atomic).unwrap();
+        assert_eq!(d, d2);
+    }
+
+    #[test]
+    fn opaque_sections_round_trip_as_exact_fixed_point() {
+        let text = "comment\n\
+\n\
+2 atoms\n\
+1 atom types\n\
+1 angle types\n\
+1 dihedral types\n\
+\n\
+0.0 10.0 xlo xhi\n\
+0.0 10.0 ylo yhi\n\
+0.0 10.0 zlo zhi\n\
+\n\
+Atoms # atomic\n\
+\n\
+1 1 0.0 0.0 0.0\n\
+2 1 1.0 0.0 0.0\n\
+\n\
+Angles\n\
+\n\
+1 1 1 2 1 # a comment on an opaque row\n\
+\n\
+Angle Coeffs\n\
+\n\
+1 100.0 109.5\n\
+";
+        let d1 = parse_lammps_data(text, LammpsAtomStyle::Atomic).unwrap();
+        assert_eq!(
+            d1.unparsed_sections,
+            vec![
+                (
+                    "Angles".to_string(),
+                    "1 1 1 2 1 # a comment on an opaque row".to_string()
+                ),
+                ("Angle Coeffs".to_string(), "1 100.0 109.5".to_string()),
+            ]
+        );
+        let written = write_lammps_data(&d1);
+        let d2 = parse_lammps_data(&written, LammpsAtomStyle::Atomic).unwrap();
+        assert_eq!(d2.unparsed_sections, d1.unparsed_sections);
+        // Fixed point: parsing the rewritten file again changes nothing further.
+        let written2 = write_lammps_data(&d2);
+        let d3 = parse_lammps_data(&written2, LammpsAtomStyle::Atomic).unwrap();
+        assert_eq!(d3, d2);
+    }
+
+    #[test]
+    fn zero_row_opaque_section_is_a_fixed_point() {
+        let text = "comment\n\
+\n\
+1 atoms\n\
+1 atom types\n\
+\n\
+0.0 10.0 xlo xhi\n\
+0.0 10.0 ylo yhi\n\
+0.0 10.0 zlo zhi\n\
+\n\
+Atoms # atomic\n\
+\n\
+1 1 0.0 0.0 0.0\n\
+\n\
+Pair Coeffs\n\
+\n\
+";
+        let d1 = parse_lammps_data(text, LammpsAtomStyle::Atomic).unwrap();
+        assert_eq!(
+            d1.unparsed_sections,
+            vec![("Pair Coeffs".to_string(), String::new())]
+        );
+        let written = write_lammps_data(&d1);
+        let d2 = parse_lammps_data(&written, LammpsAtomStyle::Atomic).unwrap();
+        assert_eq!(d2.unparsed_sections, d1.unparsed_sections);
+    }
+
+    #[test]
+    fn atom_count_mismatch_is_typed_error() {
+        let text = "comment\n\
+\n\
+5 atoms\n\
+1 atom types\n\
+\n\
+0.0 10.0 xlo xhi\n\
+0.0 10.0 ylo yhi\n\
+0.0 10.0 zlo zhi\n\
+\n\
+Atoms # atomic\n\
+\n\
+1 1 0.0 0.0 0.0\n\
+2 1 1.0 0.0 0.0\n\
+";
+        let err = parse_lammps_data(text, LammpsAtomStyle::Atomic).unwrap_err();
+        assert_eq!(
+            err,
+            LammpsDataError::AtomCountMismatch {
+                declared: 5,
+                actual: 2
+            }
+        );
+    }
+
+    #[test]
+    fn malformed_header_is_typed_error() {
+        // "not" doesn't parse as numeric, so this reads as "no header
+        // lines at all, first section is named 'not a valid header line
+        // at all @@@'" -- no box bounds were ever declared, so this
+        // surfaces as InvalidBox (missing bound lines), not
+        // TruncatedInput.
+        let text = "comment\nnot a valid header line at all @@@\n";
+        let err = parse_lammps_data(text, LammpsAtomStyle::Atomic).unwrap_err();
+        assert!(matches!(err, LammpsDataError::InvalidBox { .. }));
+
+        // A genuinely malformed header line: a leading number that
+        // matches none of the known header shapes (not a `<count>
+        // <label>` count line, not a 2-float box-bound pair, not a
+        // 3-float tilt line).
+        let text2 = "comment\n5 3 3 3 3 3 3\n";
+        let err2 = parse_lammps_data(text2, LammpsAtomStyle::Atomic).unwrap_err();
+        assert!(matches!(err2, LammpsDataError::MalformedHeader { .. }));
+    }
+
+    #[test]
+    fn non_finite_value_is_typed_error() {
+        let text = "comment\n\
+\n\
+1 atoms\n\
+1 atom types\n\
+\n\
+0.0 10.0 xlo xhi\n\
+0.0 10.0 ylo yhi\n\
+0.0 10.0 zlo zhi\n\
+\n\
+Atoms # atomic\n\
+\n\
+1 1 NaN 0.0 0.0\n\
+";
+        let err = parse_lammps_data(text, LammpsAtomStyle::Atomic).unwrap_err();
+        assert!(matches!(
+            err,
+            LammpsDataError::NonFiniteValue { section, .. } if section == "Atoms"
+        ));
+    }
+
+    #[test]
+    fn unsupported_atom_style_is_typed_error() {
+        let err = parse_lammps_data(
+            atomic_fixture(),
+            LammpsAtomStyle::Other("sphere".to_string()),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            LammpsDataError::UnsupportedAtomStyle {
+                style: "sphere".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn duplicate_atom_id_is_typed_error() {
+        let text = "comment\n\
+\n\
+2 atoms\n\
+1 atom types\n\
+\n\
+0.0 10.0 xlo xhi\n\
+0.0 10.0 ylo yhi\n\
+0.0 10.0 zlo zhi\n\
+\n\
+Atoms # atomic\n\
+\n\
+1 1 0.0 0.0 0.0\n\
+1 1 1.0 0.0 0.0\n\
+";
+        let err = parse_lammps_data(text, LammpsAtomStyle::Atomic).unwrap_err();
+        // Pin the actual source line numbers (line 12: first `1 1 0.0 0.0
+        // 0.0` row; line 13: the duplicate `1 1 1.0 0.0 0.0` row) so a
+        // regression back to reporting the atom's position instead of its
+        // real source line is caught.
+        assert_eq!(
+            err,
+            LammpsDataError::DuplicateAtomId {
+                id: 1,
+                first_line: 12,
+                line: 13,
+            }
+        );
+    }
+
+    #[test]
+    fn bond_referencing_unknown_atom_is_typed_error() {
+        let text = "comment\n\
+\n\
+2 atoms\n\
+1 atom types\n\
+1 bond types\n\
+\n\
+0.0 10.0 xlo xhi\n\
+0.0 10.0 ylo yhi\n\
+0.0 10.0 zlo zhi\n\
+\n\
+Atoms # atomic\n\
+\n\
+1 1 0.0 0.0 0.0\n\
+2 1 1.0 0.0 0.0\n\
+\n\
+Bonds\n\
+\n\
+1 1 1 99\n\
+";
+        let err = parse_lammps_data(text, LammpsAtomStyle::Atomic).unwrap_err();
+        assert_eq!(
+            err,
+            LammpsDataError::BondReferencesUnknownAtom {
+                bond_id: 1,
+                atom_id: 99
+            }
+        );
+    }
+
+    #[test]
+    fn type_labels_framework_is_rejected_not_misparsed() {
+        let text = "comment\n\
+\n\
+1 atoms\n\
+1 atom types\n\
+\n\
+0.0 10.0 xlo xhi\n\
+0.0 10.0 ylo yhi\n\
+0.0 10.0 zlo zhi\n\
+\n\
+Atom Type Labels\n\
+\n\
+1 C\n\
+\n\
+Atoms # atomic\n\
+\n\
+1 1 0.0 0.0 0.0\n\
+";
+        let err = parse_lammps_data(text, LammpsAtomStyle::Atomic).unwrap_err();
+        assert_eq!(
+            err,
+            LammpsDataError::TypeLabelsUnsupported {
+                section: "Atom Type Labels".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn trailing_comments_are_stripped_on_typed_rows() {
+        let text = "comment\n\
+\n\
+1 atoms\n\
+1 atom types\n\
+\n\
+0.0 10.0 xlo xhi\n\
+0.0 10.0 ylo yhi\n\
+0.0 10.0 zlo zhi\n\
+\n\
+Masses\n\
+\n\
+1 12.011 # carbon\n\
+\n\
+Atoms # atomic\n\
+\n\
+1 1 0.0 0.0 0.0 # salt ion\n\
+";
+        let d = parse_lammps_data(text, LammpsAtomStyle::Atomic).unwrap();
+        assert_eq!(d.masses[0].mass, 12.011);
+        assert_eq!(d.atoms[0].x, 0.0);
+    }
+
+    #[test]
+    fn invalid_box_is_typed_error() {
+        let text = "comment\n\
+\n\
+1 atoms\n\
+1 atom types\n\
+\n\
+10.0 0.0 xlo xhi\n\
+0.0 10.0 ylo yhi\n\
+0.0 10.0 zlo zhi\n\
+\n\
+Atoms # atomic\n\
+\n\
+1 1 0.0 0.0 0.0\n\
+";
+        let err = parse_lammps_data(text, LammpsAtomStyle::Atomic).unwrap_err();
+        assert!(matches!(err, LammpsDataError::InvalidBox { .. }));
+    }
+}

--- a/crates/chematic-mol/src/lammps_dump.rs
+++ b/crates/chematic-mol/src/lammps_dump.rs
@@ -1,0 +1,1035 @@
+//! LAMMPS dump/trajectory file (`dump` command's default text style)
+//! reader and writer.
+//!
+//! ## Provenance
+//!
+//! Implemented independently against LAMMPS's own official manual
+//! (<https://docs.lammps.org/dump.html>, <https://docs.lammps.org/Howto_triclinic.html>).
+//! Both pages were fetched and their content confirmed directly against
+//! the live pages (each fetch mediated by a summarization step, not a raw
+//! byte-for-byte scrape -- formulas quoted below were independently
+//! cross-checked by re-fetching the specific sentence/formula in
+//! isolation, but are presented here as *confirmed*, not as a guaranteed
+//! character-exact transcription). No source code, comments, or tables
+//! were copied from LAMMPS, VMD, OVITO, MDAnalysis, or any other tool.
+//!
+//! ## Structure
+//!
+//! Each frame is:
+//! ```text
+//! ITEM: TIMESTEP
+//! <int>
+//! ITEM: NUMBER OF ATOMS
+//! <int>
+//! ITEM: BOX BOUNDS <flags>
+//! <xlo_or_bound> <xhi_or_bound> [<xy>]
+//! <ylo_or_bound> <yhi_or_bound> [<xz>]
+//! <zlo_or_bound> <zhi_or_bound> [<yz>]
+//! ITEM: ATOMS <column-name-list>
+//! <one row per atom>
+//! ```
+//! A trajectory file is simply N frames concatenated back to back, with
+//! no separator beyond the next `ITEM: TIMESTEP`.
+//!
+//! ## Box bounds: orthogonal vs. triclinic
+//!
+//! The `ITEM: BOX BOUNDS` line's own trailing tokens say which shape
+//! follows: dump.html's own example headers are
+//! `ITEM: BOX BOUNDS xx yy zz` (orthogonal -- `xx`/`yy`/`zz` are 2-
+//! character boundary-condition flag pairs like `pp`, e.g.
+//! `ITEM: BOX BOUNDS pp pp pp`) versus
+//! `ITEM: BOX BOUNDS xy xz yz xx yy zz` (triclinic -- the literal tokens
+//! `xy xz yz` appear before the same 3 flag pairs, e.g.
+//! `ITEM: BOX BOUNDS xy xz yz pp pp pp`), with the 3 data rows then
+//! carrying `xlo_bound xhi_bound xy` / `ylo_bound yhi_bound xz` /
+//! `zlo_bound zhi_bound yz` instead of plain `xlo xhi` / `ylo yhi` /
+//! `zlo zhi`. This reader detects triclinic-ness from the header line's
+//! `xy xz yz` tokens (not from counting the 3 data rows' own column
+//! count) but cross-checks both signals -- a row with 3 columns after an
+//! orthogonal header, or 2 columns after a triclinic header, is a typed
+//! [`LammpsDumpError::InvalidBox`] (indicating a corrupt/hand-edited
+//! file), not silently reinterpreted.
+//!
+//! ## Triclinic bounding-box <-> true-box conversion
+//!
+//! Confirmed against <https://docs.lammps.org/Howto_triclinic.html>,
+//! which states the bounding-box extents are computed from the true box
+//! as:
+//! ```text
+//! xlo_bound = xlo + MIN(0.0, xy, xz, xy+xz)
+//! xhi_bound = xhi + MAX(0.0, xy, xz, xy+xz)
+//! ylo_bound = ylo + MIN(0.0, yz)
+//! yhi_bound = yhi + MAX(0.0, yz)
+//! zlo_bound = zlo
+//! zhi_bound = zhi
+//! ```
+//! and that this can be inverted (the page gives the `xlo` case
+//! explicitly: `xlo = xlo_bound - MIN(0.0, xy, xz, xy+xz)`) to recover the
+//! true box from a dump file's bounding-box values -- this is exactly the
+//! formula this brief specified, independently confirmed rather than
+//! taken on trust; see [`box_bounds_to_true`]/[`true_to_box_bounds`] and
+//! this module's tests (both a bound->true->bound identity check over
+//! several distinct tilt fixtures *and* a hand-computed-absolute-value
+//! check, since the identity check alone cannot distinguish a correct
+//! `MIN`/`MAX` formula from a subtly wrong one that happens to be its own
+//! inverse).
+//!
+//! ## Scaled coordinates (`xs ys zs`)
+//!
+//! Per the same Howto_triclinic page, a restricted triclinic box's edge
+//! vectors are **A** = `(xhi-xlo, 0, 0)`, **B** = `(xy, yhi-ylo, 0)`,
+//! **C** = `(xz, yz, zhi-zlo)`, with origin `(xlo, ylo, zlo)`; dump.html
+//! states "the actual unscaled (x,y,z) coordinate is `xs*A + ys*B +
+//! zs*C`". Taken completely literally that sentence omits the box
+//! origin, but it cannot be correct without it: dump.html separately
+//! defines `xs`/`ys`/`zs` as "scaled to the box size so that each value
+//! is 0.0 to 1.0", and `xs=ys=zs=0` must therefore map to the box's own
+//! `(xlo,ylo,zlo)` corner, not to the coordinate origin `(0,0,0)`.
+//! [`LammpsDumpFrame::cartesian_positions`] therefore computes
+//! `(xlo,ylo,zlo) + xs*A + ys*B + zs*C`, expanding to:
+//! ```text
+//! x = xlo + xs*(xhi-xlo) + ys*xy + zs*xz
+//! y = ylo + ys*(yhi-ylo) + zs*yz
+//! z = zlo + zs*(zhi-zlo)
+//! ```
+//! (reducing to ordinary independent per-axis scaling when `tilt` is
+//! `None`). **Medium confidence**: the `A`/`B`/`C` edge-vector
+//! definitions and the `xs*A+ys*B+zs*C` sentence are both confirmed
+//! against the live docs; the origin term is this module's own necessary
+//! completion of that sentence, not a verbatim-quoted part of it --
+//! flagged explicitly per this project's stop-and-report-rather-than-
+//! silently-guess convention (see `crate::cube`'s module docs for the
+//! same discipline applied to Cube's Bohr/Ångström ambiguity). Verified
+//! against a hand-computed example in this module's tests.
+//!
+//! `xu yu zu` ("unwrapped") coordinates need no transform -- "unwrapped"
+//! specifically means not passed through periodic-boundary wrapping (an
+//! atom that crossed a periodic boundary many times can have an
+//! unwrapped coordinate far outside the visible box), a materially
+//! different physical quantity from a wrapped Cartesian position, not
+//! merely an unscaled one. [`LammpsDumpFrame::cartesian_positions`]
+//! deliberately does not resolve `xu`/`yu`/`zu` itself (returns `None` if
+//! neither `x y z` nor `xs ys zs` is present, even when `xu yu zu` is) --
+//! callers wanting them should use [`LammpsDumpFrame::column`]`("xu")`
+//! etc. directly, since they need no transform, and conflating "current
+//! position" with "unwrapped position" into one accessor would be
+//! misleading.
+//!
+//! ## Arbitrary, self-declared columns -- no fixed schema
+//!
+//! The `ITEM: ATOMS` column list varies per `dump` command invocation.
+//! [`LammpsDumpFrame`] stores it as parallel `column_names`/`rows`
+//! (row-major: `rows[i][j]` is column `j`'s value for atom `i`), not a
+//! `HashMap<String, Vec<f64>>` -- this project's standing determinism
+//! rule -- which exactly preserves original column names and order.
+//!
+//! ## Streaming reader
+//!
+//! [`LammpsDumpReader`] follows this crate's `SdfFileReader` precedent
+//! (`crate::sdf`) -- `impl Iterator<Item = Result<LammpsDumpFrame,
+//! LammpsDumpError>>` over any `BufRead` source -- rather than
+//! `crate::cube::CubeFileReader`'s one-shot `.read()`, since a dump
+//! trajectory is inherently multi-record (like SDF) while a Cube file is
+//! a single grid.
+//!
+//! ## Box type
+//!
+//! Reuses [`crate::lammps_data::LammpsBox`] -- both formats describe the
+//! same physical concept (an axis-aligned box plus 3 tilt factors). Only
+//! *this* module performs the bound<->true conversion: a LAMMPS **data**
+//! file's `xlo xhi`/`xy xz yz` header lines already give the true box
+//! directly (data files have no bounding-box concept at all -- that only
+//! exists in dump output, for tools that expect an axis-aligned
+//! rendering box around a tilted cell).
+
+use crate::lammps_data::LammpsBox;
+use crate::volumetric::LineFeed;
+
+// ---------------------------------------------------------------------------
+// Box-bounds <-> true-box conversion
+// ---------------------------------------------------------------------------
+
+/// `(min(0, xy, xz, xy+xz), max(0, xy, xz, xy+xz))` -- the x-axis
+/// bounding-box shift term. See module docs for the citation.
+fn x_shift(xy: f64, xz: f64) -> (f64, f64) {
+    let candidates = [0.0, xy, xz, xy + xz];
+    let min = candidates.iter().copied().fold(f64::INFINITY, f64::min);
+    let max = candidates.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    (min, max)
+}
+
+/// `(min(0, yz), max(0, yz))` -- the y-axis bounding-box shift term.
+fn y_shift(yz: f64) -> (f64, f64) {
+    (0.0f64.min(yz), 0.0f64.max(yz))
+}
+
+/// Convert a dump file's `ITEM: BOX BOUNDS` values into the true
+/// simulation box. `tilt` is `None` for an orthogonal box (in which case
+/// bound and true coincide). See module docs for the formula's citation.
+pub fn box_bounds_to_true(
+    bound_lo: [f64; 3],
+    bound_hi: [f64; 3],
+    tilt: Option<[f64; 3]>,
+) -> LammpsBox {
+    match tilt {
+        None => LammpsBox {
+            lo: bound_lo,
+            hi: bound_hi,
+            tilt: None,
+        },
+        Some([xy, xz, yz]) => {
+            let (xmin, xmax) = x_shift(xy, xz);
+            let (ymin, ymax) = y_shift(yz);
+            LammpsBox {
+                lo: [bound_lo[0] - xmin, bound_lo[1] - ymin, bound_lo[2]],
+                hi: [bound_hi[0] - xmax, bound_hi[1] - ymax, bound_hi[2]],
+                tilt: Some([xy, xz, yz]),
+            }
+        }
+    }
+}
+
+/// Inverse of [`box_bounds_to_true`]: convert a true [`LammpsBox`] into
+/// the `xlo_bound/xhi_bound/...` values a dump file's `ITEM: BOX BOUNDS`
+/// section would show.
+pub fn true_to_box_bounds(b: &LammpsBox) -> ([f64; 3], [f64; 3]) {
+    match b.tilt {
+        None => (b.lo, b.hi),
+        Some([xy, xz, yz]) => {
+            let (xmin, xmax) = x_shift(xy, xz);
+            let (ymin, ymax) = y_shift(yz);
+            (
+                [b.lo[0] + xmin, b.lo[1] + ymin, b.lo[2]],
+                [b.hi[0] + xmax, b.hi[1] + ymax, b.hi[2]],
+            )
+        }
+    }
+}
+
+/// Real Cartesian position from box-scaled coordinates, each
+/// conventionally in `[0, 1]`. See module docs for the derivation.
+fn scaled_to_cartesian(b: &LammpsBox, xs: f64, ys: f64, zs: f64) -> [f64; 3] {
+    match b.tilt {
+        None => [
+            b.lo[0] + xs * (b.hi[0] - b.lo[0]),
+            b.lo[1] + ys * (b.hi[1] - b.lo[1]),
+            b.lo[2] + zs * (b.hi[2] - b.lo[2]),
+        ],
+        Some([xy, xz, yz]) => [
+            b.lo[0] + xs * (b.hi[0] - b.lo[0]) + ys * xy + zs * xz,
+            b.lo[1] + ys * (b.hi[1] - b.lo[1]) + zs * yz,
+            b.lo[2] + zs * (b.hi[2] - b.lo[2]),
+        ],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LammpsDumpFrame
+// ---------------------------------------------------------------------------
+
+/// One frame of a LAMMPS dump/trajectory file.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LammpsDumpFrame {
+    pub timestep: i64,
+    pub num_atoms: usize,
+    pub box_bounds: LammpsBox,
+    /// The 2-character boundary-condition flag pair for each axis (x, y,
+    /// z) -- e.g. `"pp"`, `"ff"`, `"ss"`, `"mm"`, or a mixed pair --
+    /// taken verbatim from the `ITEM: BOX BOUNDS ... <flags>` line.
+    /// Stored, not interpreted: this module has no periodic-wrapping
+    /// logic of its own.
+    pub boundary_flags: [String; 3],
+    pub column_names: Vec<String>,
+    /// `rows[i][j]` = value of `column_names[j]` for atom `i`, in file
+    /// order. Row-major, index-parallel with `column_names` -- not a
+    /// `HashMap<String, Vec<f64>>` -- see module docs.
+    pub rows: Vec<Vec<f64>>,
+}
+
+impl LammpsDumpFrame {
+    /// Index of `name` within [`Self::column_names`], if present.
+    pub fn column_index(&self, name: &str) -> Option<usize> {
+        self.column_names.iter().position(|c| c == name)
+    }
+
+    /// The values of column `name` across every atom, in file order.
+    ///
+    /// Returns an owned `Vec<f64>`, not a borrowed slice: [`Self::rows`]
+    /// is row-major, so a single column is not stored contiguously and
+    /// cannot be borrowed without a copy. This is a deliberate deviation
+    /// from a `&[f64]`-returning signature (which would require
+    /// column-oriented storage, the very layout `rows`/`column_names`'s
+    /// row-major shape was chosen to avoid per this module's determinism
+    /// rule) -- documented here rather than silently changed without
+    /// comment.
+    pub fn column(&self, name: &str) -> Option<Vec<f64>> {
+        let idx = self.column_index(name)?;
+        Some(self.rows.iter().map(|r| r[idx]).collect())
+    }
+
+    /// Real Cartesian positions per atom, in file order, from whichever
+    /// of the recognized coordinate-triple conventions is present:
+    /// - `x y z`: already real Cartesian, passed through as-is.
+    /// - `xs ys zs`: box-scaled, transformed through the box (including
+    ///   the triclinic shear terms when [`LammpsBox::tilt`] is `Some` --
+    ///   see module docs; **not** simply independent per-axis scaling).
+    ///
+    /// Returns `None` if neither triple is fully present -- including
+    /// when only `xu yu zu` ("unwrapped") is present; see module docs for
+    /// why those are deliberately not resolved by this method. Never
+    /// drops or overwrites `column_names`/`rows`: this is a read-only
+    /// convenience view over them.
+    pub fn cartesian_positions(&self) -> Option<Vec<[f64; 3]>> {
+        if let (Some(x), Some(y), Some(z)) = (self.column("x"), self.column("y"), self.column("z"))
+        {
+            return Some(
+                x.into_iter()
+                    .zip(y)
+                    .zip(z)
+                    .map(|((x, y), z)| [x, y, z])
+                    .collect(),
+            );
+        }
+        if let (Some(xs), Some(ys), Some(zs)) =
+            (self.column("xs"), self.column("ys"), self.column("zs"))
+        {
+            return Some(
+                xs.into_iter()
+                    .zip(ys)
+                    .zip(zs)
+                    .map(|((xs, ys), zs)| scaled_to_cartesian(&self.box_bounds, xs, ys, zs))
+                    .collect(),
+            );
+        }
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors from [`parse_lammps_dump_frame`]/[`LammpsDumpReader`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum LammpsDumpError {
+    /// A header value line (`TIMESTEP`/`NUMBER OF ATOMS` value, or a
+    /// `BOX BOUNDS` line with the wrong token shape) failed to parse.
+    MalformedHeader { line: usize, detail: String },
+    /// An `ITEM:` line did not match what was expected at this point in
+    /// the frame.
+    UnexpectedItem { expected: String, found: String },
+    /// The box bounds were inconsistent (wrong row column count for the
+    /// declared orthogonal/triclinic-ness, a non-finite value, or
+    /// `hi <= lo`).
+    InvalidBox { reason: String },
+    /// An `ATOMS` data row's field count did not match the number of
+    /// declared columns.
+    ColumnCountMismatch {
+        declared: usize,
+        actual: usize,
+        line: usize,
+    },
+    /// A field failed to parse as a number at all.
+    InvalidNumber {
+        column: String,
+        row: usize,
+        raw: String,
+    },
+    /// A field parsed but was NaN/Infinite.
+    NonFiniteValue { column: String, row: usize },
+    /// `ITEM: NUMBER OF ATOMS` declared more atoms than the file actually
+    /// had before hitting the next `ITEM:` line.
+    AtomCountMismatch { declared: usize, actual: usize },
+    /// The input ended before a required section/field was fully read.
+    TruncatedInput { context: &'static str },
+    /// An IO error occurred while reading from a streaming
+    /// [`LammpsDumpReader`] source.
+    Io(String),
+}
+
+impl std::fmt::Display for LammpsDumpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MalformedHeader { line, detail } => {
+                write!(f, "malformed header line at line {line}: '{detail}'")
+            }
+            Self::UnexpectedItem { expected, found } => {
+                write!(f, "expected '{expected}', found '{found}'")
+            }
+            Self::InvalidBox { reason } => write!(f, "invalid LAMMPS dump box: {reason}"),
+            Self::ColumnCountMismatch {
+                declared,
+                actual,
+                line,
+            } => write!(
+                f,
+                "line {line}: expected {declared} column(s), found {actual}"
+            ),
+            Self::InvalidNumber { column, row, raw } => write!(
+                f,
+                "invalid value '{raw}' for column '{column}' at atom row {row}"
+            ),
+            Self::NonFiniteValue { column, row } => write!(
+                f,
+                "non-finite value for column '{column}' at atom row {row}"
+            ),
+            Self::AtomCountMismatch { declared, actual } => write!(
+                f,
+                "ITEM: NUMBER OF ATOMS declared {declared} but only {actual} row(s) were present"
+            ),
+            Self::TruncatedInput { context } => {
+                write!(f, "unexpected end of input while reading {context}")
+            }
+            Self::Io(msg) => write!(f, "IO error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for LammpsDumpError {}
+
+// ---------------------------------------------------------------------------
+// Parser core
+// ---------------------------------------------------------------------------
+
+fn expect_item_exact(line: &str, expected: &str) -> Result<(), LammpsDumpError> {
+    let want = format!("ITEM: {expected}");
+    if line.trim_end() != want {
+        return Err(LammpsDumpError::UnexpectedItem {
+            expected: want,
+            found: line.to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn strip_item_prefix<'a>(line: &'a str, expected: &str) -> Result<&'a str, LammpsDumpError> {
+    let prefix = format!("ITEM: {expected}");
+    match line.trim_end().strip_prefix(&prefix) {
+        Some(rest) => Ok(rest.trim()),
+        None => Err(LammpsDumpError::UnexpectedItem {
+            expected: prefix,
+            found: line.to_string(),
+        }),
+    }
+}
+
+/// Read one frame from `feed`, or `Ok(None)` on a clean EOF *between*
+/// frames (i.e. before any of this frame's lines have been read).
+fn read_frame_from_feed<F>(
+    feed: &mut LineFeed<LammpsDumpError, F>,
+) -> Result<Option<LammpsDumpFrame>, LammpsDumpError>
+where
+    F: FnMut() -> Result<Option<String>, LammpsDumpError>,
+{
+    let Some(line) = feed.line()? else {
+        return Ok(None);
+    };
+    expect_item_exact(&line, "TIMESTEP")?;
+
+    let ts_line = feed.line()?.ok_or(LammpsDumpError::TruncatedInput {
+        context: "TIMESTEP value",
+    })?;
+    let timestep: i64 = ts_line
+        .trim()
+        .parse()
+        .map_err(|_| LammpsDumpError::MalformedHeader {
+            line: feed.line_no,
+            detail: ts_line.clone(),
+        })?;
+
+    let noa_item = feed.line()?.ok_or(LammpsDumpError::TruncatedInput {
+        context: "ITEM: NUMBER OF ATOMS",
+    })?;
+    expect_item_exact(&noa_item, "NUMBER OF ATOMS")?;
+    let count_line = feed.line()?.ok_or(LammpsDumpError::TruncatedInput {
+        context: "NUMBER OF ATOMS value",
+    })?;
+    let num_atoms: usize =
+        count_line
+            .trim()
+            .parse()
+            .map_err(|_| LammpsDumpError::MalformedHeader {
+                line: feed.line_no,
+                detail: count_line.clone(),
+            })?;
+
+    let bb_line = feed.line()?.ok_or(LammpsDumpError::TruncatedInput {
+        context: "ITEM: BOX BOUNDS",
+    })?;
+    let bb_rest = strip_item_prefix(&bb_line, "BOX BOUNDS")?;
+    let bb_toks: Vec<&str> = bb_rest.split_whitespace().collect();
+    let (triclinic, boundary_flags) =
+        if bb_toks.len() == 6 && bb_toks[0] == "xy" && bb_toks[1] == "xz" && bb_toks[2] == "yz" {
+            (
+                true,
+                [
+                    bb_toks[3].to_string(),
+                    bb_toks[4].to_string(),
+                    bb_toks[5].to_string(),
+                ],
+            )
+        } else if bb_toks.len() == 3 {
+            (
+                false,
+                [
+                    bb_toks[0].to_string(),
+                    bb_toks[1].to_string(),
+                    bb_toks[2].to_string(),
+                ],
+            )
+        } else {
+            return Err(LammpsDumpError::MalformedHeader {
+                line: feed.line_no,
+                detail: bb_line.clone(),
+            });
+        };
+
+    let mut raw_rows: Vec<Vec<f64>> = Vec::with_capacity(3);
+    for _ in 0..3 {
+        let l = feed.line()?.ok_or(LammpsDumpError::TruncatedInput {
+            context: "BOX BOUNDS data row",
+        })?;
+        let line_no = feed.line_no;
+        let toks: Vec<&str> = l.split_whitespace().collect();
+        let expected_cols = if triclinic { 3 } else { 2 };
+        if toks.len() != expected_cols {
+            return Err(LammpsDumpError::InvalidBox {
+                reason: format!(
+                    "BOX BOUNDS row at line {line_no} has {} column(s), but the header's \
+                     'xy xz yz' flag {} present, which requires {expected_cols} -- \
+                     inconsistent, possibly hand-edited file",
+                    toks.len(),
+                    if triclinic { "is" } else { "is not" }
+                ),
+            });
+        }
+        let mut vals = Vec::with_capacity(expected_cols);
+        for t in &toks {
+            let v: f64 = t.parse().map_err(|_| LammpsDumpError::MalformedHeader {
+                line: line_no,
+                detail: l.clone(),
+            })?;
+            if !v.is_finite() {
+                return Err(LammpsDumpError::InvalidBox {
+                    reason: format!("non-finite BOX BOUNDS value '{t}' at line {line_no}"),
+                });
+            }
+            vals.push(v);
+        }
+        raw_rows.push(vals);
+    }
+
+    let tilt = triclinic.then(|| [raw_rows[0][2], raw_rows[1][2], raw_rows[2][2]]);
+    let bound_lo = [raw_rows[0][0], raw_rows[1][0], raw_rows[2][0]];
+    let bound_hi = [raw_rows[0][1], raw_rows[1][1], raw_rows[2][1]];
+    let box_bounds = box_bounds_to_true(bound_lo, bound_hi, tilt);
+    box_bounds
+        .validate()
+        .map_err(|reason| LammpsDumpError::InvalidBox { reason })?;
+
+    let atoms_line = feed.line()?.ok_or(LammpsDumpError::TruncatedInput {
+        context: "ITEM: ATOMS",
+    })?;
+    let cols_rest = strip_item_prefix(&atoms_line, "ATOMS")?;
+    let column_names: Vec<String> = cols_rest.split_whitespace().map(str::to_string).collect();
+
+    let mut rows: Vec<Vec<f64>> = Vec::with_capacity(num_atoms);
+    for row_idx in 0..num_atoms {
+        let Some(row_line) = feed.line()? else {
+            return Err(LammpsDumpError::TruncatedInput {
+                context: "ATOMS data row",
+            });
+        };
+        let line_no = feed.line_no;
+        if row_line.starts_with("ITEM:") {
+            return Err(LammpsDumpError::AtomCountMismatch {
+                declared: num_atoms,
+                actual: row_idx,
+            });
+        }
+        let toks: Vec<&str> = row_line.split_whitespace().collect();
+        if toks.len() != column_names.len() {
+            return Err(LammpsDumpError::ColumnCountMismatch {
+                declared: column_names.len(),
+                actual: toks.len(),
+                line: line_no,
+            });
+        }
+        let mut vals = Vec::with_capacity(toks.len());
+        for (col_idx, t) in toks.iter().enumerate() {
+            let v: f64 = t.parse().map_err(|_| LammpsDumpError::InvalidNumber {
+                column: column_names[col_idx].clone(),
+                row: row_idx,
+                raw: t.to_string(),
+            })?;
+            if !v.is_finite() {
+                return Err(LammpsDumpError::NonFiniteValue {
+                    column: column_names[col_idx].clone(),
+                    row: row_idx,
+                });
+            }
+            vals.push(v);
+        }
+        rows.push(vals);
+    }
+
+    Ok(Some(LammpsDumpFrame {
+        timestep,
+        num_atoms,
+        box_bounds,
+        boundary_flags,
+        column_names,
+        rows,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Whole-string entry point
+// ---------------------------------------------------------------------------
+
+/// Parse a single LAMMPS dump frame from `text`.
+///
+/// If `text` contains more than one frame (multiple `ITEM: TIMESTEP`
+/// blocks concatenated, as a trajectory file would), only the first is
+/// parsed; anything after it is silently ignored. Use
+/// [`LammpsDumpReader`] to read every frame of a multi-frame trajectory.
+pub fn parse_lammps_dump_frame(text: &str) -> Result<LammpsDumpFrame, LammpsDumpError> {
+    let mut lines = text.lines();
+    let next_line =
+        move || -> Result<Option<String>, LammpsDumpError> { Ok(lines.next().map(str::to_string)) };
+    let mut feed = LineFeed::new(next_line);
+    read_frame_from_feed(&mut feed)?.ok_or(LammpsDumpError::TruncatedInput {
+        context: "frame (empty input)",
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Streaming reader
+// ---------------------------------------------------------------------------
+
+/// Streaming-*input* reader over a LAMMPS dump/trajectory file, yielding
+/// one [`LammpsDumpFrame`] at a time without loading the whole trajectory
+/// into memory at once. Follows this crate's `SdfFileReader`
+/// (`crate::sdf`) precedent -- `Iterator<Item = Result<LammpsDumpFrame,
+/// LammpsDumpError>>` over any [`std::io::BufRead`] source -- since a
+/// trajectory, like SDF, is inherently multi-record (unlike
+/// `crate::cube::CubeFileReader`'s single-grid `.read()`).
+pub struct LammpsDumpReader<R: std::io::BufRead> {
+    reader: R,
+    done: bool,
+}
+
+impl<R: std::io::BufRead> LammpsDumpReader<R> {
+    /// Wrap any `BufRead` source (e.g. `BufReader<File>`).
+    pub fn new(reader: R) -> Self {
+        Self {
+            reader,
+            done: false,
+        }
+    }
+}
+
+impl<R: std::io::BufRead> Iterator for LammpsDumpReader<R> {
+    type Item = Result<LammpsDumpFrame, LammpsDumpError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        let reader = &mut self.reader;
+        let next_line = move || -> Result<Option<String>, LammpsDumpError> {
+            let mut buf = String::new();
+            match reader.read_line(&mut buf) {
+                Ok(0) => Ok(None),
+                Ok(_) => Ok(Some(buf.trim_end_matches(['\n', '\r']).to_string())),
+                Err(e) => Err(LammpsDumpError::Io(e.to_string())),
+            }
+        };
+        let mut feed = LineFeed::new(next_line);
+        match read_frame_from_feed(&mut feed) {
+            Ok(Some(frame)) => Some(Ok(frame)),
+            Ok(None) => {
+                self.done = true;
+                None
+            }
+            Err(e) => {
+                self.done = true;
+                Some(Err(e))
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Writer
+// ---------------------------------------------------------------------------
+
+/// Write one [`LammpsDumpFrame`] as LAMMPS dump text.
+pub fn write_lammps_dump_frame(frame: &LammpsDumpFrame) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let _ = writeln!(out, "ITEM: TIMESTEP");
+    let _ = writeln!(out, "{}", frame.timestep);
+    let _ = writeln!(out, "ITEM: NUMBER OF ATOMS");
+    let _ = writeln!(out, "{}", frame.num_atoms);
+
+    let (bound_lo, bound_hi) = true_to_box_bounds(&frame.box_bounds);
+    let [f0, f1, f2] = &frame.boundary_flags;
+    match frame.box_bounds.tilt {
+        Some([xy, xz, yz]) => {
+            let _ = writeln!(out, "ITEM: BOX BOUNDS xy xz yz {f0} {f1} {f2}");
+            let _ = writeln!(out, "{} {} {}", bound_lo[0], bound_hi[0], xy);
+            let _ = writeln!(out, "{} {} {}", bound_lo[1], bound_hi[1], xz);
+            let _ = writeln!(out, "{} {} {}", bound_lo[2], bound_hi[2], yz);
+        }
+        None => {
+            let _ = writeln!(out, "ITEM: BOX BOUNDS {f0} {f1} {f2}");
+            let _ = writeln!(out, "{} {}", bound_lo[0], bound_hi[0]);
+            let _ = writeln!(out, "{} {}", bound_lo[1], bound_hi[1]);
+            let _ = writeln!(out, "{} {}", bound_lo[2], bound_hi[2]);
+        }
+    }
+
+    let _ = writeln!(out, "ITEM: ATOMS {}", frame.column_names.join(" "));
+    for row in &frame.rows {
+        let strs: Vec<String> = row.iter().map(f64::to_string).collect();
+        let _ = writeln!(out, "{}", strs.join(" "));
+    }
+    out
+}
+
+/// Write multiple frames as one trajectory file (plain concatenation --
+/// see module docs, a trajectory is just N frames back to back). Only the
+/// *reader* streams; a caller assembling a `&[LammpsDumpFrame]` to pass
+/// here already holds every frame in memory.
+pub fn write_lammps_trajectory(frames: &[LammpsDumpFrame]) -> String {
+    frames.iter().map(write_lammps_dump_frame).collect()
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn orthogonal_frame() -> LammpsDumpFrame {
+        LammpsDumpFrame {
+            timestep: 1000,
+            num_atoms: 2,
+            box_bounds: LammpsBox {
+                lo: [0.0, 0.0, 0.0],
+                hi: [10.0, 20.0, 30.0],
+                tilt: None,
+            },
+            boundary_flags: ["pp".to_string(), "pp".to_string(), "pp".to_string()],
+            column_names: vec![
+                "id".to_string(),
+                "type".to_string(),
+                "x".to_string(),
+                "y".to_string(),
+                "z".to_string(),
+            ],
+            rows: vec![vec![1.0, 1.0, 1.0, 2.0, 3.0], vec![2.0, 1.0, 4.0, 5.0, 6.0]],
+        }
+    }
+
+    fn triclinic_frame() -> LammpsDumpFrame {
+        LammpsDumpFrame {
+            timestep: 2000,
+            num_atoms: 1,
+            box_bounds: LammpsBox {
+                lo: [0.0, 0.0, 0.0],
+                hi: [10.0, 10.0, 10.0],
+                tilt: Some([2.0, 1.0, 0.5]),
+            },
+            boundary_flags: ["pp".to_string(), "ff".to_string(), "ss".to_string()],
+            column_names: vec![
+                "id".to_string(),
+                "xs".to_string(),
+                "ys".to_string(),
+                "zs".to_string(),
+            ],
+            rows: vec![vec![1.0, 0.5, 0.5, 0.5]],
+        }
+    }
+
+    #[test]
+    fn round_trip_orthogonal_frame() {
+        let frame = orthogonal_frame();
+        let text = write_lammps_dump_frame(&frame);
+        let parsed = parse_lammps_dump_frame(&text).unwrap();
+        assert_eq!(parsed, frame);
+    }
+
+    #[test]
+    fn round_trip_triclinic_frame() {
+        let frame = triclinic_frame();
+        let text = write_lammps_dump_frame(&frame);
+        let parsed = parse_lammps_dump_frame(&text).unwrap();
+        assert_eq!(parsed, frame);
+    }
+
+    #[test]
+    fn triclinic_bound_true_bound_identity_over_several_tilts() {
+        // Cheap inverse-consistency check: bound -> true -> bound is the
+        // identity for *any* tilt, including this formula's own sign
+        // convention -- but see the hand-computed test below for why this
+        // alone cannot prove the formula itself is correct (a
+        // self-consistently-wrong MIN/MAX definition would also pass
+        // this).
+        let tilts = [[3.0, 4.0, 2.0], [-3.0, -4.0, -2.0], [3.0, 4.0, -2.0]];
+        for tilt in tilts {
+            let bound_lo = [1.0, 2.0, 3.0];
+            let bound_hi = [11.0, 22.0, 33.0];
+            let true_box = box_bounds_to_true(bound_lo, bound_hi, Some(tilt));
+            let (round_lo, round_hi) = true_to_box_bounds(&true_box);
+            for i in 0..3 {
+                assert!(
+                    (round_lo[i] - bound_lo[i]).abs() < 1e-9,
+                    "lo[{i}] tilt={tilt:?}"
+                );
+                assert!(
+                    (round_hi[i] - bound_hi[i]).abs() < 1e-9,
+                    "hi[{i}] tilt={tilt:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn triclinic_bound_conversion_matches_hand_computed_absolute_values() {
+        // The identity test above cannot catch a formula that's
+        // internally self-consistent but wrong (e.g. MAX(0,xy,xz)
+        // instead of MAX(0,xy,xz,xy+xz)) -- both directions would use the
+        // same wrong extremum and still round-trip. This test instead
+        // asserts true_to_box_bounds against hand-computed absolute
+        // values, picking tilts where xy+xz (not just xy or xz alone) is
+        // the true extremum.
+        //
+        // true box: lo=[0,0,0] hi=[10,10,10], tilt=[xy=3, xz=4, yz=2]
+        //   x candidates {0,3,4,7}: min=0, max=7 -> xlo_bound=0+0=0, xhi_bound=10+7=17
+        //   y candidates {0,2}:     min=0, max=2 -> ylo_bound=0+0=0, yhi_bound=10+2=12
+        //   z: no tilt term         -> zlo_bound=0, zhi_bound=10
+        let b1 = LammpsBox {
+            lo: [0.0, 0.0, 0.0],
+            hi: [10.0, 10.0, 10.0],
+            tilt: Some([3.0, 4.0, 2.0]),
+        };
+        let (lo1, hi1) = true_to_box_bounds(&b1);
+        assert_eq!(lo1, [0.0, 0.0, 0.0]);
+        assert_eq!(hi1, [17.0, 12.0, 10.0]);
+
+        // tilt=[-3,-4,-2]: x candidates {0,-3,-4,-7}: min=-7,max=0 -> xlo_bound=-7, xhi_bound=10
+        //                  y candidates {0,-2}: min=-2,max=0 -> ylo_bound=-2, yhi_bound=10
+        let b2 = LammpsBox {
+            lo: [0.0, 0.0, 0.0],
+            hi: [10.0, 10.0, 10.0],
+            tilt: Some([-3.0, -4.0, -2.0]),
+        };
+        let (lo2, hi2) = true_to_box_bounds(&b2);
+        assert_eq!(lo2, [-7.0, -2.0, 0.0]);
+        assert_eq!(hi2, [10.0, 10.0, 10.0]);
+
+        // tilt=[3,4,-2]: x same as b1 (min=0,max=7) -> xlo_bound=0, xhi_bound=17
+        //                y candidates {0,-2}: min=-2,max=0 -> ylo_bound=-2, yhi_bound=10
+        let b3 = LammpsBox {
+            lo: [0.0, 0.0, 0.0],
+            hi: [10.0, 10.0, 10.0],
+            tilt: Some([3.0, 4.0, -2.0]),
+        };
+        let (lo3, hi3) = true_to_box_bounds(&b3);
+        assert_eq!(lo3, [0.0, -2.0, 0.0]);
+        assert_eq!(hi3, [17.0, 10.0, 10.0]);
+
+        // And the read-direction inverse recovers the original true box
+        // from each hand-computed bound pair.
+        for (b, lo, hi) in [(b1, lo1, hi1), (b2, lo2, hi2), (b3, lo3, hi3)] {
+            let recovered = box_bounds_to_true(lo, hi, b.tilt);
+            assert_eq!(recovered, b);
+        }
+    }
+
+    #[test]
+    fn multi_frame_streaming_round_trip() {
+        use std::io::{BufReader, Cursor};
+        let mut f1 = orthogonal_frame();
+        f1.timestep = 0;
+        let mut f2 = orthogonal_frame();
+        f2.timestep = 100;
+        let mut f3 = triclinic_frame();
+        f3.timestep = 200;
+        let frames = vec![f1, f2, f3];
+
+        let text = write_lammps_trajectory(&frames);
+        let cursor = Cursor::new(text.into_bytes());
+        let read_back: Result<Vec<LammpsDumpFrame>, LammpsDumpError> =
+            LammpsDumpReader::new(BufReader::new(cursor)).collect();
+        assert_eq!(read_back.unwrap(), frames);
+    }
+
+    #[test]
+    fn scaled_coordinates_orthogonal_hand_computed() {
+        // box lo=[0,0,0] hi=[10,20,30], xs=0.5 ys=0.25 zs=0.1
+        // x = 0 + 0.5*10 = 5.0
+        // y = 0 + 0.25*20 = 5.0
+        // z = 0 + 0.1*30 = 3.0
+        let frame = LammpsDumpFrame {
+            timestep: 0,
+            num_atoms: 1,
+            box_bounds: LammpsBox {
+                lo: [0.0, 0.0, 0.0],
+                hi: [10.0, 20.0, 30.0],
+                tilt: None,
+            },
+            boundary_flags: ["pp".to_string(), "pp".to_string(), "pp".to_string()],
+            column_names: vec![
+                "id".to_string(),
+                "xs".to_string(),
+                "ys".to_string(),
+                "zs".to_string(),
+            ],
+            rows: vec![vec![1.0, 0.5, 0.25, 0.1]],
+        };
+        let pos = frame.cartesian_positions().unwrap();
+        assert!((pos[0][0] - 5.0).abs() < 1e-9);
+        assert!((pos[0][1] - 5.0).abs() < 1e-9);
+        assert!((pos[0][2] - 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn scaled_coordinates_triclinic_hand_computed() {
+        // box lo=[0,0,0] hi=[10,10,10], tilt xy=2 xz=1 yz=0.5, xs=ys=zs=0.5
+        // x = 0 + 0.5*10 + 0.5*2 + 0.5*1 = 5 + 1 + 0.5 = 6.5
+        // y = 0 + 0.5*10 + 0.5*0.5 = 5 + 0.25 = 5.25
+        // z = 0 + 0.5*10 = 5.0
+        let frame = triclinic_frame();
+        let pos = frame.cartesian_positions().unwrap();
+        assert!((pos[0][0] - 6.5).abs() < 1e-9);
+        assert!((pos[0][1] - 5.25).abs() < 1e-9);
+        assert!((pos[0][2] - 5.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cartesian_positions_passes_through_x_y_z() {
+        let frame = orthogonal_frame();
+        let pos = frame.cartesian_positions().unwrap();
+        assert_eq!(pos, vec![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+    }
+
+    #[test]
+    fn cartesian_positions_none_for_unwrapped_only_columns() {
+        let mut frame = orthogonal_frame();
+        frame.column_names = vec![
+            "id".to_string(),
+            "xu".to_string(),
+            "yu".to_string(),
+            "zu".to_string(),
+        ];
+        frame.rows = vec![vec![1.0, 100.0, 200.0, 300.0], vec![2.0, 1.0, 2.0, 3.0]];
+        assert_eq!(frame.cartesian_positions(), None);
+        // But the raw column is still directly accessible.
+        assert_eq!(frame.column("xu"), Some(vec![100.0, 1.0]));
+    }
+
+    #[test]
+    fn custom_column_names_round_trip() {
+        let mut frame = orthogonal_frame();
+        frame.column_names = vec![
+            "id".to_string(),
+            "c_myCompute[1]".to_string(),
+            "f_myFix".to_string(),
+        ];
+        frame.rows = vec![vec![1.0, 0.123, -4.5], vec![2.0, 0.456, 7.8]];
+        let text = write_lammps_dump_frame(&frame);
+        let parsed = parse_lammps_dump_frame(&text).unwrap();
+        assert_eq!(parsed.column_names, frame.column_names);
+        assert_eq!(parsed.rows, frame.rows);
+    }
+
+    #[test]
+    fn zero_atom_frame_does_not_panic_or_error() {
+        let mut frame = orthogonal_frame();
+        frame.num_atoms = 0;
+        frame.rows = Vec::new();
+        let text = write_lammps_dump_frame(&frame);
+        let parsed = parse_lammps_dump_frame(&text).unwrap();
+        assert_eq!(parsed.num_atoms, 0);
+        assert!(parsed.rows.is_empty());
+    }
+
+    #[test]
+    fn unexpected_item_is_typed_error() {
+        let text = "ITEM: NOT TIMESTEP\n0\n";
+        let err = parse_lammps_dump_frame(text).unwrap_err();
+        assert!(matches!(err, LammpsDumpError::UnexpectedItem { .. }));
+    }
+
+    #[test]
+    fn column_count_mismatch_is_typed_error() {
+        let text = "ITEM: TIMESTEP\n0\nITEM: NUMBER OF ATOMS\n1\nITEM: BOX BOUNDS pp pp pp\n\
+                     0.0 10.0\n0.0 10.0\n0.0 10.0\nITEM: ATOMS id type x y z\n1 1 0.0 0.0\n";
+        let err = parse_lammps_dump_frame(text).unwrap_err();
+        assert_eq!(
+            err,
+            LammpsDumpError::ColumnCountMismatch {
+                declared: 5,
+                actual: 4,
+                line: 10
+            }
+        );
+    }
+
+    #[test]
+    fn non_finite_value_is_typed_error() {
+        let text = "ITEM: TIMESTEP\n0\nITEM: NUMBER OF ATOMS\n1\nITEM: BOX BOUNDS pp pp pp\n\
+                     0.0 10.0\n0.0 10.0\n0.0 10.0\nITEM: ATOMS id x\n1 NaN\n";
+        let err = parse_lammps_dump_frame(text).unwrap_err();
+        assert_eq!(
+            err,
+            LammpsDumpError::NonFiniteValue {
+                column: "x".to_string(),
+                row: 0
+            }
+        );
+    }
+
+    #[test]
+    fn atom_count_mismatch_is_typed_error_not_corruption() {
+        let text = "ITEM: TIMESTEP\n0\nITEM: NUMBER OF ATOMS\n3\nITEM: BOX BOUNDS pp pp pp\n\
+                     0.0 10.0\n0.0 10.0\n0.0 10.0\nITEM: ATOMS id x\n1 0.0\n2 1.0\nITEM: TIMESTEP\n1\n";
+        let err = parse_lammps_dump_frame(text).unwrap_err();
+        assert_eq!(
+            err,
+            LammpsDumpError::AtomCountMismatch {
+                declared: 3,
+                actual: 2
+            }
+        );
+    }
+
+    #[test]
+    fn box_bounds_column_count_disagrees_with_header_flag_is_typed_error() {
+        // Header says orthogonal (no "xy xz yz"), but a data row has 3
+        // columns -- inconsistent, must fail rather than silently
+        // guessing which signal to trust.
+        let text = "ITEM: TIMESTEP\n0\nITEM: NUMBER OF ATOMS\n1\nITEM: BOX BOUNDS pp pp pp\n\
+                     0.0 10.0 1.0\n0.0 10.0\n0.0 10.0\nITEM: ATOMS id x\n1 0.0\n";
+        let err = parse_lammps_dump_frame(text).unwrap_err();
+        assert!(matches!(err, LammpsDumpError::InvalidBox { .. }));
+    }
+
+    #[test]
+    fn truncated_input_is_typed_error_not_panic() {
+        let text = "ITEM: TIMESTEP\n0\nITEM: NUMBER OF ATOMS\n";
+        let err = parse_lammps_dump_frame(text).unwrap_err();
+        assert!(matches!(err, LammpsDumpError::TruncatedInput { .. }));
+    }
+
+    #[test]
+    fn empty_input_is_truncated_input_not_panic() {
+        let err = parse_lammps_dump_frame("").unwrap_err();
+        assert!(matches!(err, LammpsDumpError::TruncatedInput { .. }));
+    }
+}

--- a/crates/chematic-mol/src/lib.rs
+++ b/crates/chematic-mol/src/lib.rs
@@ -26,6 +26,8 @@ pub mod cube;
 pub mod error;
 pub mod gaussian;
 pub mod ket;
+pub mod lammps_data;
+pub mod lammps_dump;
 pub mod mmcif;
 pub mod mol2000;
 pub mod mol2_tripos;
@@ -67,6 +69,14 @@ pub use cube::{
 pub use error::MolParseError as MolError;
 pub use gaussian::{GaussianError, GaussianLogResult, parse_gaussian_log, parse_gjf, write_gjf};
 pub use ket::{KetError, parse_ket, parse_ket_3d, write_ket, write_ket_3d};
+pub use lammps_data::{
+    LammpsAtom, LammpsAtomStyle, LammpsBond, LammpsBox, LammpsData, LammpsDataError, LammpsMass,
+    LammpsVelocity, parse_lammps_data, write_lammps_data,
+};
+pub use lammps_dump::{
+    LammpsDumpError, LammpsDumpFrame, LammpsDumpReader, box_bounds_to_true,
+    parse_lammps_dump_frame, true_to_box_bounds, write_lammps_dump_frame, write_lammps_trajectory,
+};
 pub use mmcif::{
     MmcifAtomRecord, MmcifError, MmcifParseLimits, MmcifResult, parse_mmcif,
     parse_mmcif_with_limits, write_mmcif,


### PR DESCRIPTION
## Summary

Issue #227 format-expansion Wave 2, continued: LAMMPS `read_data`-format
data files and `dump`-command text-style trajectory files, explicitly
promised in the mmCIF/PQR/QCSchema/ORCA Wave-1 CHANGELOG entry ("LAMMPS
data/dump ... are scoped for a later Wave 2, not this PR"). Two new
independent modules in `chematic-mol`:

- `crates/chematic-mol/src/lammps_data.rs` — LAMMPS data file
  (`parse_lammps_data` / `write_lammps_data`)
- `crates/chematic-mol/src/lammps_dump.rs` — LAMMPS dump/trajectory file
  (`parse_lammps_dump_frame`, streaming `LammpsDumpReader`,
  `write_lammps_dump_frame`, `write_lammps_trajectory`)

Both are **standalone document types**, deliberately not integrated with
`chematic_core::Molecule` — LAMMPS bonds/angles/etc. are raw atom-index
topology, not chemically perceived bonds, and an MD atom under some
`atom_style`s is not necessarily even a chemical element.

No new crate, no `Cargo.toml` changes, no `unsafe`, no new external
dependencies, no `HashMap`-iteration-order dependence anywhere reachable
from parsing/writing. No Python/WASM bindings this step (consistent with
every other format module added in this Wave).

## Format verification against LAMMPS's own docs

Before writing any code, `docs.lammps.org/read_data.html`,
`docs.lammps.org/dump.html`, and `docs.lammps.org/Howto_triclinic.html`
were fetched and used to independently confirm the format details,
rather than trusting the implementation brief blindly.

**Nothing in the brief needed correcting** — every detail was confirmed,
not assumed:
- All 4 atom-style column layouts (`Atomic`/`Charge`/`Molecular`/`Full`)
  and the optional trailing image-flag convention.
- That `atom_style` genuinely cannot be inferred from the file alone
  (LAMMPS's own docs state it must be set before `read_data` runs), and
  the specific ambiguity example (`charge` vs. `molecular`, both 6
  fields) — confirmed, not just plausible.
- The mandatory "next line after a section keyword is always skipped"
  rule, and that `#` trailing comments are legal on header lines,
  section-keyword lines, and individual data rows (with a required blank
  before `#`).
- **The triclinic bounding-box↔true-box conversion formula, confirmed in
  both directions**: `Howto_triclinic.html` states the true→bound
  direction explicitly (`xlo_bound = xlo + MIN(0.0,xy,xz,xy+xz)`, etc.)
  and gives the inverse explicitly too (`xlo = xlo_bound -
  MIN(0.0,xy,xz,xy+xz)`) — exactly the formula given in the
  implementation brief, independently verified rather than taken on
  trust.

One place needed this module's own derivation beyond a literal doc
quote, flagged medium-confidence in the module docs (mirroring this
project's Cube/OpenDX citation-confidence convention): the
scaled-coordinate (`xs ys zs`) → Cartesian transform's box-origin term.
`dump.html`'s sentence ("the actual unscaled coordinate is `xs*A + ys*B
+ zs*C`") omits the box origin `(xlo,ylo,zlo)`, but the transform cannot
be correct without it — `xs=ys=zs=0` must map to the box's own corner,
per the same page's own definition of scaled coordinates as "0.0 to
1.0". Verified against a hand-computed example in the test suite.

## Design notes / judgment calls

- **`LammpsAtomStyle::Other(String)`**: `parse_lammps_data` takes
  `atom_style` as a required parameter (per the brief), but also needs a
  typed `UnsupportedAtomStyle` error path for a style outside the 4
  supported ones — resolved via an `Other(String)` variant carrying the
  raw style name, so the type system stays a closed set of "the 4
  supported styles, or an explicit escape hatch" rather than requiring a
  separate pre-filtering step from every caller.
- **LAMMPS's type-label framework is fail-closed rejected** (new
  `LammpsDataError::TypeLabelsUnsupported`, not in the brief's minimum
  error list, added because it's needed): a `Masses`/`Atoms`/`Bonds` row
  can key off a string label (e.g. `C 12.011`) instead of a numeric
  type/ID under this LAMMPS extension. This module's section-boundary
  detection is numeric-token-based, and a label-keyed row is
  indistinguishable from a new section header to that heuristic — left
  unguarded, such a file would be silently mis-split (real data rows
  eaten as a bogus section's "mandatory skipped line"), not merely
  under-supported. Any section name ending in `"Type Labels"` now fails
  the whole parse closed instead.
- **`column()` returns `Option<Vec<f64>>`, not `Option<&[f64]>`**: the
  brief's illustrative `LammpsDumpFrame` shape is row-major
  (`rows: Vec<Vec<f64>>`, chosen specifically to avoid a
  `HashMap<String, Vec<f64>>`), but its own suggested accessor signature
  (`&[f64]`) implicitly assumes column-oriented storage. Row-major
  storage cannot yield a borrowed, contiguous column slice — `column()`
  collects into an owned `Vec<f64>` instead, documented as a deliberate
  deviation rather than silently changed.
- **`cartesian_positions()` returns `None` for `xu/yu/zu`-only frames**,
  per a literal reading of the brief's explicit instruction — `xu/yu/zu`
  ("unwrapped": not passed through periodic-boundary wrapping, a
  materially different physical quantity from a wrapped position) are
  left to `column("xu")` etc. directly rather than folded into this
  convenience accessor.
- Two additional error variants beyond the brief's stated minimum:
  `LammpsDataError::TypeLabelsUnsupported` (above) and
  `LammpsDumpError::InvalidNumber`/`LammpsDumpError::Io` (a token that
  fails to parse as a number at all is a different failure mode from one
  that parses to NaN/Infinity; `Io` mirrors `CubeError::Io` for the
  streaming `BufRead` reader's genuine I/O-error path).
- The triclinic round-trip test suite includes both a
  bound→true→bound **identity** check over several distinct tilt
  fixtures *and* a **hand-computed absolute-value** check — the identity
  check alone would also pass a self-consistently-wrong `MIN`/`MAX` term
  (e.g. missing the `xy+xz` candidate), since both directions would use
  the same wrong extremum and still round-trip. The absolute-value test
  is the one that actually pins the formula.

## Verification

- `cargo test --workspace --all-features` — pass (see counts below)
- `cargo test --workspace --no-default-features` — pass (see counts below)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean, 0 warnings
- `cargo fmt --all -- --check` — clean

35 new tests across both modules (the brief's own itemized fixture list
implies close to this many distinct scenarios — implemented every one
rather than trimming to an arbitrary lower count), covering: all 4 atom
styles' round-trip (incl. image flags), orthogonal + triclinic box
round-trip, opaque-section round-trip as an exact fixed point (incl.
zero-row sections), every typed-error path (`AtomCountMismatch`,
malformed header, non-finite value, unsupported atom_style, duplicate
atom ID with real source-line numbers, dangling bond reference, LAMMPS
type-label rejection), dump single-frame round-trip (orthogonal +
triclinic), the triclinic bound-conversion identity *and*
absolute-value tests above, multi-frame streaming round-trip via
`LammpsDumpReader` (3 frames), scaled-coordinate conversion against
hand-computed values (orthogonal + triclinic), custom/unrecognized
dump column preservation, and a zero-atom dump frame (no panic/error).

**No `pipeline_v2`/RDKit-differential/RMSD/TFD/large-corpus measurement
was run.** This is a deliberate scope decision, not an omission: both
new modules are isolated, pure-text I/O with zero existing callers and
touch no chemistry/3D-embedding code at all, so there is no blast radius
into that territory to measure.

## Not supported, by design

- Any `atom_style` outside Atomic/Charge/Molecular/Full → typed
  `UnsupportedAtomStyle` error.
- Semantic parsing of `Angles`/`Dihedrals`/`Impropers`/any `*Coeffs`
  section (opaquely preserved byte-for-byte instead).
- LAMMPS's type-label framework (`Atom Type Labels`/...) → typed
  `TypeLabelsUnsupported` error.
- Any unit conversion or inference (LAMMPS data files don't declare a
  unit system in-file at all).
- Binary dump formats (only the default text `dump` style).
- Any `Molecule`/bond-perception integration — both types are
  standalone document types.
- Atom removal/renumbering (read/write/round-trip only in v1 — see the
  "Mutation safety" doc comment on `LammpsData`).
- Exact preservation of the *interleaving* order between typed and
  opaque sections in a data file on write (`write_lammps_data` always
  emits the 4 typed sections first, then opaque sections in their
  original relative order — each section's own content is still
  preserved exactly).
- Python/WASM bindings (separate, later concern).

## Test plan

- [x] `cargo test --workspace --all-features`
- [x] `cargo test --workspace --no-default-features`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`

Draft PR — not to be merged without explicit review/approval.
