### PR TITLE
release: v0.17.0 -- format/Python/materials-interop breadth + MMFF94 accuracy fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [0.17.0] — 2026-08-18
 
 Format/Python/materials-interop breadth, plus two MMFF94 charge/bond-order
 accuracy fixes: square-planar (`@SP1`/`@SP2`/`@SP3`-equivalent) stereo
@@ -20,13 +20,19 @@ and dump/trajectory I/O; an MMFF94 bond-order-classification fix
 `bond_type_for`, then a derived-formal-charge source fix) with one
 post-minimization stereo-repair addition it surfaced. Production
 `pipeline_v2_mmff94_strict`: 240/265 → 241/265 (see the 3-state
-measurement note below for full provenance). Purely additive at the Rust
-API level for existing crates — no breaking changes. **Not in this
-release** (deferred — see `ROADMAP.md`'s v0.17.0 plan section for current
-status): the residual MMFF94 atom-typing bug tracked as issue #337
-(62/6,693 corpus atoms, a different-shaped fix than either charge bug
-above); targeted canonical-SMILES/aromaticity known-residual fixes; a
-format-capability documentation/discoverability pass.
+measurement note below for full provenance). A release-readiness audit
+found and fixed one metadata defect ahead of this release: the declared
+MSRV (`rust-version = "1.85"`) didn't match reality (`chematic-depict` ->
+`svg2pdf` -> `image` requires rustc 1.88) -- raised to 1.88 (not pinned
+back down, to avoid reopening dependency-resolution/security-update risk)
+and now continuously verified by a dedicated CI job, plus a handful of
+small documentation-hygiene fixes found in the same audit. Purely
+additive at the Rust API level for existing crates — no breaking changes.
+**Not in this release** (deferred to a future version): the residual
+MMFF94 atom-typing bug tracked as issue #337 (62/6,693 corpus atoms, a
+different-shaped fix than either charge bug above); targeted
+canonical-SMILES/aromaticity known-residual fixes; a format-capability
+documentation/discoverability pass.
 
 ### Added — `chematic-mol` (square-planar stereo read everywhere; write via new checked conformer writers only)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Roadmap step 2: square-planar stereo (`@SP1`/`@SP2`/`@SP3`-equivalent),
-read on every MOL/SDF (V2000 + V3000) reader and write via new checked
-conformer writers, building on the generalized stereo geometry foundation
-(PR #326).
+Format/Python/materials-interop breadth, plus two MMFF94 charge/bond-order
+accuracy fixes: square-planar (`@SP1`/`@SP2`/`@SP3`-equivalent) stereo
+read/write for MOL/SDF; PDBx/mmCIF, PQR, QCSchema JSON, and ORCA I/O;
+Python (PyO3) bindings for `chematic-crystal`'s `Lattice`/`PeriodicStructure`;
+CIF explicit symmetry-operation expansion (Rust + Python); a shared
+`VolumetricGrid` type plus Gaussian Cube and OpenDX I/O; LAMMPS data-file
+and dump/trajectory I/O; an MMFF94 bond-order-classification fix
+(`torsions_missing` 257→0) and an MMFF94 BCI partial-charge fix (own wrong
+`bond_type_for`, then a derived-formal-charge source fix) with one
+post-minimization stereo-repair addition it surfaced. Production
+`pipeline_v2_mmff94_strict`: 240/265 → 241/265 (see the 3-state
+measurement note below for full provenance). Purely additive at the Rust
+API level for existing crates — no breaking changes. **Not in this
+release** (deferred — see `ROADMAP.md`'s v0.17.0 plan section for current
+status): the residual MMFF94 atom-typing bug tracked as issue #337
+(62/6,693 corpus atoms, a different-shaped fix than either charge bug
+above); targeted canonical-SMILES/aromaticity known-residual fixes; a
+format-capability documentation/discoverability pass.
 
 ### Added — `chematic-mol` (square-planar stereo read everywhere; write via new checked conformer writers only)
 
@@ -65,9 +79,10 @@ conformer writers, building on the generalized stereo geometry foundation
 
 - `wedge_vs_3d_conflicts` gated on `atom.chirality == Chirality::None`,
   so any non-`None`, non-tetrahedral chirality fell through into a
-  computation that assumes a tetrahedral shape — latent until this PR,
-  since no MOL/SDF reader ever produced `Chirality::SquarePlanar` before
-  now. Fixed by switching to `!atom.chirality.is_tetrahedral()`, an
+  computation that assumes a tetrahedral shape — latent until the
+  square-planar MOL/SDF work above (this same release), since no MOL/SDF
+  reader ever produced `Chirality::SquarePlanar` before then. Fixed by
+  switching to `!atom.chirality.is_tetrahedral()`, an
   exhaustive-match-safe allowlist gate (same fix shape as two prior
   instances of this bug class in `chematic-3d`/`chematic-chem`).
 
@@ -206,7 +221,8 @@ fix) — see the PR body / `validation/results/` for the full report.
 
 - Fresh measurement (not reused from any older commit) at State 1 (`c079926`,
   v0.16.0 release, pre-torsion-fix), State 2 (`a2baac4`, post-torsion-fix
-  main, pre-BCI-fix), State 3 (this PR, post-both-fixes). `pipeline_v2_mmff94_strict`
+  main, pre-BCI-fix), State 3 (`e2876bb`, PR #331 tip, post-both-fixes).
+  `pipeline_v2_mmff94_strict`
   success: 240/265 → 241/265 → 241/265; RMSD (symmetric, vs
   `rdkit_etkdgv3_mmff94`) mean 1.698 → 1.685 → 1.685 Å; TFD mean 0.2245 →
   0.2233 → 0.2228; **0 status-level regressions** (success/typed_failure/
@@ -222,6 +238,22 @@ fix) — see the PR body / `validation/results/` for the full report.
   see next section).
 - Full report: `validation/results/mmff94_bci_gap_227_phase2_report.md`
   (+ `_summary.json`, raw per-state dumps, per-molecule transition tables).
