### PR TITLE
release: v0.18.0 -- Python/WASM bindings for 7 formats + MMFF94 atom-typing fix + binding quality pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [0.18.0] — 2026-08-20
+
+Python and WASM bindings for the 7 file formats `chematic-mol` gained in
+v0.17.0 (mmCIF, PQR, ORCA, QCSchema, Gaussian Cube, OpenDX, LAMMPS
+data/dump), which had zero Python/WASM exposure until now, plus an MMFF94
+atom-typing fix and a finishing cross-language-consistency pass. One
+sub-bug of issue #337 (aryl isothiocyanate cumulated-double-bond CSP
+carbon) fixed via a strict-superset condition matching RDKit's real rule
+(`getTotalDegree() == 2`); the other 6/8 molecules behind that issue were
+re-diagnosed as a genuine RDKit Kekulization/MMFF-aromaticity-perception
+artifact rather than a locally-fixable typing rule, and left as an
+honestly-disclosed residual (confirmed via direct negative-control
+fragments, not merely asserted). The Binding Quality Pack that closes out
+this release adds `VolumetricGrid.values_3d` (Python), a verified-in-wheel
+`py.typed` marker with a `mypy --strict` check against a fresh-venv wheel
+install, 5 additive `js_sys::Float64Array`/`Uint32Array`-returning WASM
+functions alongside the existing JSON-string API (this crate's first
+typed-array precedent), cross-language parity fixtures proving Rust/
+Python/WASM agree on the same small Cube/OpenDX/mmCIF/LAMMPS-dump inputs,
+and runnable Python + Node.js examples — deliberately scoped as polish and
+consistency, not new format support. Purely additive at the Rust API
+level for existing crates — no breaking changes. **Not in this release**
+(deferred to a future version): the residual MMFF94 atom-typing artifact
+noted above; targeted canonical-SMILES/aromaticity known-residual fixes;
+Rustdoc warning cleanup and a broader API/format-capability documentation
+pass; Gaussian Cube multi-dataset support.
 
 ### Fixed — `chematic-ff` (MMFF94 atom typing: aryl isothiocyanate CSP carbon, issue #337)
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,5 +23,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.17.0
+version: 0.18.0
 date-released: "2026-08-12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.17.0
+# chematic v0.18.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-07-17, v0.4.29 vs RDKit 2026.03.3 --
@@ -427,6 +427,13 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +1
 
 ## Recent Development
 
+**v0.18.0** (2026-08-20): **Python/WASM bindings for the 7 v0.17.0 formats, plus an MMFF94 atom-typing fix and a binding-quality/cross-language-consistency pass**
+- `chematic-ff`: fixed the aryl-isothiocyanate cumulated-double-bond CSP carbon mistyping from issue #337 (`getTotalDegree() == 2` replacing a `triple_bonds > 0`-only check — a strict superset, RDKit's real rule); the other 6/8 molecules behind that issue were re-diagnosed as a genuine RDKit Kekulization/MMFF-aromaticity-perception artifact (confirmed via direct negative-control fragments) rather than a locally-fixable typing rule, and left as an honestly-disclosed residual
+- `chematic-py`: Python bindings for all 7 v0.17.0 formats (mmCIF, PQR, ORCA, QCSchema, Gaussian Cube, OpenDX, LAMMPS data/dump) — previously Rust-only; `VolumetricGrid`/`LammpsDumpFrame` pyclasses with numpy-array properties, `to_opendx`/`to_opendx_lossy` fail-closed split preserved faithfully; a `py.typed` marker verified to actually ship in the built wheel (`mypy --strict` passes against a fresh-venv wheel install, not just the source tree)
+- `chematic-wasm`: WASM (wasm-bindgen) bindings for the same 7 formats, plus 5 additive `js_sys::Float64Array`/`Uint32Array`-returning functions alongside the existing JSON-string API (large numeric grid/row data without a full JSON round trip) — this crate's first typed-array precedent
+- Cross-language parity: the same 4 small fixtures (Cube, OpenDX, mmCIF, LAMMPS triclinic dump) independently verified to produce identical results from Rust, Python, and WASM entry points — no discrepancy found
+- Full details in `CHANGELOG.md`'s `[0.18.0]` section
+
 **v0.17.0** (2026-08-17): **Format/Python/materials-interop breadth, plus two MMFF94 charge/bond-order accuracy fixes**
 - `chematic-mol`: square-planar (`@SP1`/`@SP2`/`@SP3`-equivalent) stereo read/write for MOL/SDF via 3D-coordinate-derived reperception; PDBx/mmCIF, PQR, QCSchema JSON, and ORCA input/output; CIF explicit symmetry-operation expansion into a full unit cell (Rust + Python); a shared `VolumetricGrid` type plus Gaussian Cube and OpenDX (APBS-scoped) I/O; LAMMPS data-file (`read_data` format) and dump/trajectory-file I/O as standalone document types, not integrated with `Molecule`
 - `chematic-py`: new Python bindings for `chematic-crystal`'s `Lattice`/`PeriodicStructure`/`Site` — found and fixed a real pre-existing bug along the way (`to_cif()` silently re-declared an unexpanded-symmetry CIF as false P1)
