### PR TITLE
feat(chematic-ff): UFF minimizer soundness signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added — `chematic-ff`/`chematic-py`/`chematic-wasm` (UFF minimizer soundness signal, ROADMAP.md Backlog item 5a)
+
+- `UffMinimizeResult` (`crates/chematic-ff/src/uff.rs`) gains a `sound: bool`
+  field: true iff the final coordinates are all-finite and no bond exceeds
+  a 3.0 Å sane-covalent-bond ceiling — the same, already corpus-validated
+  threshold `chematic-3d`'s `minimize::MAX_SANE_BOND_LENGTH` uses for its
+  own (unrelated, `embed_pipeline_v2`-only) soundness gate. `chematic-ff`
+  cannot depend on `chematic-3d` (the dependency runs the other way), so
+  this is a deliberately duplicated copy of that constant/check, not an
+  independently chosen one.
+- Deliberately independent of `converged`: steepest descent frequently
+  reports `converged == false` on perfectly sound geometries that simply
+  haven't hit the tight RMS-gradient stopping threshold within `max_iter`
+  — treating `converged` alone as a quality signal would be a false-failure
+  generator, the same rationale `chematic-3d`'s own soundness gate already
+  documents.
+- Before this change, `chematic-py`'s `Mol.minimize_uff()` and
+  `chematic-wasm`'s `minimize_uff_json()` called UFF directly with zero
+  soundness signal of any kind — a caller had no way to distinguish a
+  genuinely converged, trustworthy geometry from one where UFF's
+  torsion/out-of-plane-incomplete potential settled at a real but unsound
+  stationary point (e.g. a fused polycyclic aromatic folding non-planar
+  with a blown-up bond — issue #185's finding). Both bindings now surface
+  `sound` alongside `coords`/`energy`/`iterations`/`converged`.
+- Does not add a residual-force half of the gate the way `chematic-3d`'s
+  own `check_minimization_soundness` has (`max_residual_force` ceiling):
+  `minimize_uff`'s steepest-descent loop doesn't retain a converged
+  gradient norm past each iteration, and computing one is out of scope for
+  this change — the bond-length check alone is a real, if partial, signal
+  that previously didn't exist at all.
+- **4 new tests** (`crates/chematic-ff/src/uff.rs`): known-sound (ordinary
+  ethanol minimizing normally), known-unsound via a deliberately-stretched
+  5.0 Å bond (using `max_iter=0` to deterministically exercise the
+  bond-length check without depending on steepest descent actually getting
+  stuck there), and non-finite coordinates.
+
 ## [0.18.0] — 2026-08-20
 
 Python and WASM bindings for the 7 file formats `chematic-mol` gained in

--- a/crates/chematic-ff/src/uff.rs
+++ b/crates/chematic-ff/src/uff.rs
@@ -523,6 +523,41 @@ fn uff_gradient(
     grad
 }
 
+/// No legitimate covalent bond stretches anywhere near this length; a
+/// post-minimization bond longer than this indicates a blown-up geometry,
+/// not a slow-but-fine one. Mirrors `chematic-3d`'s
+/// `minimize::MAX_SANE_BOND_LENGTH` (that crate can't be depended on from
+/// here — `chematic-3d` depends on `chematic-ff`, not the reverse — so this
+/// is a deliberately-duplicated copy of the same, already-corpus-validated
+/// constant, not an independently chosen one; keep the two in sync).
+const MAX_SANE_UFF_BOND_LENGTH: f64 = 3.0;
+
+fn worst_uff_bond_length(mol: &Molecule, coords: &[[f64; 3]]) -> f64 {
+    let dist = |a: [f64; 3], b: [f64; 3]| {
+        let d = [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+        (d[0] * d[0] + d[1] * d[1] + d[2] * d[2]).sqrt()
+    };
+    mol.bonds()
+        .map(|(_, b)| dist(coords[b.atom1.0 as usize], coords[b.atom2.0 as usize]))
+        .fold(0.0_f64, f64::max)
+}
+
+/// True iff every coordinate is finite and no bond exceeds
+/// [`MAX_SANE_UFF_BOND_LENGTH`]. Deliberately independent of `converged`:
+/// steepest descent frequently reports `converged == false` on perfectly
+/// sound geometries that simply haven't hit the tight RMS-gradient
+/// threshold within `max_iter` (same rationale as `chematic-3d`'s
+/// `check_minimization_soundness`, which this mirrors the bond-length half
+/// of — that gate's other half, a residual-force ceiling, has no UFF
+/// equivalent here since this steepest-descent loop doesn't retain a
+/// converged gradient norm past each iteration).
+fn is_sound_uff_geometry(mol: &Molecule, coords: &[[f64; 3]]) -> bool {
+    if coords.iter().any(|p| p.iter().any(|x| !x.is_finite())) {
+        return false;
+    }
+    worst_uff_bond_length(mol, coords) <= MAX_SANE_UFF_BOND_LENGTH
+}
+
 /// Result of UFF minimisation.
 pub struct UffMinimizeResult {
     /// Final atomic coordinates (Å).
@@ -533,6 +568,18 @@ pub struct UffMinimizeResult {
     pub iterations: usize,
     /// True if the gradient norm converged below threshold.
     pub converged: bool,
+    /// True if `coords` is a geometrically sound result (all-finite, no
+    /// bond stretched past [`MAX_SANE_UFF_BOND_LENGTH`]) — independent of
+    /// `converged`, which only reports whether the RMS-gradient stopping
+    /// criterion was met, not whether the geometry itself is trustworthy.
+    /// Callers that skip a soundness check of their own (both
+    /// `chematic-py`'s `Mol.minimize_uff()` and `chematic-wasm`'s
+    /// `minimize_uff_json()` did, until this field existed) previously had
+    /// no signal at all that a result like a blown-up bond in a fused
+    /// aromatic ring folding non-planar (a real stationary point of UFF's
+    /// torsion/out-of-plane-incomplete potential, not slow convergence) had
+    /// occurred.
+    pub sound: bool,
 }
 
 /// Minimise UFF energy using steepest descent (convergence criterion: RMS
@@ -561,11 +608,13 @@ pub fn minimize_uff(
         };
 
         if rms < 0.01 {
+            let sound = is_sound_uff_geometry(mol, &coords);
             return UffMinimizeResult {
                 coords,
                 energy,
                 iterations: iter,
                 converged: true,
+                sound,
             };
         }
 
@@ -586,22 +635,26 @@ pub fn minimize_uff(
         } else {
             step *= 0.5;
             if step < 1e-8 {
+                let sound = is_sound_uff_geometry(mol, &coords);
                 return UffMinimizeResult {
                     coords,
                     energy,
                     iterations: iter,
                     converged: false,
+                    sound,
                 };
             }
         }
     }
 
     let energy = uff_total_energy(mol, types, &coords);
+    let sound = is_sound_uff_geometry(mol, &coords);
     UffMinimizeResult {
         coords,
         energy,
         iterations: max_iter,
         converged: false,
+        sound,
     }
 }
 
@@ -668,6 +721,44 @@ mod tests {
             "minimisation should reduce energy: {e0} → {}",
             result.energy
         );
+    }
+
+    #[test]
+    fn minimize_uff_reports_sound_on_ordinary_ethanol() {
+        let mol = parse("CCO").unwrap();
+        let types = assign_uff_types(&mol);
+        let coords: Vec<[f64; 3]> = vec![[0.0, 0.0, 0.0], [1.54, 0.0, 0.0], [2.5, 1.2, 0.0]];
+        let result = minimize_uff(&mol, &types, coords, 200);
+        assert!(
+            result.sound,
+            "an ordinary small molecule minimizing normally should report sound"
+        );
+    }
+
+    #[test]
+    fn minimize_uff_reports_unsound_on_a_blown_up_bond() {
+        // max_iter=0 returns the initial coords untouched (the `for iter in
+        // 0..max_iter` loop never runs), so this deterministically exercises
+        // `sound`'s bond-length check against a deliberately-stretched
+        // C-C bond (5.0 Å, well past MAX_SANE_UFF_BOND_LENGTH) without
+        // depending on steepest descent actually getting stuck there.
+        let mol = parse("CCO").unwrap();
+        let types = assign_uff_types(&mol);
+        let coords: Vec<[f64; 3]> = vec![[0.0, 0.0, 0.0], [5.0, 0.0, 0.0], [6.0, 1.2, 0.0]];
+        let result = minimize_uff(&mol, &types, coords, 0);
+        assert!(
+            !result.sound,
+            "a 5.0 Å C-C bond must be reported unsound regardless of `converged`"
+        );
+    }
+
+    #[test]
+    fn minimize_uff_reports_unsound_on_non_finite_coordinates() {
+        let mol = parse("CCO").unwrap();
+        let types = assign_uff_types(&mol);
+        let coords: Vec<[f64; 3]> = vec![[0.0, 0.0, 0.0], [f64::NAN, 0.0, 0.0], [2.5, 1.2, 0.0]];
+        let result = minimize_uff(&mol, &types, coords, 0);
+        assert!(!result.sound, "non-finite coordinates must be unsound");
     }
 
     /// Propane skeleton (C0-C1-C2, heavy atoms only — implicit H fills

