### PR TITLE
docs: v0.18 adoption and API capability guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ Full worked examples → [Use cases](https://kent-tokyo.github.io/chematic/use-c
 
 ---
 
+## Choose your interface
+
+- [Rust](#quick-start)
+- [Python](#quick-start)
+- [WebAssembly / Node.js](#javascript--typescript-webassembly)
+- [Materials and simulation formats](docs/format-capabilities.md) — mmCIF, PQR, QCSchema, ORCA, Gaussian Cube, OpenDX, LAMMPS
+- [Migrating from RDKit](docs/rdkit-migration.md) — feature-by-feature Supported/Partial/Not-supported breakdown
+
+---
+
 ## Quick Start
 
 ### Installation

--- a/README_ja.md
+++ b/README_ja.md
@@ -59,6 +59,16 @@ WASM サイズ: chematic **719 KB** · RDKit.js ~30 MB · Indigo WASM ~40 MB
 
 ---
 
+## インターフェースを選ぶ
+
+- [Rust](#クイックスタート)
+- [Python](#クイックスタート)
+- [WebAssembly / Node.js](README.md#javascript--typescript-webassembly)
+- [材料・シミュレーション用フォーマット](docs/format-capabilities.md) — mmCIF, PQR, QCSchema, ORCA, Gaussian Cube, OpenDX, LAMMPS
+- [RDKit からの移行](docs/rdkit-migration.md) — 機能ごとの Supported / Partial / Not-supported 対応表
+
+---
+
 ## クイックスタート
 
 ### インストール

--- a/README_zh.md
+++ b/README_zh.md
@@ -59,6 +59,16 @@ WASM 包体积对比：chematic **719 KB** · RDKit.js ~30 MB · Indigo WASM ~40
 
 ---
 
+## 选择你的接口
+
+- [Rust](#快速开始)
+- [Python](#快速开始)
+- [WebAssembly / Node.js](README.md#javascript--typescript-webassembly)
+- [材料与模拟格式](docs/format-capabilities.md) — mmCIF、PQR、QCSchema、ORCA、Gaussian Cube、OpenDX、LAMMPS
+- [从 RDKit 迁移](docs/rdkit-migration.md) — 按功能划分的 Supported / Partial / Not-supported 对照表
+
+---
+
 ## 快速开始
 
 ### 安装

--- a/crates/chematic-mol/src/cdxml.rs
+++ b/crates/chematic-mol/src/cdxml.rs
@@ -118,7 +118,8 @@ pub struct CdxmlParseOptions {
 ///
 /// **Coordinate system:** The returned `coords` use **ChemDraw Y-down convention**
 /// (Y increases downward, matching screen/SVG pixel space). No Y-axis conversion is required
-/// for SVG rendering; coordinates can be used directly in [`crate::svg::render_svg`] or similar.
+/// for SVG rendering; coordinates can be used directly with an SVG renderer such as
+/// `render_svg` (see `chematic-depict`).
 pub fn parse_cdxml(input: &str) -> Result<(Molecule, Vec<(f64, f64)>), CdxmlError> {
     parse_cdxml_with_options(input, &CdxmlParseOptions::default())
 }

--- a/crates/chematic-mol/src/cml.rs
+++ b/crates/chematic-mol/src/cml.rs
@@ -192,8 +192,8 @@ struct CmlAtomData {
 ///
 /// **Coordinate system:** The returned `coords` use **chemical Y-up convention**
 /// (Y increases upward, matching mathematical axes). This differs from SVG/screen Y-down.
-/// When rendering via [`crate::svg::render_svg`] or similar, callers must negate Y coordinates
-/// to match SVG pixel space.
+/// When rendering with an SVG renderer such as `render_svg` (see `chematic-depict`),
+/// callers must negate Y coordinates to match SVG pixel space.
 ///
 /// # Example
 /// ```text

--- a/docs/error-and-limits.md
+++ b/docs/error-and-limits.md
@@ -1,0 +1,217 @@
+# Error Handling & Parse Limits
+
+What actually limits input size, how typed errors surface in each language,
+and which operations are explicitly named as lossy. This describes real,
+specific, checkable behavior — bounded input validation on the formats
+that have it, not a claim that chematic is broadly "secure." Formats
+without a documented limit type are named as such below, not silently
+folded into a "handled" bucket.
+
+See also: [`format-capabilities.md`](format-capabilities.md) for the
+per-format matrix these limits are drawn from, and
+[`language-bindings.md`](language-bindings.md) for the `ValueError`/
+JS-error mapping in more general terms.
+
+---
+
+## Parse limits, by format
+
+Only 4 of the 15 formats covered in [`format-capabilities.md`](format-capabilities.md)
+have a dedicated `*ParseLimits` type. The rest do not — this is not
+inconsistent oversight to be quietly worked around; it reflects that most of
+these formats have no natural analogue of "grid points" or a comparably
+unbounded substructure, or simply have not had a limits type added yet.
+
+| Format | Limits type | Fields |
+|---|---|---|
+| mmCIF | `MmcifParseLimits` | `max_input_bytes`, `max_atoms`, `max_line_len` |
+| PQR | `PqrParseLimits` | `max_input_bytes`, `max_atoms`, `max_line_len` |
+| Gaussian Cube | `CubeParseLimits` | `max_input_bytes`, `max_atoms`, `max_grid_points` |
+| OpenDX | `OpenDxParseLimits` | `max_input_bytes`, `max_grid_points` (no `max_atoms` — the format has no atom section) |
+| SMILES | none | — |
+| SMARTS | none | — |
+| MOL/SDF | none | — |
+| PDB | none | — |
+| CIF (plain) | none | — |
+| XYZ / Extended XYZ | none | — |
+| QCSchema | none | — (JSON-size limits, if any, are whatever the caller or `serde_json` impose) |
+| ORCA input | none | — |
+| ORCA output | none | — |
+| LAMMPS data | none | — |
+| LAMMPS dump/trajectory | none | — |
+
+In Python, each `*ParseLimits` field is exposed as an optional keyword
+argument on the corresponding `parse_*_with_limits`-style function, using
+the Rust `Default` values when omitted (e.g. `parse_mmcif(text,
+max_input_bytes=None, max_atoms=None, max_line_len=None)`).
+
+---
+
+## Checked arithmetic and NaN/Infinity rejection
+
+- `VolumetricGrid::checked_index` (shared by Cube and OpenDX) computes the
+  flat-array index from `(i, j, k)` with explicit bounds checking — it
+  returns `None` rather than panicking or wrapping on out-of-range input,
+  including index-arithmetic overflow.
+- QCSchema rejects every non-finite numeric leaf (`NaN`/`Infinity`) rather
+  than letting it pass through — `serde_json::Number` itself cannot
+  represent a non-finite value, and the parser treats an attempt to smuggle
+  one in as a typed error rather than silently coercing it to `null` or `0`.
+- LAMMPS dump's box-bounds/triclinic conversion (`box_bounds_to_true`/
+  `true_to_box_bounds`) is typed to reject a non-finite coordinate, not just
+  a malformed one.
+
+---
+
+## Unsupported-format-subset behavior: reject, don't guess
+
+Every one of these is a **typed rejection**, not a silent best-effort
+fallback or a silent truncation:
+
+| Situation | Behavior |
+|---|---|
+| LAMMPS data with an `atom_style` outside `atomic`/`charge`/`molecular`/`full` | `LammpsDataError::UnsupportedAtomStyle` — `charge` and `molecular` rows are both genuinely ambiguous 6-field rows by column count alone, so there is no safe guess to fall back to. |
+| LAMMPS "Type Labels" sections (`Atom Type Labels`, `Bond Type Labels`, etc.) | rejected — any section name ending in `"Type Labels"` fails the parse rather than being silently misread as a different section shape. |
+| Gaussian Cube file with more than one dataset | `CubeError::MultiDatasetUnsupported` — rejected, not silently truncated to the first dataset. |
+| OpenDX write of a `Bohr`-tagged grid via `write_opendx` | `OpenDxError::NonAngstromUnits` — see the fail-closed section below. |
+| OpenDX write of a grid with any atoms (either writer) | `OpenDxError::AtomsNotSupported` — there is no lossy-atom-dropping path; the format simply has no atom section to write to. |
+
+---
+
+## Typed-error taxonomy → `ValueError` / JS-error mapping
+
+Every format module defines its own error enum (`LammpsDataError`,
+`OpenDxError`, `CubeError`, `MmcifError`, `PqrError`, `OrcaInputError`,
+`OrcaOutputError`, `QcSchemaError`, `CifError`, `XyzError`,
+`MolParseError`, `CdxmlError`, `CmlError`, ...). The mapping across
+language boundaries is uniform but lossy in one specific sense:
+
+| Language | Representation |
+|---|---|
+| Rust | the original typed enum variant, with its own fields (e.g. `CubeError::MultiDatasetUnsupported { natoms_field, nval }`) |
+| Python | `ValueError`, message = the Rust error's `Display` text |
+| WASM | thrown JS error / `JsValue::from_str(...)`, message = the Rust error's `Display` text |
+
+Both bindings currently flatten the structured Rust variant down to a
+string message — neither language exposes the original enum's fields
+programmatically across the boundary today. If you need to distinguish
+error *kinds* (not just read a message) in Python or JS, you currently have
+to do it by matching on message text, which is a real limitation, not an
+oversight this page is hiding.
+
+---
+
+## Fail-closed writers
+
+`write_opendx` is the clearest example in the codebase: given a grid whose
+`units` field is `GridUnits::Bohr`, it refuses to write rather than
+producing an OpenDX file (a format with no in-file unit tag) that a
+downstream reader would silently misinterpret as Ångström. The explicit
+opt-in for the lossy path is `write_opendx_lossy` — see the naming
+convention below. This same fail-closed principle applies to the
+unsupported-format-subset rejections in the table above: every one of them
+raises a typed error instead of writing/returning a best-effort,
+potentially-wrong result.
+
+---
+
+## The `*_lossy` naming convention
+
+Every explicitly lossy write path in this codebase is named with a
+`_lossy` suffix and is **opt-in only** — never the default, never triggered
+implicitly by a missing flag:
+
+- `write_opendx_lossy` (Rust) / `VolumetricGrid.to_opendx_lossy()` (Python)
+  / `write_opendx_lossy_json` (WASM) — the sole named lossy operation
+  across all 15 formats in this pass. It rescales `origin`/`axes` from
+  Bohr to Ångström; it never rescales `values`, and it still refuses
+  (`AtomsNotSupported`) a grid with atoms.
+
+No other format in this documentation pass has a `_lossy`-suffixed
+function. Where a format has a *documented* lossy characteristic that isn't
+behind an explicit opt-in — e.g. mmCIF's `label_*`/`auth_*` tag-pair
+collapse on read, which is unconditional, not a named lossy function — it
+is called out in [`format-capabilities.md`](format-capabilities.md)'s
+per-format detail instead, precisely because it doesn't fit this
+opt-in-only convention.
+
+---
+
+## Formats that never fabricate bonds
+
+mmCIF, PQR, ORCA (input and output), Gaussian Cube, OpenDX, LAMMPS data,
+and plain CIF never infer or fabricate a bond table. PDB and
+`chematic_3d::parse_xyz` are the two exceptions among the 15 covered here —
+both infer bonds from 3D geometry (distance-based), a disclosed,
+documented choice specific to those two entry points, not a default
+behavior you should assume elsewhere. See
+[`format-capabilities.md`](format-capabilities.md#formats-that-never-fabricate-bonds)
+for the full per-format connectivity notes.
+
+---
+
+## Streaming vs. full materialization, per format/language
+
+LAMMPS dump/trajectory is the one format with a real Rust-level
+streaming-vs-materializing distinction: `LammpsDumpReader<R: BufRead>` is a
+true streaming `Iterator`, while both the Python (`parse_lammps_dump_all`)
+and WASM (`lammps_trajectory_to_json`) bindings materialize the whole
+trajectory instead — a disclosed scope choice from CHANGELOG `[0.17.0]`/
+`[0.18.0]`, not a gap uncovered by this pass. MOL/SDF's `SdfFileReader<R:
+BufRead>` is a true streaming reader too, but this is not currently called
+out in CHANGELOG the way the LAMMPS case is. See
+[`language-bindings.md`](language-bindings.md#streaming-vs-materialization-by-language)
+for the full per-format table.
+
+---
+
+## Misuse-prevention examples
+
+These are short illustrations of the fail-closed/typed-rejection behavior
+above — not new functionality, just what already happens if you try the
+tempting-but-wrong thing.
+
+**OpenDX: writing a Bohr-tagged grid without `_lossy`**
+
+```rust
+// grid.units == GridUnits::Bohr
+let err = write_opendx(&grid).unwrap_err();
+// err is OpenDxError::NonAngstromUnits { units: GridUnits::Bohr } —
+// the file is not written. Use write_opendx_lossy(&grid) if you
+// intend the Bohr->Angstrom conversion (rescales origin/axes only).
+```
+
+**Gaussian Cube: a multi-dataset file**
+
+```rust
+// input .cube has natoms field encoding "2 datasets"
+let err = parse_cube(text).unwrap_err();
+// err is CubeError::MultiDatasetUnsupported { natoms_field, nval } —
+// not silently parsed as dataset 1 of N.
+```
+
+**LAMMPS: guessing `atom_style` instead of stating it**
+
+```rust
+// A 6-field Atoms row is ambiguous: could be `charge` (id type q x y z)
+// or `molecular` (id mol-id type x y z). Passing the wrong style
+// doesn't error at read time -- it silently mis-assigns which
+// column is charge vs. molecule-id. Always pass the atom_style the
+// simulation actually used; an out-of-set value (e.g. a typo) is
+// caught (`UnsupportedAtomStyle`), but a *wrong-but-valid* style is not.
+let data = parse_lammps_data(text, LammpsAtomStyle::Full)?; // be explicit
+```
+
+**QCSchema: assuming `connectivity` is always present**
+
+```rust
+let qc: QcMolecule = parse_qcschema_molecule(text)?;
+// qc.connectivity: Option<Vec<(usize, usize, f64)>> -- QCSchema does
+// not require a bond list. Unwrapping without checking panics on any
+// spec-valid molecule that omits it (most do).
+if let Some(bonds) = &qc.connectivity {
+    // only reachable if the source document actually included one
+} else {
+    // no bonds available -- do not fabricate them here
+}
+```

--- a/docs/format-capabilities.md
+++ b/docs/format-capabilities.md
@@ -1,0 +1,387 @@
+# Format Capability Matrix
+
+What each of chematic's 15 supported file formats actually does, in Rust,
+Python, and WASM, as of v0.18.0 — read/write coverage, streaming, coordinate
+units, connectivity handling, round-trip fidelity, lossy operations, parse
+limits, and known limitations.
+
+See also: [`rdkit-migration.md`](rdkit-migration.md) for a feature-by-feature
+Supported/Partial/Not-supported breakdown against RDKit, and
+[`language-bindings.md`](language-bindings.md) for cross-language API
+mapping (function names, return shapes, `None`/`null`/`Err` divergences).
+
+This page describes what exists today. It does not claim "full support" for
+any format — each row states exactly what is implemented and names the gaps.
+
+---
+
+## Support matrix
+
+Read (R) / Write (W) per language. A dash means that operation is not
+exposed in that language. "—" in the WASM columns for CIF means CIF has
+**zero** WASM exposure at all, not an oversight in this table.
+
+| Format | Rust R | Rust W | Python R | Python W | WASM R | WASM W |
+|---|---|---|---|---|---|---|
+| SMILES | Y | Y | Y | Y (`Mol.smiles` property) | Y | Y |
+| SMARTS | Y | — (matching, not writing) | validation only | — | Y (match) | — |
+| MOL/SDF | Y | Y | Y | Y (`Mol.to_mol_block()`/`.to_mol_block_2d()`) | Y | Y |
+| PDB | Y | Y | Y | Y (`Mol.to_pdb(coords)`) | Y | Y (`ConformerHandle.get_conformer_pdb(idx)`) |
+| mmCIF | Y | Y | Y | Y | Y | Y |
+| CIF (small-molecule) | Y | Y | Y | — | — | — |
+| PQR | Y | Y | Y | Y | Y | Y |
+| XYZ | Y | Y | Y | — | Y | Y |
+| Extended XYZ | Y | Y | Y | Y | Y | Y |
+| QCSchema | Y | Y | Y | Y | Y | — (validation only, no writer) |
+| ORCA input | Y | Y | Y | Y | Y | Y |
+| ORCA output | Y | — (no writer exists in Rust) | Y | — | Y | — |
+| Gaussian Cube | Y | Y | Y (via `VolumetricGrid`) | Y (via `VolumetricGrid`) | Y | Y |
+| OpenDX | Y | Y (strict + `_lossy`) | Y (via `VolumetricGrid`) | Y (via `VolumetricGrid`, strict + `_lossy`) | Y | Y (strict + `_lossy`) |
+| LAMMPS data | Y | Y | Y | Y | Y | Y |
+| LAMMPS dump/trajectory | Y | Y | Y | Y | Y | Y |
+
+Notes on the cells above that need qualification:
+
+- **SMILES Python write / MOL-SDF Python write**: exposed as `Mol` object
+  methods/properties (`Mol.smiles`, `Mol.to_mol_block()`/
+  `.to_mol_block_2d()`), not as free `formats.rs` functions in the same
+  shape as the read side (`from_smiles`, `from_mol_block`, etc.). Both
+  directions exist; the binding shape just differs from the read side —
+  see [`language-bindings.md`](language-bindings.md) for the exact names.
+- **QCSchema WASM write**: `qcschema_validate_atomic_input` /
+  `qcschema_validate_atomic_result` validate a JSON document; the only WASM
+  writer present is `to_qcschema_molecule_json` (for `QcMolecule`, not
+  `AtomicInput`/`AtomicResult`).
+
+---
+
+## Per-format detail
+
+### SMILES
+
+- **Rust**: `chematic_smiles::{parse, write, canonical_smiles, parse_cxsmiles, write_cxsmiles, parse_smi_file, write_smi_file, random_smiles}`.
+- **Python**: `from_smiles`, `from_cxsmiles`, `is_valid_smiles`, `parse_smi_file`, `write_smi_file`.
+- **WASM**: `parse_smiles`/`write_smiles`, `mol_block_from_smiles`, `smiles_array_to_sdf`, `parse_cxsmiles_json`, `normalize_cxsmiles`, `is_valid_smiles`.
+- **Streaming**: `parse_smi_file`/`write_smi_file` materialize fully. Separately,
+  `chematic-mol`'s `smiles_table` module (`SmilesRecordReader`/`SmilesRecordWriter`,
+  a **different sub-format** — delimited SMILES-table files with name/property
+  columns, not plain `.smi`) implements a true `BufRead`-backed streaming
+  `Iterator`. It is not exposed to Python/WASM and is out of scope for the
+  "15 formats" table this page otherwise tracks; noted here only because it
+  bears directly on any "no format in this codebase streams" claim.
+- **Coordinate units**: N/A — SMILES encodes graph topology and stereo parity,
+  not coordinates. CXSMILES can carry optional 2D coordinates as an extension.
+- **Connectivity**: native — bonds are the primary content of the format.
+- **Round-trip**: graph-canonical, not byte-identical (whitespace/atom order
+  are not preserved). `canonical_smiles()` is **not** guaranteed to be a safe
+  dedup/cache key today — see the Known Limitations section below.
+- **Lossy operations**: none inherent to the format itself.
+- **Parse limits**: no `*ParseLimits` type exists for SMILES.
+- **Known limitations**: `canonical_smiles()` has a documented residual —
+  isolated/simple E/Z double bonds can still produce two different, both-valid
+  canonical strings for the same molecule in ~1 in 18 stereo-bearing
+  molecules (measured on a 5,000-mol ChEMBL corpus; see README's "Known
+  Limitations" section for the exact figures). Do not use it as a dedup key
+  without accounting for this.
+
+### SMARTS
+
+- **Rust**: `chematic_smarts::{parse_smarts, find_matches, find_matches_with_rings, ...}`.
+- **Python**: `is_valid_smarts` — validation only. Full parse/substructure
+  matching is exposed through `Mol.find_matches()`/`Mol.has_substructure()`
+  (on the molecule object, not as a `formats.rs`-style free function) — do
+  not read this as "SMARTS has no Python support," it means the shape of the
+  binding differs from the other formats in this table.
+- **WASM**: `smarts_match_atoms`, `smarts_match_atoms_with_chirality`, `match_smarts_smiles`, `parse_cxsmarts_json`.
+- SMARTS is a query language, not a molecule storage format — streaming,
+  coordinate units, connectivity, round-trip, and lossy-operation columns
+  don't apply in the same sense as the other 14 formats.
+- **Parse limits**: no `*ParseLimits` type exists.
+
+### MOL/SDF
+
+- **Rust read**: `parse_mol`, `parse_mol_with_coords`, `read_mol_with_diagnostics`, `parse_mol_v3000*`, `SdfReader`, `SdfFileReader`, `SdfRecordReader`.
+- **Rust write**: `write_mol`, `write_mol_with_conformer[_checked]`, `write_sdf*`, `write_mol_v3000*`.
+- **Python**: `from_mol_block`, `from_mol_block_with_coords`, `from_mol_block_with_diagnostics`, `parse_sdf_with_coords`, `from_mol_v3000[_with_coords|_with_diagnostics]`.
+- **WASM**: `mol_from_v3000_block`, `mol_from_sdf_block`, `to_mol_block`, `to_mol_v3000_block`, `sdf_to_smiles_json`, `sdf_to_records_json`, `sdf_from_records_json`, `mol_block_stereo_diagnostics_json`, `mol_v3000_stereo_diagnostics_json`, `mol_block_coords_json`.
+- **Streaming**: `SdfFileReader<R: BufRead>` is a true I/O-streaming `Iterator`
+  (does not require the whole file in memory up front). `SdfReader`/
+  `SdfRecordReader` are lazy iterators over an already-loaded `&str` (do not
+  eagerly collect every record into a `Vec`, but do require the full text in
+  memory). Python and WASM bindings materialize (no streaming reader is
+  bound in either language).
+- **Coordinate units**: Ångström, per the Ctab standard.
+- **Connectivity**: native Ctab bond table.
+- **Round-trip**: semantic, not byte-identical — `write_mol` regenerates a
+  Ctab from the `Molecule`'s own perceived bonds/coordinates, not a copy of
+  the original text.
+- **Lossy operations**: none named beyond the stereo-write scope below.
+- **Square-planar stereo (`@SP1`/`@SP2`/`@SP3`)**: read automatically on
+  every MOL/SDF parse. Write is **opt-in only**, via exactly 3 functions —
+  `write_mol_with_conformer_checked`, `write_mol_v3000_with_conformer_checked`,
+  `write_sdf_record_with_conformer_checked`. Do not describe MOL/SDF writing
+  in general as "square-planar supported" — the plain `write_mol`/`write_sdf`
+  path does not perceive or emit it.
+- **Parse limits**: no `*ParseLimits` type exists for MOL/SDF.
+
+### PDB
+
+- **Rust**: `chematic_3d::{PdbAtom, parse_pdb_atoms, pdb_to_molecule, write_pdb}` —
+  this format lives in `chematic-3d`, not `chematic-mol`; the one exception
+  among these 15.
+- **Python**: `from_pdb` (delegates to `chematic_3d`) for reading;
+  `Mol.to_pdb(coords)` for writing.
+- **WASM**: `mol_from_pdb`, `pdb_coords_json` for reading. Writing is
+  exposed as a method, not a free function:
+  `ConformerHandle.get_conformer_pdb(idx)` returns conformer `idx` as a PDB
+  string (or `null` if `idx` is out of range), delegating to
+  `chematic_3d::write_pdb` internally — this is real write capability, just
+  shaped around an existing conformer handle rather than a
+  `write_pdb_json(mol, coords)`-style free function.
+- **Coordinate units**: Ångström (PDB standard).
+- **Connectivity**: `pdb_to_molecule` perceives bonds from geometry
+  (distance-based), unlike most of the other formats in this table, which
+  either carry an explicit bond table or never infer one.
+- **Round-trip**: not characterized in this pass — no documented round-trip
+  guarantee found; treat as best-effort.
+- **Lossy operations**: none named.
+- **Parse limits**: no `*ParseLimits` type exists.
+
+### mmCIF
+
+- **Rust**: `chematic_mol::{parse_mmcif, parse_mmcif_with_limits, write_mmcif, MmcifAtomRecord, MmcifError, MmcifParseLimits, MmcifResult}`.
+- **Python**: `parse_mmcif`, `write_mmcif`.
+- **WASM**: `mol_from_mmcif`, `mmcif_coords_json`, `mmcif_to_json`, `write_mmcif_json`.
+- **Streaming**: no streaming reader type exists for mmCIF.
+- **Coordinate units**: always orthogonal Ångström (unlike small-molecule CIF's fractional coordinates).
+- **Connectivity**: **no bond table, ever** — this module never infers bonds.
+- **Round-trip**: lossy on read for the `label_*`/`auth_*` tag-pair collapse —
+  `auth_*` is preferred when both are present, both are treated as one
+  logical field, except `label_seq_id` (kept as its own field since it is
+  legitimately `.` for non-polymer atoms even when `auth_seq_id` is normal).
+  `write_mmcif` writes the single stored value into both columns, so a
+  read→write round trip loses the distinction if the source file's `label_*`
+  and `auth_*` genuinely disagreed. Unrecognized `_atom_site` columns are
+  collected into `unhandled_columns` rather than silently dropped, but are
+  not necessarily re-emitted verbatim on write.
+- **Lossy operations**: the `label_*`/`auth_*` collapse above.
+- **Parse limits**: `MmcifParseLimits { max_input_bytes, max_atoms, max_line_len }`.
+
+### CIF (plain, small-molecule)
+
+- **Rust**: `chematic_mol::{parse_cif, write_cif, CifError, CifResult, UnitCell}`, plus `#[cfg(feature = "crystal")]`-gated periodic-structure variants.
+- **Python**: `parse_cif` — **read only**, no `write_cif` binding exists in `chematic-py`.
+- **WASM**: **none.** Zero WASM exposure — confirmed by grep, not by omission from this table.
+- **Coordinate units**: fractional cell coordinates converted to orthogonal Ångström on read (IUCr convention).
+- **Connectivity**: **no bond table at all** — CIF's `_atom_site` loop carries only positions; this module returns atoms with no bonds.
+- **Round-trip**: symmetry expansion is **not** performed on the plain (non-`crystal`-feature) path — only atoms literally listed in `_atom_site_*` are returned (effectively P1 treatment). See `docs/crystal_scope.md` for the `crystal`-feature periodic-structure variants.
+- **Lossy operations**: symmetry-operation information is not applied/round-tripped on the plain path.
+- **Parse limits**: no `*ParseLimits` type exists for plain CIF.
+
+### PQR
+
+- **Rust**: `chematic_mol::{parse_pqr, parse_pqr_with_limits, write_pqr, infer_element, PqrAtomRecord, PqrError, PqrParseLimits, PqrResult}`.
+- **Python**: `parse_pqr`, `write_pqr`, `infer_element`.
+- **WASM**: `mol_from_pqr`, `pqr_coords_json`, `pqr_to_json`, `write_pqr_json`, `pqr_infer_element`.
+- **Coordinate units**: Ångström.
+- **Connectivity**: **no bond table, none inferred** (unlike PDB, which does infer from geometry).
+- **Element**: PQR has no element column in the format; `Element` is
+  inferred from the atom name via `infer_element`, a documented heuristic
+  matching classic PDB-parser convention for blank element columns.
+- **Round-trip**: not characterized beyond the element-inference note above.
+- **Lossy operations**: none named beyond element inference (which is a
+  read-side reconstruction, not a write-side loss).
+- **Parse limits**: `PqrParseLimits { max_input_bytes, max_atoms, max_line_len }`.
+
+### XYZ / Extended XYZ
+
+Two distinct functions share the name `parse_xyz` in different crates —
+disambiguate by crate, not by name alone:
+
+- `chematic_3d::parse_xyz -> Result<(Molecule, Coords3D), XyzError>` —
+  infers bonds by distance, returns a full `Molecule`.
+- `chematic_mol::parse_xyz -> Result<XyzFrame, XyzError>` — no `Molecule`,
+  no bonds; the Extended-XYZ-superset document type. Also has
+  `parse_extxyz`/`parse_extxyz_all`/`write_extxyz`/`write_xyz`,
+  `XyzReader`/`ExtxyzReader`/`ExtxyzWriter`.
+- **Python**: `from_xyz` uses `chematic_3d`'s bond-inferring version.
+  `from_extxyz`/`from_extxyz_all`/`to_extxyz` use `chematic_mol`'s
+  non-bond version.
+- **WASM**: `mol_from_xyz`/`to_xyz` use `chematic_3d`'s version.
+  `mol_from_extxyz`/`extxyz_frame_json`/`to_extxyz_json` use
+  `chematic_mol`'s version.
+- **Streaming**: `XyzReader`/`ExtxyzReader` are lazy iterators over an
+  already-loaded `&str` (same category as `SdfReader`, not a `BufRead`-based
+  reader). No `BufRead`-backed streaming type exists for XYZ. Python/WASM
+  materialize.
+- **Coordinate units**: Ångström (standard XYZ/extended-XYZ convention).
+- **Connectivity**: `chematic_3d::parse_xyz` infers bonds by distance;
+  `chematic_mol::parse_xyz`/`parse_extxyz` never do (no `Molecule` is even
+  produced on that path).
+- **Round-trip**: not characterized beyond the two-crate split above.
+- **Lossy operations**: none named.
+- **Parse limits**: no `*ParseLimits` type exists for either crate's XYZ path.
+
+### QCSchema
+
+- **Rust**: `chematic_mol::{QcMolecule, AtomicInput, AtomicResult, parse_qcschema_molecule, write_qcschema_molecule, parse_atomic_input, write_atomic_input, parse_atomic_result, write_atomic_result, chematic_to_qc_molecule, qc_molecule_to_chematic}`.
+- **Python**: same names, routed through Python's stdlib `json` module rather than a hand-mapped dict.
+- **WASM**: `mol_from_qcschema_molecule`, `qcschema_molecule_coords_json`, `to_qcschema_molecule_json`, `qcschema_validate_atomic_input`, `qcschema_validate_atomic_result`.
+- **Coordinate units**: `QcMolecule.geometry` is explicitly **Bohr (a0)** in Rust; Python and WASM bindings convert to Ångström for convenience.
+- **Connectivity**: `connectivity: Option<Vec<(usize, usize, f64)>>` is the
+  **only** one of these 15 formats where bonds are ever an optional,
+  spec-native part of the document — used if present, never fabricated if
+  absent.
+- **Round-trip**: open extensibility bags (`extras`/`keywords`/`protocols`/
+  `native_files`/`properties`) round-trip losslessly via `BTreeMap`, kept
+  distinct from an `unknown_fields` bag for genuinely undocumented
+  top-level keys.
+- **Lossy operations**: none named — every numeric leaf is rejected if
+  non-finite rather than silently coerced.
+- **Parse limits**: no `*ParseLimits` type exists (size limits, if any, are
+  whatever the caller or `serde_json` impose).
+
+### ORCA input
+
+- **Rust**: `chematic_mol::{parse_orca_input, write_orca_input, OrcaInput, OrcaInputError, OrcaBlock, OrcaCoords, OrcaAtom}`.
+- **Python**: `parse_orca_input`, `write_orca_input`.
+- **WASM**: `mol_from_orca_input`, `orca_input_coords_json`, `orca_input_to_json`, `write_orca_input_json`.
+- **Coordinate units**: Ångström.
+- **Connectivity**: no bond perception anywhere in this module.
+- **Round-trip**: lossless preservation of unknown `%block ... end` blocks, including nested sub-blocks.
+- **Lossy operations**: none named.
+- **Parse limits**: no `OrcaParseLimits` type exists (unlike mmCIF/PQR/Cube/OpenDX).
+
+### ORCA output
+
+- **Rust**: `chematic_mol::{parse_orca_output, OrcaOutput, OrcaOutputError, OrcaTermination, OrcaOptConvergence}` — **read-only, no writer, in all 3 languages.**
+- **Python**: `parse_orca_output`.
+- **WASM**: `orca_output_to_json`.
+- **Coordinate units**: Ångström.
+- **Connectivity**: no bond perception.
+- **Semantics**: `termination` and `optimization_convergence` are two
+  independently-reported fields — `ORCA TERMINATED NORMALLY` alone does
+  **not** imply a requested geometry optimization converged; check both.
+- **Parse limits**: no `*ParseLimits` type exists.
+
+### Gaussian Cube
+
+- **Rust**: `chematic_mol::{parse_cube, parse_cube_with_limits, write_cube, CubeError, CubeFileReader, CubeParseLimits}`, plus the shared `VolumetricGrid` type.
+- **Python**: no free functions — only via the `VolumetricGrid` pyclass: `VolumetricGrid.from_cube()` (staticmethod), `.to_cube()`, `.values_3d`.
+- **WASM**: `mol_from_cube`, `cube_grid_json`, `write_cube_json`, plus typed-array `cube_values_f64`, `cube_shape_u32`.
+- **Streaming**: `CubeFileReader<R: BufRead>` streams the *input reading*
+  only (reduces peak parse-time memory) — the returned
+  `VolumetricGrid.values` is always one fully-materialized `Vec<f64>`. This
+  is a different sense of "streaming" than `SdfFileReader`/`LammpsDumpReader`
+  (Cube is a single-dataset format, so there is nothing to iterate across).
+- **Coordinate units**: `GridUnits::{Bohr, Angstrom}` explicit tag; values
+  are never silently normalized between them. The sign of the first-axis
+  voxel count in the header disambiguates Bohr vs. Ångström (documented
+  against a real spec source).
+- **Connectivity**: no bonds, ever. `GridAtom.charge` is effective nuclear
+  charge, not partial/formal charge.
+- **Multi-dataset files**: **typed-rejected**, not silently truncated —
+  `CubeError::MultiDatasetUnsupported`. Cube is single-dataset-only in this
+  codebase today.
+- **Round-trip**: not byte-identical (no claim of verbatim footer/comment
+  preservation is made in the module docs).
+- **Lossy operations**: none named on the read/write path itself (the
+  multi-dataset case is rejected, not silently truncated).
+- **Parse limits**: `CubeParseLimits { max_input_bytes, max_atoms, max_grid_points }`.
+
+### OpenDX
+
+- **Rust**: `chematic_mol::{parse_opendx, parse_opendx_with_limits, write_opendx, write_opendx_lossy, OpenDxError, OpenDxParseLimits}`.
+- **Python**: no free functions — only via the `VolumetricGrid` pyclass: `.from_opendx()`, `.to_opendx()`, `.to_opendx_lossy()`. No `mol_from_opendx` — OpenDX has no atom section at all.
+- **WASM**: `opendx_grid_json`, `write_opendx_json`, `write_opendx_lossy_json`, plus typed-array `opendx_values_f64`, `opendx_shape_u32`.
+- **Coordinate units**: OpenDX has **no in-file unit tag** — every parsed
+  grid is tagged `Angstrom` by convention (an assumption about the dominant
+  real-world producer, not information recovered from the file itself).
+- **Connectivity**: no bonds — OpenDX carries no atom section.
+- **Round-trip**: footer boilerplate is regenerated on write, not preserved byte-for-byte.
+- **Lossy operations, explicitly named**:
+  - `write_opendx` **fails closed** (`OpenDxError::NonAngstromUnits`) on a `Bohr`-tagged grid — it will not silently write a wrong-unit file.
+  - `write_opendx_lossy` is the explicit opt-in Bohr→Ångström conversion. It rescales `origin`/`axes` only — it **never** rescales `values`.
+  - Both writers refuse (`OpenDxError::AtomsNotSupported`) any grid with non-empty atoms — there is no lossy-atom-dropping path.
+- **Parse limits**: `OpenDxParseLimits { max_input_bytes, max_grid_points }` — no `max_atoms` (the format has none).
+
+### LAMMPS data
+
+- **Rust**: `chematic_mol::{parse_lammps_data, write_lammps_data, LammpsData, LammpsDataError, LammpsAtom, LammpsAtomStyle, LammpsBond, LammpsBox, LammpsMass, LammpsVelocity}`.
+- **Python**: `parse_lammps_data`, `write_lammps_data` (plain dict).
+- **WASM**: `lammps_data_to_json`, `write_lammps_data_json`.
+- **`atom_style` handling**: `atom_style` **cannot be inferred from the
+  file** and must be passed explicitly. `atomic`/`charge`/`molecular`/`full`
+  are supported; anything else maps to `LammpsAtomStyle::Other` and is
+  rejected with `LammpsDataError::UnsupportedAtomStyle` — there is no
+  best-effort guess, because `charge` and `molecular` rows are both
+  genuinely ambiguous 6-field rows by column count alone.
+- **Connectivity**: raw index topology (atom-type/bond indices), not
+  chemically perceived — this is a standalone document type, not integrated
+  with `Molecule`.
+- **Section handling**: 4 sections are typed (`Masses`/`Atoms`/`Velocities`/
+  `Bonds`); everything else is preserved byte-for-byte verbatim in
+  `unparsed_sections` (an ordered `Vec<(String, String)>`, not a
+  `HashMap`). The writer emits typed sections first, then opaque sections in
+  their original relative order — interleaving between typed and opaque
+  sections is **not** preserved, though each opaque section's own content is.
+- **LAMMPS "Type Labels" extension**: explicitly **unsupported**, fails
+  closed — any section whose name ends in `"Type Labels"` is rejected
+  rather than silently mishandled.
+- **Coordinate units**: none stated in-file — LAMMPS units come from the
+  simulation's own `units` command, not this file type; chematic does not
+  infer or convert them.
+- **Round-trip**: opaque sections round-trip verbatim; typed sections
+  round-trip through the typed representation (not guaranteed
+  byte-identical, e.g. whitespace).
+- **Parse limits**: no `LammpsParseLimits` type exists.
+
+### LAMMPS dump/trajectory
+
+- **Rust**: `chematic_mol::{parse_lammps_dump_frame, write_lammps_dump_frame, write_lammps_trajectory, box_bounds_to_true, true_to_box_bounds, LammpsDumpFrame, LammpsDumpReader, LammpsDumpError}`.
+- **Python**: `parse_lammps_dump_frame`, `parse_lammps_dump_all` (**materializes the whole trajectory** — does not expose `LammpsDumpReader`'s streaming; a disclosed scope choice, already stated in CHANGELOG), `write_lammps_dump_frame`, `write_lammps_trajectory`, `box_bounds_to_true`, `true_to_box_bounds`; pyclass `LammpsDumpFrame` (`.column()`, `.cartesian_positions()`).
+- **WASM**: `lammps_dump_frame_to_json_str`, `lammps_trajectory_to_json` (**also materializes, does not stream** — same disclosed choice), `write_lammps_dump_frame_json`, `write_lammps_trajectory_json`, `lammps_dump_cartesian_positions_json`, plus typed-array `lammps_dump_rows_f64`, `lammps_dump_cartesian_positions_f64`.
+- **Streaming**: `LammpsDumpReader<R: BufRead>` is a **true streaming
+  `Iterator`** over any `BufRead` — reads and yields one frame at a time
+  without holding the whole trajectory in memory. Together with
+  `SdfFileReader`, this is one of two `BufRead`-backed streaming readers
+  among these 15 Rust formats, and the only one whose Python/WASM bindings
+  both deliberately materialize instead of streaming (a disclosed
+  trade-off, not an oversight — see CHANGELOG `[0.18.0]`/`[0.17.0]`).
+- **Box bounds**: triclinic box-bounds↔true-box conversion
+  (`box_bounds_to_true`/`true_to_box_bounds`) independently verified
+  against LAMMPS's own documentation. `LammpsBox` is reused from the
+  `lammps_data` module; only this module performs the bound↔true conversion.
+- **`cartesian_positions()`**: resolves `x y z` (passthrough) or
+  `xs ys zs` (triclinic-aware scaled transform), but **deliberately does
+  not** resolve `xu yu zu` ("unwrapped" coordinates) — returns `None` if
+  neither of the first two triples is present, even if unwrapped
+  coordinates are, since conflating "current position" with "unwrapped
+  position" would mislead. Callers use `.column("xu")` directly for that case.
+- **Divergence between JSON and typed-array WASM bindings**: when a frame
+  has no resolvable coordinate columns,
+  `lammps_dump_cartesian_positions_json` returns JSON `null`, but
+  `lammps_dump_cartesian_positions_f64` returns `Err` — a `Float64Array`
+  has no `null` representation. Both are doc-commented; this is disclosed,
+  not accidental. See [`language-bindings.md`](language-bindings.md).
+- **Coordinate units**: not stated in-file (same as LAMMPS data).
+- **Parse limits**: no `*ParseLimits` type exists.
+
+---
+
+## Formats that never fabricate bonds
+
+mmCIF, PQR, ORCA (input and output), Gaussian Cube, OpenDX, LAMMPS data, and
+plain CIF never infer or fabricate a bond table — they either have no bond
+concept in the format at all, or (PQR specifically) have an element-inference
+step that is documented separately from connectivity. PDB and
+`chematic_3d::parse_xyz` are the exceptions among these 15: both infer bonds
+from 3D geometry (distance-based), which is a documented, disclosed choice,
+not a default you should assume applies elsewhere.
+
+## Cross-reference
+
+For the exact per-language function signatures, return-value shapes, and
+`None`/`null`/`Err` divergence points summarized above, see
+[`language-bindings.md`](language-bindings.md). For how these facts map to
+RDKit's equivalent APIs, see [`rdkit-migration.md`](rdkit-migration.md).

--- a/docs/language-bindings.md
+++ b/docs/language-bindings.md
@@ -1,0 +1,177 @@
+# Language Bindings Cross-Reference
+
+chematic ships three language surfaces over the same Rust core: the Rust
+crates directly, Python (PyO3), and WASM (wasm-bindgen). They are not
+identical APIs — this page documents where they agree, where they diverge,
+and why, using real function names (not illustrative examples) so the
+divergences are checkable against source.
+
+See also: [`format-capabilities.md`](format-capabilities.md) for the
+per-format read/write/streaming/limits matrix this page's examples are
+drawn from.
+
+---
+
+## The three surfaces, in one sentence each
+
+- **Rust** (`chematic-*` crates): the source of truth. Typed errors
+  (`thiserror`-style enums), zero-copy where the type system allows it,
+  `BufRead`-based streaming where a reader type exists.
+- **Python** (`chematic-py`, PyO3): free functions mirroring the Rust free
+  functions where practical (`parse_mmcif`, `parse_pqr`, ...), plus `Mol`
+  and a handful of dedicated pyclasses (`VolumetricGrid`, `LammpsDumpFrame`,
+  `PipelineV2Config`). Typed Rust errors map to Python `ValueError`.
+  NumPy arrays are used for large numeric payloads (fingerprints, grid
+  values) — **always fresh copies, never views**.
+- **WASM** (`chematic-wasm`, wasm-bindgen): mostly free functions returning
+  JSON strings (`Result<String, JsValue>`), with 6 functions (as of
+  v0.18.0) additionally returning `js_sys::Float64Array`/`Uint32Array` for
+  large numeric grid/row payloads — **also always fresh copies, never
+  views.** Typed Rust errors map to a thrown JS error / `JsValue`.
+
+**No zero-copy exists anywhere in this codebase today** — not in NumPy
+arrays, not in WASM typed arrays. Every array crossing a language boundary
+is a fresh allocation and copy of the underlying Rust data. This is a
+current-state fact, not a promise about the future.
+
+**No format auto-detection/dispatch exists anywhere.** Every parse function
+name states the format it parses; there is no `parse_any(text)` that
+sniffs format from content.
+
+---
+
+## Copy-vs-view semantics
+
+| Boundary | Owns a view of Rust memory? | Notes |
+|---|---|---|
+| Python NumPy arrays (`ecfp4_numpy()`, `VolumetricGrid.values`, `VolumetricGrid.values_3d`, ...) | No — fresh copy | `values_3d` reshapes the flat `values` copy to `(nx, ny, nz)`, third axis (`k`) fastest, matching `chematic_mol::VolumetricGrid::checked_index`. |
+| WASM `js_sys::Float64Array`/`Uint32Array` (`cube_values_f64`, `opendx_values_f64`, `lammps_dump_rows_f64`, `lammps_dump_cartesian_positions_f64`, `cube_shape_u32`, `opendx_shape_u32`) | No — fresh copy | Added in v0.18.0's Binding Quality Pack, additively alongside the pre-existing JSON-string functions; neither replaces the other. |
+| WASM JSON strings (`cube_grid_json`, `opendx_grid_json`, `mmcif_to_json`, ...) | No — serialized copy | The oldest/default binding shape in `chematic-wasm`; large numeric arrays here round-trip through a JSON number array, a disclosed perf trade-off versus the typed-array functions above. |
+
+---
+
+## Unit-conversion ownership: who converts what
+
+| Concept | Owned by | Where |
+|---|---|---|
+| Gaussian Cube Bohr/Ångström tag | Rust core | `GridUnits::{Bohr, Angstrom}` — read and preserved as-is, never silently converted, in Rust, Python, and WASM alike. |
+| OpenDX Ångström assumption | Rust core | No in-file unit tag exists; every parsed grid is tagged `Angstrom` by convention in `chematic_mol::opendx`. This is a core-crate assumption, not a binding-layer one — Python and WASM inherit it unchanged. |
+| QCSchema geometry Bohr → Ångström | **Binding layer**, not core | `chematic_mol::QcMolecule.geometry` stays in Bohr (a0), matching the QCSchema spec. Python and WASM bindings convert to Ångström for convenience when exposing coordinates — this conversion does **not** happen in `chematic-mol` itself. |
+| mmCIF/PQR/ORCA coordinate units | Rust core | Always Ångström as documented per-format; no binding-layer conversion involved since there is nothing to convert. |
+
+---
+
+## `None` / `null` / `Err` divergence points
+
+These are real, disclosed differences in how "no value" is represented
+across the three languages for the *same* underlying Rust computation —
+not accidents.
+
+### LAMMPS dump Cartesian positions — the clearest case
+
+`chematic_mol::LammpsDumpFrame::cartesian_positions()` returns
+`Option<Vec<[f64; 3]>>` — `None` when the frame has no `x y z` or `xs ys zs`
+columns (it deliberately does not fall back to `xu yu zu`; see
+[`format-capabilities.md`](format-capabilities.md#lammps-dumptrajectory)).
+
+| Language | Function | "no value" representation |
+|---|---|---|
+| Rust | `LammpsDumpFrame::cartesian_positions()` | `None` |
+| Python | `LammpsDumpFrame.cartesian_positions()` | (Python-native `None`, same `Option` mapping) |
+| WASM (JSON) | `lammps_dump_cartesian_positions_json` | JSON `null` |
+| WASM (typed array) | `lammps_dump_cartesian_positions_f64` | **`Err`**, not `null` — a `Float64Array` has no `null` representation, so the unresolvable case becomes a thrown error with a message naming the columns it looked for. |
+
+This is the one place in the codebase where the *same* WASM concept has two
+different "no value" behaviors depending on which of its two sibling
+functions you call — both are doc-commented at their definitions
+(`crates/chematic-wasm/src/format_io.rs`), and this is deliberate: it is
+not safe to assume every `*_json` / `*_f64` sibling pair behaves the same
+way just because one does.
+
+### Typed-error mapping
+
+| Rust | Python | WASM |
+|---|---|---|
+| A typed error enum (e.g. `LammpsDataError::UnsupportedAtomStyle`, `OpenDxError::NonAngstromUnits`, `MmcifError::...`) | `ValueError` with the Rust error's `Display` text as the message | Thrown JS error / `JsValue::from_str(...)` with the same `Display` text |
+
+Python and WASM represent the **same underlying Rust error type**
+differently at the language boundary — `ValueError` vs. a JS exception —
+even when the Rust-side error and its message text are identical. Neither
+language currently exposes the original Rust error's structured
+variant/fields across the boundary; both flatten to a string message.
+
+### QCSchema unknown fields
+
+`chematic_mol::qcschema`'s `unknown_fields: JsonObject` bag (kept distinct
+from the spec's own open extensibility bags — `extras`/`keywords`/
+`protocols`/`native_files`/`properties`) round-trips losslessly in **all
+three** language bindings — Rust, Python (routed through Python's own
+`json` module as the dict↔text boundary, not a hand-written field mapper),
+and WASM. This is one of the few places where all three surfaces behave
+identically rather than diverging; noted here for contrast with the
+divergent cases above.
+
+---
+
+## Worked examples: same concept, three languages
+
+### Gaussian Cube parse + grid values
+
+| Language | Parse | Access grid values |
+|---|---|---|
+| Rust | `chematic_mol::parse_cube(text)` / `parse_cube_with_limits(text, limits)` → `VolumetricGrid` | `grid.values: Vec<f64>` (flat, row-major, third-axis-fastest — see `checked_index`) |
+| Python | `chematic.VolumetricGrid.from_cube(text)` (staticmethod) | `grid.values` (flat NumPy copy) or `grid.values_3d` (reshaped `(nx, ny, nz)` NumPy copy, `k` fastest) |
+| WASM | `cube_grid_json(text)` → JSON string | `cube_values_f64(text)` → `Float64Array` (flat, same ordering) or parse the JSON string's `values` field |
+
+### OpenDX strict vs. lossy write
+
+| Language | Strict (fails closed on non-Ångström units) | Explicit lossy (Bohr→Ångström, opt-in) |
+|---|---|---|
+| Rust | `write_opendx(&grid)` → `Err(OpenDxError::NonAngstromUnits)` for a `Bohr`-tagged grid | `write_opendx_lossy(&grid)` — rescales `origin`/`axes` only, never `values` |
+| Python | `grid.to_opendx()` → raises `ValueError` for `Bohr` | `grid.to_opendx_lossy()` |
+| WASM | `write_opendx_json(grid_json)` → `Err`/thrown error | `write_opendx_lossy_json(grid_json)` |
+
+No language collapses these into a single lossy-by-default function — the
+strict/lossy split from the Rust core is preserved identically in every
+binding.
+
+### LAMMPS Cartesian positions
+
+| Language | Function | Notes |
+|---|---|---|
+| Rust | `LammpsDumpFrame::cartesian_positions()` | `Option<Vec<[f64; 3]>>` |
+| Python | `LammpsDumpFrame.cartesian_positions()` | pyclass method, same resolution rules |
+| WASM (JSON) | `lammps_dump_cartesian_positions_json(frame_json)` | `null` on unresolvable |
+| WASM (typed array) | `lammps_dump_cartesian_positions_f64(frame_json)` | `Err` on unresolvable — see divergence table above |
+
+---
+
+## Streaming vs. materialization, by language
+
+| Format | Rust | Python | WASM |
+|---|---|---|---|
+| MOL/SDF | `SdfFileReader<R: BufRead>` — true streaming `Iterator` | materializes (no streaming reader bound) | materializes |
+| LAMMPS dump/trajectory | `LammpsDumpReader<R: BufRead>` — true streaming `Iterator` | `parse_lammps_dump_all` materializes the whole trajectory as a list (disclosed scope choice, not a silently dropped capability) | `lammps_trajectory_to_json` materializes (same disclosed choice) |
+| Gaussian Cube | `CubeFileReader<R: BufRead>` streams the *input reading* only — the returned `VolumetricGrid.values` is still one fully-materialized `Vec<f64>` (single-dataset format, nothing to iterate across) | via `VolumetricGrid.from_cube()`, materializes | materializes |
+| All other 12 formats | no `BufRead`-backed streaming reader type exists | materializes | materializes |
+
+LAMMPS dump is the one format where a real Rust-level streaming/
+materializing distinction exists **and** both bindings deliberately choose
+materialization — this is the case CHANGELOG `[0.17.0]`/`[0.18.0]` call out
+explicitly, not a gap this PR discovered.
+
+---
+
+## Fail-closed behavior (binding-independent)
+
+These fail-closed checks live in the Rust core and are inherited unchanged
+by both bindings — no binding loosens or bypasses them:
+
+- `write_opendx` on a `Bohr`-tagged grid → typed error in all 3 languages (see OpenDX table above).
+- Both OpenDX writers on a grid with any atoms → `OpenDxError::AtomsNotSupported` in all 3 languages (no lossy-atom-dropping path exists at all).
+- Gaussian Cube multi-dataset input → `CubeError::MultiDatasetUnsupported` in all 3 languages (typed rejection, not silent truncation).
+- LAMMPS data with an unrecognized `atom_style` → `LammpsDataError::UnsupportedAtomStyle` in all 3 languages (no best-effort guess).
+- LAMMPS "Type Labels" sections → rejected in all 3 languages.
+
+See [`error-and-limits.md`](error-and-limits.md) for the full typed-error
+taxonomy and parse-limit reference.

--- a/docs/rdkit-comparison.md
+++ b/docs/rdkit-comparison.md
@@ -2,6 +2,8 @@
 
 This page gives a direct comparison between chematic and RDKit for teams evaluating which library to use.
 
+See also: [`rdkit-migration.md`](rdkit-migration.md) for a feature-by-feature Supported/Partial/Not-supported breakdown.
+
 ---
 
 ## TL;DR

--- a/docs/rdkit-migration.md
+++ b/docs/rdkit-migration.md
@@ -1,0 +1,311 @@
+# RDKit → chematic Feature Support Matrix
+
+Honest, feature-by-feature capability-transfer guidance for teams coming
+from RDKit. This page classifies each area as **Supported**, **Partially
+supported**, or **Not currently supported**, names the real chematic API
+alongside RDKit's, and states known residuals — it is not a marketing
+document, and it does not claim general superiority over RDKit.
+
+See also: [`rdkit_cheatsheet.md`](rdkit_cheatsheet.md) (side-by-side API
+snippets for common tasks) and [`rdkit-comparison.md`](rdkit-comparison.md)
+(prose comparison of chematic vs. RDKit for teams evaluating which library
+to use). This page's added value over both: a per-feature-area
+Supported/Partial/Not-supported classification with explicit RDKit-API ↔
+chematic-API rows, sourced against this repository's own code and
+CHANGELOG rather than general impressions.
+
+**What "verified" means on this page**: every chematic function name below
+was checked against `crates/chematic-py/python/chematic/__init__.pyi` or
+`crates/chematic-py/src/*.rs` directly (grep + read, not memory). RDKit
+function names are its well-documented, stable public API (`Chem.*`,
+`AllChem.*`, `rdMolDescriptors.*`, ...) — this page does not assert
+anything about RDKit's internal implementation it has not verified against
+its public interface.
+
+---
+
+## Legend
+
+- **Supported** — chematic has a direct, tested equivalent.
+- **Partially supported** — chematic has *an* equivalent, but with a
+  narrower scope, a different default, or a documented residual gap.
+- **Not currently supported** — no chematic equivalent exists today.
+
+---
+
+## SMILES parsing
+
+**Supported.**
+
+| | RDKit | chematic |
+|---|---|---|
+| Parse | `Chem.MolFromSmiles(smiles)` | `chematic.from_smiles(smiles)` (Python); `chematic_smiles::parse` (Rust); `parse_smiles` (WASM) |
+| Validate only | `Chem.MolFromSmiles(smiles) is not None` | `chematic.is_valid_smiles(smiles)` |
+| CXSMILES | `Chem.MolFromSmiles(s, params)` with `Chem.SmilesParserParams` | `chematic.from_cxsmiles(s)` / `chematic_smiles::parse_cxsmiles` |
+
+Migration note: chematic's parser is a from-scratch Rust implementation, not
+a port of RDKit's — expect the same molecule for valid SMILES, but do not
+assume identical error messages or identical handling of edge-case/
+malformed input.
+
+## Canonical SMILES
+
+**Partially supported — known residual, do not treat as a safe dedup key today.**
+
+| | RDKit | chematic |
+|---|---|---|
+| Canonicalize | `Chem.MolToSmiles(mol, canonical=True)` | `mol.smiles` / `chematic.canonical_smiles(...)` (`chematic_smiles::canonical_smiles`) |
+
+Structural correctness of canonical SMILES round-tripping is measured at
+**100% (0/5000)** on a 5,000-mol ChEMBL corpus and **0/33** on a dedicated
+acyclic-polyene corpus (tretinoin/β-carotene/lycopene-class molecules),
+per README's "Known Limitations" section — an earlier corruption bug (two
+independent parser bugs, both ring-closure-specific) is fixed.
+
+The residual gap is narrower but real: `canonical_smiles()` can still emit
+two different, individually-valid `/`/`\` spellings for the same E/Z
+double-bond system depending on input traversal order, in roughly **1 in
+18** stereo-bearing molecules (measured worst-of-10 on the same 5,000-mol
+corpus — 275/5000 unstable, confirmed 100% cosmetic, not structural
+corruption). **Do not use `canonical_smiles()` as a dedup or cache key**
+until this closes; use `apply_aromaticity()`-normalized output as your own
+dedup key in the meantime if this matters for your use case. Full figures
+and root-cause detail: README.md's "Known Limitations" section.
+
+## SMARTS matching
+
+**Supported.**
+
+| | RDKit | chematic |
+|---|---|---|
+| Match | `mol.GetSubstructMatch(patt)` / `GetSubstructMatches(patt)` | `mol.has_substructure(smarts)` / `mol.find_matches(smarts)` (Python); `chematic_smarts::find_matches` (Rust); `smarts_match_atoms` (WASM) |
+| Validate | `Chem.MolFromSmarts(smarts) is not None` | `chematic.is_valid_smarts(smarts)` |
+| Bulk | `[mol.HasSubstructMatch(patt) for mol in mols]` | `chematic.bulk.substructure_search(smarts, smiles_list)` / `chematic.bulk.substructure_match(smarts, mols)` (Rayon-parallel) |
+
+## Fingerprints
+
+**Supported** for the common bit-vector families; **partially supported**
+for exact-parity claims against RDKit's implementation (not independently
+re-verified on this pass — see `docs/verification_coverage.md` for what has
+been measured).
+
+| | RDKit | chematic |
+|---|---|---|
+| ECFP4 (Morgan, radius 2) | `AllChem.GetMorganFingerprintAsBitVect(mol, 2, nBits=2048)` | `mol.ecfp4()` (bytes) / `mol.ecfp4_numpy()` (NumPy `(2048,)` uint8) |
+| ECFP6 | `AllChem.GetMorganFingerprintAsBitVect(mol, 3, nBits=2048)` | `mol.ecfp6()` |
+| Chiral ECFP4 | `useChirality=True` | `mol.ecfp4_chiral()` |
+| FCFP4 | `useFeatures=True` | `mol.fcfp4()` |
+| MACCS 166-bit | `MACCSkeys.GenMACCSKeys(mol)` | `mol.maccs()` / `mol.maccs_numpy()` |
+| Atom-pair | `Pairs.GetAtomPairFingerprintAsBitVect(mol)` | `mol.atom_pair_fp()` (bytes) |
+| Topological torsion | `Torsions.GetTopologicalTorsionFingerprintAsIntVect(mol)` | `mol.torsion_fp()` |
+| Layered | `Chem.LayeredFingerprint(mol, layerFlags=0x7F)` | `mol.layered_fp_layers()` — 7-layer list, documented as equivalent to RDKit's `layerFlags=0x7F` |
+| MAP4 (not in RDKit core) | — | `mol.map4()` / `mol.map4_numpy()` |
+| Tanimoto similarity | `DataStructs.TanimotoSimilarity(fp1, fp2)` | `chematic.tanimoto(fp1, fp2)` |
+| Bulk fingerprints | list comprehension over `mols` | `chematic.bulk.ecfp4(smiles_list)` (NumPy `(N, 2048)` uint8, Rayon-parallel) |
+
+Performance note: batch ECFP4 was measured at **~78 µs/mol vs. RDKit's
+~160–235 µs/mol** (2–3×) on a diverse 5,000-mol ChEMBL corpus, and up to
+**126 ms vs. ~839 ms** (6.7×) on a small repeated-fixture 10,000-mol batch —
+both numbers from `docs/benchmark.md` (measured Python 3.13.6, Apple M4,
+chematic v0.4.29, RDKit 2026.03.3; not re-measured for this PR). Cite these
+exact, already-measured figures if you cite speed at all — do not
+extrapolate to other batch sizes or fingerprint types not in that table.
+
+## Descriptors
+
+**Supported** for the commonly-used physicochemical set.
+
+| | RDKit | chematic |
+|---|---|---|
+| One descriptor | `Descriptors.MolWt(mol)`, `rdMolDescriptors.CalcTPSA(mol)`, etc. | `mol.mw`, `mol.tpsa`, ... (property access) |
+| All at once | manual loop over `Descriptors._descList` | `mol.descriptors()` — dict of 70+ scalar descriptors in one call |
+| Bulk / DataFrame | manual loop + `pd.DataFrame(...)` | `chematic.bulk.descriptors(smiles_list)` / `chematic.descriptors_df(smiles_list)` (Rayon-parallel, returns a list of dicts / DataFrame directly) |
+
+Accuracy vs. RDKit, per `docs/benchmark.md` and README's badge comment
+(4,999-mol ChEMBL subset, chematic v0.4.29 vs. RDKit 2026.03.3, descriptor
+calculation paths unchanged through v0.8.0 and not re-measured since): MW/
+HBA/HBD/ARC **100%**, TPSA **100% within ±0.1 Å²** (README's "TPSA edge
+cases" bullet notes a residual 0.3%/16-molecule gap in exotic
+phosphazene/S=N=P chemistry), LogP (Crippen) **100%*** (max Δ =
+1.1×10⁻¹³). These are the only descriptor-accuracy figures this page
+cites, and only because README/CHANGELOG already document them.
+
+## Aromaticity
+
+**Partially supported — documented, root-caused gap.**
+
+chematic applies Hückel 4n+2 per SSSR ring independently; RDKit uses
+fused-ring electron delocalization. Per README's "Aromaticity model"
+bullet: aromaticity-flag parity on Kekulized input is measured at **96.3%**
+worst-of-10 (5,000-mol ChEMBL); visible differences concentrate in
+N-heterocycles (pyridone, quinolone, indolizine) and non-alternant/
+bridgehead-heavy structures (azulene, purine). Root cause is documented as
+an `aromatic_context` bypass mechanism, not yet fixed.
+
+## Stereocenter / CIP assignment
+
+**Partially supported.**
+
+Per README's badge comment: stereocenter count **99.96%** (legacy) /
+**98.6%** (new CIP `FindPotentialStereo`-equivalent path); CIP R/S label
+**96.30%** vs. modern RDKit `rdCIPLabeler`, **96.83%** vs. legacy RDKit CIP
+assignment. Square-planar (`@SP1`/`@SP2`/`@SP3`-equivalent) stereo is read
+automatically from MOL/SDF; write is opt-in only via 3 specific `_checked`
+functions — see [`format-capabilities.md`](format-capabilities.md#molsdf).
+
+## Conformer generation
+
+**Partially supported — real gap in generation quality, not just parity measurement.**
+
+| | RDKit | chematic |
+|---|---|---|
+| Single conformer | `AllChem.EmbedMolecule(mol)` (ETKDGv3) | `mol.generate_3d()` — distance geometry + DREIDING minimization |
+| Multiple conformers | `AllChem.EmbedMultipleConfs(mol, numConfs=N)` | `mol.conformer_ensemble(n, rmsd_threshold=0.5)` — RMSD-based pruning |
+| Torsion-knowledge-aware pipeline | ETKDGv3's built-in torsion preferences | `mol.embed_pipeline_v2(config)` — opt-in v2 pipeline: torsion-knowledge-aware distance geometry + stereo verification/repair + policy-gated force field |
+
+README's "Use RDKit if" section states this directly: RDKit's ETKDGv3
+includes ML-assisted torsion corrections chematic does not have. The
+feature-maturity table in README.md marks 3D conformer generation
+(distance geometry + MMFF94) as **Experimental**. This page does not
+attempt to quantify the conformer-quality gap further than that, because no
+already-measured RDKit-comparison figure for conformer RMSD/TFD exists in
+this repository's own docs to cite (this PR does not run new 3D/RMSD/TFD
+measurement scripts — see the PR description's scope note).
+
+## Force-field optimization
+
+**Partially supported.**
+
+| | RDKit | chematic |
+|---|---|---|
+| MMFF94 | `AllChem.MMFFOptimizeMolecule(mol)` | `mol.minimize_mmff94(coords)`; energy via `mol.mmff94_total_energy(coords)` / `mol.mmff94_energy_breakdown(coords)` |
+| UFF | `AllChem.UFFOptimizeMolecule(mol)` | `mol.minimize_uff(coords)` — per its own docstring, UFF covers all elements including metals, unlike chematic's MMFF94, which is limited |
+| DREIDING (not in RDKit core) | — | `mol.minimize_dreiding(coords)` |
+
+Known residual: MMFF94 atom-typing issue #337 — as of CHANGELOG `[0.18.0]`,
+one sub-bug (aryl isothiocyanate cumulated-double-bond CSP carbon) is
+fixed; 6 of the original 8 affected molecules remain an honestly-disclosed
+residual, root-caused to a genuine RDKit Kekulization/MMFF-aromaticity-
+perception artifact for a specific fused, macrocyclic ring topology (a
+pyridinium-conjugated exocyclic-amine scaffold) rather than a locally-
+statable atom-typing rule gap — 32/6,693 type-mismatched and 56/6,693
+charge-mismatched atoms remain on the 264-molecule reference corpus. See
+`CHANGELOG.md`'s `[0.18.0]` entry and `scripts/mmff94_provenance/PROVENANCE.md`
+for the full writeup; this page does not re-derive it.
+
+## Molecular depiction (2D)
+
+**Supported** for SVG; **not currently supported** for PNG-only workflows
+without the optional `png` feature.
+
+| | RDKit | chematic |
+|---|---|---|
+| Single molecule SVG | `Draw.MolToImage(mol)` / `rdMolDraw2D.MolDraw2DSVG` | `mol._repr_svg_()` (Jupyter auto-render) / `chematic-depict::depict_svg(mol)` (Rust) |
+| Grid of molecules | `Draw.MolsToGridImage(mols)` | `chematic.depict_grid(mols, cols)` |
+| Reaction depiction | `Draw.ReactionToImage(rxn)` | `chematic.reaction_svg(reaction_smiles)` |
+
+## InChI
+
+**Partially supported — two distinct code paths with different accuracy characteristics.**
+
+| | RDKit | chematic |
+|---|---|---|
+| Standard InChI | `Chem.MolToInchi(mol)` (vendored InChI C library) | `mol.standard_inchi` / `mol.standard_inchikey` — bit-exact, via the vendored InChI C library (v1.07.5), **requires the `native-inchi` Cargo feature** |
+| Default (no C dependency) | — | `mol.inchi` / `mol.inchikey` — pure-Rust approximation, not bit-exact |
+
+Migration note: if your pipeline depends on bit-exact standard InChI
+without enabling `native-inchi`, chematic's default path is an
+approximation, not a drop-in replacement — README's "Use RDKit if" section
+states this explicitly as a reason to prefer RDKit.
+
+## Substructure search
+
+**Supported** — see the SMARTS matching row above; this row exists
+separately only because RDKit users often look up "substructure search" as
+its own topic. Same functions apply: `mol.has_substructure`/
+`mol.find_matches` (single), `chematic.bulk.substructure_search`/
+`substructure_match` (bulk, Rayon-parallel).
+
+## Reactions / SMIRKS
+
+**Supported** for template-based reaction application; **not currently
+supported** for RDKit's full reaction-standardization/validation toolkit
+beyond what's listed.
+
+| | RDKit | chematic |
+|---|---|---|
+| Apply a reaction | `rxn = AllChem.ReactionFromSmarts(smirks); rxn.RunReactants(reactants)` | `chematic.run_smirks(smirks, reactants)` |
+| Combinatorial library enumeration | manual loop over `RunReactants` | `chematic.enumerate_library(smirks, fragment_sets)` |
+| Reaction fingerprint similarity | (community recipes, not core RDKit) | `chematic.tanimoto_reaction_fp(rxn1, rxn2)` |
+| Query a reaction by SMARTS | manual matching | `chematic.query_reaction(reaction_smiles, smarts)` / `chematic.batch_query_reactions(reactions, smarts)` |
+| Atom economy / mass balance | manual computation | `chematic.atom_economy(reaction_smiles)` / `chematic.balance_check(reaction_smiles)` |
+
+## Maximum Common Substructure (MCS)
+
+**Supported**, single-function scope.
+
+| | RDKit | chematic |
+|---|---|---|
+| MCS of a set of molecules | `rdFMCS.FindMCS(mols)` | `chematic.find_mcs(mols)` → `Optional[Mol]` |
+
+Migration note: RDKit's `rdFMCS.FindMCS` exposes tunable parameters
+(atom/bond comparison mode, timeout, ring-matching strictness, ...) via
+`MCSParameters`. `chematic.find_mcs` is a single-call function with no
+documented equivalent tuning surface in `__init__.pyi` as of this pass —
+if your RDKit usage depends on non-default `MCSParameters`, verify the
+chematic result matches your needs before switching.
+
+## CIF / materials & simulation formats
+
+**Supported**, broader than RDKit's out-of-the-box coverage for this
+category — to our knowledge, RDKit's core Python package does not ship
+native mmCIF/PQR/QCSchema/ORCA/Cube/OpenDX/LAMMPS readers (some may be
+reachable indirectly via other tools in the wider ecosystem, which this
+page does not attempt to catalogue or verify).
+See [`format-capabilities.md`](format-capabilities.md) for the full
+15-format matrix, including which of these formats has **zero WASM
+exposure** (plain CIF) and which Python bindings are read-only (plain CIF).
+This is a real area where chematic covers formats RDKit's core package
+does not — stated narrowly, without a general "chematic beats RDKit on
+formats" claim.
+
+## Python batch processing
+
+**Supported.**
+
+| | RDKit | chematic |
+|---|---|---|
+| Bulk parse | `[Chem.MolFromSmiles(s) for s in smiles_list]` | `chematic.bulk.parse(smiles_list)` (Rayon-parallel) |
+| Bulk fingerprints / descriptors | manual `for` loop, optionally with `multiprocessing` | `chematic.bulk.ecfp4(...)`, `chematic.bulk.maccs(...)`, `chematic.bulk.descriptors(...)`, `chematic.descriptors_df(...)` — Rayon-parallel inside a single PyO3 call, no `multiprocessing` boilerplate needed |
+| Bulk Tanimoto | `DataStructs.BulkTanimotoSimilarity` | `chematic.bulk.tanimoto(...)` / `chematic.bulk.tanimoto_matrix(...)` / `chematic.bulk.tanimoto_search(query, library)` |
+
+## WASM / browser usage
+
+**Not applicable to RDKit's core package** — RDKit has no first-party
+Python-style WASM bindings; RDKit.js is a separate community project.
+chematic ships `chematic-wasm` directly from the same Rust source as the
+Python bindings. Per `docs/benchmark.md`/README's badge table: chematic's
+WASM bundle is **719 KB**, versus RDKit.js's **~30 MB** (~42× smaller) —
+cited because it is already measured and documented in this repository, not
+asserted fresh here. See [`format-capabilities.md`](format-capabilities.md)
+for exactly which formats are and are not exposed at the WASM layer (plain
+CIF, notably, is not).
+
+---
+
+## What this page deliberately does not claim
+
+- No "full compatibility" claim anywhere on this page — every row is
+  scoped to what was actually verified against source.
+- No performance claim beyond the specific, already-measured figures in
+  `docs/benchmark.md`/`CHANGELOG.md`, cited with their measurement context
+  (environment, corpus, version) intact.
+- No claim of general superiority over RDKit. Where chematic has a real,
+  narrow advantage (WASM bundle size, native mmCIF/PQR/QCSchema/ORCA/Cube/
+  OpenDX/LAMMPS I/O), it is stated as exactly that — narrow and specific —
+  not generalized.
+- Known residuals (canonical-SMILES E/Z direction-normalization gap,
+  aromaticity `aromatic_context` gap, MMFF94 issue #337 residual, InChI
+  approximation without `native-inchi`) are stated here, not hidden, and
+  are sourced from README.md's "Known Limitations" section and
+  CHANGELOG.md rather than invented for this page.

--- a/docs/rdkit_cheatsheet.md
+++ b/docs/rdkit_cheatsheet.md
@@ -2,6 +2,8 @@
 
 Side-by-side API reference for users coming from RDKit. chematic is pure Rust with zero C/C++ dependencies — install with `pip install chematic`, no conda required.
 
+See also: [`rdkit-migration.md`](rdkit-migration.md) for a feature-by-feature Supported/Partial/Not-supported breakdown.
+
 ## Installation
 
 ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,11 +63,16 @@ nav:
   - Cookbook (EN): cookbook.md
   - Cookbook (日本語): cookbook_ja.md
   - Benchmark: benchmark.md
+  - Formats & Bindings:
+    - Format Capability Matrix: format-capabilities.md
+    - Language Bindings Cross-Reference: language-bindings.md
+    - Error Handling & Limits: error-and-limits.md
   - Reliability:
     - Validation vs RDKit: validation.md
     - Detailed RDKit Comparison: rdkit-comparison.md
     - RDKit Issue Lessons: rdkit_issue_lessons.md
   - RDKit Migration Guide: rdkit_cheatsheet.md
+  - RDKit Feature Support Matrix: rdkit-migration.md
   - API Reference:
     - chematic: api/chematic.md
   - Changelog: changelog.md


### PR DESCRIPTION
## Summary

Closes the documentation gap named explicitly in two consecutive CHANGELOG release summaries ([0.17.0] and [0.18.0]): "a broader API/format-capability documentation pass" and "Rustdoc warning cleanup." This is documentation/adoption work, not new capability.

- **`docs/format-capabilities.md`** — per-format (all 15: SMILES, SMARTS, MOL/SDF, PDB, mmCIF, CIF, PQR, XYZ/Extended XYZ, QCSchema, ORCA input/output, Gaussian Cube, OpenDX, LAMMPS data, LAMMPS dump/trajectory) read/write/streaming/coordinate-units/connectivity/round-trip/lossy-operations/parse-limits/known-limitations matrix across Rust, Python, and WASM.
- **`docs/language-bindings.md`** — cross-language function-name and return-shape reference: JSON vs. NumPy vs. TypedArray, `None`/`null`/`Err` divergence points (e.g. `lammps_dump_cartesian_positions_f64` returning `Err` where its JSON sibling returns `null`), copy-vs-view semantics (no zero-copy exists anywhere in this codebase today), and unit-conversion ownership.
- **`docs/rdkit-migration.md`** — feature-by-feature Supported / Partially supported / Not-currently-supported classification against RDKit (SMILES, canonical SMILES, SMARTS, fingerprints, descriptors, SDF, conformer generation, force fields, depiction, InChI, substructure search, reactions/SMIRKS, MCS, materials formats, batch processing, WASM). Cites only already-measured figures from `docs/benchmark.md`/`CHANGELOG.md`; makes no new performance or "full compatibility" claims; states known residuals (canonical-SMILES E/Z direction-normalization gap, aromaticity `aromatic_context` gap, MMFF94 issue #337 residual) rather than hiding them.
- **`docs/error-and-limits.md`** — parse-limit types per format (only 4 of 15 formats have a `*ParseLimits` type — named explicitly, not implied uniform), typed-error → `ValueError`/JS-error mapping, fail-closed writers (`write_opendx` is the clearest example), the `*_lossy` opt-in-only naming convention, and streaming-vs-materialization per format/language.
- Cross-linked the 4 new docs with the existing `docs/rdkit_cheatsheet.md` and `docs/rdkit-comparison.md` (one "See also" line added to each, no other changes to those files), and registered all 4 in `mkdocs.yml`'s nav under a new "Formats & Bindings" section plus an "RDKit Feature Support Matrix" entry alongside the existing "RDKit Migration Guide" entry.
- Fixed the one confirmed broken rustdoc intra-doc link: `` crate::svg::render_svg `` in `crates/chematic-mol/src/cdxml.rs:121` and `crates/chematic-mol/src/cml.rs:195` doc comments referenced a `svg` module that does not exist in `chematic-mol`. `chematic-mol` has no dependency on `chematic-depict` (the crate that actually has `render_svg`), so both are de-linked to plain backtick text pointing readers at `chematic-depict`'s real `render_svg` function, rather than an intra-doc link that would still fail to resolve.
- Added a short "Choose your interface" section (Rust / Python / WebAssembly-Node.js / Materials and simulation formats / Migrating from RDKit) to README.md, README_ja.md, and README_zh.md, linking out to the relevant existing quickstart sections or the 4 new docs — no large API table embedded in the README, no rewrite of existing content.

## Scope notes

This PR fixes the one rustdoc broken-link occurrence confirmed via static analysis. Further rustdoc warnings (if any survive) are left to CI's own `cargo doc` run in this PR — see the CI results before merge — and get their own narrowly-scoped follow-up rather than a speculative fix list here.

**Documentation-only. No runtime behavior, dependency, or version changes. No new performance or accuracy claims. No local build/test/benchmark was run. Awaiting CI's own results before any merge decision.**

## Test plan

- [ ] CI's `cargo doc` run confirms the two fixed links resolve and reports no new warnings from this PR's changes
- [ ] `mkdocs build` (CI, if configured) renders the 4 new nav entries without errors
- [ ] Spot-check a sample of README.md / README_ja.md / README_zh.md rendered links on GitHub