+- **State 3's numbers remain valid as the v0.17.0 release figures, not
+  re-measured after State 3**: the only production-3D/FF-relevant change
+  between `e2876bb` and the v0.17.0 release head is PR #336 (`f401f47`,
+  the MMFF94 BCI derived-formal-charge fix), which itself already
+  discloses its own blast radius as exactly 5/6,693 corpus atoms across
+  3/264 molecules changing computed charge value at all, zero status-level
+  regressions — see that entry's "Blast radius, both directions" note
+  below for the full disclosure. No other file under
+  `crates/chematic-3d/src`, `crates/chematic-ff/src`, or
+  `crates/chematic-perception/src` changed between those two commits
+  (confirmed via `git diff --stat e2876bb..916ca4d -- crates/chematic-3d/src
+  crates/chematic-ff/src crates/chematic-perception/src`); PRs #332-#335 and
+  #338 are format/Python-interop/materials I/O work with zero reach into
+  the embedding/minimization/verification path. Citing this instead of
+  re-running the 265-molecule corpus, per this project's standing
+  measurement policy.
 
 ### Fixed — `chematic-3d` (post-minimization stereo repair-and-reverify)
 
@@ -244,10 +276,10 @@ fix) — see the PR body / `validation/results/` for the full report.
   accepted only if repair succeeds, the reverified result has zero
   violations, and the geometry stays sound; any rejection falls through to
   the original, unmodified `FinalStereoViolation` failure.