--- a/crates/chematic-py/python/chematic/__init__.pyi
+++ b/crates/chematic-py/python/chematic/__init__.pyi
@@ -153,7 +153,10 @@ class Mol:
 
         Returns:
             dict with keys ``coords`` (list[list[float]]), ``energy`` (float,
-            kcal/mol), ``iterations`` (int), ``converged`` (bool).
+            kcal/mol), ``iterations`` (int), ``converged`` (bool), ``sound``
+            (bool — all-finite coordinates and no bond stretched past a sane
+            covalent-bond length; independent of ``converged``, check this
+            before trusting a result).
         """
         ...
 

--- a/crates/chematic-py/src/mol_methods.rs
+++ b/crates/chematic-py/src/mol_methods.rs
@@ -376,13 +376,19 @@ impl Mol {
     /// Returns:
     ///     dict with keys:
     ///     ``coords`` (list of [x,y,z]), ``energy`` (float, kcal/mol),
-    ///     ``iterations`` (int), ``converged`` (bool).
+    ///     ``iterations`` (int), ``converged`` (bool), ``sound`` (bool —
+    ///     all-finite coordinates and no bond stretched past a sane
+    ///     covalent-bond length; independent of ``converged``, since
+    ///     steepest descent often reports ``converged=False`` on geometries
+    ///     that are perfectly fine but simply haven't hit the tight
+    ///     RMS-gradient threshold yet. Check this, not just ``converged``,
+    ///     before trusting a result).
     ///
     /// Example::
     ///
     ///     mol = chematic.from_smiles("CCO")
     ///     result = mol.minimize_uff([[0,0,0],[1.54,0,0],[2.5,1.2,0]])
-    ///     print(result["energy"], result["converged"])
+    ///     print(result["energy"], result["converged"], result["sound"])
     fn minimize_uff<'py>(
         &self,
         py: Python<'py>,
@@ -398,6 +404,7 @@ impl Mol {
         d.set_item("energy", result.energy)?;
         d.set_item("iterations", result.iterations)?;
         d.set_item("converged", result.converged)?;
+        d.set_item("sound", result.sound)?;
         Ok(d)
     }
 

--- a/crates/chematic-wasm/src/mol_3d.rs
+++ b/crates/chematic-wasm/src/mol_3d.rs
@@ -620,8 +620,13 @@ pub fn depict_data_with_coords_json(mol: &MolHandle, coords_json: &str) -> Strin
 /// `coords_json` — JSON array of `[x,y,z]` arrays (Å), one per atom.
 /// `max_iter` — maximum iterations (0 = default 500).
 ///
-/// Returns JSON: `{"coords":[[x,y,z],...], "energy":float, "iterations":int, "converged":bool}`
-/// or `{"error":"<msg>"}` on failure.
+/// Returns JSON: `{"coords":[[x,y,z],...], "energy":float, "iterations":int, "converged":bool, "sound":bool}`
+/// or `{"error":"<msg>"}` on failure. `sound` is all-finite coordinates and
+/// no bond stretched past a sane covalent-bond length — independent of
+/// `converged`, since steepest descent often reports `converged:false` on
+/// geometries that are perfectly fine but simply haven't hit the tight
+/// RMS-gradient threshold yet. Check `sound`, not just `converged`, before
+/// trusting a result.
 #[wasm_bindgen]
 pub fn minimize_uff_json(smiles: &str, coords_json: &str, max_iter: u32) -> String {
     let mol = match chematic_smiles::parse(smiles) {
@@ -646,8 +651,8 @@ pub fn minimize_uff_json(smiles: &str, coords_json: &str, max_iter: u32) -> Stri
         .collect::<Vec<_>>()
         .join(",");
     format!(
-        "{{\"coords\":[{coords_str}],\"energy\":{:.4},\"iterations\":{},\"converged\":{}}}",
-        result.energy, result.iterations, result.converged
+        "{{\"coords\":[{coords_str}],\"energy\":{:.4},\"iterations\":{},\"converged\":{},\"sound\":{}}}",
+        result.energy, result.iterations, result.converged, result.sound
     )
 }
 


### PR DESCRIPTION
## Summary
- ROADMAP.md Backlog item 5a. `UffMinimizeResult` gains `sound: bool` — all-finite coordinates and no bond stretched past a 3.0 Å sane-covalent-bond ceiling, mirroring `chematic-3d`'s already corpus-validated `MAX_SANE_BOND_LENGTH` check (duplicated here since `chematic-ff` can't depend on `chematic-3d` — the dependency runs the other way).
- Deliberately independent of `converged`: steepest descent frequently reports `converged=false` on geometries that are perfectly sound but simply haven't hit the tight RMS-gradient stopping threshold within `max_iter`.
- `chematic-py`'s `Mol.minimize_uff()` and `chematic-wasm`'s `minimize_uff_json()` previously called UFF directly with zero soundness signal of any kind (only `coords`/`energy`/`iterations`/`converged`). Both now also return `sound`.
- Does not add a residual-force half of the gate the way `chematic-3d`'s own soundness check has — `minimize_uff`'s steepest-descent loop doesn't retain a converged gradient norm past each iteration, and computing one is out of scope here. The bond-length check alone is a real, previously-nonexistent signal.

## Test plan
- [x] `cargo test -p chematic-ff` — 4 new tests (known-sound ethanol, known-unsound via a deliberately-stretched 5.0 Å bond at `max_iter=0`, non-finite coordinates), all passing alongside the existing 7
- [x] `cargo test -p chematic-ff -p chematic-3d` — full suite, 198+ tests, 0 failed (confirms no regression to `chematic-3d`'s existing UFF-blowup regression test on naphthalene)
- [x] `cargo check -p chematic-py` and `cargo check -p chematic-wasm --target wasm32-unknown-unknown` — both clean (pyo3 `cdylib`/wasm-bindgen `cdylib` crate types can't run `cargo test` directly; this matches this project's established verification depth for binding-layer changes)
- [x] `cargo check --workspace --all-features` clean
- [x] `cargo clippy` clean (also ran automatically via pre-commit hook)
- [x] `cargo fmt --all -- --check` clean