@@ -569,7 +576,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v0.17.0)
+├── Cargo.toml                    workspace root (v0.18.0)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)
@@ -623,7 +630,7 @@ If you use chematic in academic or research work, please cite:
   author    = {kent-tokyo},
   title     = {chematic: A pure-Rust cheminformatics toolkit},
   url       = {https://github.com/kent-tokyo/chematic},
-  version   = {0.17.0},
+  version   = {0.18.0},
   year      = {2026},
 }
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -106,7 +106,7 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.17.0
+# chematic v0.18.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-06, v0.4.22 vs RDKit 2026.03.3 --
@@ -283,6 +283,13 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi      
 ---
 
 ## 最近の開発
+
+**v0.18.0**（2026-08-20）: **v0.17.0の7新形式へのPython/WASMバインディング、MMFF94 atom-typing修正、言語間一貫性の仕上げ**
+- `chematic-ff`：issue #337のアリールイソチオシアネート累積二重結合CSP炭素の誤タイプを修正（`getTotalDegree() == 2`、RDKitの実際のルールに合わせた厳密な上位集合）。残る6/8分子はRDKit自身のKekulization/MMFF芳香族性認識に起因する真正のアーティファクトと再診断し（negative-control fragmentsで直接検証）、誠実な残課題として開示
+- `chematic-py`：v0.17.0の7形式（mmCIF・PQR・ORCA・QCSchema・Gaussian Cube・OpenDX・LAMMPS data/dump）全てにPythonバインディングを追加——これまでRust限定だった機能。`VolumetricGrid`/`LammpsDumpFrame`のpyclassはNumPy配列プロパティを持ち、`to_opendx`/`to_opendx_lossy`のfail-closed分離も忠実に維持。`py.typed`マーカーが実際にビルド済みwheelへ含まれることを検証済み（ソースツリーではなく新規venvへのwheel installに対して`mypy --strict`が通過）
+- `chematic-wasm`：同じ7形式へのWASM（wasm-bindgen）バインディング、加えて既存のJSON文字列APIに追加する形で`js_sys::Float64Array`/`Uint32Array`を返す5つの新規関数（大きな数値グリッド/行データをJSON往復なしで取得）——このクレート初のtyped-array対応
+- 言語間の一貫性：同一の4つの小規模fixture（Cube・OpenDX・mmCIF・LAMMPS triclinic dump）がRust・Python・WASMの3言語entry pointで同一結果を返すことを独立検証、不一致なし
+- 詳細は`CHANGELOG.md`の`[0.18.0]`section参照
 
 **v0.17.0**（2026-08-17）: **フォーマット/Python/材料科学の相互運用性拡充、およびMMFF94電荷・結合次数の精度修正2件**
 - `chematic-mol`：square-planar（`@SP1`/`@SP2`/`@SP3`相当）立体化学のMOL/SDF read/write（3D座標からの再認識）、PDBx/mmCIF・PQR・QCSchema JSON・ORCA入出力、CIF明示的symmetry操作の展開（Rust/Python両方）、共有`VolumetricGrid`型 + Gaussian Cube/OpenDX I/O、LAMMPS data/dump（trajectory）I/O（`Molecule`とは独立した専用document型）

--- a/README_zh.md
+++ b/README_zh.md
@@ -251,6 +251,13 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi      
 
 ## 近期开发
 
