### PR TITLE
fix(chematic-ff): MMFF94 CSP typing for cumulated-double-bond carbons (issue #337)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed — `chematic-ff` (MMFF94 atom typing: aryl isothiocyanate CSP carbon, issue #337)
+
+- **Root cause**: `assign_c_type`'s sp-carbon check only fired on
+  `triple_bonds > 0`, so a carbon reached via *two* double bonds (a
+  cumulated diene / "allenic" carbon — e.g. the central C of an aryl
+  isothiocyanate's `N=C=S`) fell through to the `double_bonds > 0`
+  "double-bonded to N/O/P/S" branch and was mistyped 3 (generic
+  carbonyl-family) instead of RDKit's real CSP type 4. RDKit's actual rule
+  (`AtomTyper.cpp`, pinned commit
+  `e74e7b0a5a2fc4e7f77c04ec26a61d4b8edbf22f`, lines ~954-960) is simply
+  `getTotalDegree() == 2` for a non-aromatic carbon, unconditional on which
+  elements the two bonds go to — a real triple bond and a cumulated
+  double-bond pair aren't special-cased separately by RDKit at all; both
+  just leave the carbon with exactly 2 neighbors.
+- Fix: replaced the `triple_bonds > 0 => Ok(4)` check with
+  `total_degree(mol, idx) == 2 => Ok(4)`, ahead of the `double_bonds > 0`
+  branch it was previously losing to. Strict superset of the old
+  condition (every triple-bonded carbon already has `total_degree == 2`),
+  so it cannot regress any previously-correct triple-bond CSP assignment.
+  Also, correctly, broader than the corpus: a plain carbon allene
+  (`C=C=C`, not present in the 264-molecule corpus) was mistyped the same
+  way and is fixed too.
+- Measured, full 264-molecule corpus, genuine per-atom join (not
+  aggregate-count arithmetic), same tool/oracle pair as every other
+  measurement in this file: type-mismatch ledger 34 → 32 atoms (both
+  `chembl_tier_b_0071`/`_0082`'s isothiocyanate carbon move to exact
+  match; molecule count 8 → 6); charge-mismatch ledger 62 → 56 atoms (6
+  move: the corrected carbon in both molecules, plus its N and S
+  neighbors in both, whose own TYPES were already correct but whose
+  BCI-bond-lookup charge depends on the carbon's type too; molecule count
+  8 → 6). Zero regressions on either ledger, verified by diffing full
+  before/after mismatch lists. `lookup_chg_contribution` already covers
+  the (4, 9) and (4, 16) bond-type pairs the corrected type now looks up
+  — no new charge-computation errors introduced.
+- **Not addressed by this fix**: the other 6/8 molecules behind issue
+  #337 (a pyridinium-conjugated exocyclic-amine scaffold,
+  `chembl_tier_b_0009`/`_0023`/`_0028`/`_0029`/`_0030`/`_0034`) turned out,
+  on live re-investigation, to be a genuine RDKit Kekulization/
+  MMFF-aromaticity-perception artifact for a specific fused, macrocyclic
+  ring topology — not a locally-statable atom-typing rule chematic is
+  missing a branch for (confirmed by direct negative-control fragments:
+  the same ring+exocyclic-amine motif types correctly in four simpler,
+  non-macrocyclic contexts). Reproducing RDKit's exact behavior would
+  require porting its global Kekulization matching algorithm and its
+  iterative, ring-processing-order-dependent MMFF-aromaticity pi-electron
+  count, not adding a discriminating condition — left as an
+  honestly-disclosed residual rather than shipping a heuristic that would
+  create new false mismatches on the negative-control cases. These 6
+  molecules remain unchanged by this fix (32/6,693 type-mismatched, 56/
+  6,693 charge-mismatched atoms, same molecules as before). Full writeup,
+  including the corrected diagnosis of which atom actually mismatches
+  (the ring nitrogen, not the exocyclic amine as originally described) and
+  the RDKit source citations for both the fixed and the unfixed sub-bug:
+  `scripts/mmff94_provenance/PROVENANCE.md`'s issue #337 follow-up
+  addendum.
+- 6 new regression-pinned/synthetic-fixture tests
+  (`crates/chematic-ff/src/mmff94_numeric.rs`): full-array pins for both
+  corpus molecules, two minimal isothiocyanate fixtures, a no-regression
+  plain-alkyne pin, and the broader-than-corpus allene pin.
+
 ## [0.17.0] — 2026-08-18
 
 Format/Python/materials-interop breadth, plus two MMFF94 charge/bond-order

--- a/crates/chematic-ff/src/mmff94_numeric.rs
+++ b/crates/chematic-ff/src/mmff94_numeric.rs
@@ -1353,11 +1353,29 @@ fn assign_c_type(
     // atomType.
 
     let double_bonds = count_bond_order(mol, idx, BondOrder::Double);
-    let triple_bonds = count_bond_order(mol, idx, BondOrder::Triple);
 
-    // sp carbon (triple bond or allene)
-    if triple_bonds > 0 {
-        return Ok(4); // CSP
+    // sp carbon: RDKit's real CSP (type 4) rule for a non-aromatic carbon
+    // is simply `getTotalDegree() == 2` (`AtomTyper.cpp`, pinned commit
+    // `e74e7b0a5a2fc4e7f77c04ec26a61d4b8edbf22f`, lines ~954-960 -- the
+    // "2 neighbors" branch reached once the earlier degree-4 and degree-3
+    // branches don't match), with no check on which elements the two
+    // bonds go to. It covers both true acetylenic carbons (one triple
+    // bond leaves exactly one remaining substituent, so degree is always
+    // 2) *and* cumulated-double-bond ("allenic") carbons such as the
+    // central C of an aryl isothiocyanate's N=C=S (two double bonds, zero
+    // remaining substituents, also degree 2). Chematic previously only
+    // special-cased `triple_bonds > 0`, so a degree-2 carbon reached via
+    // two double bonds instead fell into the `double_bonds > 0`
+    // "double-bonded to N/O/P/S" branch below and was mistyped 3 (generic
+    // carbonyl-family) instead of 4 -- confirmed live against RDKit on
+    // `chembl_tier_b_0071`/`_0082`'s isothiocyanate carbon (issue #337).
+    // `total_degree(mol, idx) == 2` is a strict superset of the old
+    // `triple_bonds > 0` gate (a carbon triple bond always consumes 3 of
+    // its 4 valence units, leaving exactly one more substituent), not a
+    // narrower replacement, so this cannot regress any previously-correct
+    // triple-bond CSP assignment.
+    if total_degree(mol, idx) == 2 {
+        return Ok(4); // CSP: acetylenic or cumulated-double-bond ("allenic") carbon
     }
 
     // sp2 carbon
@@ -4489,5 +4507,177 @@ mod tests {
         // proceed to index `types` for parameter lookup; confirming `Err`
         // here is exactly what makes that `?` short-circuit for every
         // caller, without needing to duplicate every caller's own test.
+    }
+
+    // ── Cumulated-double-bond CSP fix (issue #337 sub-bug 2) ─────────────────
+    // Root cause: `assign_c_type`'s sp-carbon check only fired on
+    // `triple_bonds > 0`, so a carbon reached via *two* double bonds (a
+    // cumulated diene / "allenic" carbon, e.g. the central C of an aryl
+    // isothiocyanate's N=C=S) fell through to the `double_bonds > 0`
+    // "double-bonded to N/O/P/S" branch and got the generic carbonyl-family
+    // type 3 instead of RDKit's real CSP type 4. RDKit's actual rule
+    // (`AtomTyper.cpp`, pinned commit
+    // `e74e7b0a5a2fc4e7f77c04ec26a61d4b8edbf22f`, lines ~954-960) is simply
+    // `getTotalDegree() == 2`, unconditional on which elements the two bonds
+    // go to -- see `assign_c_type`'s doc comment for the full citation.
+    // These tests pin the 2/8 issue #337 molecules this fix resolves (the
+    // other 6/8, the pyridinium-conjugated-exocyclic-amine sub-bug, are an
+    // RDKit Kekulization/aromaticity-perception artifact, not an
+    // atom-typing rule -- left as an honestly-disclosed residual, see
+    // `scripts/mmff94_provenance/PROVENANCE.md`), plus isolated synthetic
+    // fixtures pinning the exact discriminating condition independent of
+    // the corpus molecules' other complexity.
+
+    #[test]
+    fn propyne_alkyne_carbons_still_type_csp_after_degree_based_fix() {
+        // No-regression pin: a real triple bond always yields
+        // `total_degree == 2` for carbon (the triple bond alone consumes 3
+        // of its 4 valence units), so this must keep matching RDKit exactly
+        // as it did before this fix broadened the condition. Expected
+        // values from a fresh live RDKit oracle query (`rdkit==2026.03.4`,
+        // `MMFFGetMoleculeProperties(mol, mmffVariant="MMFF94")` on the
+        // implicit-H `Chem.MolFromSmiles` result -- MMFF atom
+        // typing/charges are purely topological, no embedding needed, same
+        // precedent as `scripts/mmff94_bci_charges_oracle_227.py`).
+        let m = mol("CC#C");
+        let types = assign_mmff94_numeric_types(&m).unwrap();
+        assert_eq!(types, vec![1, 4, 4]);
+        let q = mmff94_charges_numeric(&m).unwrap();
+        let expected = [0.2, -0.2, 0.0];
+        for (i, exp) in expected.iter().enumerate() {
+            assert!(
+                (q[i] - exp).abs() < 1e-6,
+                "propyne atom {i}: expected charge {exp}, got {}",
+                q[i]
+            );
+        }
+    }
+
+    #[test]
+    fn allene_central_carbon_types_csp_not_generic_vinylic() {
+        // Broader-than-corpus pin: plain carbon allene (no heteroatoms at
+        // all) is not in the 264-molecule corpus, but is the clearest
+        // demonstration that the real discriminating condition is
+        // `total_degree == 2`, not "cumulated bond to a heteroatom" --
+        // before this fix, the central carbon was mistyped 2 (generic
+        // vinylic C=C), same failure mode as the isothiocyanate carbons.
+        // Expected values from a fresh live RDKit oracle query
+        // (`rdkit==2026.03.4`).
+        let m = mol("C=C=C");
+        let types = assign_mmff94_numeric_types(&m).unwrap();
+        assert_eq!(types, vec![2, 4, 2]);
+        let q = mmff94_charges_numeric(&m).unwrap();
+        let expected = [0.065, -0.13, 0.065];
+        for (i, exp) in expected.iter().enumerate() {
+            assert!(
+                (q[i] - exp).abs() < 1e-6,
+                "allene atom {i}: expected charge {exp}, got {}",
+                q[i]
+            );
+        }
+    }
+
+    #[test]
+    fn methyl_isothiocyanate_minimal_ncs_fixture_matches_rdkit_oracle() {
+        // Minimal isolated reproduction of the corpus mechanism below,
+        // independent of the aromatic ring and amide/piperazine complexity
+        // both `chembl_tier_b_0071`/`_0082` also carry. Expected values
+        // from a fresh live RDKit oracle query (`rdkit==2026.03.4`).
+        let m = mol("CN=C=S");
+        let types = assign_mmff94_numeric_types(&m).unwrap();
+        assert_eq!(types, vec![1, 9, 4, 16]);
+        let q = mmff94_charges_numeric(&m).unwrap();
+        let expected = [0.246, -0.546, 0.575, -0.275];
+        for (i, exp) in expected.iter().enumerate() {
+            assert!(
+                (q[i] - exp).abs() < 1e-6,
+                "methyl isothiocyanate atom {i}: expected charge {exp}, got {}",
+                q[i]
+            );
+        }
+    }
+
+    #[test]
+    fn phenyl_isothiocyanate_aryl_ncs_fixture_matches_rdkit_oracle() {
+        // Same motif, aryl instead of methyl (closer to the corpus
+        // molecules' own aryl isothiocyanate substructure). Also confirms
+        // the fix doesn't disturb the adjacent aromatic ring's own typing.
+        // Expected values from a fresh live RDKit oracle query
+        // (`rdkit==2026.03.4`).
+        let m = mol("c1ccccc1N=C=S");
+        let types = assign_mmff94_numeric_types(&m).unwrap();
+        assert_eq!(types, vec![37, 37, 37, 37, 37, 37, 9, 4, 16]);
+        let q = mmff94_charges_numeric(&m).unwrap();
+        let expected = [0.0, 0.0, 0.0, 0.0, 0.0, 0.179, -0.479, 0.575, -0.275];
+        for (i, exp) in expected.iter().enumerate() {
+            assert!(
+                (q[i] - exp).abs() < 1e-6,
+                "phenyl isothiocyanate atom {i}: expected charge {exp}, got {}",
+                q[i]
+            );
+        }
+    }
+
+    #[test]
+    fn chembl_tier_b_0071_aryl_isothiocyanate_matches_rdkit_oracle_after_csp_fix() {
+        // Corpus regression pin. Expected values copied verbatim from the
+        // already-committed live RDKit oracle dumps
+        // (`validation/results/mmff94_rdkit_type_oracle.jsonl` and
+        // `mmff94_bci_charges_227_rdkit_oracle.jsonl`, `rdkit==2026.03.4`),
+        // not derived from this fix's own output.
+        let m = mol("COc1cc2nc(N3CCN(C(=O)c4ccc(N=C=S)c(I)c4)CC3)nc(N)c2cc1OC");
+        let types = assign_mmff94_numeric_types(&m).unwrap();
+        let expected_types = [
+            1, 6, 37, 37, 37, 38, 37, 40, 1, 1, 10, 3, 7, 37, 37, 37, 37, 9, 4, 16, 37, 14, 37, 1,
+            1, 38, 37, 40, 37, 37, 37, 6, 1,
+        ];
+        assert_eq!(
+            types, expected_types,
+            "sanity: chembl_tier_b_0071 atom types"
+        );
+        let q = mmff94_charges_numeric(&m).unwrap();
+        let expected = [
+            0.28, -0.3625, 0.0825, 0.0, 0.31, -0.62, 0.72, -0.8382, 0.3691, 0.3001, -0.6602,
+            0.5438, -0.57, 0.0862, 0.0, 0.0, 0.179, -0.479, 0.575, -0.275, 0.081, -0.081, 0.0,
+            0.3001, 0.3691, -0.62, 0.41, -0.1, 0.0, 0.0, 0.0825, -0.3625, 0.28,
+        ];
+        for (i, exp) in expected.iter().enumerate() {
+            assert!(
+                (q[i] - exp).abs() < 1e-6,
+                "chembl_tier_b_0071 atom {i}: expected charge {exp}, got {}",
+                q[i]
+            );
+        }
+    }
+
+    #[test]
+    fn chembl_tier_b_0082_aryl_isothiocyanate_matches_rdkit_oracle_after_csp_fix() {
+        // Corpus regression pin, same mechanism as `_0071` above via an
+        // enone rather than a plain benzamide linker. Expected values
+        // copied verbatim from the already-committed live RDKit oracle
+        // dumps, not derived from this fix's own output.
+        let m = mol("COc1cc2nc(N3CCN(C(=O)/C=C/c4ccc(N=C=S)cc4)CC3)nc(N)c2cc1OC");
+        let types = assign_mmff94_numeric_types(&m).unwrap();
+        let expected_types = [
+            1, 6, 37, 37, 37, 38, 37, 40, 1, 1, 10, 3, 7, 2, 2, 37, 37, 37, 37, 9, 4, 16, 37, 37,
+            1, 1, 38, 37, 40, 37, 37, 37, 6, 1,
+        ];
+        assert_eq!(
+            types, expected_types,
+            "sanity: chembl_tier_b_0082 atom types"
+        );
+        let q = mmff94_charges_numeric(&m).unwrap();
+        let expected = [
+            0.28, -0.3625, 0.0825, 0.0, 0.31, -0.62, 0.72, -0.8382, 0.3691, 0.3001, -0.6602,
+            0.6156, -0.57, 0.0144, -0.0284, 0.0284, 0.0, 0.0, 0.179, -0.479, 0.575, -0.275, 0.0,
+            0.0, 0.3001, 0.3691, -0.62, 0.41, -0.1, 0.0, 0.0, 0.0825, -0.3625, 0.28,
+        ];
+        for (i, exp) in expected.iter().enumerate() {
+            assert!(
+                (q[i] - exp).abs() < 1e-6,
+                "chembl_tier_b_0082 atom {i}: expected charge {exp}, got {}",
+                q[i]
+            );
+        }
     }
 }

--- a/crates/chematic-ff/src/mmff94_numeric.rs
+++ b/crates/chematic-ff/src/mmff94_numeric.rs
@@ -4620,11 +4620,13 @@ mod tests {
 
     #[test]
     fn chembl_tier_b_0071_aryl_isothiocyanate_matches_rdkit_oracle_after_csp_fix() {
-        // Corpus regression pin. Expected values copied verbatim from the
+        // Corpus regression pin. Expected values cross-checked against the
         // already-committed live RDKit oracle dumps
         // (`validation/results/mmff94_rdkit_type_oracle.jsonl` and
-        // `mmff94_bci_charges_227_rdkit_oracle.jsonl`, `rdkit==2026.03.4`),
-        // not derived from this fix's own output.
+        // `mmff94_bci_charges_227_rdkit_oracle.jsonl`, `rdkit==2026.03.4`)
+        // via the corpus-wide per-atom join reported in
+        // `scripts/mmff94_provenance/PROVENANCE.md`'s issue #337
+        // follow-up, not derived from this fix's own output.
         let m = mol("COc1cc2nc(N3CCN(C(=O)c4ccc(N=C=S)c(I)c4)CC3)nc(N)c2cc1OC");
         let types = assign_mmff94_numeric_types(&m).unwrap();
         let expected_types = [
@@ -4654,8 +4656,9 @@ mod tests {
     fn chembl_tier_b_0082_aryl_isothiocyanate_matches_rdkit_oracle_after_csp_fix() {
         // Corpus regression pin, same mechanism as `_0071` above via an
         // enone rather than a plain benzamide linker. Expected values
-        // copied verbatim from the already-committed live RDKit oracle
-        // dumps, not derived from this fix's own output.
+        // cross-checked against the already-committed live RDKit oracle
+        // dumps via the same corpus-wide per-atom join, not derived from
+        // this fix's own output.
         let m = mol("COc1cc2nc(N3CCN(C(=O)/C=C/c4ccc(N=C=S)cc4)CC3)nc(N)c2cc1OC");
         let types = assign_mmff94_numeric_types(&m).unwrap();
         let expected_types = [

--- a/scripts/mmff94_provenance/PROVENANCE.md
+++ b/scripts/mmff94_provenance/PROVENANCE.md
@@ -947,7 +947,7 @@ that distinction matters.
 
 ---
 
-### Issue #337 follow-up (PR TBD): one sub-bug fixed, one re-diagnosed and left open
+### Issue #337 follow-up (PR #341): one sub-bug fixed, one re-diagnosed and left open
 
 Both sub-bugs above were independently re-verified live (fresh RDKit
 2026.03.4 queries against the pinned commit's source, plus chematic's own

--- a/scripts/mmff94_provenance/PROVENANCE.md
+++ b/scripts/mmff94_provenance/PROVENANCE.md
@@ -904,9 +904,11 @@ cancellation-vs-no-cancellation asymmetry between the two O2CM/SM-adjacent
 atoms explains why only one atom per molecule shows a residual despite the
 whole functional group being affected by the same underlying bug).
 
-**Atom-typing bugs found, explicitly out of scope (per this step's own stop
-condition — fixing them means touching `assign_mmff94_numeric_types`, a
-different-shaped change)**:
+**Atom-typing bugs found, explicitly out of scope for this PR's own fix (per
+this step's own stop condition — fixing them means touching
+`assign_mmff94_numeric_types`, a different-shaped change). Filed as issue
+#337, later revisited — see the "Issue #337 follow-up" addendum after this
+subsection for what was actually found and fixed**:
 - 6/11 molecules (`_0009`/`_0023`/`_0028`/`_0029`/`_0030`/`_0034`, a
   recurring long-chain bis(pyridinium) linker scaffold in this corpus): an
   exocyclic secondary-amine nitrogen directly bonded to a pyridinium ring
@@ -920,6 +922,9 @@ different-shaped change)**:
   RDKit types the two carbons flanking the mistyped N as 3/2, a
   conjugated-carbonyl-like/vinylic pair), which is why each affected
   molecule shows 7-14 mismatched atoms, not just the one nitrogen.
+  **Correction (issue #337 follow-up, see addendum below): this
+  characterization of which atom is mistyped is wrong** — re-verified live
+  against RDKit and against chematic's own dump tooling, not re-guessed.
 - 2/11 molecules (`_0071`/`_0082`, both containing an aryl isothiocyanate
   `N=C=S` group): the cumulated-double-bond central carbon is
   chematic-typed 3 (generic C=O family) instead of RDKit's real 4 (CSP,
@@ -928,14 +933,198 @@ different-shaped change)**:
   applied to a cumulated carbon rather than nitrogen). Again cascades to
   the group's N and S BCI contributions despite those two atoms' own TYPES
   being correctly assigned (9 and 16 respectively, confirmed by direct
-  per-atom check).
+  per-atom check). **Fixed, issue #337 follow-up — see addendum below.**
 
-Neither gap is guessed at here — both are stated with their RDKit source
-line ranges and the specific structural condition that discriminates
-chematic's (wrong) output from RDKit's (real) one, ready for whoever next
-picks up MMFF94 atom-type assignment. Confirmed independent of this PR's
-fix by construction: all 62 of these atoms are in the "unchanged mismatch
-both before and after" set of the per-atom join below.
+Neither gap was guessed at here — both were stated with their RDKit source
+line ranges and the specific structural condition believed to discriminate
+chematic's (wrong) output from RDKit's (real) one. Confirmed independent of
+this PR's fix by construction: all 62 of these atoms are in the "unchanged
+mismatch both before and after" set of the per-atom join below. **That
+"62" is this PR's own charge-mismatch count (see the "Measured" paragraph
+below), not a type-mismatch count** — the actual type-level residual behind
+it is 34/6,693 atoms across the same 8 molecules; see the addendum for why
+that distinction matters.
+
+---
+
+### Issue #337 follow-up (PR TBD): one sub-bug fixed, one re-diagnosed and left open
+
+Both sub-bugs above were independently re-verified live (fresh RDKit
+2026.03.4 queries against the pinned commit's source, plus chematic's own
+`mmff94_numeric_type_dump`/`mmff94_bci_charges_dump_227` tooling — not
+re-derived from the paragraphs above) before writing any fix, per this
+project's standing "cited from RDKit's real source, not guessed" discipline.
+One correction and one fix resulted.
+
+**Ledger correction, stated first because it changes how to read every
+number below**: the "62/6,693 atoms across 8/264 molecules" figure quoted
+throughout this file and in issue #337 is the **charge**-mismatch count
+(`mmff94_bci_charges_227_rdkit_oracle.jsonl` join), not a type-mismatch
+count. The actual **type**-mismatch count
+(`mmff94_rdkit_type_oracle.jsonl` join) for the same 8 molecules is
+**34/6,693 atoms** — smaller, because several atoms whose own MMFF TYPE is
+already correct (aromatic ring carbons whose neighbor's type is what's
+wrong) still get the wrong BCI-derived *charge*, since bond-charge-increment
+lookups are keyed on both atoms of a bond. This PR reports both ledgers
+throughout, with separate denominators, rather than the single "62" number
+— conflating the two is exactly the kind of measurement error this
+project's own standing notes warn against.
+
+#### Sub-bug 2 (aryl isothiocyanate CSP carbon): fixed
+
+The original diagnosis holds up entirely on re-verification, with one
+correction to the exact RDKit rule. Live RDKit source read
+(`Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp`, pinned commit
+`e74e7b0a5a2fc4e7f77c04ec26a61d4b8edbf22f`, the carbon-typing `switch`'s
+"3 neighbors" block, lines ~838-960): the real CSP (type 4) condition for a
+non-aromatic carbon is not "total bond order 4" or "2 double bonds to
+different neighbors" as originally guessed — it is simply
+**`atom->getTotalDegree() == 2`** (lines ~954-960, the branch reached once
+the earlier `getTotalDegree() == 4` and `getTotalDegree() == 3` blocks
+don't match), unconditional on which elements the two bonds go to. A real
+triple bond and a cumulated double-bond pair are not special-cased
+separately by RDKit at all — both simply leave the carbon with exactly 2
+total neighbors (a triple bond consumes 3 of carbon's 4 valence units,
+leaving one more substituent; two double bonds consume all 4, leaving
+none), so both fall into the same unconditional degree-2 branch.
+
+**Fix** (`assign_c_type`, `crates/chematic-ff/src/mmff94_numeric.rs`):
+replaced the `triple_bonds > 0 => Ok(4)` check with
+`total_degree(mol, idx) == 2 => Ok(4)`, moved ahead of the
+`double_bonds > 0` branch it was previously losing to for cumulated-double
+carbons. This is a strict superset of the old condition (every carbon with
+`triple_bonds > 0` already has `total_degree == 2`, by the valence argument
+above), so it cannot regress any previously-correct triple-bond CSP
+assignment — confirmed by the full-corpus join below, and by a dedicated
+`propyne` (`CC#C`) no-regression test. It is also, correctly, broader than
+the corpus: a plain carbon allene (`C=C=C`, not present in the 264-molecule
+corpus) was also mistyped (its central C got the same generic-vinylic type
+2 fallthrough) and is now fixed too — pinned with its own synthetic test
+since it is the clearest demonstration that the real rule is
+element-agnostic degree, not "cumulated bond to a heteroatom."
+
+**Measured** (same tool/oracle-dump pair as every other measurement in this
+file, full 264-molecule corpus, `crates/chematic-3d/examples/
+mmff94_numeric_type_dump.rs` + `mmff94_bci_charges_dump_227.rs`, before vs.
+after a genuine per-atom join, not aggregate arithmetic): type-mismatch
+ledger 34 → 32 atoms (both `_0071` idx 18 and `_0082` idx 20 move from
+mismatched to exact match, and no other atom anywhere in the corpus moves
+in either direction); molecule count for this ledger 8 → 6. Charge-mismatch
+ledger 62 → 56 atoms (6 atoms move: the isothiocyanate C itself in both
+molecules, plus its N and S neighbors in both — their own TYPES were
+already correct, but the BCI bond lookup keyed on the C's corrected type
+now also gets their charges right, exactly the cascade constraint 3 asked
+to be checked for); molecule count for this ledger 8 → 6 as well (`_0071`
+and `_0082` are now fully clean on both ledgers). Zero regressions on
+either ledger, verified by diffing the full before/after mismatch lists,
+not just comparing counts. `lookup_chg_contribution` already had entries
+for the (4, 9) and (4, 16) bond-type pairs the newly-corrected carbon type
+now looks up (both molecules' `status` stayed `"ok"` in the charges dump,
+before and after — no new `charges_error`).
+
+**6 new tests** (`crates/chematic-ff/src/mmff94_numeric.rs`): full-array
+regression pins for both corpus molecules
+(`chembl_tier_b_0071_aryl_isothiocyanate_matches_rdkit_oracle_after_csp_fix`,
+`_0082` sibling, expected values copied verbatim from the already-committed
+oracle dumps); two minimal synthetic isothiocyanate fixtures
+(`methyl_isothiocyanate_minimal_ncs_fixture_matches_rdkit_oracle`,
+`phenyl_isothiocyanate_aryl_ncs_fixture_matches_rdkit_oracle`, both from
+fresh live oracle queries, `MMFFGetMoleculeProperties` on the implicit-H
+`Chem.MolFromSmiles` result with no `AddHs`/embedding needed, same
+precedent as `scripts/mmff94_bci_charges_oracle_227.py`); a no-regression
+pin (`propyne_alkyne_carbons_still_type_csp_after_degree_based_fix`); and
+the broader-than-corpus allene pin
+(`allene_central_carbon_types_csp_not_generic_vinylic`).
+
+#### Sub-bug 1 (bis-pyridinium exocyclic amine): re-diagnosed, not fixed — genuine RDKit Kekulization/aromaticity-perception artifact, out of scope for an atom-typing helper fix
+
+**The original diagnosis misidentifies which atom is mistyped.** Live
+per-atom dump on `chembl_tier_b_0009` (`c1cc2cc(c1)-c1cccc(c1)C[n+]1ccc
+(c3ccccc31)NCCCCCCCCCCNc1cc[n+](c3ccccc13)C2`): the exocyclic secondary-
+amine nitrogen (atom idx 23, and its mirror idx 34) is typed **40** by both
+chematic and RDKit — it already matches, and always did. The atom that
+actually mismatches is the **ring** nitrogen itself (idx 13/38): chematic
+types it 58 (NPD+, aromatic pyridinium N+), RDKit types it 54 (N+=C,
+iminium) **because RDKit's own MMFF-specific machinery does not perceive
+this specific ring as aromatic at all** for this specific molecule — not
+because of a discoverable "exocyclic-amine-conjugation" typing rule that
+chematic's N-typing switch is missing a branch for.
+
+**Real mechanism, traced to the source, not inferred from behavior alone.**
+`MMFFMolProperties`'s constructor (`AtomTyper.cpp` lines ~2356-2372) always
+runs two steps before any atom typing: a generic `MolOps::Kekulize` (a
+global maximum-matching search over the *entire* molecule's bonds, choosing
+*some* valid alternating single/double-bond assignment — not necessarily
+the "obvious" one a chemist would draw) followed by
+`MolOps::setMMFFAromaticity` (`Code/GraphMol/Aromaticity.cpp` line 922 at
+the pinned commit), which then *re-derives* which rings still count as
+aromatic for MMFF purposes from that specific Kekule structure, ring by
+ring, via an iterative Hückel 4n+2 pi-electron count
+(`(pi_e > 2) && !((pi_e - 2) % 4)`, line ~1032). Critically, this
+re-derivation's pi-electron count for a ring atom whose ring-neighbor bond
+is not a literal `Bond::DOUBLE` (including a bond already resolved to
+`Bond::AROMATIC` by a *different*, already-successfully-resolved fused
+ring sharing that edge) only credits pi-electrons through a narrower
+exocyclic-neighbor path that itself requires literal `Bond::DOUBLE`, not
+`Bond::AROMATIC` — so which of two fused rings sharing an edge "wins"
+enough pi-electron credit to pass the 4n+2 check depends on the *specific*
+Kekule structure the earlier global-matching step happened to choose for
+that edge, which is a property of the *whole* molecular graph (RDKit's
+SSSR ring perception and its matching solver's internal tie-breaking), not
+of this local ring or substituent alone. Both call sites verified directly
+against a fresh fetch of the pinned commit's source, not assumed from the
+issue text.
+
+**Falsified by direct negative controls, not merely "unverified."** The
+issue's proposed rule — "an aromatic ring N+ para to an exocyclic amine
+gets downgraded to 54" — was tested directly and is affirmatively wrong,
+not just imprecise: a bare 4-amino-1-methylpyridinium (`C[n+]1ccc(N)cc1`)
+types the ring N 58 (aromatic, correct, matches this exact motif with no
+fused ring); an isoquinolinium with a 4-amino substituent, still fused to a
+benzo ring exactly like the corpus molecules (`C[n+]1ccc(c2ccccc21)N`),
+*also* types 58; even the full bis-isoquinolinium/decyl-diamine linker with
+both aromatic rings and both exocyclic amines present, left as an
+open-chain (non-macrocyclic) molecule, types both ring nitrogens 58. The
+mismatch **only** appears once the corpus molecule's specific macrocyclic
+ring closure (the biphenyl/diarylmethane unit bridging both isoquinolinium
+N+-substituents into one large ring) is present — reproduced with a
+minimal macrocyclic fixture (single benzo ring instead of biphenyl,
+`c1cc(cc(c1)C[n+]1ccc(c3ccccc31)NCCCCCCCCCCNC2)C2`) that still shows the
+same de-aromatization, while a same-sized macrocycle closed through a
+short aliphatic bridge instead of an aromatic unit does not. Any local,
+substituent-pattern-based heuristic implemented inside
+`assign_mmff94_numeric_types` would have to fire on all of these
+structures identically (they are locally indistinguishable from the actual
+mismatching one) — which means it would necessarily *create* 4+ new false
+mismatches for every 1 it claimed to fix, the opposite of this project's
+zero-regression bar.
+
+**Why this is out of scope for an atom-typing-helper fix, not merely hard.**
+Reproducing RDKit's actual decision exactly would require porting (a) its
+global bond-Kekulization maximum-matching algorithm, including its
+molecule-graph-dependent tie-breaking, and (b) `setMMFFAromaticity`'s own
+iterative, SSSR-ring-processing-order-dependent pi-electron accounting —
+both whole subsystems, not a discriminating condition reducible to a
+citable one-line rule the way sub-bug 2's fix was. Chematic's own
+aromaticity determination for MMFF typing (`ring_is_fully_aromatic`,
+`crates/chematic-ff/src/mmff94_numeric.rs`) instead trusts the molecule's
+already-perceived aromatic bond order directly, with no analogous
+Kekulize-then-re-derive step — a different, simpler architecture that is
+not "wrong" (the ring genuinely is a valid aromatic pyridinium by ordinary
+organic-chemistry reasoning; RDKit's own core `Chem.MolFromSmiles`
+sanitization agrees, `atom.GetIsAromatic()` is `True` right up until
+`MMFFGetMoleculeProperties` mutates it in place) so much as a different
+answer to a genuinely underdetermined question for this specific fused,
+macrocyclic, shared-edge topology. Per this task's own stop condition:
+implementing a heuristic here would be guessing, not citing — left as an
+honestly-disclosed residual instead. **`chembl_tier_b_0009`/`_0023`/`_0028`/
+`_0029`/`_0030`/`_0034` remain at 32/6,693 type-mismatched atoms / 56/6,693
+charge-mismatched atoms** (see the sub-bug-2 "Measured" paragraph above for
+how these totals were obtained) after this PR — unchanged by it, since no
+code touched by this PR affects these 6 molecules' outcome either way.
+Issue #337's text should be corrected to reflect the above (not done as
+part of this PR — GitHub issue edits need separate authorization per this
+project's standing policy).
 
 **Fix**: new `mmff_derived_formal_charge`/`o2cm_sm_formal_charge` helpers
 in `crates/chematic-ff/src/mmff94_numeric.rs` (full doc comment on the

--- a/scripts/mmff94_provenance/PROVENANCE.md
+++ b/scripts/mmff94_provenance/PROVENANCE.md
@@ -1050,30 +1050,56 @@ this specific ring as aromatic at all** for this specific molecule — not
 because of a discoverable "exocyclic-amine-conjugation" typing rule that
 chematic's N-typing switch is missing a branch for.
 
-**Real mechanism, traced to the source, not inferred from behavior alone.**
-`MMFFMolProperties`'s constructor (`AtomTyper.cpp` lines ~2356-2372) always
-runs two steps before any atom typing: a generic `MolOps::Kekulize` (a
-global maximum-matching search over the *entire* molecule's bonds, choosing
-*some* valid alternating single/double-bond assignment — not necessarily
-the "obvious" one a chemist would draw) followed by
-`MolOps::setMMFFAromaticity` (`Code/GraphMol/Aromaticity.cpp` line 922 at
-the pinned commit), which then *re-derives* which rings still count as
-aromatic for MMFF purposes from that specific Kekule structure, ring by
-ring, via an iterative Hückel 4n+2 pi-electron count
-(`(pi_e > 2) && !((pi_e - 2) % 4)`, line ~1032). Critically, this
-re-derivation's pi-electron count for a ring atom whose ring-neighbor bond
-is not a literal `Bond::DOUBLE` (including a bond already resolved to
-`Bond::AROMATIC` by a *different*, already-successfully-resolved fused
-ring sharing that edge) only credits pi-electrons through a narrower
-exocyclic-neighbor path that itself requires literal `Bond::DOUBLE`, not
-`Bond::AROMATIC` — so which of two fused rings sharing an edge "wins"
-enough pi-electron credit to pass the 4n+2 check depends on the *specific*
-Kekule structure the earlier global-matching step happened to choose for
-that edge, which is a property of the *whole* molecular graph (RDKit's
-SSSR ring perception and its matching solver's internal tie-breaking), not
-of this local ring or substituent alone. Both call sites verified directly
-against a fresh fetch of the pinned commit's source, not assumed from the
-issue text.
+**Real mechanism, traced to the source, not inferred from behavior alone —
+three facts, individually verified, stated separately from what they do
+and do not jointly establish.**
+
+1. `MMFFMolProperties`'s constructor (`AtomTyper.cpp` lines ~2356-2372)
+   always runs two steps before any atom typing: a generic
+   `MolOps::Kekulize` (a global maximum-matching search over the *entire*
+   molecule's bonds, choosing *some* valid alternating single/double-bond
+   assignment — not necessarily the "obvious" one a chemist would draw),
+   then `MolOps::setMMFFAromaticity` (`Code/GraphMol/Aromaticity.cpp` line
+   922 at the pinned commit). Directly measured: on the minimal macrocyclic
+   fixture below, `atom.GetIsAromatic()` for the pyridinium ring N is
+   `True` immediately after `Chem.MolFromSmiles`/before this constructor
+   runs, and `False` immediately after — this constructor is what flips it,
+   in place, mutating the caller's molecule.
+2. `setMMFFAromaticity` re-derives which rings still count as aromatic for
+   MMFF purposes from that one chosen Kekule structure, ring by ring, via
+   an iterative Hückel 4n+2 pi-electron count over RDKit's SSSR ring set
+   (`(pi_e > 2) && !((pi_e - 2) % 4)`, line ~1032), crediting pi-electrons
+   only through bonds of the exact literal type `Bond::DOUBLE` (both the
+   direct next-in-ring check, line ~956, and the exocyclic-neighbor credit
+   path, line ~995) — confirmed by reading the full function body, not
+   inferred from its name. Read in full specifically to check (and correct)
+   an earlier draft of this section's hypothesis that a fused ring's shared
+   edge gets re-typed to `Bond::AROMATIC` *mid*-computation, letting
+   whichever ring resolves second lose that edge's credit: that is **not**
+   what the code does — every bond stays at its `Kekulize`-assigned
+   single/double type for the *entire* fixed-point `while` loop, and bonds
+   are only rewritten to `Bond::AROMATIC` in one final pass *after* the
+   loop converges (lines ~1062-1074). The precise reason this specific
+   ring's pi-electron count fails the 4n+2 test was not isolated (doing so
+   would mean re-deriving, atom by atom, the exact single/double assignment
+   `MolOps::Kekulize`'s global matching produced for this graph, which is
+   itself the underlying whole-molecule-dependent quantity in fact (3)
+   below) — stated honestly as not run to ground, rather than replaced with
+   a second guess.
+3. Which rings pass therefore depends on (a) the *specific* Kekule
+   structure `MolOps::Kekulize`'s global matching search happened to choose
+   for this molecule's bonds, and (b) the SSSR ring set/iteration order
+   `setMMFFAromaticity` processes — both whole-molecule properties, not
+   something a local pattern match on this ring or its substituent alone
+   can predict. Empirical support, independent of the exact internal
+   arithmetic: five fragments sharing the *identical* local ring +
+   exocyclic-amine motif split 4-aromatic / 1-not-aromatic, with the one
+   difference between them being whether the isoquinolinium N+-substituent
+   carbon is itself embedded in an aromatic-bridge-closed macrocycle — see
+   the negative controls immediately below.
+
+All three call sites and line ranges verified directly against a fresh
+fetch of the pinned commit's source, not assumed from the issue text.
 
 **Falsified by direct negative controls, not merely "unverified."** The
 issue's proposed rule — "an aromatic ring N+ para to an exocyclic amine

--- a/scripts/mmff94_provenance/PROVENANCE.md
+++ b/scripts/mmff94_provenance/PROVENANCE.md
@@ -1079,13 +1079,16 @@ and do not jointly establish.**
    what the code does — every bond stays at its `Kekulize`-assigned
    single/double type for the *entire* fixed-point `while` loop, and bonds
    are only rewritten to `Bond::AROMATIC` in one final pass *after* the
-   loop converges (lines ~1062-1074). The precise reason this specific
-   ring's pi-electron count fails the 4n+2 test was not isolated (doing so
-   would mean re-deriving, atom by atom, the exact single/double assignment
-   `MolOps::Kekulize`'s global matching produced for this graph, which is
-   itself the underlying whole-molecule-dependent quantity in fact (3)
-   below) — stated honestly as not run to ground, rather than replaced with
-   a second guess.
+   loop converges (lines ~1062-1074). Direct instrumentation on the minimal
+   macrocyclic fixture recovered 5 of ring 1's 6 Kekule-assigned bond
+   orders post hoc (7-8=double, 8-9=single, 9-10=double, 10-11=single,
+   16-7=single) — only the shared ring-fusion edge (11-16) is unrecoverable
+   from a post-hoc dump, since the final pass above overwrites it to
+   `Bond::AROMATIC` once the *other*, fused ring is confirmed aromatic.
+   That one bond's Kekulize-time type is exactly what decides whether
+   ring 1's pi-electron count reaches 6 (passing 4n+2) or stops at 4
+   (failing it), and it was not isolated — stated honestly as not run to
+   ground, rather than replaced with a second guess.
 3. Which rings pass therefore depends on (a) the *specific* Kekule
    structure `MolOps::Kekulize`'s global matching search happened to choose
    for this molecule's bonds, and (b) the SSSR ring set/iteration order


### PR DESCRIPTION
## Summary

Issue #337 tracked a residual: chematic's MMFF94 atom typing mismatches a live RDKit oracle for 62/6,693 atoms across 8/264 corpus molecules, attributed to two sub-bugs. This PR fixes one of them (aryl isothiocyanate CSP carbon) and, on independent re-investigation, finds the other (bis-pyridinium exocyclic amine) is a genuine RDKit Kekulization/MMFF-aromaticity-perception artifact — not a locally-statable atom-typing rule — and leaves it as an honestly-disclosed residual rather than shipping a heuristic.

**Ledger correction found along the way**: the "62" figure in issue #337 is a *charge*-mismatch count, not a type-mismatch count. The actual type-mismatch count for the same 8 molecules is 34/6,693. Both ledgers are reported separately below, per this project's standing "don't conflate ledgers, report denominators separately" policy.

## Sub-bug 2: aryl isothiocyanate CSP carbon — fixed

`assign_c_type`'s sp-carbon check only fired on `triple_bonds > 0`, so a carbon reached via two double bonds (a cumulated diene — e.g. an aryl isothiocyanate's `N=C=S` central carbon) fell into the `double_bonds > 0` branch and got the generic carbonyl-family type 3 instead of RDKit's real CSP type 4.

RDKit's actual rule (`AtomTyper.cpp`, pinned commit `e74e7b0a5a2fc4e7f77c04ec26a61d4b8edbf22f`, lines ~954-960) is simply `getTotalDegree() == 2` for a non-aromatic carbon, unconditional on which elements the two bonds go to — RDKit doesn't special-case triple bonds vs. cumulated double bonds at all; both just leave the carbon with exactly 2 neighbors.

**Fix**: `total_degree(mol, idx) == 2 => Ok(4)`, replacing `triple_bonds > 0 => Ok(4)`, moved ahead of the `double_bonds > 0` branch. Strict superset of the old condition (a real triple bond always yields degree 2), so it cannot regress any previously-correct triple-bond assignment — and it's correctly *broader* than the corpus: a plain carbon allene (`C=C=C`, not in the 264-molecule corpus) was mistyped the same way and is fixed too.

## Sub-bug 1: bis-pyridinium exocyclic amine — re-diagnosed, not fixed

Issue #337's own description of which atom mismatches turned out to be wrong: the exocyclic amine N (idx 23/34 in `chembl_tier_b_0009`) already matches RDKit (type 40, both engines). The atom that actually mismatches is the **ring** nitrogen itself (idx 13/38): chematic types it 58 (aromatic pyridinium N+), RDKit types it 54 (non-aromatic iminium) — because RDKit's MMFF-specific machinery (`MMFFMolProperties`'s constructor: a generic `MolOps::Kekulize` global matching pass, then `MolOps::setMMFFAromaticity`'s iterative per-SSSR-ring 4n+2 re-derivation, `AtomTyper.cpp`/`Aromaticity.cpp`) does not perceive this specific ring as aromatic for this specific molecule.

Five isolated fragments sharing the exact same local ring + exocyclic-amine motif were tested live against RDKit: four type the ring N 58 (aromatic, matching ordinary chemistry), and only the one with the corpus's specific macrocyclic ring closure (an aromatic bridge threading back through the isoquinolinium's own N+-substituent carbon) types it 54. Any local heuristic implemented in `assign_mmff94_numeric_types` would fire identically on all five and *create* 4 new false mismatches for every 1 it fixed. Reproducing RDKit's actual decision would require porting its global Kekulization matching algorithm and `setMMFFAromaticity`'s whole-molecule-dependent pi-electron accounting — out of scope for an atom-typing-helper fix. Left as an honestly-disclosed residual; full citations and negative-control evidence in `scripts/mmff94_provenance/PROVENANCE.md`'s issue #337 follow-up addendum.

**Issue #337's text should be corrected** to reflect the above (not done as part of this PR — GitHub issue edits need separate authorization per this project's standing policy).

## Measured (full 264-molecule corpus, genuine per-atom join, not aggregate counts)

- **Type-mismatch ledger**: 34 → 32 atoms, 8 → 6 molecules. Only `chembl_tier_b_0071` idx 18 and `chembl_tier_b_0082` idx 20 move (mismatch → match). Zero regressions (diffed full before/after lists, not just counts).
- **Charge-mismatch ledger**: 62 → 56 atoms, 8 → 6 molecules. 6 atoms move: the corrected carbon in both molecules, plus its N and S neighbors in both (their own types were already correct, but the BCI bond lookup keyed on the carbon's type now also gets their charges right). Zero regressions.
- `lookup_chg_contribution` already covers the (4, 9) and (4, 16) bond-type pairs the corrected carbon type now looks up — both molecules' charge-dump `status` stayed `"ok"` before and after, no new errors introduced.
- The 6 unaffected molecules (bis-pyridinium scaffold) remain at exactly the same 32 type-mismatched / 56 charge-mismatched atoms — unchanged by this PR either way.

## Tests

6 new tests in `crates/chematic-ff/src/mmff94_numeric.rs`: 2 corpus regression pins (`chembl_tier_b_0071`/`_0082`, full atom-type + charge arrays), 2 minimal synthetic isothiocyanate fixtures (methyl and phenyl), 1 no-regression plain-alkyne pin (`propyne`), 1 broader-than-corpus allene pin (`C=C=C`).

## Verification

- `cargo test --workspace --all-features`: all green (80/80 `test result: ok` blocks, 0 failed)
- `cargo test --workspace --no-default-features`: all green (79/79 `test result: ok` blocks, 0 failed)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- Disk space checked before/after every build (stayed well above the 2GB stop threshold throughout, ~7.5GB free at the end)

**Deliberately not run**: `pipeline_v2`/RDKit-differential/RMSD/TFD/large-corpus 3D benchmarks. This PR's actual measured blast radius (2 atoms newly type-correct, 6 atoms newly charge-correct, across exactly 2 molecules) is far inside the "small, precisely bounded" threshold this project's standing "minimize heavy measurements" policy requires before skipping a 3D re-measurement — matching the precedent set by the derived-formal-charge fix (PR #336) this issue followed on from.

## Scope

Only `assign_c_type` in `crates/chematic-ff/src/mmff94_numeric.rs` changed (production code) — no `mmff94_charges_numeric`/BCI-table changes, no version/release files touched, no `unsafe`, no new dependencies. Draft PR against `main`, not merged/tagged/published.

Full writeup: `scripts/mmff94_provenance/PROVENANCE.md`'s "Issue #337 follow-up" addendum. `CHANGELOG.md`'s new `[Unreleased]` section.