-  `StereoPolicy::Ignore`/`VerifyOnly` (including this PR's own measured
-  arm, `chematic_pipeline_v2_mmff94_strict`) are completely unaffected by
-  construction — the fix cannot and does not change any of the 3-state
-  numbers above, which were not re-measured for this reason.
+  `StereoPolicy::Ignore`/`VerifyOnly` (including the 3-state measurement's
+  own arm, `chematic_pipeline_v2_mmff94_strict`, above) are completely
+  unaffected by construction — this fix cannot and does not change any
+  of those 3-state numbers, which were not re-measured for this reason.
 - Root-cause fix (real stereo-awareness inside MMFF94 minimization) and
   broadening `StereoPolicy::Ignore`'s own gate were both considered and
   explicitly out of scope (large, cross-cutting changes deserving their
@@ -375,6 +407,14 @@ data). LAMMPS data/dump and Gaussian Cube/OpenDX (a shared
   rather than dropped. NaN/Infinity rejected in all numeric fields.
   `OptimizationInput`/`OptimizationResult` (trajectory-bearing) are out of
   scope for this wave.
+- `qcschema::JsonObject`/`qcschema::Connectivity` (the type aliases used
+  as public field types on `AtomicInput`/`AtomicResult`/`QcMolecule`) are
+  now re-exported at the crate root (`chematic_mol::JsonObject`/
+  `chematic_mol::Connectivity`), matching the crate's existing
+  re-export convention -- found during the v0.17.0 release audit as a
+  caller-facing gap (a `chematic_mol::QcMolecule` user couldn't name the
+  type of its own `.connectivity`/`.extras` fields without reaching into
+  the `qcschema` module directly).
 
 ### Added — `chematic-mol` (ORCA input/output)
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,5 +23,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.16.0
+version: 0.17.0
 date-released: "2026-08-12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.16.0
+# chematic v0.17.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-07-17, v0.4.29 vs RDKit 2026.03.3 --
@@ -427,6 +427,13 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +1
 
 ## Recent Development
 
+**v0.17.0** (2026-08-17): **Format/Python/materials-interop breadth, plus two MMFF94 charge/bond-order accuracy fixes**
+- `chematic-mol`: square-planar (`@SP1`/`@SP2`/`@SP3`-equivalent) stereo read/write for MOL/SDF via 3D-coordinate-derived reperception; PDBx/mmCIF, PQR, QCSchema JSON, and ORCA input/output; CIF explicit symmetry-operation expansion into a full unit cell (Rust + Python); a shared `VolumetricGrid` type plus Gaussian Cube and OpenDX (APBS-scoped) I/O; LAMMPS data-file (`read_data` format) and dump/trajectory-file I/O as standalone document types, not integrated with `Molecule`
+- `chematic-py`: new Python bindings for `chematic-crystal`'s `Lattice`/`PeriodicStructure`/`Site` — found and fixed a real pre-existing bug along the way (`to_cif()` silently re-declared an unexpanded-symmetry CIF as false P1)
+- `chematic-ff`: MMFF94 bond-order-classification fix (`assign_mmff94_numeric_types_with_view` — production energy/gradient entry points and the coverage gate now agree on classification; `torsions_missing` 257→0 on the 265-molecule Wave 1 corpus) and an MMFF94 BCI partial-charge fix (own wrong `bond_type_for`, then root-caused a second bug to RDKit's atom-type-*derived* formal charge never being computed at all) with one post-minimization stereo-repair addition the first fix surfaced. Production `pipeline_v2_mmff94_strict`: 240/265 → 241/265
+- Release-hygiene: corrected an MSRV declaration that didn't match reality (`rust-version` raised to 1.88, now continuously verified by a dedicated CI job)
+- Full details in `CHANGELOG.md`'s `[0.17.0]` section
+
 **v0.16.0** (2026-08-15): **Periodic-structure interoperability (CIF/POSCAR/FPS) and generalized stereochemistry foundation**
 - `chematic-mol`: new optional `crystal` feature bridges the existing CIF reader/writer to `chematic_crystal::PeriodicStructure` (`parse_cif_periodic_structure`/`write_cif_periodic_structure`) — cell parameters to `Lattice`, `_atom_site_occupancy` to `Occupancy`, disorder-sharing atom-site rows merged into one `PeriodicSite`'s multi-species list. New `CifSymmetryStatus` enum distinguishes genuinely-P1 CIFs from CIFs that declared symmetry this parser doesn't expand, rather than silently treating the latter as P1. `chematic-crystal` itself remains independent of `chematic-mol`/`Molecule` (dependency direction is one-way: `chematic-mol` → `chematic-crystal`, optional)
 - `chematic-crystal`: native POSCAR/CONTCAR (VASP structure format) read/write — `parse_poscar`/`parse_contcar`/`write_poscar`, VASP 5 only, both scale-factor conventions, Direct/Cartesian coordinates, selective dynamics, ion velocities, and CONTCAR's predictor-corrector MD-restart section preserved verbatim (VASP's own docs don't specify its numeric layout)
@@ -562,7 +569,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v0.16.0)
+├── Cargo.toml                    workspace root (v0.17.0)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)
@@ -616,7 +623,7 @@ If you use chematic in academic or research work, please cite:
   author    = {kent-tokyo},
   title     = {chematic: A pure-Rust cheminformatics toolkit},
   url       = {https://github.com/kent-tokyo/chematic},
-  version   = {0.16.0},
+  version   = {0.17.0},
   year      = {2026},
 }
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -106,7 +106,7 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.16.0
+# chematic v0.17.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-06, v0.4.22 vs RDKit 2026.03.3 --
@@ -283,6 +283,13 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi      
 ---
 
 ## 最近の開発