+**v0.18.0**（2026-08-20）：**为 v0.17.0 的 7 种新格式添加 Python/WASM 绑定，一项 MMFF94 原子类型修复，以及跨语言一致性完善**
+- `chematic-ff`：修复了 issue #337 中芳基异硫氰酸酯累积双键 CSP 碳的误判类型（`getTotalDegree() == 2`，是 RDKit 真实规则的严格超集）。其余 6/8 个分子被重新诊断为 RDKit 自身 Kekulization/MMFF 芳香性识别的真实伪影（通过直接的负对照片段验证），并作为诚实披露的遗留问题保留
+- `chematic-py`：为 v0.17.0 的全部 7 种格式（mmCIF、PQR、ORCA、QCSchema、Gaussian Cube、OpenDX、LAMMPS data/dump）新增 Python 绑定——此前仅限 Rust 使用。`VolumetricGrid`/`LammpsDumpFrame` pyclass 具有 numpy 数组属性，`to_opendx`/`to_opendx_lossy` 的 fail-closed 分离被忠实保留；`py.typed` 标记已验证确实包含在构建的 wheel 中（对新建 venv 中安装的 wheel 而非源码树运行 `mypy --strict` 通过）
+- `chematic-wasm`：为相同 7 种格式新增 WASM（wasm-bindgen）绑定，并在现有 JSON 字符串 API 之外新增 5 个返回 `js_sys::Float64Array`/`Uint32Array` 的附加函数（无需完整 JSON 往返即可获取大型数值网格/行数据）——该 crate 首次支持 typed array
+- 跨语言一致性：同一组 4 个小型 fixture（Cube、OpenDX、mmCIF、LAMMPS triclinic dump）已独立验证在 Rust、Python、WASM 三个语言入口点产生一致结果，未发现差异
+- 详见 `CHANGELOG.md` 的 `[0.18.0]` 部分
+
 **v0.17.0**（2026-08-17）：**格式/Python/材料科学互操作性扩展，以及两项 MMFF94 电荷/键级精度修复**
 - `chematic-mol`：平面四方（`@SP1`/`@SP2`/`@SP3` 等价）立体化学的 MOL/SDF 读写（基于 3D 坐标重新识别）、PDBx/mmCIF、PQR、QCSchema JSON、ORCA 输入输出、CIF 显式对称操作展开（Rust 与 Python 均支持）、共享 `VolumetricGrid` 类型加 Gaussian Cube/OpenDX I/O、LAMMPS data/dump（轨迹）I/O（作为独立于 `Molecule` 的专用 document 类型）
 - `chematic-py`：新增 `chematic-crystal` 的 `Lattice`/`PeriodicStructure`/`Site` Python 绑定——开发过程中发现并修复了一个真实的既有 bug（`to_cif()` 曾将未展开对称性的 CIF 错误地重新声明为 P1）

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.17.0 | Yes | Current release — active support |
+| v0.18.0 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.17.0) receives all security updates.  
+**Active Support**: Latest release (v0.18.0) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -17,12 +17,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.17.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.17.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.17.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.17.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.17.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.18.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.18.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.18.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.18.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.18.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.18.0" }
 serde_json          = "1.0"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #219); web-time

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -17,14 +17,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.17.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.18.0" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.17.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.17.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.17.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.17.0" }
-chematic-cip        = { path = "../chematic-cip",        version = "0.17.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.18.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.18.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.18.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.18.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.18.0" }
+chematic-cip        = { path = "../chematic-cip",        version = "0.18.0" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.17.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.18.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.18.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-crystal/Cargo.toml
+++ b/crates/chematic-crystal/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 serde = ["dep:serde"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.17.0" }
+chematic-core = { path = "../chematic-core", version = "0.18.0" }
 serde         = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -23,10 +23,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.17.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.17.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.17.0" }
+chematic-core = { path = "../chematic-core", version = "0.18.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.18.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.18.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.18.0" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.17.0" }
+chematic-core = { path = "../chematic-core", version = "0.18.0" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.17.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.18.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.18.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -23,13 +23,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.17.0" }
+chematic-core = { path = "../chematic-core", version = "0.18.0" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.17.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.17.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.17.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.18.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.18.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.18.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.18.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -19,10 +19,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.17.0", path = "../chematic-core" }
-chematic-smiles = { version = "0.17.0", path = "../chematic-smiles" }
-chematic-chem = { version = "0.17.0", path = "../chematic-chem" }
-chematic-rxn = { version = "0.17.0", path = "../chematic-rxn" }
+chematic-core = { version = "0.18.0", path = "../chematic-core" }
+chematic-smiles = { version = "0.18.0", path = "../chematic-smiles" }
+chematic-chem = { version = "0.18.0", path = "../chematic-chem" }
+chematic-rxn = { version = "0.18.0", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.17.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.18.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.18.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -18,15 +18,15 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.17.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.17.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.17.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.17.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.17.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.17.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.17.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.17.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.18.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.18.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.18.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.18.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.18.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.18.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.18.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.18.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.18.0" }
 
 [dev-dependencies]
 # Real JSON Schema 2020-12 validator, used only in tests to independently

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -25,11 +25,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 crystal = ["dep:chematic-crystal"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.17.0" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.17.0" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.17.0" }
-chematic-smiles      = { path = "../chematic-smiles",      version = "0.17.0" }
-chematic-crystal     = { path = "../chematic-crystal",     version = "0.17.0", optional = true }
+chematic-core        = { path = "../chematic-core",        version = "0.18.0" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.18.0" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.18.0" }
+chematic-smiles      = { path = "../chematic-smiles",      version = "0.18.0" }
+chematic-crystal     = { path = "../chematic-crystal",     version = "0.18.0", optional = true }
 serde_json           = "1.0"
 
 [dev-dependencies]

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.17.0" }
+chematic-core = { path = "../chematic-core", version = "0.18.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,17 +25,17 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.17.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.17.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.17.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.17.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.17.0", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.17.0", features = ["crystal"] }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.17.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.17.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.17.0" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.17.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.17.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.17.0" }
-chematic-crystal    = { path = "../chematic-crystal",    version = "0.17.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.18.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.18.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.18.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.18.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.18.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.18.0", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.18.0", features = ["crystal"] }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.18.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.18.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.18.0" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.18.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.18.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.18.0" }
+chematic-crystal    = { path = "../chematic-crystal",    version = "0.18.0" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -23,9 +23,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 perf-instrumentation = []
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.17.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.17.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.17.0" }
+chematic-core   = { path = "../chematic-core",   version = "0.18.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.18.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.18.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.17.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
+chematic-core = { path = "../chematic-core", version = "0.18.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.18.0" }
 rustc-hash = "2"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #221); web-time

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.17.0" }
+chematic-core = { path = "../chematic-core", version = "0.18.0" }
 
 [features]
 # Feature-gated internal work counters for the orbit-pruning canonical

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -32,16 +32,16 @@ web-sys = { version = "0.3", features = ["console"] }
 js-sys = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.17.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.17.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.17.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.17.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.17.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.17.0", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.17.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.17.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.17.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.17.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.17.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.17.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.17.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.18.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.18.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.18.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.18.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.18.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.18.0", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.18.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.18.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.18.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.18.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.18.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.18.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.18.0" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -54,16 +54,16 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.17.0", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.17.0", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.17.0", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.17.0", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.17.0", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.17.0", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.17.0", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.17.0", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.17.0", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.17.0", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.17.0", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.17.0", optional = true }
-chematic-crystal    = { path = "../chematic-crystal",    version = "0.17.0", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.18.0", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.18.0", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.18.0", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.18.0", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.18.0", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.18.0", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.18.0", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.18.0", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.18.0", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.18.0", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.18.0", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.18.0", optional = true }
+chematic-crystal    = { path = "../chematic-crystal",    version = "0.18.0", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

v0.18.0 release candidate: **Python/WASM bindings for the 7 v0.17.0 formats, an MMFF94 atom-typing fix, and a binding-quality/cross-language-consistency pass.**

- `chematic-ff`: fixed issue #337's aryl isothiocyanate cumulated-double-bond CSP carbon mistyping (`getTotalDegree() == 2` replacing a `triple_bonds > 0`-only check — RDKit's real rule, a strict superset of the old condition). The other 6/8 molecules behind that issue were re-diagnosed (issue text itself had the wrong atom identified) as a genuine RDKit Kekulization/MMFF-aromaticity-perception artifact for a specific fused, macrocyclic ring topology — not a locally-statable typing rule — confirmed via 5 direct negative-control fragment tests, and left as an honestly-disclosed residual rather than a heuristic that would create new false mismatches.
- `chematic-py`: Python (PyO3) bindings for all 7 v0.17.0 formats (mmCIF, PQR, ORCA, QCSchema, Gaussian Cube, OpenDX, LAMMPS data/dump) — previously Rust-only. `VolumetricGrid`/`LammpsDumpFrame` pyclasses with numpy-array properties; OpenDX's fail-closed `to_opendx`/`to_opendx_lossy` split preserved faithfully.
- `chematic-wasm`: WASM (wasm-bindgen) bindings for the same 7 formats, JSON-string convention matching the crate's existing `mol_io.rs` precedent; `LammpsDumpFrame::cartesian_positions()` (triclinic-aware) properly delegated rather than left unreachable to JS callers.
- Binding Quality Pack (final feature PR of this cycle): `VolumetricGrid.values_3d` (Python, axis order independently verified against a non-cubic fixture); a `py.typed` marker verified to actually ship in the built wheel with a `mypy --strict` check against a fresh-venv install; 5 additive `js_sys::Float64Array`/`Uint32Array` WASM functions alongside the existing JSON API (this crate's first typed-array precedent); Rust/Python/WASM parity fixtures for Cube/OpenDX/mmCIF/LAMMPS-dump (all 3 language surfaces independently verified to agree, no discrepancy found); runnable Python + Node.js examples.

PRs #341, #342, #343, #344 — full itemized list in `CHANGELOG.md`'s `[0.18.0]` section.

Not in this release (deferred): the residual MMFF94 atom-typing artifact noted above; targeted canonical-SMILES/aromaticity known-residual fixes; Rustdoc warning cleanup + a broader API/format-capability documentation pass; Gaussian Cube multi-dataset support.

## Why no heavy 3D/RDKit measurement

This release touches zero production 3D-embedding/canonical-SMILES code. PR #341's MMFF94 fix is atom-typing/charge-lookup only, with its own disclosed full-264-molecule-corpus per-atom join (34→32 type-mismatch, 62→56 charge-mismatch, zero regressions) already in the CHANGELOG. PRs #342-#344 are Python/WASM binding + test/example/fixture work with no reach into `chematic-3d`/`chematic-ff`'s embedding or minimization path. No new pipeline_v2/RDKit-differential measurement was run — none of this cycle's changes could affect those numbers.

## Verification

- `bash scripts/check.sh` (fmt, clippy, `cargo test --workspace` incl. doctests, cargo-deny, publish-graph, version-consistency across all files): **all green**, 0 failures, run twice (pre- and post-version-bump).
- MSRV: `cargo +1.88 check --workspace --all-features` passes cleanly (no new dependency requirements introduced this cycle).
- `cargo doc --workspace --all-features --no-deps --exclude chematic-py` + `cargo doc -p chematic-py --all-features --no-deps` standalone: same pre-existing warning counts as the v0.17.0 release audit (17 in `chematic-mol`, 4 in `chematic-wasm`, 0 in `chematic-py`) — zero new warnings from this cycle's work.
- `cargo package --workspace --registry crates-io --allow-dirty`: all **20** real crates (19 crates.io + `chematic-py`) package successfully at `0.18.0`. Fails only at `tools/gen_sa_table` (`publish = false` internal dev tool, not part of the publish graph) — expected, unrelated.
- `python scripts/check_publish_graph.py`: OK, 19 publishable crates, safe order unchanged.
- Version consistency: every `Cargo.toml` (workspace root + all 20 crates) coherently at `0.18.0`; every internal path-dependency version pin updated to match.
- Cross-referenced README.md/README_ja.md/README_zh.md's "Recent Development" sections for stale/false claims relative to this cycle's actual changes — none found (`chematic-crystal/README.md`'s "No WASM/MCP bindings" note, fixed during the v0.17.0 audit, remains accurate since this cycle's bindings target `chematic-mol`'s formats, not `chematic-crystal`).

## Test plan

- [x] `bash scripts/check.sh` green (both before and after version bump)
- [x] MSRV 1.88 confirmed clean
- [x] `cargo package --workspace` dry-run: 20/20 real crates succeed
- [x] `check_publish_graph.py` OK
- [x] `cargo doc` warning-count regression check: zero new warnings
- [ ] CI green on this PR (pending)

Draft PR — merge, tag, GitHub Release, and crates.io/PyPI/npm publish are separate, explicit follow-up steps, not part of this PR.
