### PR TITLE
feat(chematic-py): Python bindings for mmCIF/PQR/ORCA/QCSchema/Cube/OpenDX/LAMMPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added — chematic-py (Python bindings for the 7 v0.17.0 file formats)
+
+- Python (PyO3) bindings for the 7 file-format modules `chematic-mol`
+  gained in v0.17.0, which had zero Python exposure until now: mmCIF, PQR,
+  ORCA input/output, QCSchema (`Molecule`/`AtomicInput`/`AtomicResult`),
+  Gaussian Cube, OpenDX, and LAMMPS data/dump.
+- `chematic.parse_mmcif`/`write_mmcif`, `chematic.parse_pqr`/`write_pqr`/
+  `infer_element`, `chematic.parse_orca_input`/`write_orca_input`/
+  `parse_orca_output` (`formats.rs`) — plain functions returning/consuming
+  dicts, matching the existing `parse_cif` convention; every typed Rust
+  parse error maps to `ValueError`; `*ParseLimits` are exposed as optional
+  keyword arguments with the Rust `Default` values.
+- `chematic.parse_qcschema_molecule`/`write_qcschema_molecule`,
+  `chematic.chematic_to_qc_molecule`/`qc_molecule_to_chematic`,
+  `chematic.parse_atomic_input`/`write_atomic_input`,
+  `chematic.parse_atomic_result`/`write_atomic_result` (`formats.rs`) —
+  routed through Python's own `json` module as the dict<->text boundary
+  rather than a hand-written field-by-field struct mapper, so QCSchema's
+  open extensibility bags (`extras`/`unknown_fields`/`keywords`/
+  `protocols`/`native_files`/`wavefunction`) round-trip losslessly with no
+  new dependency (`serde_json` is not linked into `chematic-py`).
+- `chematic.VolumetricGrid` (new `volumetric.rs`), a pyclass shared by Cube
+  and OpenDX (both read/write the same underlying Rust type): `from_cube`/
+  `from_opendx` constructors, `to_cube`/`to_opendx`/`to_opendx_lossy`
+  writers (the fail-closed `to_opendx` vs. explicit-opt-in
+  `to_opendx_lossy` split from PR #335 is preserved faithfully — no boolean
+  flag defaulting to lossy), `get`/`checked_index`/`point_count`/
+  `to_molecule` methods, and numpy-array `values`/`axes` properties.
+- `chematic.parse_lammps_data`/`write_lammps_data` (plain dict, new
+  `lammps.rs`) and `chematic.LammpsDumpFrame` (pyclass, real `column`/
+  `cartesian_positions` behavior) plus `parse_lammps_dump_frame`/
+  `parse_lammps_dump_all`/`write_lammps_dump_frame`/
+  `write_lammps_trajectory`/`box_bounds_to_true`/`true_to_box_bounds`.
+  `parse_lammps_dump_all` materializes the whole trajectory as a list
+  rather than exposing `LammpsDumpReader`'s true streaming iteration to
+  Python — a disclosed scope decision (see the function's docstring), not
+  a silently dropped capability.
+- pytest coverage for all 7 formats in `crates/chematic-py/tests/` (at
+  least one round-trip test and one typed-error-to-`ValueError` test per
+  format).
+
 ## [0.17.0] — 2026-08-18
 
 Format/Python/materials-interop breadth, plus two MMFF94 charge/bond-order

--- a/crates/chematic-py/python/chematic/__init__.pyi
+++ b/crates/chematic-py/python/chematic/__init__.pyi
@@ -2331,6 +2331,205 @@ def to_extxyz(
     """
     ...
 
+def parse_mmcif(
+    text: str,
+    max_input_bytes: Optional[int] = None,
+    max_atoms: Optional[int] = None,
+    max_line_len: Optional[int] = None,
+) -> dict:
+    """Parse an mmCIF (macromolecular CIF, ``_atom_site.*`` loop) string.
+
+    Returns:
+        dict: ``{"mol": Mol, "coords": list[list[float]], "atoms":
+        list[dict], "cell": dict | None, "space_group": str | None,
+        "unhandled_columns": list[str]}``.
+
+    Raises:
+        ValueError: on parse failure.
+    """
+    ...
+
+def write_mmcif(
+    atoms: list[dict],
+    cell: Optional[dict] = None,
+    space_group: Optional[str] = None,
+    data_block_name: str = "chematic",
+) -> str:
+    """Write an mmCIF file from atom records (same dict shape as
+    :func:`parse_mmcif`'s ``"atoms"``).
+    """
+    ...
+
+def parse_pqr(
+    text: str,
+    max_input_bytes: Optional[int] = None,
+    max_atoms: Optional[int] = None,
+    max_line_len: Optional[int] = None,
+) -> dict:
+    """Parse a PQR (PDB-like ATOM/HETATM + per-atom charge/radius) string.
+
+    Returns:
+        dict: ``{"mol": Mol, "coords": list[list[float]], "atoms": list[dict]}``.
+
+    Raises:
+        ValueError: on parse failure.
+    """
+    ...
+
+def write_pqr(atoms: list[dict]) -> str:
+    """Write a PQR file from atom records (same dict shape as
+    :func:`parse_pqr`'s ``"atoms"``); ``element`` is inferred via
+    :func:`infer_element` when omitted.
+    """
+    ...
+
+def infer_element(group_pdb: str, res_name: str, atom_name: str) -> Optional[str]:
+    """Infer an element symbol from a PQR/PDB atom name."""
+    ...
+
+def parse_orca_input(text: str) -> dict:
+    """Parse an ORCA input file (``.inp``).
+
+    Returns:
+        dict: ``{"comments": list[str], "keywords": list[str], "blocks":
+        list[dict], "coords": dict | None}``.
+
+    Raises:
+        ValueError: on parse failure.
+    """
+    ...
+
+def write_orca_input(input: dict) -> str:
+    """Write an ORCA input file from a dict, same shape as
+    :func:`parse_orca_input`'s return value.
+    """
+    ...
+
+def parse_orca_output(text: str) -> dict:
+    """Parse an ORCA output file (``.out``/``.log``).
+
+    Returns:
+        dict: ``{"charge": int | None, "multiplicity": int | None,
+        "final_energy_hartree": float | None, "trajectory": list[dict],
+        "frequencies_cm1": list[float], "termination": dict,
+        "optimization_convergence": str}``.
+
+    Raises:
+        ValueError: on a non-finite value or oversized input.
+    """
+    ...
+
+def parse_qcschema_molecule(text: str) -> dict:
+    """Parse a QCSchema ``Molecule`` JSON document.
+
+    Returns every QCSchema ``Molecule`` field plus ``"mol"``/``"coords"``
+    convenience keys; :func:`write_qcschema_molecule` strips both before
+    re-serializing, so this dict round-trips through it directly.
+
+    Raises:
+        ValueError: on malformed JSON or a schema violation.
+    """
+    ...
+
+def write_qcschema_molecule(molecule: dict) -> str:
+    """Serialize a QCSchema ``Molecule`` dict to canonical JSON text."""
+    ...
+
+def chematic_to_qc_molecule(
+    mol: Mol,
+    coords: list[list[float]],
+    molecular_charge: float = 0.0,
+    molecular_multiplicity: int = 1,
+) -> dict:
+    """Convert a chematic ``Mol`` + coordinates into a QCSchema ``Molecule`` dict."""
+    ...
+
+def qc_molecule_to_chematic(molecule: dict) -> tuple[Mol, list[list[float]], float, int]:
+    """Convert a QCSchema ``Molecule`` dict into ``(Mol, coords,
+    molecular_charge, molecular_multiplicity)``.
+    """
+    ...
+
+def parse_atomic_input(text: str) -> dict:
+    """Parse a QCSchema ``AtomicInput`` JSON document.
+
+    Returns every ``AtomicInput`` field plus ``"mol"``/``"coords"``
+    convenience keys built from ``"molecule"``.
+
+    Raises:
+        ValueError: on malformed JSON or a schema violation.
+    """
+    ...
+
+def write_atomic_input(input: dict) -> str:
+    """Serialize an ``AtomicInput`` dict to canonical QCSchema JSON text."""
+    ...
+
+def parse_atomic_result(text: str) -> dict:
+    """Parse a QCSchema ``AtomicResult`` JSON document.
+
+    Raises:
+        ValueError: on malformed JSON or a schema violation.
+    """
+    ...
+
+def write_atomic_result(result: dict) -> str:
+    """Serialize an ``AtomicResult`` dict to canonical QCSchema JSON text."""
+    ...
+
+def parse_lammps_data(text: str, atom_style: str) -> dict:
+    """Parse a LAMMPS data file (``read_data`` command format).
+
+    ``atom_style`` is one of ``"atomic"``/``"charge"``/``"molecular"``/``"full"``.
+
+    Returns:
+        dict: ``{"counts": dict[str, int], "atom_style": str, "box": dict,
+        "masses": list[dict], "atoms": list[dict], "velocities": list[dict],
+        "bonds": list[dict], "unparsed_sections": list[tuple[str, str]]}``.
+
+    Raises:
+        ValueError: on parse failure.
+    """
+    ...
+
+def write_lammps_data(data: dict) -> str:
+    """Write a LAMMPS data file from a dict, same shape as
+    :func:`parse_lammps_data`'s return value.
+    """
+    ...
+
+def box_bounds_to_true(
+    bound_lo: tuple[float, float, float],
+    bound_hi: tuple[float, float, float],
+    tilt: Optional[tuple[float, float, float]] = None,
+) -> dict:
+    """Convert a dump file's ``ITEM: BOX BOUNDS`` values into the true box."""
+    ...
+
+def true_to_box_bounds(
+    box_dict: dict,
+) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
+    """Inverse of :func:`box_bounds_to_true`."""
+    ...
+
+def parse_lammps_dump_frame(text: str) -> LammpsDumpFrame:
+    """Parse a single LAMMPS dump frame.
+
+    Raises:
+        ValueError: on parse failure.
+    """
+    ...
+
+def parse_lammps_dump_all(text: str) -> list[LammpsDumpFrame]:
+    """Parse every frame of a LAMMPS dump/trajectory file.
+
+    Raises:
+        ValueError: on the first parse failure.
+    """
+    ...
+
+def write_lammps_dump_frame(frame: LammpsDumpFrame) -> str: ...
+def write_lammps_trajectory(frames: list[LammpsDumpFrame]) -> str: ...
 def tanimoto_map4(a: list[int], b: list[int]) -> float:
     """Estimate MAP4 Tanimoto similarity between two MAP4 fingerprints.
 
@@ -3194,6 +3393,95 @@ class PeriodicStructure:
     def formula(self) -> str: ...
     def to_cif(self) -> str: ...
     def to_poscar(self) -> str: ...
+    def __repr__(self) -> str: ...
+
+# ---------------------------------------------------------------------------
+# VolumetricGrid (Gaussian Cube / OpenDX)
+# ---------------------------------------------------------------------------
+
+class VolumetricGrid:
+    """A scalar field on a regular 3D grid, shared by Gaussian Cube and OpenDX.
+
+    ``values`` is a flat numpy array in row-major, third-axis-fastest order:
+    ``index = (i * shape[1] + j) * shape[2] + k``.
+    """
+
+    def __new__(
+        cls,
+        origin: tuple[float, float, float],
+        axes: list[list[float]],
+        shape: tuple[int, int, int],
+        values: list[float],
+        atoms: list[tuple[str, float, tuple[float, float, float]]] = [],
+        units: str = "angstrom",
+    ) -> VolumetricGrid: ...
+    @staticmethod
+    def from_cube(
+        text: str,
+        max_input_bytes: Optional[int] = None,
+        max_atoms: Optional[int] = None,
+        max_grid_points: Optional[int] = None,
+    ) -> VolumetricGrid: ...
+    @staticmethod
+    def from_opendx(
+        text: str,
+        max_input_bytes: Optional[int] = None,
+        max_grid_points: Optional[int] = None,
+    ) -> VolumetricGrid: ...
+    def to_cube(self) -> str: ...
+    def to_opendx(self) -> str:
+        """Raises ``ValueError`` for a Bohr-units grid or a grid with atoms."""
+        ...
+    def to_opendx_lossy(self) -> str: ...
+    @property
+    def origin(self) -> tuple[float, float, float]: ...
+    @property
+    def axes(self) -> ndarray: ...
+    @property
+    def shape(self) -> tuple[int, int, int]: ...
+    @property
+    def values(self) -> ndarray: ...
+    @property
+    def units(self) -> str: ...
+    @property
+    def atoms(self) -> list[tuple[str, float, tuple[float, float, float]]]: ...
+    def point_count(self) -> int: ...
+    def checked_index(self, i: int, j: int, k: int) -> Optional[int]: ...
+    def get(self, i: int, j: int, k: int) -> Optional[float]: ...
+    def to_molecule(self) -> tuple[Mol, list[list[float]]]: ...
+    def __repr__(self) -> str: ...
+
+# ---------------------------------------------------------------------------
+# LammpsDumpFrame
+# ---------------------------------------------------------------------------
+
+class LammpsDumpFrame:
+    """One frame of a LAMMPS dump/trajectory file."""
+
+    def __new__(
+        cls,
+        timestep: int,
+        box_bounds: dict,
+        column_names: list[str],
+        rows: list[list[float]],
+        boundary_flags: tuple[str, str, str] = ("pp", "pp", "pp"),
+        num_atoms: Optional[int] = None,
+    ) -> LammpsDumpFrame: ...
+    @property
+    def timestep(self) -> int: ...
+    @property
+    def num_atoms(self) -> int: ...
+    @property
+    def box_bounds(self) -> dict: ...
+    @property
+    def boundary_flags(self) -> tuple[str, str, str]: ...
+    @property
+    def column_names(self) -> list[str]: ...
+    @property
+    def rows(self) -> ndarray: ...
+    def column_index(self, name: str) -> Optional[int]: ...
+    def column(self, name: str) -> Optional[list[float]]: ...
+    def cartesian_positions(self) -> Optional[ndarray]: ...
     def __repr__(self) -> str: ...
 
 # ---------------------------------------------------------------------------

--- a/crates/chematic-py/src/formats.rs
+++ b/crates/chematic-py/src/formats.rs
@@ -1134,6 +1134,1044 @@ fn write_smi_file(records: Vec<(Mol, String)>) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// Small dict-extraction helpers shared by mmCIF/PQR/ORCA below.
+//
+// QCSchema (further down) deliberately does *not* use these -- it routes
+// through Python's own `json` module instead (see that section's docs).
+// ---------------------------------------------------------------------------
+
+pub(crate) fn dict_get<'py, T>(d: &Bound<'py, PyDict>, key: &str, default: T) -> PyResult<T>
+where
+    T: for<'a> FromPyObject<'a, 'py>,
+{
+    match d.get_item(key)? {
+        Some(v) if !v.is_none() => v.extract::<T>().map_err(Into::into),
+        _ => Ok(default),
+    }
+}
+
+pub(crate) fn dict_get_opt<'py, T>(d: &Bound<'py, PyDict>, key: &str) -> PyResult<Option<T>>
+where
+    T: for<'a> FromPyObject<'a, 'py>,
+{
+    match d.get_item(key)? {
+        Some(v) if !v.is_none() => Ok(Some(v.extract::<T>().map_err(Into::into)?)),
+        _ => Ok(None),
+    }
+}
+
+pub(crate) fn dict_get_required<'py, T>(d: &Bound<'py, PyDict>, key: &str) -> PyResult<T>
+where
+    T: for<'a> FromPyObject<'a, 'py>,
+{
+    match d.get_item(key)? {
+        Some(v) if !v.is_none() => v.extract::<T>().map_err(Into::into),
+        _ => Err(PyValueError::new_err(format!(
+            "missing required key '{key}'"
+        ))),
+    }
+}
+
+/// A `str`-typed dict value that must be exactly one character (Python has
+/// no separate `char` type). Rejects a multi-character string rather than
+/// silently truncating it to its first character.
+pub(crate) fn dict_get_opt_char(d: &Bound<PyDict>, key: &str) -> PyResult<Option<char>> {
+    match dict_get_opt::<String>(d, key)? {
+        None => Ok(None),
+        Some(s) => {
+            let mut chars = s.chars();
+            let c = chars.next().ok_or_else(|| {
+                PyValueError::new_err(format!(
+                    "'{key}' must be a single character, got an empty string"
+                ))
+            })?;
+            if chars.next().is_some() {
+                return Err(PyValueError::new_err(format!(
+                    "'{key}' must be a single character, got {s:?}"
+                )));
+            }
+            Ok(Some(c))
+        }
+    }
+}
+
+fn element_from_symbol(sym: &str) -> PyResult<chematic_core::Element> {
+    chematic_core::Element::from_symbol(sym)
+        .ok_or_else(|| PyValueError::new_err(format!("unknown element symbol: {sym:?}")))
+}
+
+// ---------------------------------------------------------------------------
+// mmCIF
+// ---------------------------------------------------------------------------
+
+fn mmcif_atom_to_pydict<'py>(
+    py: Python<'py>,
+    a: &chematic_mol::MmcifAtomRecord,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("group_pdb", &a.group_pdb)?;
+    d.set_item("serial", a.serial)?;
+    d.set_item("element", a.element.symbol())?;
+    d.set_item("atom_name", &a.atom_name)?;
+    d.set_item("alt_loc", a.alt_loc.map(|c| c.to_string()))?;
+    d.set_item("res_name", &a.res_name)?;
+    d.set_item("chain_id", &a.chain_id)?;
+    d.set_item("res_seq", a.res_seq)?;
+    d.set_item("label_seq_id", a.label_seq_id)?;
+    d.set_item("icode", a.icode.map(|c| c.to_string()))?;
+    d.set_item("x", a.x)?;
+    d.set_item("y", a.y)?;
+    d.set_item("z", a.z)?;
+    d.set_item("occupancy", a.occupancy)?;
+    d.set_item("b_iso", a.b_iso)?;
+    d.set_item("formal_charge", a.formal_charge)?;
+    d.set_item("entity_id", &a.entity_id)?;
+    d.set_item("model_num", a.model_num)?;
+    Ok(d)
+}
+
+fn pydict_to_mmcif_atom(d: &Bound<PyDict>) -> PyResult<chematic_mol::MmcifAtomRecord> {
+    let element: String = dict_get_required(d, "element")?;
+    Ok(chematic_mol::MmcifAtomRecord {
+        group_pdb: dict_get(d, "group_pdb", "ATOM".to_string())?,
+        serial: dict_get(d, "serial", 1i64)?,
+        element: element_from_symbol(&element)?,
+        atom_name: dict_get(d, "atom_name", String::new())?,
+        alt_loc: dict_get_opt_char(d, "alt_loc")?,
+        res_name: dict_get(d, "res_name", "UNL".to_string())?,
+        chain_id: dict_get(d, "chain_id", "A".to_string())?,
+        res_seq: dict_get(d, "res_seq", 1i64)?,
+        label_seq_id: dict_get_opt(d, "label_seq_id")?,
+        icode: dict_get_opt_char(d, "icode")?,
+        x: dict_get_required(d, "x")?,
+        y: dict_get_required(d, "y")?,
+        z: dict_get_required(d, "z")?,
+        occupancy: dict_get(d, "occupancy", 1.0)?,
+        b_iso: dict_get(d, "b_iso", 0.0)?,
+        formal_charge: dict_get_opt(d, "formal_charge")?,
+        entity_id: dict_get_opt(d, "entity_id")?,
+        model_num: dict_get(d, "model_num", 1i32)?,
+    })
+}
+
+fn unit_cell_to_pydict<'py>(
+    py: Python<'py>,
+    cell: &chematic_mol::UnitCell,
+) -> PyResult<Bound<'py, PyDict>> {
+    let cd = PyDict::new(py);
+    cd.set_item("a", cell.a)?;
+    cd.set_item("b", cell.b)?;
+    cd.set_item("c", cell.c)?;
+    cd.set_item("alpha", cell.alpha)?;
+    cd.set_item("beta", cell.beta)?;
+    cd.set_item("gamma", cell.gamma)?;
+    Ok(cd)
+}
+
+fn pydict_to_unit_cell(d: &Bound<PyDict>) -> PyResult<chematic_mol::UnitCell> {
+    Ok(chematic_mol::UnitCell {
+        a: dict_get_required(d, "a")?,
+        b: dict_get_required(d, "b")?,
+        c: dict_get_required(d, "c")?,
+        alpha: dict_get_required(d, "alpha")?,
+        beta: dict_get_required(d, "beta")?,
+        gamma: dict_get_required(d, "gamma")?,
+    })
+}
+
+/// Parse an mmCIF (macromolecular CIF, `_atom_site.*` loop) string.
+///
+/// Unlike :func:`parse_cif` (small-molecule CIF), this reads the
+/// `_atom_site` loop's full per-atom detail (residue/chain/occupancy/
+/// B-factor/model number) rather than just element+position.
+///
+/// Args:
+///     text: mmCIF file contents.
+///     max_input_bytes: byte-size limit (default 128 MiB).
+///     max_atoms: `_atom_site` row-count limit, across all models (default
+///         2,000,000).
+///     max_line_len: per-line byte limit (default 8192).
+///
+/// Returns:
+///     dict: ``{"mol": Mol, "coords": list[list[float]], "atoms":
+///     list[dict], "cell": dict | None, "space_group": str | None,
+///     "unhandled_columns": list[str]}``. ``mol``/``coords`` include every
+///     model's atoms (no bonds -- mmCIF carries no bond table); filter
+///     ``atoms`` by its ``"model_num"`` key first if only one model is
+///     wanted. Each atom dict has keys ``group_pdb``, ``serial``,
+///     ``element``, ``atom_name``, ``alt_loc``, ``res_name``, ``chain_id``,
+///     ``res_seq``, ``label_seq_id``, ``icode``, ``x``, ``y``, ``z``,
+///     ``occupancy``, ``b_iso``, ``formal_charge``, ``entity_id``,
+///     ``model_num``.
+///
+/// Raises:
+///     ValueError: on parse failure (no ``_atom_site`` loop, missing
+///     required column, unresolvable element, non-finite number, or a
+///     limit exceeded).
+///
+/// Example::
+///
+///     result = chematic.parse_mmcif(open("structure.cif").read())
+///     print(result["mol"].formula, len(result["atoms"]))
+#[pyfunction]
+#[pyo3(signature = (text, max_input_bytes=None, max_atoms=None, max_line_len=None))]
+fn parse_mmcif<'py>(
+    py: Python<'py>,
+    text: &str,
+    max_input_bytes: Option<usize>,
+    max_atoms: Option<usize>,
+    max_line_len: Option<usize>,
+) -> PyResult<Bound<'py, PyDict>> {
+    let mut limits = chematic_mol::MmcifParseLimits::default();
+    if let Some(v) = max_input_bytes {
+        limits.max_input_bytes = v;
+    }
+    if let Some(v) = max_atoms {
+        limits.max_atoms = v;
+    }
+    if let Some(v) = max_line_len {
+        limits.max_line_len = v;
+    }
+    let result = chematic_mol::parse_mmcif_with_limits(text, &limits)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let (mol, coords) = result.to_molecule();
+
+    let d = PyDict::new(py);
+    d.set_item(
+        "mol",
+        Mol {
+            inner: Arc::new(mol),
+            props: Default::default(),
+        },
+    )?;
+    let py_coords: Vec<Vec<f64>> = coords.iter().map(|&(x, y, z)| vec![x, y, z]).collect();
+    d.set_item("coords", py_coords)?;
+    let atoms: Vec<Bound<PyDict>> = result
+        .atoms
+        .iter()
+        .map(|a| mmcif_atom_to_pydict(py, a))
+        .collect::<PyResult<_>>()?;
+    d.set_item("atoms", atoms)?;
+    match &result.cell {
+        Some(cell) => d.set_item("cell", unit_cell_to_pydict(py, cell)?)?,
+        None => d.set_item("cell", py.None())?,
+    }
+    d.set_item("space_group", &result.space_group)?;
+    d.set_item("unhandled_columns", &result.unhandled_columns)?;
+    Ok(d)
+}
+
+/// Write an mmCIF file from atom records.
+///
+/// Args:
+///     atoms: list of dicts, same shape as :func:`parse_mmcif`'s
+///         ``"atoms"`` entries. Every key is optional except ``element``,
+///         ``x``, ``y``, ``z`` -- see :func:`parse_mmcif` for the full key
+///         list and their defaults (``group_pdb`` defaults to ``"ATOM"``,
+///         ``chain_id`` to ``"A"``, ``occupancy`` to ``1.0``, etc.).
+///     cell: optional ``{"a", "b", "c", "alpha", "beta", "gamma"}`` dict,
+///         same shape as :func:`parse_cif`'s ``"cell"``.
+///     space_group: optional space-group name (``_symmetry.space_group_name_H-M``).
+///     data_block_name: the CIF ``data_<name>`` block name (default
+///         ``"chematic"``).
+///
+/// Raises:
+///     ValueError: on an unknown element symbol or a malformed
+///         ``alt_loc``/``icode`` (must be a single character).
+#[pyfunction]
+#[pyo3(signature = (atoms, cell=None, space_group=None, data_block_name="chematic"))]
+fn write_mmcif(
+    atoms: Vec<Bound<PyDict>>,
+    cell: Option<Bound<PyDict>>,
+    space_group: Option<&str>,
+    data_block_name: &str,
+) -> PyResult<String> {
+    let records: Vec<chematic_mol::MmcifAtomRecord> = atoms
+        .iter()
+        .map(pydict_to_mmcif_atom)
+        .collect::<PyResult<_>>()?;
+    let cell = cell.as_ref().map(pydict_to_unit_cell).transpose()?;
+    Ok(chematic_mol::write_mmcif(
+        &records,
+        cell.as_ref(),
+        space_group,
+        data_block_name,
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// PQR
+// ---------------------------------------------------------------------------
+
+fn pqr_atom_to_pydict<'py>(
+    py: Python<'py>,
+    a: &chematic_mol::PqrAtomRecord,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("group_pdb", &a.group_pdb)?;
+    d.set_item("serial", a.serial)?;
+    d.set_item("atom_name", &a.atom_name)?;
+    d.set_item("res_name", &a.res_name)?;
+    d.set_item("chain_id", &a.chain_id)?;
+    d.set_item("res_seq", a.res_seq)?;
+    d.set_item("icode", a.icode.map(|c| c.to_string()))?;
+    d.set_item("x", a.x)?;
+    d.set_item("y", a.y)?;
+    d.set_item("z", a.z)?;
+    d.set_item("charge", a.charge)?;
+    d.set_item("radius", a.radius)?;
+    d.set_item("element", a.element.symbol())?;
+    Ok(d)
+}
+
+/// Build a [`chematic_mol::PqrAtomRecord`] from a Python dict. `element` is
+/// optional -- when omitted, it is inferred the same way [`parse_pqr`]
+/// infers it for a real PQR file, via [`chematic_mol::infer_element`],
+/// since [`chematic_mol::write_pqr`] never reads a record's `element` field
+/// back out anyway (PQR has no element column at all -- see that module's
+/// docs). Callers shouldn't have to supply a field the format itself
+/// doesn't store.
+fn pydict_to_pqr_atom(d: &Bound<PyDict>) -> PyResult<chematic_mol::PqrAtomRecord> {
+    let group_pdb: String = dict_get(d, "group_pdb", "ATOM".to_string())?;
+    let atom_name: String = dict_get(d, "atom_name", String::new())?;
+    let res_name: String = dict_get(d, "res_name", "UNL".to_string())?;
+    let element = match dict_get_opt::<String>(d, "element")? {
+        Some(sym) => element_from_symbol(&sym)?,
+        None => chematic_mol::infer_element(&group_pdb, &res_name, &atom_name).ok_or_else(|| {
+            PyValueError::new_err(format!(
+                "could not infer an element from atom name {atom_name:?} (pass element= explicitly)"
+            ))
+        })?,
+    };
+    Ok(chematic_mol::PqrAtomRecord {
+        group_pdb,
+        serial: dict_get(d, "serial", 1i64)?,
+        atom_name,
+        res_name,
+        chain_id: dict_get_opt(d, "chain_id")?,
+        res_seq: dict_get(d, "res_seq", 1i64)?,
+        icode: dict_get_opt_char(d, "icode")?,
+        x: dict_get_required(d, "x")?,
+        y: dict_get_required(d, "y")?,
+        z: dict_get_required(d, "z")?,
+        charge: dict_get(d, "charge", 0.0)?,
+        radius: dict_get(d, "radius", 0.0)?,
+        element,
+    })
+}
+
+/// Parse a PQR (PDB-like ATOM/HETATM records with per-atom charge/radius)
+/// string.
+///
+/// Args:
+///     text: PQR file contents.
+///     max_input_bytes: byte-size limit (default 64 MiB).
+///     max_atoms: atom-count limit (default 2,000,000).
+///     max_line_len: per-line byte limit (default 1024).
+///
+/// Returns:
+///     dict: ``{"mol": Mol, "coords": list[list[float]], "atoms":
+///     list[dict]}`` (no bonds -- PQR carries no connectivity). Each atom
+///     dict has keys ``group_pdb``, ``serial``, ``atom_name``, ``res_name``,
+///     ``chain_id`` (``None`` if the file omits the chain column), ``res_seq``,
+///     ``icode``, ``x``, ``y``, ``z``, ``charge``, ``radius``, ``element``
+///     (inferred from the atom name -- see :func:`infer_element`).
+///
+/// Raises:
+///     ValueError: on parse failure (no ATOM/HETATM records, wrong field
+///     count, unresolvable element, non-finite value, or a limit exceeded).
+///
+/// Example::
+///
+///     result = chematic.parse_pqr(open("structure.pqr").read())
+///     charges = [a["charge"] for a in result["atoms"]]
+#[pyfunction]
+#[pyo3(signature = (text, max_input_bytes=None, max_atoms=None, max_line_len=None))]
+fn parse_pqr<'py>(
+    py: Python<'py>,
+    text: &str,
+    max_input_bytes: Option<usize>,
+    max_atoms: Option<usize>,
+    max_line_len: Option<usize>,
+) -> PyResult<Bound<'py, PyDict>> {
+    let mut limits = chematic_mol::PqrParseLimits::default();
+    if let Some(v) = max_input_bytes {
+        limits.max_input_bytes = v;
+    }
+    if let Some(v) = max_atoms {
+        limits.max_atoms = v;
+    }
+    if let Some(v) = max_line_len {
+        limits.max_line_len = v;
+    }
+    let result = chematic_mol::parse_pqr_with_limits(text, &limits)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let (mol, coords) = result.to_molecule();
+
+    let d = PyDict::new(py);
+    d.set_item(
+        "mol",
+        Mol {
+            inner: Arc::new(mol),
+            props: Default::default(),
+        },
+    )?;
+    let py_coords: Vec<Vec<f64>> = coords.iter().map(|&(x, y, z)| vec![x, y, z]).collect();
+    d.set_item("coords", py_coords)?;
+    let atoms: Vec<Bound<PyDict>> = result
+        .atoms
+        .iter()
+        .map(|a| pqr_atom_to_pydict(py, a))
+        .collect::<PyResult<_>>()?;
+    d.set_item("atoms", atoms)?;
+    Ok(d)
+}
+
+/// Write a PQR file from atom records.
+///
+/// Args:
+///     atoms: list of dicts, same shape as :func:`parse_pqr`'s ``"atoms"``
+///         entries. Every key is optional except ``x``, ``y``, ``z`` --
+///         ``element`` is inferred via :func:`infer_element` when omitted
+///         (PQR itself has no element column, so this never affects the
+///         written file).
+///
+/// Example::
+///
+///     text = chematic.write_pqr([
+///         {"atom_name": "N", "res_name": "ALA", "res_seq": 1,
+///          "x": -0.966, "y": 1.523, "z": 1.412, "charge": -0.4, "radius": 1.5},
+///     ])
+#[pyfunction]
+fn write_pqr(atoms: Vec<Bound<PyDict>>) -> PyResult<String> {
+    let records: Vec<chematic_mol::PqrAtomRecord> = atoms
+        .iter()
+        .map(pydict_to_pqr_atom)
+        .collect::<PyResult<_>>()?;
+    Ok(chematic_mol::write_pqr(&records))
+}
+
+/// Infer an element symbol from a PQR/PDB atom name (PQR has no element
+/// column of its own -- see module docs on ``chematic_mol::pqr``).
+///
+/// Returns:
+///     str | None: the element symbol, or ``None`` if no element could be
+///     inferred (e.g. an atom name with no alphabetic characters at all).
+///
+/// Example::
+///
+///     chematic.infer_element("ATOM", "ALA", "CA")     # "C" (not "Ca")
+///     chematic.infer_element("HETATM", "ZN", "ZN")     # "Zn"
+#[pyfunction]
+fn infer_element(group_pdb: &str, res_name: &str, atom_name: &str) -> Option<String> {
+    chematic_mol::infer_element(group_pdb, res_name, atom_name).map(|e| e.symbol().to_string())
+}
+
+// ---------------------------------------------------------------------------
+// ORCA input
+// ---------------------------------------------------------------------------
+
+fn orca_block_to_pydict<'py>(
+    py: Python<'py>,
+    b: &chematic_mol::OrcaBlock,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("name", &b.name)?;
+    d.set_item("raw", &b.raw)?;
+    d.set_item("has_end", b.has_end)?;
+    Ok(d)
+}
+
+fn pydict_to_orca_block(d: &Bound<PyDict>) -> PyResult<chematic_mol::OrcaBlock> {
+    Ok(chematic_mol::OrcaBlock {
+        name: dict_get_required(d, "name")?,
+        raw: dict_get(d, "raw", String::new())?,
+        has_end: dict_get(d, "has_end", true)?,
+    })
+}
+
+fn orca_atom_to_pydict<'py>(
+    py: Python<'py>,
+    a: &chematic_mol::OrcaAtom,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("element", a.element.symbol())?;
+    d.set_item("x", a.x)?;
+    d.set_item("y", a.y)?;
+    d.set_item("z", a.z)?;
+    d.set_item("frozen", a.frozen.to_vec())?;
+    d.set_item("extra", &a.extra)?;
+    Ok(d)
+}
+
+fn pydict_to_orca_atom(d: &Bound<PyDict>) -> PyResult<chematic_mol::OrcaAtom> {
+    let sym: String = dict_get_required(d, "element")?;
+    let frozen: Vec<bool> = dict_get(d, "frozen", vec![false, false, false])?;
+    if frozen.len() != 3 {
+        return Err(PyValueError::new_err(
+            "'frozen' must have exactly 3 entries (x, y, z)",
+        ));
+    }
+    Ok(chematic_mol::OrcaAtom {
+        element: element_from_symbol(&sym)?,
+        x: dict_get_required(d, "x")?,
+        y: dict_get_required(d, "y")?,
+        z: dict_get_required(d, "z")?,
+        frozen: [frozen[0], frozen[1], frozen[2]],
+        extra: dict_get_opt(d, "extra")?,
+    })
+}
+
+fn orca_coords_to_pydict<'py>(
+    py: Python<'py>,
+    c: &chematic_mol::OrcaCoords,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    match c {
+        chematic_mol::OrcaCoords::Xyz {
+            charge,
+            multiplicity,
+            atoms,
+        } => {
+            d.set_item("kind", "xyz")?;
+            d.set_item("charge", charge)?;
+            d.set_item("multiplicity", multiplicity)?;
+            let py_atoms: Vec<Bound<PyDict>> = atoms
+                .iter()
+                .map(|a| orca_atom_to_pydict(py, a))
+                .collect::<PyResult<_>>()?;
+            d.set_item("atoms", py_atoms)?;
+        }
+        chematic_mol::OrcaCoords::XyzFile {
+            charge,
+            multiplicity,
+            filename,
+        } => {
+            d.set_item("kind", "xyzfile")?;
+            d.set_item("charge", charge)?;
+            d.set_item("multiplicity", multiplicity)?;
+            d.set_item("filename", filename)?;
+        }
+        chematic_mol::OrcaCoords::GzmtFile {
+            charge,
+            multiplicity,
+            filename,
+        } => {
+            d.set_item("kind", "gzmtfile")?;
+            d.set_item("charge", charge)?;
+            d.set_item("multiplicity", multiplicity)?;
+            d.set_item("filename", filename)?;
+        }
+        chematic_mol::OrcaCoords::Internal {
+            charge,
+            multiplicity,
+            raw,
+        } => {
+            d.set_item("kind", "int")?;
+            d.set_item("charge", charge)?;
+            d.set_item("multiplicity", multiplicity)?;
+            d.set_item("raw", raw)?;
+        }
+    }
+    Ok(d)
+}
+
+fn pydict_to_orca_coords(d: &Bound<PyDict>) -> PyResult<chematic_mol::OrcaCoords> {
+    let kind: String = dict_get_required(d, "kind")?;
+    let charge: i32 = dict_get(d, "charge", 0)?;
+    let multiplicity: u32 = dict_get(d, "multiplicity", 1)?;
+    match kind.as_str() {
+        "xyz" => {
+            let atoms_list: Vec<Bound<PyDict>> = dict_get(d, "atoms", Vec::new())?;
+            let atoms = atoms_list
+                .iter()
+                .map(pydict_to_orca_atom)
+                .collect::<PyResult<_>>()?;
+            Ok(chematic_mol::OrcaCoords::Xyz {
+                charge,
+                multiplicity,
+                atoms,
+            })
+        }
+        "xyzfile" => Ok(chematic_mol::OrcaCoords::XyzFile {
+            charge,
+            multiplicity,
+            filename: dict_get_required(d, "filename")?,
+        }),
+        "gzmtfile" => Ok(chematic_mol::OrcaCoords::GzmtFile {
+            charge,
+            multiplicity,
+            filename: dict_get_required(d, "filename")?,
+        }),
+        "int" => Ok(chematic_mol::OrcaCoords::Internal {
+            charge,
+            multiplicity,
+            raw: dict_get(d, "raw", String::new())?,
+        }),
+        other => Err(PyValueError::new_err(format!(
+            "unknown coords 'kind' {other:?}, expected 'xyz'/'xyzfile'/'gzmtfile'/'int'"
+        ))),
+    }
+}
+
+/// Parse an ORCA input file (`.inp`).
+///
+/// Returns:
+///     dict: ``{"comments": list[str], "keywords": list[str], "blocks":
+///     list[dict], "coords": dict | None}``.
+///
+///     Each block dict is ``{"name": str, "raw": str, "has_end": bool}``
+///     (``%name ... end`` blocks; ``has_end=False`` for a single-line
+///     directive like ``%maxcore 3000``).
+///
+///     ``coords`` (if the input has a ``* ... *`` block) is tagged by a
+///     ``"kind"`` key:
+///
+///     - ``"xyz"``: ``{"kind": "xyz", "charge": int, "multiplicity": int,
+///       "atoms": list[dict]}``, each atom dict
+///       ``{"element": str, "x": float, "y": float, "z": float,
+///       "frozen": [bool, bool, bool], "extra": str | None}``.
+///     - ``"xyzfile"`` / ``"gzmtfile"``: ``{"kind": ..., "charge": int,
+///       "multiplicity": int, "filename": str}`` (external geometry file).
+///     - ``"int"``: ``{"kind": "int", "charge": int, "multiplicity": int,
+///       "raw": str}`` (internal/Z-matrix coordinates, preserved verbatim
+///       -- not semantically parsed).
+///
+/// Raises:
+///     ValueError: on parse failure.
+///
+/// Example::
+///
+///     result = chematic.parse_orca_input(open("job.inp").read())
+///     print(result["keywords"])
+#[pyfunction]
+fn parse_orca_input<'py>(py: Python<'py>, text: &str) -> PyResult<Bound<'py, PyDict>> {
+    let input =
+        chematic_mol::parse_orca_input(text).map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let chematic_mol::OrcaInput {
+        comments,
+        keywords,
+        blocks,
+        coords,
+    } = input;
+
+    let d = PyDict::new(py);
+    d.set_item("comments", comments)?;
+    d.set_item("keywords", keywords)?;
+    let py_blocks: Vec<Bound<PyDict>> = blocks
+        .iter()
+        .map(|b| orca_block_to_pydict(py, b))
+        .collect::<PyResult<_>>()?;
+    d.set_item("blocks", py_blocks)?;
+    match &coords {
+        Some(c) => d.set_item("coords", orca_coords_to_pydict(py, c)?)?,
+        None => d.set_item("coords", py.None())?,
+    }
+    Ok(d)
+}
+
+/// Write an ORCA input file (`.inp`) from a dict, same shape as
+/// :func:`parse_orca_input`'s return value (every key optional -- an empty
+/// dict writes an empty file).
+///
+/// Example::
+///
+///     text = chematic.write_orca_input({
+///         "keywords": ["B3LYP", "def2-SVP", "Opt"],
+///         "coords": {"kind": "xyz", "charge": 0, "multiplicity": 1,
+///                    "atoms": [{"element": "O", "x": 0.0, "y": 0.0, "z": 0.0}]},
+///     })
+#[pyfunction]
+fn write_orca_input(input: &Bound<PyDict>) -> PyResult<String> {
+    let comments: Vec<String> = dict_get(input, "comments", Vec::new())?;
+    let keywords: Vec<String> = dict_get(input, "keywords", Vec::new())?;
+    let blocks_list: Vec<Bound<PyDict>> = dict_get(input, "blocks", Vec::new())?;
+    let blocks = blocks_list
+        .iter()
+        .map(pydict_to_orca_block)
+        .collect::<PyResult<_>>()?;
+    let coords_dict: Option<Bound<PyDict>> = dict_get_opt(input, "coords")?;
+    let coords = coords_dict
+        .as_ref()
+        .map(pydict_to_orca_coords)
+        .transpose()?;
+    let orca_input = chematic_mol::OrcaInput {
+        comments,
+        keywords,
+        blocks,
+        coords,
+    };
+    Ok(chematic_mol::write_orca_input(&orca_input))
+}
+
+// ---------------------------------------------------------------------------
+// ORCA output
+// ---------------------------------------------------------------------------
+
+/// Parse an ORCA output file (`.out` / `.log`).
+///
+/// Never raises on truncated/crashed output -- see ``"termination"``.
+///
+/// Returns:
+///     dict: ``{"charge": int | None, "multiplicity": int | None,
+///     "final_energy_hartree": float | None, "trajectory": list[dict],
+///     "frequencies_cm1": list[float], "termination": dict,
+///     "optimization_convergence": str}``.
+///
+///     ``trajectory`` is one ``{"mol": Mol, "coords": list[list[float]]}``
+///     dict per ``CARTESIAN COORDINATES (ANGSTROEM)`` block found, in file
+///     order (the geometry trajectory for an optimization job, or a single
+///     frame for a single-point/frequency job); ``trajectory[-1]`` is the
+///     final geometry.
+///
+///     ``termination`` is ``{"kind": "normal" | "error" | "incomplete",
+///     "message": str | None}`` (``message`` is the verbatim error line,
+///     only set for ``"error"``). Per the ORCA manual, ``"normal"`` does
+///     **not** by itself mean a requested geometry optimization converged
+///     -- check ``"optimization_convergence"`` separately.
+///
+///     ``optimization_convergence`` is one of ``"not_requested"``
+///     (not an optimization job), ``"converged"``, ``"not_converged"``, or
+///     ``"unknown"`` (truncated mid-optimization).
+///
+/// Raises:
+///     ValueError: on a non-finite energy/coordinate/frequency value, or
+///     an oversized input.
+///
+/// Example::
+///
+///     result = chematic.parse_orca_output(open("job.out").read())
+///     if result["termination"]["kind"] == "normal":
+///         print(result["final_energy_hartree"])
+#[pyfunction]
+fn parse_orca_output<'py>(py: Python<'py>, text: &str) -> PyResult<Bound<'py, PyDict>> {
+    let output =
+        chematic_mol::parse_orca_output(text).map_err(|e| PyValueError::new_err(e.to_string()))?;
+
+    let d = PyDict::new(py);
+    d.set_item("charge", output.charge)?;
+    d.set_item("multiplicity", output.multiplicity)?;
+    d.set_item("final_energy_hartree", output.final_energy_hartree)?;
+
+    let trajectory: Vec<Bound<PyDict>> = output
+        .trajectory
+        .into_iter()
+        .map(|f| {
+            let fd = PyDict::new(py);
+            fd.set_item(
+                "mol",
+                Mol {
+                    inner: Arc::new(f.mol),
+                    props: Default::default(),
+                },
+            )?;
+            let coords: Vec<Vec<f64>> = f.coords.iter().map(|&(x, y, z)| vec![x, y, z]).collect();
+            fd.set_item("coords", coords)?;
+            Ok::<_, PyErr>(fd)
+        })
+        .collect::<PyResult<_>>()?;
+    d.set_item("trajectory", trajectory)?;
+    d.set_item("frequencies_cm1", output.frequencies_cm1)?;
+
+    let (term_kind, term_msg): (&str, Option<String>) = match output.termination {
+        chematic_mol::OrcaTermination::Normal => ("normal", None),
+        chematic_mol::OrcaTermination::Error(msg) => ("error", Some(msg)),
+        chematic_mol::OrcaTermination::Incomplete => ("incomplete", None),
+    };
+    let term_dict = PyDict::new(py);
+    term_dict.set_item("kind", term_kind)?;
+    term_dict.set_item("message", term_msg)?;
+    d.set_item("termination", term_dict)?;
+
+    let convergence = match output.optimization_convergence {
+        chematic_mol::OrcaOptConvergence::NotRequested => "not_requested",
+        chematic_mol::OrcaOptConvergence::Converged => "converged",
+        chematic_mol::OrcaOptConvergence::NotConverged => "not_converged",
+        chematic_mol::OrcaOptConvergence::Unknown => "unknown",
+    };
+    d.set_item("optimization_convergence", convergence)?;
+
+    Ok(d)
+}
+
+// ---------------------------------------------------------------------------
+// QCSchema (MolSSI Quantum Chemistry Schema)
+//
+// `chematic_mol`'s own `parse_*`/`write_*` functions already speak
+// canonical JSON *text* end to end. Rather than hand-mapping every field of
+// `QcMolecule`/`AtomicInput`/`AtomicResult` (23+ fields on `QcMolecule`
+// alone, several of them open JSON bags -- `extras`/`unknown_fields`/
+// `keywords`/`protocols`/`native_files`/`wavefunction` -- that are part of
+// the spec's own extensibility design, see `qcschema.rs`'s module docs)
+// onto bespoke `PyDict` field-by-field code, this binding routes through
+// Python's own `json` module (stdlib) as the dict<->text boundary:
+// `json.loads`/`json.dumps` on the canonical text `chematic_mol`'s own
+// `write_*` functions already produce/accept. This is strictly *more*
+// faithful than a hand-rolled mapping (an open bag field can never be
+// silently dropped by an oversight it wasn't written to handle) and needs
+// zero new dependencies -- `serde_json` is not a `chematic-py` dependency,
+// and this deliberately never needs to name it (`chematic_mol::JsonObject`
+// is never touched directly here).
+//
+// `write_*` strips the `"mol"`/`"coords"` convenience keys `parse_*` adds
+// before re-serializing (a bare Python `Mol` object isn't JSON-serializable
+// at all), so `chematic.write_qcschema_molecule(chematic.parse_qcschema_molecule(text))`
+// round-trips without the caller needing to strip those themselves.
+// ---------------------------------------------------------------------------
+
+fn json_loads<'py>(py: Python<'py>, text: &str) -> PyResult<Bound<'py, PyDict>> {
+    let value = py.import("json")?.call_method1("loads", (text,))?;
+    value
+        .cast::<PyDict>()
+        .map_err(|e| PyValueError::new_err(e.to_string()))
+        .cloned()
+}
+
+/// `json.dumps` a dict, first stripping the `"mol"`/`"coords"` convenience
+/// keys the `parse_*` functions in this section add (see section docs).
+fn json_dumps_stripped(d: &Bound<PyDict>) -> PyResult<String> {
+    let py = d.py();
+    let clean = d.copy()?;
+    let _ = clean.del_item("mol");
+    let _ = clean.del_item("coords");
+    py.import("json")?
+        .call_method1("dumps", (clean,))?
+        .extract()
+}
+
+/// `(Mol, coords)` from an owned [`chematic_mol::ChematicMoleculeView`],
+/// `coords` in Ångström as `[[x, y, z], ...]`.
+fn qc_view_into_py(view: chematic_mol::ChematicMoleculeView) -> (Mol, Vec<Vec<f64>>) {
+    let coords = view
+        .coords
+        .points
+        .iter()
+        .map(|p| vec![p.x, p.y, p.z])
+        .collect();
+    let mol = Mol {
+        inner: Arc::new(view.molecule),
+        props: Default::default(),
+    };
+    (mol, coords)
+}
+
+/// Parse a QCSchema `Molecule` JSON document (`schema_name:
+/// "qcschema_molecule"`).
+///
+/// Returns a dict with every QCSchema `Molecule` field (``symbols``,
+/// ``geometry`` in Bohr, ``molecular_charge``, ``connectivity``, ...; see
+/// <https://molssi.github.io/QCElemental/model_molecule.html> for the full
+/// field reference) plus two chematic-side convenience keys:
+///
+/// - ``"mol"``: a :class:`Mol` built from ``symbols``/``connectivity`` (see
+///   :func:`qc_molecule_to_chematic` for exactly what is gained/lost).
+/// - ``"coords"``: the same geometry, converted to Ångström, as
+///   ``[[x, y, z], ...]``.
+///
+/// :func:`write_qcschema_molecule` ignores/strips both convenience keys, so
+/// this dict round-trips through it directly.
+///
+/// Raises:
+///     ValueError: on malformed JSON, a schema violation, or (for the
+///     ``"mol"``/``"coords"`` keys specifically) an unresolvable element
+///     symbol or an out-of-range ``connectivity`` atom index.
+///
+/// Example::
+///
+///     result = chematic.parse_qcschema_molecule(open("water.json").read())
+///     print(result["symbols"], result["mol"].formula)
+#[pyfunction]
+fn parse_qcschema_molecule<'py>(py: Python<'py>, text: &str) -> PyResult<Bound<'py, PyDict>> {
+    let qc = chematic_mol::parse_qcschema_molecule(text)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let canonical = chematic_mol::write_qcschema_molecule(&qc);
+    let d = json_loads(py, &canonical)?;
+    let view = chematic_mol::qc_molecule_to_chematic(&qc)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let (mol, coords) = qc_view_into_py(view);
+    d.set_item("mol", mol)?;
+    d.set_item("coords", coords)?;
+    Ok(d)
+}
+
+/// Serialize a QCSchema `Molecule` dict (as returned by
+/// :func:`parse_qcschema_molecule`, or hand-built with the same keys) to
+/// canonical QCSchema JSON text.
+///
+/// Raises:
+///     ValueError: if `molecule` doesn't validate as a QCSchema `Molecule`
+///     document (missing required key, wrong type, non-finite number, ...).
+#[pyfunction]
+fn write_qcschema_molecule(molecule: &Bound<PyDict>) -> PyResult<String> {
+    let text = json_dumps_stripped(molecule)?;
+    let qc = chematic_mol::parse_qcschema_molecule(&text)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    Ok(chematic_mol::write_qcschema_molecule(&qc))
+}
+
+/// Convert a chematic :class:`Mol` + coordinates into a QCSchema `Molecule`
+/// dict (geometry in Bohr, per spec).
+///
+/// Args:
+///     mol: the molecule (topology/bond orders).
+///     coords: Cartesian coordinates (Å), ``[[x, y, z], ...]``, same order
+///         and length as `mol`'s atoms.
+///     molecular_charge: total charge (default ``0.0``).
+///     molecular_multiplicity: spin multiplicity (default ``1``).
+///
+/// Raises:
+///     ValueError: if `coords`' length doesn't match `mol`'s atom count.
+///
+/// Example::
+///
+///     qc = chematic.chematic_to_qc_molecule(mol, coords)
+///     open("mol.json", "w").write(chematic.write_qcschema_molecule(qc))
+#[pyfunction]
+#[pyo3(signature = (mol, coords, molecular_charge=0.0, molecular_multiplicity=1))]
+fn chematic_to_qc_molecule<'py>(
+    py: Python<'py>,
+    mol: &Mol,
+    coords: Vec<[f64; 3]>,
+    molecular_charge: f64,
+    molecular_multiplicity: i64,
+) -> PyResult<Bound<'py, PyDict>> {
+    let c3d = flat_to_coords3d(&coords);
+    let qc = chematic_mol::chematic_to_qc_molecule(
+        &mol.inner,
+        &c3d,
+        molecular_charge,
+        molecular_multiplicity,
+    )
+    .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let text = chematic_mol::write_qcschema_molecule(&qc);
+    json_loads(py, &text)
+}
+
+/// Convert a QCSchema `Molecule` dict into a chematic ``(Mol, coords,
+/// molecular_charge, molecular_multiplicity)`` tuple.
+///
+/// ``coords`` is Ångström, ``[[x, y, z], ...]``. See
+/// ``chematic_mol::qc_molecule_to_chematic``'s Rust docs for exactly what
+/// is gained/lost by this conversion (QCSchema has no aromaticity/stereo
+/// concept; ``connectivity`` bond orders map onto the nearest chematic
+/// bond order).
+///
+/// Raises:
+///     ValueError: unresolvable element symbol, or a ``connectivity`` entry
+///     referencing an out-of-range atom index.
+#[pyfunction]
+fn qc_molecule_to_chematic(molecule: &Bound<PyDict>) -> PyResult<(Mol, Vec<Vec<f64>>, f64, i64)> {
+    let text = json_dumps_stripped(molecule)?;
+    let qc = chematic_mol::parse_qcschema_molecule(&text)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let view = chematic_mol::qc_molecule_to_chematic(&qc)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let charge = view.molecular_charge;
+    let multiplicity = view.molecular_multiplicity;
+    let (mol, coords) = qc_view_into_py(view);
+    Ok((mol, coords, charge, multiplicity))
+}
+
+/// Parse a QCSchema `AtomicInput` JSON document (a molecule plus what to
+/// compute on it: `driver`, `model`, `keywords`).
+///
+/// Returns a dict with every `AtomicInput` field (``"molecule"`` -- itself
+/// shaped like :func:`parse_qcschema_molecule`'s return value minus the
+/// ``"mol"``/``"coords"`` convenience keys --, ``"driver"``, ``"model"``,
+/// ``"keywords"``, ``"protocols"``, ``"extras"``, ``"provenance"``, ...)
+/// plus two top-level convenience keys built from ``"molecule"``:
+///
+/// - ``"mol"``: :class:`Mol`.
+/// - ``"coords"``: ``[[x, y, z], ...]`` in Ångström.
+///
+/// :func:`write_atomic_input` strips both before re-serializing.
+///
+/// Raises:
+///     ValueError: on malformed JSON or a schema violation.
+///
+/// Example::
+///
+///     result = chematic.parse_atomic_input(open("job.json").read())
+///     print(result["driver"], result["model"]["method"])
+#[pyfunction]
+fn parse_atomic_input<'py>(py: Python<'py>, text: &str) -> PyResult<Bound<'py, PyDict>> {
+    let input =
+        chematic_mol::parse_atomic_input(text).map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let canonical = chematic_mol::write_atomic_input(&input);
+    let d = json_loads(py, &canonical)?;
+    let view = chematic_mol::qc_molecule_to_chematic(&input.molecule)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let (mol, coords) = qc_view_into_py(view);
+    d.set_item("mol", mol)?;
+    d.set_item("coords", coords)?;
+    Ok(d)
+}
+
+/// Serialize an `AtomicInput` dict (as returned by
+/// :func:`parse_atomic_input`) to canonical QCSchema JSON text.
+///
+/// Raises:
+///     ValueError: if `input` doesn't validate as a QCSchema `AtomicInput`
+///     document.
+#[pyfunction]
+fn write_atomic_input(input: &Bound<PyDict>) -> PyResult<String> {
+    let text = json_dumps_stripped(input)?;
+    let a = chematic_mol::parse_atomic_input(&text)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    Ok(chematic_mol::write_atomic_input(&a))
+}
+
+/// Parse a QCSchema `AtomicResult` JSON document (an `AtomicInput` plus the
+/// computed result: `return_result`/`properties`/`success`/`error`/
+/// `provenance`).
+///
+/// Same shape as :func:`parse_atomic_input`'s return value, plus
+/// ``"return_result"`` (``float`` for an ``"energy"`` driver, ``list[float]``
+/// for ``"gradient"``/``"hessian"``, or a ``dict`` for ``"properties"`` --
+/// shaped by ``"driver"``, only present when ``"success"`` is ``True``),
+/// ``"success"`` (bool), ``"error"`` (``{"error_type": str,
+/// "error_message": str, ...}`` dict, only present when ``"success"`` is
+/// ``False``), ``"properties"``, ``"provenance"``, ``"stdout"``/``"stderr"``.
+///
+/// Raises:
+///     ValueError: on malformed JSON or a schema violation (including the
+///     spec's own ``success``/``return_result``/``error`` consistency
+///     rule).
+///
+/// Example::
+///
+///     result = chematic.parse_atomic_result(open("result.json").read())
+///     if result["success"]:
+///         print(result["return_result"])
+#[pyfunction]
+fn parse_atomic_result<'py>(py: Python<'py>, text: &str) -> PyResult<Bound<'py, PyDict>> {
+    let result = chematic_mol::parse_atomic_result(text)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let canonical = chematic_mol::write_atomic_result(&result);
+    let d = json_loads(py, &canonical)?;
+    let view = chematic_mol::qc_molecule_to_chematic(&result.molecule)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let (mol, coords) = qc_view_into_py(view);
+    d.set_item("mol", mol)?;
+    d.set_item("coords", coords)?;
+    Ok(d)
+}
+
+/// Serialize an `AtomicResult` dict (as returned by
+/// :func:`parse_atomic_result`) to canonical QCSchema JSON text.
+///
+/// Raises:
+///     ValueError: if `result` doesn't validate as a QCSchema `AtomicResult`
+///     document.
+#[pyfunction]
+fn write_atomic_result(result: &Bound<PyDict>) -> PyResult<String> {
+    let text = json_dumps_stripped(result)?;
+    let r = chematic_mol::parse_atomic_result(&text)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    Ok(chematic_mol::write_atomic_result(&r))
+}
+
+// ---------------------------------------------------------------------------
 // Register
 // ---------------------------------------------------------------------------
 
@@ -1177,5 +2215,21 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(nearest_neighbors_from_fp, m)?)?;
     m.add_function(wrap_pyfunction!(parse_smi_file, m)?)?;
     m.add_function(wrap_pyfunction!(write_smi_file, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_mmcif, m)?)?;
+    m.add_function(wrap_pyfunction!(write_mmcif, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_pqr, m)?)?;
+    m.add_function(wrap_pyfunction!(write_pqr, m)?)?;
+    m.add_function(wrap_pyfunction!(infer_element, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_orca_input, m)?)?;
+    m.add_function(wrap_pyfunction!(write_orca_input, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_orca_output, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_qcschema_molecule, m)?)?;
+    m.add_function(wrap_pyfunction!(write_qcschema_molecule, m)?)?;
+    m.add_function(wrap_pyfunction!(chematic_to_qc_molecule, m)?)?;
+    m.add_function(wrap_pyfunction!(qc_molecule_to_chematic, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_atomic_input, m)?)?;
+    m.add_function(wrap_pyfunction!(write_atomic_input, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_atomic_result, m)?)?;
+    m.add_function(wrap_pyfunction!(write_atomic_result, m)?)?;
     Ok(())
 }

--- a/crates/chematic-py/src/lammps.rs
+++ b/crates/chematic-py/src/lammps.rs
@@ -1,0 +1,524 @@
+//! Python bindings for `chematic-mol`'s LAMMPS data (`read_data`/`write_data`
+//! format) and dump/trajectory (`dump` command's default text style)
+//! support.
+//!
+//! Both are **standalone document types**, not integrated with
+//! `chematic_core::Molecule` -- LAMMPS bonds/atom-types are raw index
+//! topology, not chemically perceived bonds, and an MD atom under some
+//! `atom_style`s is not necessarily even a chemical element (see
+//! `chematic_mol::lammps_data`'s module docs). Callers needing a `Mol`
+//! should build one themselves from the returned atom/bond data.
+//!
+//! `LammpsData` (a single document: header + typed sections) is bound as a
+//! plain function + dict pair (`parse_lammps_data`/`write_lammps_data`),
+//! matching `formats.rs`'s `parse_cif` precedent -- its only "behavior"
+//! beyond a bag of parsed sections is `LammpsData::count(label)`, a lookup
+//! Python's own `dict.get` on the returned `"counts"` dict already covers.
+//!
+//! `LammpsDumpFrame` (one frame of a trajectory) is instead a small
+//! pyclass, [`PyLammpsDumpFrame`], because it has real computed behavior
+//! worth exposing as methods -- `column()`/`cartesian_positions()`, the
+//! latter doing a real (triclinic-aware) coordinate transform, not just a
+//! field lookup -- following `crystal.rs`'s precedent for "Rust type with
+//! real methods -> dedicated pyclass" rather than `formats.rs`'s
+//! plain-dict precedent.
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+use ndarray::Array2;
+use numpy::{IntoPyArray, PyArray2};
+
+use crate::formats::{dict_get, dict_get_opt, dict_get_required};
+
+fn atom_style_from_str(s: &str) -> chematic_mol::LammpsAtomStyle {
+    match s {
+        "atomic" => chematic_mol::LammpsAtomStyle::Atomic,
+        "charge" => chematic_mol::LammpsAtomStyle::Charge,
+        "molecular" => chematic_mol::LammpsAtomStyle::Molecular,
+        "full" => chematic_mol::LammpsAtomStyle::Full,
+        // Not pre-validated here -- `parse_lammps_data` itself rejects any
+        // `Other` style with a typed `UnsupportedAtomStyle` error; letting
+        // that be the single source of truth for "which styles are
+        // supported" avoids two places that could drift apart.
+        other => chematic_mol::LammpsAtomStyle::Other(other.to_string()),
+    }
+}
+
+fn atom_style_to_string(s: &chematic_mol::LammpsAtomStyle) -> String {
+    match s {
+        chematic_mol::LammpsAtomStyle::Atomic => "atomic".to_string(),
+        chematic_mol::LammpsAtomStyle::Charge => "charge".to_string(),
+        chematic_mol::LammpsAtomStyle::Molecular => "molecular".to_string(),
+        chematic_mol::LammpsAtomStyle::Full => "full".to_string(),
+        chematic_mol::LammpsAtomStyle::Other(s) => s.clone(),
+    }
+}
+
+fn lammps_box_to_pydict<'py>(
+    py: Python<'py>,
+    b: &chematic_mol::LammpsBox,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("lo", b.lo)?;
+    d.set_item("hi", b.hi)?;
+    d.set_item("tilt", b.tilt)?;
+    Ok(d)
+}
+
+fn pydict_to_lammps_box(d: &Bound<PyDict>) -> PyResult<chematic_mol::LammpsBox> {
+    let b = chematic_mol::LammpsBox {
+        lo: dict_get_required(d, "lo")?,
+        hi: dict_get_required(d, "hi")?,
+        tilt: dict_get_opt(d, "tilt")?,
+    };
+    b.validate().map_err(PyValueError::new_err)?;
+    Ok(b)
+}
+
+// ---------------------------------------------------------------------------
+// LammpsData (plain function + dict)
+// ---------------------------------------------------------------------------
+
+fn lammps_data_to_pydict<'py>(
+    py: Python<'py>,
+    data: &chematic_mol::LammpsData,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+
+    let counts = PyDict::new(py);
+    for (label, count) in &data.counts {
+        counts.set_item(label, count)?;
+    }
+    d.set_item("counts", counts)?;
+    d.set_item("atom_style", atom_style_to_string(&data.atom_style))?;
+    d.set_item("box", lammps_box_to_pydict(py, &data.simulation_box)?)?;
+
+    let masses: Vec<Bound<PyDict>> = data
+        .masses
+        .iter()
+        .map(|m| {
+            let md = PyDict::new(py);
+            md.set_item("atom_type", m.atom_type)?;
+            md.set_item("mass", m.mass)?;
+            Ok::<_, PyErr>(md)
+        })
+        .collect::<PyResult<_>>()?;
+    d.set_item("masses", masses)?;
+
+    let atoms: Vec<Bound<PyDict>> = data
+        .atoms
+        .iter()
+        .map(|a| {
+            let ad = PyDict::new(py);
+            ad.set_item("id", a.id)?;
+            ad.set_item("molecule_id", a.molecule_id)?;
+            ad.set_item("atom_type", a.atom_type)?;
+            ad.set_item("charge", a.charge)?;
+            ad.set_item("x", a.x)?;
+            ad.set_item("y", a.y)?;
+            ad.set_item("z", a.z)?;
+            ad.set_item("image", a.image)?;
+            Ok::<_, PyErr>(ad)
+        })
+        .collect::<PyResult<_>>()?;
+    d.set_item("atoms", atoms)?;
+
+    let velocities: Vec<Bound<PyDict>> = data
+        .velocities
+        .iter()
+        .map(|v| {
+            let vd = PyDict::new(py);
+            vd.set_item("atom_id", v.atom_id)?;
+            vd.set_item("vx", v.vx)?;
+            vd.set_item("vy", v.vy)?;
+            vd.set_item("vz", v.vz)?;
+            Ok::<_, PyErr>(vd)
+        })
+        .collect::<PyResult<_>>()?;
+    d.set_item("velocities", velocities)?;
+
+    let bonds: Vec<Bound<PyDict>> = data
+        .bonds
+        .iter()
+        .map(|b| {
+            let bd = PyDict::new(py);
+            bd.set_item("id", b.id)?;
+            bd.set_item("bond_type", b.bond_type)?;
+            bd.set_item("atom1", b.atom1)?;
+            bd.set_item("atom2", b.atom2)?;
+            Ok::<_, PyErr>(bd)
+        })
+        .collect::<PyResult<_>>()?;
+    d.set_item("bonds", bonds)?;
+
+    d.set_item("unparsed_sections", data.unparsed_sections.clone())?;
+    Ok(d)
+}
+
+fn pydict_to_lammps_data(d: &Bound<PyDict>) -> PyResult<chematic_mol::LammpsData> {
+    let counts: Vec<(String, i64)> = match d.get_item("counts")? {
+        Some(v) if !v.is_none() => {
+            let cd = v
+                .cast::<PyDict>()
+                .map_err(|e| PyValueError::new_err(e.to_string()))?;
+            cd.iter()
+                .map(|(k, v)| Ok::<_, PyErr>((k.extract::<String>()?, v.extract::<i64>()?)))
+                .collect::<PyResult<_>>()?
+        }
+        _ => Vec::new(),
+    };
+    let atom_style_str: String = dict_get(d, "atom_style", "atomic".to_string())?;
+    let box_dict: Bound<PyDict> = dict_get_required(d, "box")?;
+
+    let masses_list: Vec<Bound<PyDict>> = dict_get(d, "masses", Vec::new())?;
+    let masses = masses_list
+        .iter()
+        .map(|md| {
+            Ok::<_, PyErr>(chematic_mol::LammpsMass {
+                atom_type: dict_get_required(md, "atom_type")?,
+                mass: dict_get_required(md, "mass")?,
+            })
+        })
+        .collect::<PyResult<_>>()?;
+
+    let atoms_list: Vec<Bound<PyDict>> = dict_get(d, "atoms", Vec::new())?;
+    let atoms = atoms_list
+        .iter()
+        .map(|ad| {
+            Ok::<_, PyErr>(chematic_mol::LammpsAtom {
+                id: dict_get_required(ad, "id")?,
+                molecule_id: dict_get_opt(ad, "molecule_id")?,
+                atom_type: dict_get_required(ad, "atom_type")?,
+                charge: dict_get_opt(ad, "charge")?,
+                x: dict_get_required(ad, "x")?,
+                y: dict_get_required(ad, "y")?,
+                z: dict_get_required(ad, "z")?,
+                image: dict_get_opt(ad, "image")?,
+            })
+        })
+        .collect::<PyResult<_>>()?;
+
+    let velocities_list: Vec<Bound<PyDict>> = dict_get(d, "velocities", Vec::new())?;
+    let velocities = velocities_list
+        .iter()
+        .map(|vd| {
+            Ok::<_, PyErr>(chematic_mol::LammpsVelocity {
+                atom_id: dict_get_required(vd, "atom_id")?,
+                vx: dict_get_required(vd, "vx")?,
+                vy: dict_get_required(vd, "vy")?,
+                vz: dict_get_required(vd, "vz")?,
+            })
+        })
+        .collect::<PyResult<_>>()?;
+
+    let bonds_list: Vec<Bound<PyDict>> = dict_get(d, "bonds", Vec::new())?;
+    let bonds = bonds_list
+        .iter()
+        .map(|bd| {
+            Ok::<_, PyErr>(chematic_mol::LammpsBond {
+                id: dict_get_required(bd, "id")?,
+                bond_type: dict_get_required(bd, "bond_type")?,
+                atom1: dict_get_required(bd, "atom1")?,
+                atom2: dict_get_required(bd, "atom2")?,
+            })
+        })
+        .collect::<PyResult<_>>()?;
+
+    let unparsed_sections: Vec<(String, String)> = dict_get(d, "unparsed_sections", Vec::new())?;
+
+    Ok(chematic_mol::LammpsData {
+        counts,
+        atom_style: atom_style_from_str(&atom_style_str),
+        simulation_box: pydict_to_lammps_box(&box_dict)?,
+        masses,
+        atoms,
+        velocities,
+        bonds,
+        unparsed_sections,
+    })
+}
+
+/// Parse a LAMMPS data file (`read_data` command format).
+///
+/// Args:
+///     text: data file contents.
+///     atom_style: one of ``"atomic"``, ``"charge"``, ``"molecular"``,
+///         ``"full"`` -- **required**, since it cannot be recovered from
+///         the file alone (e.g. `atom_style charge` and `atom_style
+///         molecular` rows are both 6 fields, genuinely ambiguous by shape
+///         alone -- see `chematic_mol::lammps_data`'s module docs). Any
+///         other string is rejected with ``ValueError`` (matching
+///         `LammpsAtomStyle::Other`'s Rust-side rejection).
+///
+/// Returns:
+///     dict: ``{"counts": dict[str, int], "atom_style": str, "box": dict,
+///     "masses": list[dict], "atoms": list[dict], "velocities": list[dict],
+///     "bonds": list[dict], "unparsed_sections": list[tuple[str, str]]}``.
+///
+///     ``"box"`` is ``{"lo": (x, y, z), "hi": (x, y, z), "tilt":
+///     (xy, xz, yz) | None}``.
+///
+///     ``"unparsed_sections"`` carries every section this module doesn't
+///     semantically parse (``Angles``, ``Dihedrals``, `` *Coeffs``, ...)
+///     verbatim, as ``(section_name, raw_row_text)`` pairs -- never
+///     silently dropped.
+///
+/// Raises:
+///     ValueError: on parse failure (see `chematic_mol::LammpsDataError`,
+///     including LAMMPS's string-keyed "Type Labels" extension, which is
+///     unsupported and fails closed).
+///
+/// Example::
+///
+///     data = chematic.parse_lammps_data(open("in.data").read(), "full")
+///     print(data["counts"]["atoms"], len(data["atoms"]))
+#[pyfunction]
+fn parse_lammps_data<'py>(
+    py: Python<'py>,
+    text: &str,
+    atom_style: &str,
+) -> PyResult<Bound<'py, PyDict>> {
+    let style = atom_style_from_str(atom_style);
+    let data = chematic_mol::parse_lammps_data(text, style)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    lammps_data_to_pydict(py, &data)
+}
+
+/// Write a LAMMPS data file from a dict, same shape as
+/// :func:`parse_lammps_data`'s return value.
+///
+/// Raises:
+///     ValueError: on a missing required key or an invalid box (see
+///     `LammpsBox.validate`).
+#[pyfunction]
+fn write_lammps_data(data: &Bound<PyDict>) -> PyResult<String> {
+    let data = pydict_to_lammps_data(data)?;
+    Ok(chematic_mol::write_lammps_data(&data))
+}
+
+/// Convert a dump file's `ITEM: BOX BOUNDS` values into the true
+/// simulation box (identity for an orthogonal box; undoes the triclinic
+/// bounding-box shift otherwise -- see
+/// `chematic_mol::lammps_dump`'s module docs).
+#[pyfunction]
+fn box_bounds_to_true<'py>(
+    py: Python<'py>,
+    bound_lo: (f64, f64, f64),
+    bound_hi: (f64, f64, f64),
+    tilt: Option<(f64, f64, f64)>,
+) -> PyResult<Bound<'py, PyDict>> {
+    let b = chematic_mol::box_bounds_to_true(
+        [bound_lo.0, bound_lo.1, bound_lo.2],
+        [bound_hi.0, bound_hi.1, bound_hi.2],
+        tilt.map(|(xy, xz, yz)| [xy, xz, yz]),
+    );
+    lammps_box_to_pydict(py, &b)
+}
+
+/// Inverse of :func:`box_bounds_to_true`: convert a true box dict (``{"lo":
+/// ..., "hi": ..., "tilt": ...}``) into the `xlo_bound`/`xhi_bound`/...
+/// values a dump file's `ITEM: BOX BOUNDS` section would show.
+///
+/// Returns:
+///     tuple: ``((xlo_bound, ylo_bound, zlo_bound), (xhi_bound, yhi_bound,
+///     zhi_bound))``.
+#[pyfunction]
+#[allow(clippy::type_complexity)]
+fn true_to_box_bounds(box_dict: &Bound<PyDict>) -> PyResult<((f64, f64, f64), (f64, f64, f64))> {
+    let b = pydict_to_lammps_box(box_dict)?;
+    let (lo, hi) = chematic_mol::true_to_box_bounds(&b);
+    Ok(((lo[0], lo[1], lo[2]), (hi[0], hi[1], hi[2])))
+}
+
+// ---------------------------------------------------------------------------
+// LammpsDumpFrame (pyclass -- see module docs for why)
+// ---------------------------------------------------------------------------
+
+/// One frame of a LAMMPS dump/trajectory file.
+#[pyclass(name = "LammpsDumpFrame", from_py_object)]
+#[derive(Clone)]
+pub struct PyLammpsDumpFrame {
+    inner: chematic_mol::LammpsDumpFrame,
+}
+
+#[pymethods]
+impl PyLammpsDumpFrame {
+    /// `num_atoms` defaults to `len(rows)` when omitted.
+    #[new]
+    #[pyo3(signature = (timestep, box_bounds, column_names, rows, boundary_flags=("pp".to_string(), "pp".to_string(), "pp".to_string()), num_atoms=None))]
+    fn new(
+        timestep: i64,
+        box_bounds: &Bound<PyDict>,
+        column_names: Vec<String>,
+        rows: Vec<Vec<f64>>,
+        boundary_flags: (String, String, String),
+        num_atoms: Option<usize>,
+    ) -> PyResult<Self> {
+        let box_bounds = pydict_to_lammps_box(box_bounds)?;
+        let num_atoms = num_atoms.unwrap_or(rows.len());
+        Ok(PyLammpsDumpFrame {
+            inner: chematic_mol::LammpsDumpFrame {
+                timestep,
+                num_atoms,
+                box_bounds,
+                boundary_flags: [boundary_flags.0, boundary_flags.1, boundary_flags.2],
+                column_names,
+                rows,
+            },
+        })
+    }
+
+    #[getter]
+    fn timestep(&self) -> i64 {
+        self.inner.timestep
+    }
+
+    #[getter]
+    fn num_atoms(&self) -> usize {
+        self.inner.num_atoms
+    }
+
+    #[getter]
+    fn box_bounds<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        lammps_box_to_pydict(py, &self.inner.box_bounds)
+    }
+
+    /// The 2-character boundary-condition flag pair for each axis (x, y,
+    /// z), e.g. `("pp", "pp", "pp")` -- taken verbatim from the file, not
+    /// interpreted.
+    #[getter]
+    fn boundary_flags(&self) -> (String, String, String) {
+        let [x, y, z] = &self.inner.boundary_flags;
+        (x.clone(), y.clone(), z.clone())
+    }
+
+    #[getter]
+    fn column_names(&self) -> Vec<String> {
+        self.inner.column_names.clone()
+    }
+
+    /// `(num_atoms, num_columns)` numpy array; `rows[i][j]` is
+    /// `column_names[j]` for atom `i`, in file order.
+    #[getter]
+    fn rows<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray2<f64>> {
+        let n = self.inner.rows.len();
+        let m = self.inner.column_names.len();
+        let flat: Vec<f64> = self.inner.rows.iter().flatten().copied().collect();
+        Array2::from_shape_vec((n, m), flat)
+            .expect("LammpsDumpFrame.rows is always rectangular (enforced at parse)")
+            .into_pyarray(py)
+    }
+
+    /// Index of `name` within `column_names`, if present.
+    fn column_index(&self, name: &str) -> Option<usize> {
+        self.inner.column_index(name)
+    }
+
+    /// The values of column `name` across every atom, in file order, or
+    /// `None` if `name` isn't a declared column.
+    fn column(&self, name: &str) -> Option<Vec<f64>> {
+        self.inner.column(name)
+    }
+
+    /// Real Cartesian positions per atom, as an `(N, 3)` numpy array, from
+    /// whichever of `x y z` (passed through) or `xs ys zs` (box-scaled,
+    /// including triclinic shear terms) is present. `None` if neither
+    /// triple is fully present -- including when only `xu yu zu`
+    /// ("unwrapped") is present; use :meth:`column` for those directly (see
+    /// `chematic_mol::LammpsDumpFrame::cartesian_positions`'s Rust docs for
+    /// why "unwrapped" isn't resolved here).
+    fn cartesian_positions<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray2<f64>>> {
+        let pts = self.inner.cartesian_positions()?;
+        let n = pts.len();
+        let flat: Vec<f64> = pts.into_iter().flatten().collect();
+        Some(
+            Array2::from_shape_vec((n, 3), flat)
+                .expect("row width fixed at 3 always reshapes cleanly")
+                .into_pyarray(py),
+        )
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "LammpsDumpFrame(timestep={}, num_atoms={}, columns={:?})",
+            self.inner.timestep, self.inner.num_atoms, self.inner.column_names
+        )
+    }
+
+    fn __str__(&self) -> String {
+        self.__repr__()
+    }
+}
+
+/// Parse a single LAMMPS dump frame (the first frame, if `text` holds a
+/// multi-frame trajectory -- use :func:`parse_lammps_dump_all` for the
+/// rest).
+///
+/// Raises:
+///     ValueError: on parse failure (see `chematic_mol::LammpsDumpError`).
+#[pyfunction]
+fn parse_lammps_dump_frame(text: &str) -> PyResult<PyLammpsDumpFrame> {
+    let inner = chematic_mol::parse_lammps_dump_frame(text)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    Ok(PyLammpsDumpFrame { inner })
+}
+
+/// Parse every frame of a LAMMPS dump/trajectory file.
+///
+/// Materializes the whole trajectory as a list rather than exposing
+/// `chematic_mol::LammpsDumpReader`'s true streaming iteration to Python: a
+/// dump trajectory is inherently multi-frame (unlike a single Gaussian Cube
+/// grid, where materializing is essentially free either way -- see
+/// :func:`VolumetricGrid.from_cube`'s docs), so this is a genuine, disclosed
+/// scope decision, not a silently dropped capability: most Python callers
+/// materialize a full frame list anyway (``list(reader)``), and real
+/// streaming (a Python iterator yielding one frame at a time) can be added
+/// later if a use case needs bounded memory for a huge trajectory.
+///
+/// Raises:
+///     ValueError: on the first parse failure (stops there).
+///
+/// Example::
+///
+///     frames = chematic.parse_lammps_dump_all(open("dump.lammpstrj").read())
+///     positions = frames[-1].cartesian_positions()
+#[pyfunction]
+fn parse_lammps_dump_all(text: &str) -> PyResult<Vec<PyLammpsDumpFrame>> {
+    let reader = std::io::BufReader::new(std::io::Cursor::new(text.as_bytes()));
+    chematic_mol::LammpsDumpReader::new(reader)
+        .map(|r| {
+            r.map(|inner| PyLammpsDumpFrame { inner })
+                .map_err(|e| PyValueError::new_err(e.to_string()))
+        })
+        .collect()
+}
+
+#[pyfunction]
+fn write_lammps_dump_frame(frame: &PyLammpsDumpFrame) -> String {
+    chematic_mol::write_lammps_dump_frame(&frame.inner)
+}
+
+/// Write multiple frames as one trajectory file (plain concatenation -- a
+/// LAMMPS trajectory is just N frames back to back, with no separator
+/// beyond the next frame's own `ITEM: TIMESTEP`).
+#[pyfunction]
+fn write_lammps_trajectory(frames: Vec<PyRef<PyLammpsDumpFrame>>) -> String {
+    let inner: Vec<chematic_mol::LammpsDumpFrame> =
+        frames.iter().map(|f| f.inner.clone()).collect();
+    chematic_mol::write_lammps_trajectory(&inner)
+}
+
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyLammpsDumpFrame>()?;
+    m.add_function(wrap_pyfunction!(parse_lammps_data, m)?)?;
+    m.add_function(wrap_pyfunction!(write_lammps_data, m)?)?;
+    m.add_function(wrap_pyfunction!(box_bounds_to_true, m)?)?;
+    m.add_function(wrap_pyfunction!(true_to_box_bounds, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_lammps_dump_frame, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_lammps_dump_all, m)?)?;
+    m.add_function(wrap_pyfunction!(write_lammps_dump_frame, m)?)?;
+    m.add_function(wrap_pyfunction!(write_lammps_trajectory, m)?)?;
+    Ok(())
+}

--- a/crates/chematic-py/src/lib.rs
+++ b/crates/chematic-py/src/lib.rs
@@ -19,6 +19,7 @@ type RdkitMorganDetail = (
 
 mod crystal;
 mod formats;
+mod lammps;
 mod misc;
 mod mol_methods;
 mod pipeline_v2;
@@ -26,6 +27,7 @@ mod reactions;
 mod reports;
 mod rwmol;
 mod similarity;
+mod volumetric;
 
 mod bulk;
 mod index;
@@ -93,6 +95,8 @@ fn chematic(m: &Bound<'_, PyModule>) -> PyResult<()> {
     reports::register(m)?;
     misc::register(m)?;
     crystal::register(m)?;
+    volumetric::register(m)?;
+    lammps::register(m)?;
 
     Ok(())
 }

--- a/crates/chematic-py/src/volumetric.rs
+++ b/crates/chematic-py/src/volumetric.rs
@@ -1,0 +1,331 @@
+//! Python bindings for `chematic-mol`'s shared `VolumetricGrid` type
+//! (Gaussian Cube `.cube`/`.cub` and OpenDX `.dx` scalar-field grids).
+//!
+//! One pyclass, [`PyVolumetricGrid`] (`VolumetricGrid` in Python), shared by
+//! both formats -- they read/write the same underlying Rust type
+//! (`chematic_mol::VolumetricGrid`), which has real behavior worth exposing
+//! as methods (`get`/`checked_index`/`point_count`/`to_molecule`) and a
+//! large array-shaped `values` field, unlike the "read a molecule + some
+//! metadata" formats in `formats.rs` that return a plain dict. This follows
+//! `crystal.rs`'s precedent (a dedicated pyclass for a Rust type with real
+//! methods) rather than `formats.rs`'s `parse_cif`-style plain-function/dict
+//! precedent.
+//!
+//! `values` (a potentially large flat `f64` array) and `axes` (a `(3, 3)`
+//! matrix) are returned as numpy arrays, matching `crystal.rs`'s
+//! `Lattice.matrix`/`PeriodicStructure.cartesian_positions` convention for
+//! comparable data -- a fresh copy per call, not zero-copy, same tradeoff
+//! `crystal.rs` already made.
+//!
+//! `CubeFileReader` (streaming *input* reading) is intentionally not bound:
+//! it still materializes one full `VolumetricGrid` in memory either way (a
+//! Cube file is a single grid, not a multi-record stream -- see that type's
+//! own Rust docs), so the only thing streaming saves a Python caller is
+//! avoiding the doubled peak memory of first reading the whole file into a
+//! `str`. Python callers who need that already have `open(path).read()`
+//! either way; true zero-copy streaming for a single-grid format would
+//! require a much larger binding surface for a marginal benefit.
+
+use std::sync::Arc;
+
+use ndarray::{Array1, Array2};
+use numpy::{IntoPyArray, PyArray1, PyArray2};
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+use crate::Mol;
+
+fn cube_err(e: chematic_mol::CubeError) -> PyErr {
+    PyValueError::new_err(e.to_string())
+}
+
+fn opendx_err(e: chematic_mol::OpenDxError) -> PyErr {
+    PyValueError::new_err(e.to_string())
+}
+
+fn grid_err(e: chematic_mol::GridError) -> PyErr {
+    PyValueError::new_err(e.to_string())
+}
+
+fn units_to_str(u: chematic_mol::GridUnits) -> &'static str {
+    match u {
+        chematic_mol::GridUnits::Bohr => "bohr",
+        chematic_mol::GridUnits::Angstrom => "angstrom",
+    }
+}
+
+fn units_from_str(s: &str) -> PyResult<chematic_mol::GridUnits> {
+    match s {
+        "bohr" => Ok(chematic_mol::GridUnits::Bohr),
+        "angstrom" => Ok(chematic_mol::GridUnits::Angstrom),
+        other => Err(PyValueError::new_err(format!(
+            "unknown units {other:?}, expected 'bohr' or 'angstrom'"
+        ))),
+    }
+}
+
+fn element_from_symbol(sym: &str) -> PyResult<chematic_core::Element> {
+    chematic_core::Element::from_symbol(sym)
+        .ok_or_else(|| PyValueError::new_err(format!("unknown element symbol: {sym:?}")))
+}
+
+fn axes_to_pyarray<'py>(py: Python<'py>, axes: [[f64; 3]; 3]) -> Bound<'py, PyArray2<f64>> {
+    let flat: Vec<f64> = axes.into_iter().flatten().collect();
+    Array2::from_shape_vec((3, 3), flat)
+        .expect("3x3 fixed-size matrix always reshapes cleanly")
+        .into_pyarray(py)
+}
+
+/// A scalar field sampled on a regular (possibly non-orthogonal) 3D grid,
+/// shared by Gaussian Cube and OpenDX. `values` is a flat array in
+/// row-major, third-axis-fastest order: `index = (i * shape[1] + j) *
+/// shape[2] + k` for grid coordinates `(i, j, k)` -- see :meth:`get`/
+/// :meth:`checked_index`.
+#[pyclass(name = "VolumetricGrid")]
+pub struct PyVolumetricGrid {
+    inner: chematic_mol::VolumetricGrid,
+}
+
+#[pymethods]
+impl PyVolumetricGrid {
+    /// Construct directly. Routes through `VolumetricGrid::validate`, so an
+    /// inconsistent shape/value-count, non-finite number, or unknown
+    /// element symbol raises `ValueError` here rather than constructing an
+    /// invalid grid.
+    #[new]
+    #[pyo3(signature = (origin, axes, shape, values, atoms=Vec::new(), units="angstrom"))]
+    fn new(
+        origin: (f64, f64, f64),
+        axes: [[f64; 3]; 3],
+        shape: (usize, usize, usize),
+        values: Vec<f64>,
+        atoms: Vec<(String, f64, (f64, f64, f64))>,
+        units: &str,
+    ) -> PyResult<Self> {
+        let units = units_from_str(units)?;
+        let atoms = atoms
+            .into_iter()
+            .map(|(sym, charge, pos)| -> PyResult<chematic_mol::GridAtom> {
+                Ok(chematic_mol::GridAtom {
+                    element: element_from_symbol(&sym)?,
+                    charge,
+                    position: [pos.0, pos.1, pos.2],
+                })
+            })
+            .collect::<PyResult<_>>()?;
+        let inner = chematic_mol::VolumetricGrid {
+            origin: [origin.0, origin.1, origin.2],
+            axes,
+            shape: [shape.0, shape.1, shape.2],
+            values,
+            atoms,
+            units,
+        };
+        inner.validate().map_err(grid_err)?;
+        Ok(PyVolumetricGrid { inner })
+    }
+
+    /// Parse a Gaussian Cube file (text, not a path).
+    ///
+    /// Args:
+    ///     text: `.cube`/`.cub` file contents.
+    ///     max_input_bytes: byte-size limit (default 1 GiB).
+    ///     max_atoms: atom-count limit (default 200,000).
+    ///     max_grid_points: cap on ``shape[0] * shape[1] * shape[2]``
+    ///         (default 100,000,000), checked before the voxel data block
+    ///         is read.
+    ///
+    /// Raises:
+    ///     ValueError: on parse failure (see `chematic_mol::CubeError`,
+    ///     including a rejected multi-dataset file -- unsupported, see
+    ///     module docs).
+    #[staticmethod]
+    #[pyo3(signature = (text, max_input_bytes=None, max_atoms=None, max_grid_points=None))]
+    fn from_cube(
+        text: &str,
+        max_input_bytes: Option<usize>,
+        max_atoms: Option<usize>,
+        max_grid_points: Option<usize>,
+    ) -> PyResult<Self> {
+        let mut limits = chematic_mol::CubeParseLimits::default();
+        if let Some(v) = max_input_bytes {
+            limits.max_input_bytes = v;
+        }
+        if let Some(v) = max_atoms {
+            limits.max_atoms = v;
+        }
+        if let Some(v) = max_grid_points {
+            limits.max_grid_points = v;
+        }
+        let inner = chematic_mol::parse_cube_with_limits(text, &limits).map_err(cube_err)?;
+        Ok(PyVolumetricGrid { inner })
+    }
+
+    /// Parse an OpenDX (APBS scalar-field subset) file (text, not a path).
+    ///
+    /// Args:
+    ///     text: `.dx` file contents.
+    ///     max_input_bytes: byte-size limit (default 1 GiB).
+    ///     max_grid_points: cap on ``shape[0] * shape[1] * shape[2]``
+    ///         (default 100,000,000).
+    ///
+    /// The returned grid always has ``units="angstrom"`` (OpenDX has no
+    /// in-file unit tag; Ångström is APBS's own real-world convention --
+    /// see `chematic_mol::opendx`'s module docs) and ``atoms=[]`` (OpenDX
+    /// has no atom section at all).
+    ///
+    /// Raises:
+    ///     ValueError: on parse failure.
+    #[staticmethod]
+    #[pyo3(signature = (text, max_input_bytes=None, max_grid_points=None))]
+    fn from_opendx(
+        text: &str,
+        max_input_bytes: Option<usize>,
+        max_grid_points: Option<usize>,
+    ) -> PyResult<Self> {
+        let mut limits = chematic_mol::OpenDxParseLimits::default();
+        if let Some(v) = max_input_bytes {
+            limits.max_input_bytes = v;
+        }
+        if let Some(v) = max_grid_points {
+            limits.max_grid_points = v;
+        }
+        let inner = chematic_mol::parse_opendx_with_limits(text, &limits).map_err(opendx_err)?;
+        Ok(PyVolumetricGrid { inner })
+    }
+
+    /// Write as a Gaussian Cube file. Always a single-dataset file.
+    ///
+    /// Raises:
+    ///     ValueError: on an invalid grid (see `VolumetricGrid.validate`).
+    fn to_cube(&self) -> PyResult<String> {
+        chematic_mol::write_cube(&self.inner).map_err(cube_err)
+    }
+
+    /// Write as an OpenDX file. **Fails closed**: raises `ValueError` for a
+    /// ``units="bohr"`` grid (OpenDX has no unit tag of its own; every
+    /// real-world consumer assumes Ångström, so writing Bohr numbers as-is
+    /// would have them silently reinterpreted ~1.89x wrong on next read --
+    /// see `chematic_mol::opendx::write_opendx`'s Rust docs) and for a grid
+    /// with any `atoms` (OpenDX has no atom section). Use
+    /// :meth:`to_opendx_lossy` to explicitly opt into a Bohr->Ångström
+    /// conversion instead of refusing.
+    fn to_opendx(&self) -> PyResult<String> {
+        chematic_mol::write_opendx(&self.inner).map_err(opendx_err)
+    }
+
+    /// Like :meth:`to_opendx`, but if ``units="bohr"``, explicitly converts
+    /// `origin`/`axes` to Ångström instead of refusing (`values` -- the
+    /// scalar-field samples themselves -- are never rescaled: only
+    /// `origin`/`axes` are lengths). Still raises `ValueError` for a grid
+    /// with any `atoms`, same as :meth:`to_opendx`.
+    fn to_opendx_lossy(&self) -> PyResult<String> {
+        chematic_mol::write_opendx_lossy(&self.inner).map_err(opendx_err)
+    }
+
+    #[getter]
+    fn origin(&self) -> (f64, f64, f64) {
+        let [x, y, z] = self.inner.origin;
+        (x, y, z)
+    }
+
+    /// Per-axis step vectors, as a `(3, 3)` numpy array (rows are the 3
+    /// axis vectors).
+    #[getter]
+    fn axes<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray2<f64>> {
+        axes_to_pyarray(py, self.inner.axes)
+    }
+
+    #[getter]
+    fn shape(&self) -> (usize, usize, usize) {
+        let [nx, ny, nz] = self.inner.shape;
+        (nx, ny, nz)
+    }
+
+    /// Flat scalar-field samples as a 1-D numpy array of length
+    /// ``shape[0] * shape[1] * shape[2]``. See the class docs for the index
+    /// ordering.
+    #[getter]
+    fn values<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        Array1::from_vec(self.inner.values.clone()).into_pyarray(py)
+    }
+
+    #[getter]
+    fn units(&self) -> &'static str {
+        units_to_str(self.inner.units)
+    }
+
+    /// Atoms carried alongside the grid (Cube only; always empty for
+    /// OpenDX), as ``[(element_symbol, charge, (x, y, z)), ...]``. `charge`
+    /// is the effective nuclear charge (not a partial/formal charge -- see
+    /// `chematic_mol::GridAtom::charge`'s Rust docs); position is in
+    /// `self.units`.
+    #[getter]
+    fn atoms(&self) -> Vec<(String, f64, (f64, f64, f64))> {
+        self.inner
+            .atoms
+            .iter()
+            .map(|a| {
+                (
+                    a.element.symbol().to_string(),
+                    a.charge,
+                    (a.position[0], a.position[1], a.position[2]),
+                )
+            })
+            .collect()
+    }
+
+    /// `shape[0] * shape[1] * shape[2]`.
+    ///
+    /// Raises:
+    ///     ValueError: if that product overflows (only reachable for a
+    ///     hand-built grid with a pathological `shape`).
+    fn point_count(&self) -> PyResult<usize> {
+        self.inner.point_count().map_err(grid_err)
+    }
+
+    /// Flat index into `values` for grid coordinates `(i, j, k)`, or `None`
+    /// if out of bounds.
+    fn checked_index(&self, i: usize, j: usize, k: usize) -> Option<usize> {
+        self.inner.checked_index(i, j, k)
+    }
+
+    /// The value at grid coordinates `(i, j, k)`, or `None` if out of
+    /// bounds.
+    fn get(&self, i: usize, j: usize, k: usize) -> Option<f64> {
+        self.inner.get(i, j, k)
+    }
+
+    /// Build a plain `Mol` + per-atom Cartesian coordinates (in
+    /// `self.units`) from `atoms`, in file order. No bonds (neither Cube
+    /// nor OpenDX carries a bond table).
+    fn to_molecule(&self) -> (Mol, Vec<Vec<f64>>) {
+        let (mol, coords) = self.inner.to_molecule();
+        let py_coords = coords.iter().map(|&(x, y, z)| vec![x, y, z]).collect();
+        (
+            Mol {
+                inner: Arc::new(mol),
+                props: Default::default(),
+            },
+            py_coords,
+        )
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "VolumetricGrid(shape={:?}, units={:?}, atoms={})",
+            self.inner.shape,
+            units_to_str(self.inner.units),
+            self.inner.atoms.len()
+        )
+    }
+
+    fn __str__(&self) -> String {
+        self.__repr__()
+    }
+}
+
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyVolumetricGrid>()?;
+    Ok(())
+}

--- a/crates/chematic-py/tests/test_new_formats.py
+++ b/crates/chematic-py/tests/test_new_formats.py
@@ -1,0 +1,542 @@
+"""Tests for the v0.18.0 Python bindings of the 7 file-format modules
+chematic-mol gained in v0.17.0 (mmCIF, PQR, ORCA input/output, QCSchema,
+Gaussian Cube, OpenDX, LAMMPS data/dump) -- previously zero Python exposure.
+
+Fixture strings are hand-authored/adapted from the corresponding Rust-side
+fixtures in crates/chematic-mol/src/{mmcif,pqr,orca,cube,opendx,lammps_data,
+lammps_dump}.rs (already-verified-valid inputs for each format's grammar),
+kept inline and minimal here per this test suite's existing convention.
+"""
+import pytest
+
+import chematic
+from chematic import VolumetricGrid, LammpsDumpFrame
+
+
+# ---------------------------------------------------------------------------
+# mmCIF
+# ---------------------------------------------------------------------------
+
+MMCIF_FIXTURE = """\
+data_TEST
+loop_
+_atom_site.group_PDB
+_atom_site.id
+_atom_site.type_symbol
+_atom_site.label_atom_id
+_atom_site.label_comp_id
+_atom_site.label_asym_id
+_atom_site.Cartn_x
+_atom_site.Cartn_y
+_atom_site.Cartn_z
+ATOM   1  O  O1  HOH A 1.000 2.000 3.000
+ATOM   2  H  H1  HOH A 1.500 2.500 3.500
+"""
+
+
+def test_parse_mmcif_basic():
+    result = chematic.parse_mmcif(MMCIF_FIXTURE)
+    assert isinstance(result["mol"], chematic.Mol)
+    assert len(result["atoms"]) == 2
+    assert result["atoms"][0]["element"] == "O"
+    assert result["atoms"][0]["res_name"] == "HOH"
+    assert result["atoms"][0]["x"] == pytest.approx(1.0)
+    assert result["cell"] is None
+
+
+def test_mmcif_round_trip():
+    result = chematic.parse_mmcif(MMCIF_FIXTURE)
+    text = chematic.write_mmcif(result["atoms"])
+    result2 = chematic.parse_mmcif(text)
+    assert len(result2["atoms"]) == len(result["atoms"])
+    assert result2["atoms"][0]["element"] == result["atoms"][0]["element"]
+    assert result2["atoms"][1]["x"] == pytest.approx(result["atoms"][1]["x"])
+
+
+def test_mmcif_unknown_element_raises_value_error():
+    with pytest.raises(ValueError):
+        chematic.write_mmcif([{"element": "Zz", "x": 0.0, "y": 0.0, "z": 0.0}])
+
+
+def test_mmcif_malformed_input_raises_value_error():
+    with pytest.raises(ValueError):
+        chematic.parse_mmcif("not an mmcif file at all")
+
+
+# ---------------------------------------------------------------------------
+# PQR
+# ---------------------------------------------------------------------------
+
+PQR_FIXTURE = """\
+ATOM      1  N   ALA     1     -0.966   1.523   1.412 -0.400  1.500
+ATOM      2  CA  ALA     1      0.257   0.679   1.911  0.100  1.700
+HETATM    3  ZN  ZN      2      5.000   5.000   5.000  2.000  1.090
+"""
+
+
+def test_parse_pqr_basic():
+    result = chematic.parse_pqr(PQR_FIXTURE)
+    assert len(result["atoms"]) == 3
+    assert result["atoms"][1]["element"] == "C"  # "CA" -> C, not Ca
+    assert result["atoms"][2]["element"] == "Zn"
+    assert result["coords"][0] == pytest.approx([-0.966, 1.523, 1.412])
+
+
+def test_pqr_round_trip():
+    result = chematic.parse_pqr(PQR_FIXTURE)
+    text = chematic.write_pqr(result["atoms"])
+    result2 = chematic.parse_pqr(text)
+    assert len(result2["atoms"]) == 3
+    assert result2["atoms"][2]["element"] == "Zn"
+
+
+def test_pqr_element_inferred_when_omitted():
+    text = chematic.write_pqr([
+        {"atom_name": "CA", "res_name": "ALA", "res_seq": 1, "x": 0.0, "y": 0.0, "z": 0.0},
+    ])
+    result = chematic.parse_pqr(text)
+    assert result["atoms"][0]["element"] == "C"
+
+
+def test_infer_element():
+    assert chematic.infer_element("ATOM", "ALA", "CA") == "C"
+    assert chematic.infer_element("HETATM", "ZN", "ZN") == "Zn"
+    assert chematic.infer_element("ATOM", "X", "123") is None
+
+
+def test_pqr_malformed_input_raises_value_error():
+    with pytest.raises(ValueError):
+        chematic.parse_pqr("ATOM      1  N   ALA     1     -0.966   1.523\n")
+
+
+# ---------------------------------------------------------------------------
+# ORCA input / output
+# ---------------------------------------------------------------------------
+
+ORCA_INPUT_FIXTURE = "! B3LYP def2-SVP\n! Opt Freq\n\n* xyz 0 1\nO 0 0 0\n*\n"
+
+ORCA_OUTPUT_FIXTURE = (
+    "\n Total Charge           Charge          ....    0\n"
+    " Multiplicity           Mult            ....    1\n\n"
+    "-------------------------   --------------------\n"
+    "FINAL SINGLE POINT ENERGY       -76.025678123456\n"
+    "-------------------------   --------------------\n\n"
+    "****ORCA TERMINATED NORMALLY****\n"
+)
+
+
+def test_parse_orca_input():
+    result = chematic.parse_orca_input(ORCA_INPUT_FIXTURE)
+    assert "B3LYP" in result["keywords"]
+    assert "Opt" in result["keywords"]
+    assert result["coords"]["kind"] == "xyz"
+    assert result["coords"]["charge"] == 0
+    assert result["coords"]["multiplicity"] == 1
+    assert result["coords"]["atoms"][0]["element"] == "O"
+
+
+def test_orca_input_round_trip():
+    result = chematic.parse_orca_input(ORCA_INPUT_FIXTURE)
+    text = chematic.write_orca_input(result)
+    result2 = chematic.parse_orca_input(text)
+    assert result2["keywords"] == result["keywords"]
+    assert result2["coords"]["atoms"][0]["element"] == "O"
+
+
+def test_orca_input_malformed_raises_value_error():
+    with pytest.raises(ValueError):
+        chematic.parse_orca_input("* xyz notanumber 1\nC 0 0 0\n*\n")
+
+
+def test_parse_orca_output():
+    result = chematic.parse_orca_output(ORCA_OUTPUT_FIXTURE)
+    assert result["charge"] == 0
+    assert result["multiplicity"] == 1
+    assert result["final_energy_hartree"] == pytest.approx(-76.025678123456)
+    assert result["termination"]["kind"] == "normal"
+    assert result["optimization_convergence"] == "not_requested"
+
+
+def test_orca_output_non_finite_energy_raises_value_error():
+    with pytest.raises(ValueError):
+        chematic.parse_orca_output(
+            "-------------------------   --------------------\n"
+            "FINAL SINGLE POINT ENERGY       NaN\n"
+            "-------------------------   --------------------\n"
+        )
+
+
+# ---------------------------------------------------------------------------
+# QCSchema
+# ---------------------------------------------------------------------------
+
+# r(O-H) = 0.9584 Angstrom equilibrium water geometry, converted to Bohr
+# independently (matches crates/chematic-mol/tests/qcschema.rs's own fixture).
+WATER_BOHR_GEOMETRY = [
+    0.0, 0.0, 0.0,
+    0.0, 1.431544636036637, 1.109419726497757,
+    0.0, -1.431544636036637, 1.109419726497757,
+]
+
+WATER_QCSCHEMA_MOLECULE = {
+    "schema_name": "qcschema_molecule",
+    "schema_version": 1,
+    "symbols": ["O", "H", "H"],
+    "geometry": WATER_BOHR_GEOMETRY,
+    "molecular_charge": 0.0,
+    "molecular_multiplicity": 1,
+    "connectivity": [[0, 1, 1.0], [0, 2, 1.0]],
+}
+
+
+def test_parse_qcschema_molecule():
+    import json
+    result = chematic.parse_qcschema_molecule(json.dumps(WATER_QCSCHEMA_MOLECULE))
+    assert result["symbols"] == ["O", "H", "H"]
+    assert isinstance(result["mol"], chematic.Mol)
+    assert result["mol"].formula == "H2O"
+    assert len(result["coords"]) == 3
+
+
+def test_qcschema_molecule_round_trip():
+    import json
+    result = chematic.parse_qcschema_molecule(json.dumps(WATER_QCSCHEMA_MOLECULE))
+    text = chematic.write_qcschema_molecule(result)
+    result2 = chematic.parse_qcschema_molecule(text)
+    assert result2["symbols"] == result["symbols"]
+    assert result2["geometry"] == pytest.approx(result["geometry"])
+
+
+def test_chematic_to_qc_molecule_and_back():
+    # from_xyz gives explicit H atoms in the graph (unlike from_smiles("O"),
+    # whose H count is implicit) so `coords` matches `mol`'s atom count.
+    # Checked via heavy_atoms (1 oxygen), not `.formula` -- `.formula`
+    # additionally counts *implicit* H filled in for unsatisfied valence,
+    # which depends on from_xyz's distance-based bond perception (an
+    # unrelated concern from what this test exercises: QCSchema round-trip
+    # fidelity of the atoms actually present).
+    xyz = "3\nwater\nO 0.0 0.0 0.0\nH 0.0 0.76 0.59\nH 0.0 -0.76 0.59\n"
+    mol, coords = chematic.from_xyz(xyz)
+    qc = chematic.chematic_to_qc_molecule(mol, coords)
+    assert qc["symbols"] == ["O", "H", "H"]
+    mol2, coords2, charge, mult = chematic.qc_molecule_to_chematic(qc)
+    assert mol2.heavy_atoms == 1
+    assert len(coords2) == 3
+    assert charge == 0.0
+    assert mult == 1
+
+
+def test_qcschema_molecule_malformed_raises_value_error():
+    with pytest.raises(ValueError):
+        chematic.parse_qcschema_molecule('{"symbols": ["H"], "geometry": [1.0]}')
+
+
+def test_parse_atomic_input():
+    import json
+    doc = {
+        "molecule": WATER_QCSCHEMA_MOLECULE,
+        "driver": "energy",
+        "model": {"method": "hf", "basis": "sto-3g"},
+    }
+    result = chematic.parse_atomic_input(json.dumps(doc))
+    assert result["driver"] == "energy"
+    assert result["model"]["method"] == "hf"
+    assert isinstance(result["mol"], chematic.Mol)
+
+
+def test_atomic_input_round_trip():
+    import json
+    doc = {
+        "molecule": WATER_QCSCHEMA_MOLECULE,
+        "driver": "energy",
+        "model": {"method": "hf"},
+        "keywords": {"scf_type": "df"},
+    }
+    result = chematic.parse_atomic_input(json.dumps(doc))
+    text = chematic.write_atomic_input(result)
+    result2 = chematic.parse_atomic_input(text)
+    assert result2["driver"] == "energy"
+    assert result2["keywords"] == {"scf_type": "df"}
+
+
+def test_atomic_input_malformed_raises_value_error():
+    with pytest.raises(ValueError):
+        chematic.parse_atomic_input("not json at all")
+
+
+def test_parse_atomic_result():
+    import json
+    doc = {
+        "molecule": WATER_QCSCHEMA_MOLECULE,
+        "driver": "energy",
+        "model": {"method": "hf"},
+        "provenance": {"creator": "test"},
+        "properties": {},
+        "return_result": -76.02,
+        "success": True,
+    }
+    result = chematic.parse_atomic_result(json.dumps(doc))
+    assert result["success"] is True
+    assert result["return_result"] == pytest.approx(-76.02)
+
+
+def test_atomic_result_round_trip():
+    import json
+    doc = {
+        "molecule": WATER_QCSCHEMA_MOLECULE,
+        "driver": "energy",
+        "model": {"method": "hf"},
+        "provenance": {"creator": "test"},
+        "properties": {},
+        "return_result": -76.02,
+        "success": True,
+    }
+    result = chematic.parse_atomic_result(json.dumps(doc))
+    text = chematic.write_atomic_result(result)
+    result2 = chematic.parse_atomic_result(text)
+    assert result2["success"] is True
+    assert result2["return_result"] == pytest.approx(-76.02)
+
+
+def test_atomic_result_success_inconsistency_raises_value_error():
+    import json
+    doc = {
+        "molecule": WATER_QCSCHEMA_MOLECULE,
+        "driver": "energy",
+        "model": {"method": "hf"},
+        "provenance": {"creator": "test"},
+        "success": True,
+        # success=True but no return_result -- schema violation.
+    }
+    with pytest.raises(ValueError):
+        chematic.parse_atomic_result(json.dumps(doc))
+
+
+# ---------------------------------------------------------------------------
+# Gaussian Cube
+# ---------------------------------------------------------------------------
+
+CUBE_FIXTURE = (
+    "Water density\n"
+    "Generated for chematic tests\n"
+    "1    0.000000    0.000000    0.000000\n"
+    "2    1.000000    0.000000    0.000000\n"
+    "2    0.000000    1.000000    0.000000\n"
+    "2    0.000000    0.000000    1.000000\n"
+    "8    8.000000    0.500000    0.500000    0.500000\n"
+    "0.0 1.0 2.0 3.0\n"
+    "4.0 5.0 6.0 7.0\n"
+)
+
+
+def test_parse_cube():
+    grid = VolumetricGrid.from_cube(CUBE_FIXTURE)
+    assert grid.shape == (2, 2, 2)
+    assert grid.units == "bohr"
+    assert list(grid.values) == pytest.approx([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+    assert len(grid.atoms) == 1
+    assert grid.atoms[0][0] == "O"
+    assert grid.get(1, 0, 0) == pytest.approx(4.0)
+
+
+def test_cube_round_trip():
+    grid = VolumetricGrid.from_cube(CUBE_FIXTURE)
+    text = grid.to_cube()
+    grid2 = VolumetricGrid.from_cube(text)
+    assert grid2.shape == grid.shape
+    assert list(grid2.values) == pytest.approx(list(grid.values))
+
+
+def test_cube_malformed_raises_value_error():
+    with pytest.raises(ValueError):
+        VolumetricGrid.from_cube("not a cube file\nat all\n")
+
+
+# ---------------------------------------------------------------------------
+# OpenDX
+# ---------------------------------------------------------------------------
+
+OPENDX_FIXTURE = (
+    "# Data from APBS\n"
+    "# POTENTIAL (kT/e)\n"
+    "object 1 class gridpositions counts 2 2 2\n"
+    "origin -1.0 -1.0 -1.0\n"
+    "delta 0.5 0.0 0.0\n"
+    "delta 0.0 0.5 0.0\n"
+    "delta 0.0 0.0 0.5\n"
+    "object 2 class gridconnections counts 2 2 2\n"
+    "object 3 class array type double rank 0 items 8 data follows\n"
+    "0.0 1.0 2.0\n"
+    "3.0 4.0 5.0\n"
+    "6.0 7.0\n"
+    'attribute "dep" string "positions"\n'
+    'object "regular positions regular connections" class field\n'
+    'component "positions" value 1\n'
+    'component "connections" value 2\n'
+    'component "data" value 3\n'
+)
+
+
+def test_parse_opendx():
+    grid = VolumetricGrid.from_opendx(OPENDX_FIXTURE)
+    assert grid.shape == (2, 2, 2)
+    assert grid.units == "angstrom"
+    assert grid.atoms == []
+    assert list(grid.values) == pytest.approx([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+
+
+def test_opendx_round_trip():
+    grid = VolumetricGrid.from_opendx(OPENDX_FIXTURE)
+    text = grid.to_opendx()
+    grid2 = VolumetricGrid.from_opendx(text)
+    assert grid2.origin == pytest.approx(grid.origin)
+    assert list(grid2.values) == pytest.approx(list(grid.values))
+
+
+def test_opendx_bohr_grid_fails_closed_but_lossy_succeeds():
+    # PR #335 regression guard: a Bohr-unit grid must be refused by the
+    # strict writer and only accepted through the explicitly-named lossy one.
+    # Non-zero origin so the Bohr->Angstrom conversion is actually visible
+    # (an all-zero origin would pass the old, vacuous assertion either way).
+    grid = VolumetricGrid(
+        origin=(1.0, 0.0, 0.0),
+        axes=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        shape=(2, 2, 2),
+        values=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+        units="bohr",
+    )
+    with pytest.raises(ValueError):
+        grid.to_opendx()
+    text = grid.to_opendx_lossy()
+    grid2 = VolumetricGrid.from_opendx(text)
+    # Bohr -> Angstrom conversion applied to origin/axes (lengths)...
+    assert grid2.origin[0] == pytest.approx(0.529177210903)
+    # ...never to values.
+    assert list(grid2.values) == pytest.approx(list(grid.values))
+
+
+def test_opendx_grid_with_atoms_fails_closed_even_lossy():
+    grid = VolumetricGrid(
+        origin=(0.0, 0.0, 0.0),
+        axes=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        shape=(1, 1, 1),
+        values=[0.0],
+        atoms=[("C", 6.0, (0.0, 0.0, 0.0))],
+        units="angstrom",
+    )
+    with pytest.raises(ValueError):
+        grid.to_opendx()
+    with pytest.raises(ValueError):
+        grid.to_opendx_lossy()
+
+
+def test_volumetric_grid_to_molecule():
+    grid = VolumetricGrid.from_cube(CUBE_FIXTURE)
+    mol, coords = grid.to_molecule()
+    assert isinstance(mol, chematic.Mol)
+    assert len(coords) == 1
+
+
+# ---------------------------------------------------------------------------
+# LAMMPS data
+# ---------------------------------------------------------------------------
+
+LAMMPS_DATA_FIXTURE = (
+    "comment\n"
+    "\n"
+    "1 atoms\n"
+    "1 atom types\n"
+    "\n"
+    "0.0 10.0 xlo xhi\n"
+    "0.0 10.0 ylo yhi\n"
+    "0.0 10.0 zlo zhi\n"
+    "\n"
+    "Atoms # atomic\n"
+    "\n"
+    "1 1 5.0 5.0 5.0\n"
+)
+
+
+def test_parse_lammps_data():
+    data = chematic.parse_lammps_data(LAMMPS_DATA_FIXTURE, "atomic")
+    assert data["counts"]["atoms"] == 1
+    assert data["atom_style"] == "atomic"
+    assert data["box"]["lo"] == pytest.approx((0.0, 0.0, 0.0))
+    assert data["box"]["tilt"] is None
+    assert len(data["atoms"]) == 1
+    assert data["atoms"][0]["x"] == pytest.approx(5.0)
+    assert data["atoms"][0]["charge"] is None
+
+
+def test_lammps_data_round_trip():
+    data = chematic.parse_lammps_data(LAMMPS_DATA_FIXTURE, "atomic")
+    text = chematic.write_lammps_data(data)
+    data2 = chematic.parse_lammps_data(text, "atomic")
+    assert data2["atoms"][0]["x"] == pytest.approx(data["atoms"][0]["x"])
+    assert data2["box"]["hi"] == pytest.approx(data["box"]["hi"])
+
+
+def test_lammps_data_unsupported_atom_style_raises_value_error():
+    with pytest.raises(ValueError):
+        chematic.parse_lammps_data(LAMMPS_DATA_FIXTURE, "sphere")
+
+
+def test_lammps_data_malformed_raises_value_error():
+    with pytest.raises(ValueError):
+        chematic.parse_lammps_data("not a lammps data file\n", "atomic")
+
+
+# ---------------------------------------------------------------------------
+# LAMMPS dump
+# ---------------------------------------------------------------------------
+
+LAMMPS_DUMP_FIXTURE = (
+    "ITEM: TIMESTEP\n0\nITEM: NUMBER OF ATOMS\n1\nITEM: BOX BOUNDS pp pp pp\n"
+    "0.0 10.0\n0.0 10.0\n0.0 10.0\nITEM: ATOMS id type x y z\n1 1 5.0 5.0 5.0\n"
+)
+
+
+def test_parse_lammps_dump_frame():
+    frame = chematic.parse_lammps_dump_frame(LAMMPS_DUMP_FIXTURE)
+    assert isinstance(frame, LammpsDumpFrame)
+    assert frame.timestep == 0
+    assert frame.num_atoms == 1
+    assert frame.column_names == ["id", "type", "x", "y", "z"]
+    assert frame.column("x") == pytest.approx([5.0])
+    positions = frame.cartesian_positions()
+    assert positions is not None
+    assert list(positions[0]) == pytest.approx([5.0, 5.0, 5.0])
+
+
+def test_parse_lammps_dump_all():
+    two_frames = LAMMPS_DUMP_FIXTURE + LAMMPS_DUMP_FIXTURE.replace("TIMESTEP\n0", "TIMESTEP\n1")
+    frames = chematic.parse_lammps_dump_all(two_frames)
+    assert len(frames) == 2
+    assert frames[0].timestep == 0
+    assert frames[1].timestep == 1
+
+
+def test_lammps_dump_round_trip():
+    frame = chematic.parse_lammps_dump_frame(LAMMPS_DUMP_FIXTURE)
+    text = chematic.write_lammps_dump_frame(frame)
+    frame2 = chematic.parse_lammps_dump_frame(text)
+    assert frame2.timestep == frame.timestep
+    assert frame2.column("x") == pytest.approx(frame.column("x"))
+
+
+def test_write_lammps_trajectory():
+    frame = chematic.parse_lammps_dump_frame(LAMMPS_DUMP_FIXTURE)
+    text = chematic.write_lammps_trajectory([frame, frame])
+    frames = chematic.parse_lammps_dump_all(text)
+    assert len(frames) == 2
+
+
+def test_lammps_dump_malformed_raises_value_error():
+    with pytest.raises(ValueError):
+        chematic.parse_lammps_dump_frame("ITEM: NOT TIMESTEP\n0\n")
+
+
+def test_box_bounds_round_trip_utilities():
+    box = chematic.box_bounds_to_true((0.0, 0.0, 0.0), (10.0, 10.0, 10.0), (1.0, 0.5, 0.0))
+    lo, hi = chematic.true_to_box_bounds(box)
+    assert lo == pytest.approx((0.0, 0.0, 0.0))


### PR DESCRIPTION
## Summary

Python (PyO3) bindings for the 7 `chematic-mol` file-format modules that shipped in v0.17.0 with **zero** Python exposure (confirmed via a release audit — grep of `crates/chematic-py/src/*.rs` for `mmcif`/`pqr`/`qcschema`/`orca`/`cube`/`opendx`/`lammps` returned nothing). This is item 3 of the v0.18.0 priority list ("新形式のPython/WASM導線").

Pure binding/glue code — no changes to chemistry/3D-embedding logic, no changes to `chematic-wasm` or `chematic-ff` (both explicitly out of scope, being worked in parallel/separately).

## What was bound, per format

| Format | Shape | Why |
|---|---|---|
| mmCIF | `parse_mmcif`/`write_mmcif` — plain functions + dict | "read a molecule + metadata" shape, matches `parse_cif` precedent |
| PQR | `parse_pqr`/`write_pqr`/`infer_element` — plain functions + dict | same; `element` optional on write (inferred via `infer_element`, since PQR has no element column and the Rust writer never reads it back) |
| ORCA input | `parse_orca_input`/`write_orca_input` — plain functions + dict | same |
| ORCA output | `parse_orca_output` — plain function + dict (no writer; none exists in the Rust API) | same |
| QCSchema (Molecule/AtomicInput/AtomicResult) | `parse_qcschema_molecule`/`write_qcschema_molecule`, `chematic_to_qc_molecule`/`qc_molecule_to_chematic`, `parse_atomic_input`/`write_atomic_input`, `parse_atomic_result`/`write_atomic_result` | routed through Python's own `json` module (stdlib) as the dict↔text boundary, **not** a hand-mapped struct↔dict — see below |
| Gaussian Cube + OpenDX | one shared pyclass `VolumetricGrid` | both read/write the same underlying `chematic_mol::VolumetricGrid`, which has real methods (`get`, `checked_index`, `point_count`, `to_molecule`) and array-shaped data — matches `crystal.rs`'s "real behavior → pyclass" precedent, not `formats.rs`'s dict precedent |
| LAMMPS data | `parse_lammps_data`/`write_lammps_data` — plain dict | only "behavior" beyond a parsed-section bag is `.count(label)`, which `dict.get` already covers |
| LAMMPS dump | pyclass `LammpsDumpFrame` (+ free functions) | has real computed behavior (`column()`, and `cartesian_positions()`'s triclinic-aware transform) worth exposing as methods |

## Judgment calls

- **QCSchema dict↔text boundary.** `QcMolecule`/`AtomicInput`/`AtomicResult` have 20+ fields, several open extensibility bags (`extras`/`unknown_fields`/`keywords`/`protocols`/`native_files`/`wavefunction`) that are part of the spec's own design, not a gap. Hand-mapping all of that field-by-field into `PyDict` code would be large, and any bag not explicitly wired through would silently lose data on round-trip. Since `chematic_mol`'s own `parse_*`/`write_*` already speak canonical JSON text, this binding calls those directly and uses Python's `json.loads`/`json.dumps` as the dict conversion layer — strictly more faithful (nothing can be dropped by oversight) and needs **zero new dependencies** (`serde_json` was never added to `chematic-py`; `chematic_mol::JsonObject`'s `serde_json::Value` payload is never named in this crate). `write_*` strips the `"mol"`/`"coords"` convenience keys `parse_*` adds (a bare `Mol` isn't JSON-serializable) before re-serializing, so `write_x(parse_x(text))` round-trips without the caller manually stripping anything.
- **OpenDX fail-closed preserved.** `VolumetricGrid.to_opendx()` refuses (raises `ValueError`) for a Bohr-units grid or a grid with atoms — same PR #335 guard, not collapsed into a boolean-flag API. `to_opendx_lossy()` is the separate, explicitly-named opt-in for the Bohr→Ångström conversion. Both still refuse for a grid with atoms (OpenDX has no atom section). Covered by `test_opendx_bohr_grid_fails_closed_but_lossy_succeeds` and `test_opendx_grid_with_atoms_fails_closed_even_lossy`.
- **`*ParseLimits`** (mmCIF/PQR/Cube/OpenDX) exposed as optional keyword args defaulting to the Rust `Default` impl's values (verified per-struct, not guessed).
- **LAMMPS streaming.** `parse_lammps_dump_all` materializes the whole trajectory as a `list[LammpsDumpFrame]` rather than exposing `LammpsDumpReader`'s true streaming iteration — disclosed in the docstring: most Python callers materialize anyway, real streaming can follow if a use case needs bounded memory for a huge trajectory. Cube's `CubeFileReader` is not bound at all for a different reason: it's still one grid either way (not multi-record), so streaming only halves peak text memory, not worth the extra binding surface.
- **`LammpsAtomStyle`** taken as a plain Python string (`"atomic"`/`"charge"`/`"molecular"`/`"full"`); anything else maps to `LammpsAtomStyle::Other(s)`, which the Rust parser itself rejects with a typed error — no separate Python-side validation, one source of truth.
- **numpy arrays** for `VolumetricGrid.values`/`.axes` and `LammpsDumpFrame.rows`/`.cartesian_positions()`, matching `crystal.rs`'s existing `Lattice.matrix`/`PeriodicStructure.cartesian_positions` convention (fresh copy per call, not zero-copy — same tradeoff already made there).
- **Every typed Rust error** (`CubeError`, `MmcifError`, `PqrError`, `QcSchemaError`, `OrcaInputError`/`OrcaOutputError`, `OpenDxError`, `LammpsDataError`, `LammpsDumpError`) maps to `ValueError` via `.to_string()`, matching every other `#[pyfunction]` in `formats.rs` — no new exception hierarchy.

## Registration / stubs

- New pyclasses (`VolumetricGrid`, `LammpsDumpFrame`) register in their own module's `register()`, called from `lib.rs` — matches `crystal.rs`'s existing pattern (no `lib.rs` edits beyond the two new `mod`/`register()` lines).
- `crates/chematic-py/python/chematic/__init__.pyi` extended with all new functions/classes (this project's existing hand-maintained type-stub convention).
- `CHANGELOG.md`: new `## [Unreleased]` section (didn't exist yet) with a `### Added — chematic-py (...)` entry.

## Tests

New `crates/chematic-py/tests/test_new_formats.py`: 42 tests, at least one round-trip test and one typed-error→`ValueError` test per format (fixtures adapted from the corresponding Rust-side test fixtures, kept inline per this suite's convention).

## Verification

- `cargo test --workspace --all-features` — pass (0 failures)
- `cargo test --workspace --no-default-features` — pass (0 failures)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `maturin develop --release -m crates/chematic-py/Cargo.toml` — builds and installs
- `python -m pytest crates/chematic-py/tests/ -q` — **741/741 passed** (includes the 42 new tests; zero regressions in the existing 699)

Explicitly **not** run (per the task's standing "minimize heavy measurements" policy and this PR's pure-binding scope): `pipeline_v2`/RDKit-differential/RMSD/TFD benchmarks, full-workspace `cargo doc` (pre-existing lib-name collision, documented in `CONTRIBUTING.md`).

## Not merging/tagging

Draft PR only, no version bump, no release changes.