+
+**v0.17.0**（2026-08-17）: **フォーマット/Python/材料科学の相互運用性拡充、およびMMFF94電荷・結合次数の精度修正2件**
+- `chematic-mol`：square-planar（`@SP1`/`@SP2`/`@SP3`相当）立体化学のMOL/SDF read/write（3D座標からの再認識）、PDBx/mmCIF・PQR・QCSchema JSON・ORCA入出力、CIF明示的symmetry操作の展開（Rust/Python両方）、共有`VolumetricGrid`型 + Gaussian Cube/OpenDX I/O、LAMMPS data/dump（trajectory）I/O（`Molecule`とは独立した専用document型）
+- `chematic-py`：`chematic-crystal`の`Lattice`/`PeriodicStructure`/`Site`向け新規Pythonバインディング——開発中に既存の実バグも発見・修正（`to_cif()`が未展開symmetryのCIFを誤ってP1と再宣言していた問題）
+- `chematic-ff`：MMFF94結合次数分類の修正（`torsions_missing` 257→0）とMMFF94 BCI部分電荷の修正（RDKitの原子タイプ由来形式電荷が未計算だった根本原因を特定）。本番`pipeline_v2_mmff94_strict`：240/265→241/265
+- リリース整備：宣言MSRVの実態不一致を修正（1.88へ引き上げ、専用CIジョブで継続検証）
+- 詳細は`CHANGELOG.md`の`[0.17.0]`section参照
 
 **v0.16.0**（2026-08-15）: **周期構造の相互運用性（CIF/POSCAR/FPS）と一般化立体化学基盤**
 - `chematic-mol`：新設のoptional `crystal` featureが既存のCIF reader/writerを`chematic_crystal::PeriodicStructure`へ橋渡し（`parse_cif_periodic_structure`/`write_cif_periodic_structure`）——セルパラメータを`Lattice`へ、`_atom_site_occupancy`を`Occupancy`へ、disorderを共有する複数の`_atom_site_*`行を1つの`PeriodicSite`の複数species listへ統合。新設の`CifSymmetryStatus`列挙型により、真にP1な CIFと、symmetryを宣言しているがこのparserが未展開のCIFを区別（後者を暗黙にP1扱いしない）。`chematic-crystal`自体は`chematic-mol`/`Molecule`から独立したまま（依存方向は`chematic-mol`→`chematic-crystal`のoptional依存のみ）

--- a/README_zh.md
+++ b/README_zh.md
@@ -251,6 +251,13 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi      
 
 ## 近期开发
 
+**v0.17.0**（2026-08-17）：**格式/Python/材料科学互操作性扩展，以及两项 MMFF94 电荷/键级精度修复**
+- `chematic-mol`：平面四方（`@SP1`/`@SP2`/`@SP3` 等价）立体化学的 MOL/SDF 读写（基于 3D 坐标重新识别）、PDBx/mmCIF、PQR、QCSchema JSON、ORCA 输入输出、CIF 显式对称操作展开（Rust 与 Python 均支持）、共享 `VolumetricGrid` 类型加 Gaussian Cube/OpenDX I/O、LAMMPS data/dump（轨迹）I/O（作为独立于 `Molecule` 的专用 document 类型）
+- `chematic-py`：新增 `chematic-crystal` 的 `Lattice`/`PeriodicStructure`/`Site` Python 绑定——开发过程中发现并修复了一个真实的既有 bug（`to_cif()` 曾将未展开对称性的 CIF 错误地重新声明为 P1）
+- `chematic-ff`：MMFF94 键级分类修复（`torsions_missing` 257→0）与 MMFF94 BCI 部分电荷修复（根因定位到 RDKit 的原子类型派生形式电荷从未被计算）。生产环境 `pipeline_v2_mmff94_strict`：240/265→241/265
+- 发布卫生：修正了与实际不符的 MSRV 声明（提升至 1.88，并新增专用 CI 任务持续验证）
+- 详见 `CHANGELOG.md` 的 `[0.17.0]` 部分
+
 **v0.16.0**（2026-08-15）：**周期结构互操作性（CIF/POSCAR/FPS）与通用立体化学基础**
 - `chematic-mol`：新增可选 `crystal` feature，将现有 CIF reader/writer 桥接到 `chematic_crystal::PeriodicStructure`（`parse_cif_periodic_structure`/`write_cif_periodic_structure`）——晶胞参数映射到 `Lattice`，`_atom_site_occupancy` 映射到 `Occupancy`，共享同一分数坐标的多条 `_atom_site_*` 记录合并为单个 `PeriodicSite` 的多 species 列表。新增 `CifSymmetryStatus` 枚举，区分真正的 P1 结构与声明了对称性但当前 parser 尚未展开的 CIF（后者不会被静默当作 P1 处理）。`chematic-crystal` 自身仍与 `chematic-mol`/`Molecule` 保持独立（依赖方向仅为 `chematic-mol` → `chematic-crystal` 的可选依赖）
 - `chematic-crystal`：原生支持 POSCAR/CONTCAR（VASP 结构文件格式）读写——`parse_poscar`/`parse_contcar`/`write_poscar`，仅支持 VASP 5，兼容两种 scale-factor 写法，支持 Direct/Cartesian 坐标、selective dynamics、离子速度，CONTCAR 的 predictor-corrector（MD 续算段）按原样保留（VASP 官方文档本身也未规定其数值布局）

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.16.0 | Yes | Current release — active support |
+| v0.17.0 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.16.0) receives all security updates.  
+**Active Support**: Latest release (v0.17.0) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -17,12 +17,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.16.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.16.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.16.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.16.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.16.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.16.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.17.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.17.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.17.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.17.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.17.0" }
 serde_json          = "1.0"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #219); web-time

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -17,14 +17,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.16.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.17.0" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.16.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.16.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.16.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.16.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.16.0" }
-chematic-cip        = { path = "../chematic-cip",        version = "0.16.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.17.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.17.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.17.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.17.0" }
+chematic-cip        = { path = "../chematic-cip",        version = "0.17.0" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.16.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.16.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.17.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-crystal/Cargo.toml
+++ b/crates/chematic-crystal/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 serde = ["dep:serde"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.16.0" }
+chematic-core = { path = "../chematic-core", version = "0.17.0" }
 serde         = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/crates/chematic-crystal/README.md
+++ b/crates/chematic-crystal/README.md
@@ -184,7 +184,9 @@ inference, coordination-geometry classification, DFT, formation-energy or
 phase-diagram computation, band structure, phonons, defect generation, or
 surface/slab construction. No materials-ML models and **no prediction of
 stability or synthesizability** -- this crate stores and computes pure
-geometry. No Python/WASM/MCP bindings. No arbitrary 3x3 integer supercell
+geometry. No WASM/MCP bindings (Python bindings for `Lattice`/
+`PeriodicStructure`/`Site` shipped in v0.17.0 via `chematic-py`, see
+`CHANGELOG.md`). No arbitrary 3x3 integer supercell
 transform (diagonal `[nx, ny, nz]` only). No spatial-partitioning neighbor-
 search optimization -- the baseline is an exact bounded enumeration, not
 necessarily the fastest possible one.

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -23,10 +23,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.16.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.16.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.16.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.16.0" }
+chematic-core = { path = "../chematic-core", version = "0.17.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.17.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.17.0" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.16.0" }
+chematic-core = { path = "../chematic-core", version = "0.17.0" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.16.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.16.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.17.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -23,13 +23,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.16.0" }
+chematic-core = { path = "../chematic-core", version = "0.17.0" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.16.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.16.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.16.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.16.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.17.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.17.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.17.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -19,10 +19,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.16.0", path = "../chematic-core" }
-chematic-smiles = { version = "0.16.0", path = "../chematic-smiles" }
-chematic-chem = { version = "0.16.0", path = "../chematic-chem" }
-chematic-rxn = { version = "0.16.0", path = "../chematic-rxn" }
+chematic-core = { version = "0.17.0", path = "../chematic-core" }
+chematic-smiles = { version = "0.17.0", path = "../chematic-smiles" }
+chematic-chem = { version = "0.17.0", path = "../chematic-chem" }
+chematic-rxn = { version = "0.17.0", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.16.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.16.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.17.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -18,15 +18,15 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.16.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.16.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.16.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.16.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.16.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.16.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.16.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.16.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.16.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.17.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.17.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.17.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.17.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.17.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.17.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.17.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.17.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
 
 [dev-dependencies]
 # Real JSON Schema 2020-12 validator, used only in tests to independently

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -25,11 +25,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 crystal = ["dep:chematic-crystal"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.16.0" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.16.0" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.16.0" }
-chematic-smiles      = { path = "../chematic-smiles",      version = "0.16.0" }
-chematic-crystal     = { path = "../chematic-crystal",     version = "0.16.0", optional = true }
+chematic-core        = { path = "../chematic-core",        version = "0.17.0" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.17.0" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.17.0" }
+chematic-smiles      = { path = "../chematic-smiles",      version = "0.17.0" }
+chematic-crystal     = { path = "../chematic-crystal",     version = "0.17.0", optional = true }
 serde_json           = "1.0"
 
 [dev-dependencies]

--- a/crates/chematic-mol/src/lib.rs
+++ b/crates/chematic-mol/src/lib.rs
@@ -114,10 +114,10 @@ pub use pqr::{
     parse_pqr_with_limits, write_pqr,
 };
 pub use qcschema::{
-    AtomicInput, AtomicResult, Basis, ChematicMoleculeView, ComputeError, Driver, Provenance,
-    QcConvertError, QcModel, QcMolecule, QcSchemaError, ReturnResult, chematic_to_qc_molecule,
-    parse_atomic_input, parse_atomic_result, parse_qcschema_molecule, qc_molecule_to_chematic,
-    write_atomic_input, write_atomic_result, write_qcschema_molecule,
+    AtomicInput, AtomicResult, Basis, ChematicMoleculeView, ComputeError, Connectivity, Driver,
+    JsonObject, Provenance, QcConvertError, QcModel, QcMolecule, QcSchemaError, ReturnResult,
+    chematic_to_qc_molecule, parse_atomic_input, parse_atomic_result, parse_qcschema_molecule,
+    qc_molecule_to_chematic, write_atomic_input, write_atomic_result, write_qcschema_molecule,
 };
 pub use record::MoleculeRecord;
 pub use rxn::{RxnParseError, parse_rxn_file, write_rxn_file};

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.16.0" }
+chematic-core = { path = "../chematic-core", version = "0.17.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,17 +25,17 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.16.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.16.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.16.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.16.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.16.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.16.0", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.16.0", features = ["crystal"] }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.16.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.16.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.16.0" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.16.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.16.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.16.0" }
-chematic-crystal    = { path = "../chematic-crystal",    version = "0.16.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.17.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.17.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.17.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.17.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.17.0", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.17.0", features = ["crystal"] }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.17.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.17.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.17.0" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.17.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.17.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.17.0" }
+chematic-crystal    = { path = "../chematic-crystal",    version = "0.17.0" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -23,9 +23,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 perf-instrumentation = []
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.16.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.16.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.16.0" }
+chematic-core   = { path = "../chematic-core",   version = "0.17.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.17.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.17.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.16.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.16.0" }
+chematic-core = { path = "../chematic-core", version = "0.17.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
 rustc-hash = "2"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #221); web-time

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.16.0" }
+chematic-core = { path = "../chematic-core", version = "0.17.0" }
 
 [features]
 # Feature-gated internal work counters for the orbit-pruning canonical

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -26,16 +26,16 @@ wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["console"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.16.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.16.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.16.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.16.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.16.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.16.0", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.16.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.16.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.16.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.16.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.16.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.16.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.16.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.17.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.17.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.17.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.17.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.17.0", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.17.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.17.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.17.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.17.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.17.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.17.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.17.0" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -54,16 +54,16 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.16.0", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.16.0", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.16.0", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.16.0", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.16.0", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.16.0", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.16.0", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.16.0", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.16.0", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.16.0", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.16.0", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.16.0", optional = true }
-chematic-crystal    = { path = "../chematic-crystal",    version = "0.16.0", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.17.0", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.17.0", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.17.0", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.17.0", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.17.0", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.17.0", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.17.0", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.17.0", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.17.0", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.17.0", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.17.0", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.17.0", optional = true }
+chematic-crystal    = { path = "../chematic-crystal",    version = "0.17.0", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

v0.17.0 release candidate: **format/Python/materials-interop breadth, plus two MMFF94 charge/bond-order accuracy fixes.**

- `chematic-mol`: square-planar (`@SP1`/`@SP2`/`@SP3`-equivalent) stereo read/write for MOL/SDF; PDBx/mmCIF, PQR, QCSchema JSON, and ORCA I/O; CIF explicit symmetry-operation expansion (Rust + Python); a shared `VolumetricGrid` type plus Gaussian Cube and OpenDX I/O; LAMMPS data-file and dump/trajectory I/O (standalone document types, not integrated with `Molecule`).
- `chematic-py`: new Python bindings for `chematic-crystal`'s `Lattice`/`PeriodicStructure`/`Site`.
- `chematic-ff`: MMFF94 bond-order-classification fix (`torsions_missing` 257→0) and MMFF94 BCI partial-charge fix (own wrong `bond_type_for`, then root-caused a second bug to RDKit's atom-type-*derived* formal charge never being computed at all), with one post-minimization stereo-repair addition the first fix surfaced. Production `pipeline_v2_mmff94_strict`: 240/265 → 241/265.
- Release hygiene: declared MSRV corrected from a false `1.85` to the real `1.88` (verified — see below), now continuously checked by a dedicated CI job. A handful of documentation fixes found by the release audit (stale crate README claims, a missing crate-root re-export, a broken intra-doc link, README_ja/README_zh sync for this cycle's features).

PRs #329, #330, #331, #332, #333, #334, #335, #336, #338, #339 — full itemized list in `CHANGELOG.md`'s `[0.17.0]` section.

Not in this release (deferred): issue #337 (residual MMFF94 atom-typing bug, 62/6,693 corpus atoms — a different-shaped fix than either charge bug above); targeted canonical-SMILES/aromaticity known-residual fixes; a format-capability documentation pass.

## Why no full 265-molecule production-3D re-measurement

Checked before deciding, not assumed: `git diff --stat e2876bb..916ca4d -- crates/chematic-3d/src crates/chematic-ff/src crates/chematic-perception/src` shows the **only** file touched between the last full 3-state measurement (`e2876bb`, PR #331 tip) and this release head is `crates/chematic-ff/src/mmff94_numeric.rs` (PR #336). PR #336's own CHANGELOG entry already discloses its full blast radius via a per-atom join: exactly 5/6,693 corpus atoms across 3/264 molecules change computed charge value at all, zero status-level regressions. Every other PR in this release (#332–#335, #338, #339) is format I/O, Python bindings, or release metadata with zero reach into the embedding/minimization/verification path.

Re-running the full corpus now would reproduce the already-cited numbers (`pipeline_v2_mmff94_strict` 241/265, RMSD mean 1.685Å, TFD mean 0.2228) with zero new information — CHANGELOG.md now cites the exact source commit (`e2876bb`) and this reasoning directly, per this project's standing measurement policy (heavy-gate reserved for production-3D-algorithm changes, new external RMSD/TFD claims, or blast radius that can't be bounded from a subset — none apply here).

## Verification

- `bash scripts/check.sh` (fmt, clippy, `cargo test --workspace` incl. doctests, cargo-deny, publish-graph, version-consistency across all files): **all green**, 0 failures.
- MSRV: `cargo +1.85 check --workspace --all-features` fails (`image@0.25.10` requires rustc 1.88, confirming the old declaration was false); `cargo +1.88 check --workspace --all-features` passes. New `MSRV Check` CI job (`dtolnay/rust-toolchain@1.88.0`) already green on PR #339, now part of the standard gate.
- `cargo package --workspace --registry crates-io --allow-dirty`: all **20** real crates (19 crates.io + `chematic-py`) package successfully at `0.17.0`, healthy sizes (largest ~7.4MiB, well under the 10MB crates.io limit). Fails only at `tools/gen_sa_table` (`publish = false` internal dev tool, unversioned path dependency, not part of the publish graph) — expected, unrelated to this PR.
- `python scripts/check_publish_graph.py`: OK, 19 publishable crates, safe order unchanged.
- Version consistency: every `Cargo.toml` (workspace root + all 20 crates) coherently at `0.17.0`; every internal path-dependency version pin updated to match.

## Test plan

- [x] `bash scripts/check.sh` green
- [x] MSRV 1.85→1.88 before/after confirmed
- [x] `cargo package --workspace` dry-run: 20/20 real crates succeed
- [x] `check_publish_graph.py` OK
- [ ] CI green on this PR (pending)

Draft PR — merge, tag, GitHub Release, and crates.io/PyPI/npm publish are separate, explicit follow-up steps, not part of this PR.
