### PR TITLE
fix(chematic-depict): correct 2D layout angle bugs (issue #347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bond-length check without depending on steepest descent actually getting
   stuck there), and non-finite coordinates.
 
+### Fixed — `chematic-depict` 2D auto-layout (issue #347)
+
+- Long open chains no longer drift into a monotonic ~30°/bond rotation and
+  wrap onto themselves (a plain 13-carbon chain used to place its first and
+  last atom at identical coordinates). `dfs_zigzag`
+  (`crates/chematic-depict/src/layout.rs`) was alternating its ±30°
+  deflection by a neighbor's position within its *own parent's*
+  unplaced-neighbor list, which is `0` for every ordinary single-successor
+  chain step — not a real alternation signal. Now threads an explicit
+  `sign: f64` through the DFS stack that flips on every step, so a plain
+  chain continuation genuinely zigzags.
+- Exocyclic substituent bonds at ring junctions now point along the correct
+  outward bisector instead of missing it by up to ~30°.
+  `best_outgoing_direction` had its own coarser 6-point 60° candidate grid
+  with a last-wins tie-break; it now shares the richer, chemistry-aware
+  candidate set (`suggest_bond_direction`'s existing 12-point 30° grid plus
+  bond-relative sp2/sp3/anti offsets) via a new `ranked_candidates` helper.
+- `best_outgoing_direction` also gained a positional collision check: the
+  angularly-best candidate is skipped if it would land on top of an
+  already-placed atom elsewhere in the layout (falls back through the
+  ranked list, then to the top pick if every candidate collides). This is
+  a real, independent gap the coarse grid had been accidentally masking —
+  angular separation from an atom's own bonds doesn't guard against a
+  distant already-placed atom happening to sit on the chosen ray.
+- **Known, intentional behavior change**: any MOL/SDF/CML output that
+  relies on `chematic`'s auto-generated 2D coordinates (no
+  caller-supplied coordinates) will now differ from before, since these
+  coordinates were wrong. No fixture in this repo pins the old
+  (buggy) auto-layout output as a golden value.
+- New `Mol.depict_data()` binding for `chematic-py`
+  (`crates/chematic-py/src/mol_methods.rs`): returns the full structured
+  `DepictData` (atoms with element/position/label/color/charge, bonds with
+  kind including wedge/hash stereo) as a native Python `dict`, mirroring
+  `chematic-wasm`'s existing `depict_data_json` (shipped since v0.1.20) —
+  previously Python could only get an SVG string or a function that takes
+  coordinates as input, not raw layout data.
+
 ## [0.18.0] — 2026-08-20
 
 Python and WASM bindings for the 7 file formats `chematic-mol` gained in

--- a/crates/chematic-depict/README.md
+++ b/crates/chematic-depict/README.md
@@ -10,7 +10,7 @@
 - **Ring templates**: pre-drawn benzene and other common rings for cleaner depiction
 - **Stereo bonds**: wedge (Up) and dash (Down) for 3D stereochemistry
 - **CPK coloring**: element-specific color scheme (C gray, H white, O red, N blue, etc.)
-- **Automatic 2D layout**: uses distance geometry and spring forces for readable coordinates
+- **Automatic 2D layout**: geometric placement rules (ring templates, zigzag chains, angle-aware branching) for readable coordinates — no physics simulation
 - **Atom/bond highlighting**: highlight arbitrary atoms or bonds with color overlays
 - **Label customization**: hide/show atom symbols, hydrogens, or atom indices
 - **PNG rasterization**: optional `png` feature (default=enabled) via `tiny_skia`; excluded from WASM — use SVG there

--- a/crates/chematic-depict/src/layout.rs
+++ b/crates/chematic-depict/src/layout.rs
@@ -799,7 +799,9 @@ fn best_outgoing_direction(
         );
         placed
             .iter()
-            .flatten()
+            .enumerate()
+            .filter(|(i, _)| component.contains(&AtomIdx(*i as u32)))
+            .filter_map(|(_, p)| p.as_ref())
             .any(|p| candidate.dist(p) < BOND_LEN / 2.0)
     };
 

--- a/crates/chematic-depict/src/layout.rs
+++ b/crates/chematic-depict/src/layout.rs
@@ -755,6 +755,18 @@ fn grow_layout(
 }
 
 /// Compute the best outgoing direction from a ring atom to avoid collisions.
+///
+/// Ranks candidates by angular separation via [`ranked_candidates`] (see that
+/// function's doc for why -- issue #347: this used to have its own, coarser
+/// 60°-spaced candidate set with no chemistry-aware offsets, missing the
+/// correct bisector for e.g. a hexagon-ring substituent by ~30°), then walks
+/// them best-first and skips any candidate whose resulting position would
+/// land on top of an already-placed atom elsewhere in the component --
+/// angular separation from *this atom's own bonds* alone doesn't guard
+/// against that (issue #347: a bridged-core molecule with a separate,
+/// pre-existing placement bug has an atom sitting far from where its own
+/// bonds would suggest, and the top-angular candidate can point straight at
+/// it). Falls back to the top-ranked candidate if every one collides.
 fn best_outgoing_direction(
     atom: AtomIdx,
     placed: &[Option<Point>],
@@ -779,19 +791,74 @@ fn best_outgoing_direction(
         return 0.0;
     }
 
-    // Try candidate angles at 60-degree increments and pick the one farthest from all used.
-    let candidates: Vec<f64> = (0..6)
-        .map(|i| i as f64 * std::f64::consts::PI / 3.0)
-        .collect();
+    let ranked = ranked_candidates(&used_angles);
+    let occupies = |dir: f64| -> bool {
+        let candidate = Point::new(
+            origin.x + BOND_LEN * dir.cos(),
+            origin.y + BOND_LEN * dir.sin(),
+        );
+        placed
+            .iter()
+            .flatten()
+            .any(|p| candidate.dist(p) < BOND_LEN / 2.0)
+    };
 
+    ranked
+        .iter()
+        .copied()
+        .find(|&dir| !occupies(dir))
+        .unwrap_or(ranked[0])
+}
+
+/// Pick the direction (radians) that maximizes the minimum angular separation
+/// from every angle in `used_angles`.
+///
+/// Thin wrapper over [`ranked_candidates`] -- see that function's doc for the
+/// candidate set. Returns `0.0` if `used_angles` is empty.
+fn best_direction_avoiding(used_angles: &[f64]) -> f64 {
+    if used_angles.is_empty() {
+        return 0.0;
+    }
+    ranked_candidates(used_angles)[0]
+}
+
+/// Candidate directions (radians), best-first by minimum angular separation
+/// from every angle in `used_angles`.
+///
+/// Candidates: a 30-degree grid (12 directions covering 360°), plus, for each
+/// angle already in `used_angles`: its anti-direction (α+180°), the two sp3
+/// zigzag offsets (α+150°/α+210°) and the two sp2 offsets (α±120°) --
+/// chemistry-aware candidates that a plain fixed grid alone can miss (issue
+/// #347's ring-substituent bisector case: two ring bonds 120° apart need a
+/// candidate at their exact bisector, which isn't always on a 30°-aligned
+/// grid point relative to 0°, but always is one of these bond-relative
+/// offsets). Shared by [`best_outgoing_direction`] and
+/// [`suggest_bond_direction`] (via [`best_direction_avoiding`]) -- previously
+/// duplicated with two different (one worse) candidate sets; this is the
+/// single, richer implementation both now use. Returns `[0.0]` if
+/// `used_angles` is empty.
+fn ranked_candidates(used_angles: &[f64]) -> Vec<f64> {
+    use std::f64::consts::PI;
+
+    if used_angles.is_empty() {
+        return vec![0.0];
+    }
+
+    let mut candidates: Vec<f64> = (0..12).map(|i| i as f64 * PI / 6.0).collect();
+    for &a in used_angles {
+        candidates.push(a + PI);
+        candidates.push(a + PI - PI / 6.0);
+        candidates.push(a + PI + PI / 6.0);
+        candidates.push(a + 2.0 * PI / 3.0);
+        candidates.push(a - 2.0 * PI / 3.0);
+    }
+
+    candidates.sort_by(|&a, &b| {
+        let min_sep_a = min_angle_separation(a, used_angles);
+        let min_sep_b = min_angle_separation(b, used_angles);
+        min_sep_b.partial_cmp(&min_sep_a).unwrap()
+    });
     candidates
-        .into_iter()
-        .max_by(|&a, &b| {
-            let min_sep_a = min_angle_separation(a, &used_angles);
-            let min_sep_b = min_angle_separation(b, &used_angles);
-            min_sep_a.partial_cmp(&min_sep_b).unwrap()
-        })
-        .unwrap_or(0.0)
 }
 
 /// Minimum angular separation between `angle` and any angle in `used`.
@@ -810,6 +877,15 @@ fn min_angle_separation(angle: f64, used: &[f64]) -> f64 {
 
 /// Iterative zigzag placement: place `start_atom` at `BOND_LEN` from `start_parent`
 /// in direction `start_dir`, then expand unplaced neighbors with alternating ±30° deflection.
+///
+/// The alternation is carried as a `sign` (±1.0) threaded through the DFS stack,
+/// not derived from a neighbor's position in its parent's own unplaced-neighbor
+/// list -- that would only ever alternate at a genuine branch point (2+ unplaced
+/// neighbors), and always reapply the same deflection on an ordinary single-child
+/// chain continuation (the overwhelming majority of atoms), producing a monotonic
+/// per-bond rotational drift instead of a zigzag (issue #347: a plain 13-carbon
+/// chain's first and last atoms landed on identical coordinates, since 12
+/// consecutive -30° steps trace a full circle).
 ///
 /// If a popped atom belongs to a not-yet-placed ring system (`atom_to_system`),
 /// this anchors that whole system via [`place_ring_system`]/
@@ -832,10 +908,13 @@ fn dfs_zigzag(
     system_placed: &mut [bool],
     newly_ring_placed: &mut Vec<AtomIdx>,
 ) {
-    let deflections = [-std::f64::consts::PI / 6.0, std::f64::consts::PI / 6.0];
-    let mut stack: Vec<(AtomIdx, AtomIdx, f64)> = vec![(start_atom, start_parent, start_dir)];
+    let deflection = std::f64::consts::PI / 6.0;
+    // 4th element: the sign to apply, and then flip, when this atom continues
+    // the chain alone. -1.0 matches the pre-fix first-step behavior.
+    let mut stack: Vec<(AtomIdx, AtomIdx, f64, f64)> =
+        vec![(start_atom, start_parent, start_dir, -1.0)];
 
-    while let Some((atom, parent, dir)) = stack.pop() {
+    while let Some((atom, parent, dir, sign)) = stack.pop() {
         if placed[atom.0 as usize].is_some() {
             continue;
         }
@@ -867,9 +946,19 @@ fn dfs_zigzag(
             })
             .collect();
 
-        // Push in reverse so the first neighbor is popped first, preserving DFS order.
-        for (i, nb) in unplaced.into_iter().enumerate().rev() {
-            stack.push((nb, atom, dir + deflections[i % 2]));
+        if unplaced.len() == 1 {
+            // Ordinary chain continuation: apply this atom's sign, flip it for
+            // the next step -- this is the alternation the pre-fix code missed.
+            stack.push((unplaced[0], atom, dir + sign * deflection, -sign));
+        } else {
+            // A real branch (0, or 2+, unplaced neighbors): preserve the
+            // original per-child split (alternating by position), each child
+            // then continuing its own zigzag from its own starting sign.
+            // Push in reverse so the first neighbor is popped first, preserving DFS order.
+            for (i, nb) in unplaced.into_iter().enumerate().rev() {
+                let child_sign = if i % 2 == 0 { -1.0 } else { 1.0 };
+                stack.push((nb, atom, dir + child_sign * deflection, -child_sign));
+            }
         }
     }
 }
@@ -881,22 +970,12 @@ fn dfs_zigzag(
 /// Suggest the best direction (radians, measured from positive x-axis) for a
 /// new bond leaving `atom`, given the molecule's current 2D `layout`.
 ///
-/// The algorithm:
-/// 1. Collects angles to all already-placed neighbors of `atom`.
-/// 2. Generates chemistry-aware candidate directions (see below).
-/// 3. Returns the candidate with the **maximum minimum angular separation**
-///    from all existing bond angles.
-///
-/// Candidates include:
-/// - A 30-degree grid (12 directions covering 360°).
-/// - For each existing bond at angle α: the anti-direction (α+180°) and the
-///   two zigzag offsets (α+150°, α+210°) that model sp3 chain extension,
-///   plus the two sp2 offsets (α+120°, α+240°) for aromatic / double-bonded atoms.
+/// Collects angles to all already-placed neighbors of `atom`, then delegates
+/// candidate generation/selection to [`best_direction_avoiding`] -- see that
+/// function's doc for the candidate set and selection rule.
 ///
 /// Returns `0.0` (pointing right) when `atom` has no neighbors in `layout`.
 pub fn suggest_bond_direction(mol: &Molecule, atom: AtomIdx, layout: &Layout) -> f64 {
-    use std::f64::consts::PI;
-
     let origin = layout.get(atom);
 
     // Angles to neighbors that are already placed in the layout.
@@ -913,28 +992,7 @@ pub fn suggest_bond_direction(mol: &Molecule, atom: AtomIdx, layout: &Layout) ->
         return 0.0;
     }
 
-    // Build candidate set.
-    let mut candidates: Vec<f64> = (0..12).map(|i| i as f64 * PI / 6.0).collect();
-
-    for &a in &used_angles {
-        // Anti-direction (straight opposite).
-        candidates.push(a + PI);
-        // sp3 zigzag: ±30° from the anti-direction.
-        candidates.push(a + PI - PI / 6.0);
-        candidates.push(a + PI + PI / 6.0);
-        // sp2: ±120° from the existing bond.
-        candidates.push(a + 2.0 * PI / 3.0);
-        candidates.push(a - 2.0 * PI / 3.0);
-    }
-
-    candidates
-        .into_iter()
-        .max_by(|&ca, &cb| {
-            let sa = min_angle_separation(ca, &used_angles);
-            let sb = min_angle_separation(cb, &used_angles);
-            sa.partial_cmp(&sb).unwrap()
-        })
-        .unwrap_or(0.0)
+    best_direction_avoiding(&used_angles)
 }
 
 // ---------------------------------------------------------------------------
@@ -1113,8 +1171,10 @@ mod tests {
         // distance 0.0). Tier A only (no exact/near coincidence) -- the
         // bridged core's OWN internal bond lengths have a separate,
         // pre-existing bug (`find_shared_edge` only handles a 2-atom
-        // shared edge, not the 3-atom-shared case a true bridge produces),
-        // out of scope for this fix, so Tier B/C are not asserted here.
+        // shared edge, not the 3-atom-shared case a true bridge produces --
+        // e.g. this molecule's atom5-atom6 bond, a real bond, lands ~108
+        // units apart instead of the expected `BOND_LEN` of 40), out of
+        // scope for this fix, so Tier B/C are not asserted here.
         use chematic_smiles::parse;
         let mol = parse("C1CC2CN(CC1N2c1ccccc1)c1cccc(c1)-c1ccccc1").unwrap();
         let layout = compute_layout(&mol);
@@ -1129,6 +1189,94 @@ mod tests {
     #[test]
     fn pure_chain_layout_unaffected() {
         assert_layout_clean("CCCCCCCC");
+    }
+
+    // --- Issue #347 regressions ------------------------------------------
+
+    #[test]
+    fn long_chain_does_not_wrap_onto_itself() {
+        // Pre-fix, dfs_zigzag applied a constant -30°/bond drift instead of
+        // alternating, so 12 consecutive bonds traced a full circle: a plain
+        // 13-carbon chain's first and last atoms landed on identical
+        // coordinates. 20 carbons is well past that wrap point -- a true
+        // zigzag (ping-ponging between two directions) never revisits a
+        // point no matter how long the chain runs, so this can't pass by
+        // accident the way a shorter fixture might.
+        assert_layout_clean(&"C".repeat(20));
+    }
+
+    #[test]
+    fn long_chain_bond_directions_genuinely_alternate() {
+        // Direct angle check, not just non-collision: asserts the actual
+        // zigzag pattern (ping-ponging between exactly two directions 30°
+        // apart), not merely that nothing happened to collide.
+        use chematic_smiles::parse;
+        let mol = parse(&"C".repeat(10)).unwrap();
+        let layout = compute_layout(&mol);
+        let n = mol.atom_count();
+        let dirs: Vec<f64> = (0..n - 1)
+            .map(|i| {
+                let a = layout.get(AtomIdx(i as u32));
+                let b = layout.get(AtomIdx((i + 1) as u32));
+                (b.y - a.y).atan2(b.x - a.x)
+            })
+            .collect();
+        // Consecutive bond directions must differ by exactly 30° in
+        // magnitude (a real zigzag turn), never 0° (collinear) or drifting
+        // to some other value.
+        for w in dirs.windows(2) {
+            let mut turn = (w[1] - w[0]).abs();
+            if turn > std::f64::consts::PI {
+                turn = 2.0 * std::f64::consts::PI - turn;
+            }
+            assert!(
+                (turn - std::f64::consts::PI / 6.0).abs() < 1e-6,
+                "expected a 30° zigzag turn between consecutive bonds, got {turn} rad \
+                 (dirs={dirs:?})"
+            );
+        }
+        // And the pattern must actually alternate (ping-pong), not drift:
+        // only 2 distinct directions should appear across the whole chain.
+        let mut distinct: Vec<f64> = Vec::new();
+        for &d in &dirs {
+            if !distinct.iter().any(|&e: &f64| (e - d).abs() < 1e-6) {
+                distinct.push(d);
+            }
+        }
+        assert_eq!(
+            distinct.len(),
+            2,
+            "expected exactly 2 distinct bond directions (ping-pong zigzag), got {distinct:?}"
+        );
+    }
+
+    #[test]
+    fn ring_substituent_direction_bisects_the_open_angle() {
+        // Issue #347 repro 2's exact scenario: a hexagon-ring atom with two
+        // ring bonds at -30°/90° (120° apart, as any regular-hexagon vertex
+        // is). The correct outward direction for an exocyclic substituent is
+        // the bisector of the open 240° angle: 210°. Pre-fix,
+        // best_outgoing_direction's coarse 60°-grid + broken tie-break
+        // returned 180° here -- a real ~30° miss.
+        let used_angles = [-std::f64::consts::PI / 6.0, std::f64::consts::PI / 2.0];
+        let dir = best_direction_avoiding(&used_angles);
+        let expected = 7.0 * std::f64::consts::PI / 6.0; // 210°
+        let mut diff = (dir - expected).abs();
+        if diff > std::f64::consts::PI {
+            diff = 2.0 * std::f64::consts::PI - diff;
+        }
+        assert!(
+            diff < 1e-6,
+            "expected the 210° bisector, got {} rad ({} deg)",
+            dir,
+            dir.to_degrees()
+        );
+    }
+
+    #[test]
+    fn ring_plus_exocyclic_branch_layout_unaffected() {
+        // Full end-to-end version of issue #347 repro 2.
+        assert_layout_clean("C1CCCC(C(=O)CC)C1");
     }
 
     #[test]

--- a/crates/chematic-py/python/chematic/__init__.pyi
+++ b/crates/chematic-py/python/chematic/__init__.pyi
@@ -611,6 +611,29 @@ class Mol:
         """
         ...
 
+    def depict_data(self) -> dict:
+        """Structured 2D depiction data (atoms + bonds with layout coordinates).
+
+        Use this instead of :meth:`svg` when you want to drive your own
+        renderer (e.g. matplotlib, a custom canvas) rather than parse SVG.
+
+        Returns:
+            dict with keys:
+            ``atoms`` (list of dicts: ``idx``, ``element`` (symbol string),
+            ``x``, ``y``, ``label`` (``None`` when suppressed), ``color``
+            (CSS hex string), ``charge``) and ``bonds`` (list of dicts:
+            ``idx``, ``atom1``, ``atom2``, ``kind`` — one of ``"Single"``,
+            ``"Double"``, ``"Triple"``, ``"Aromatic"``, ``"Up"``, ``"Down"``).
+
+        Example::
+
+            mol = chematic.from_smiles("CCO")
+            data = mol.depict_data()
+            for atom in data["atoms"]:
+                print(atom["element"], atom["x"], atom["y"])
+        """
+        ...
+
     def _repr_svg_(self) -> str:
         """Jupyter auto-display hook — renders the molecule automatically in a cell.
 

--- a/crates/chematic-py/src/mol_methods.rs
+++ b/crates/chematic-py/src/mol_methods.rs
@@ -1504,6 +1504,72 @@ impl Mol {
         chematic_depict::depict_svg(&self.inner)
     }
 
+    /// Structured 2D depiction data (atoms + bonds with layout coordinates).
+    ///
+    /// Use this instead of ``svg()`` when you want to drive your own
+    /// renderer (e.g. matplotlib, a custom canvas) rather than parse SVG.
+    ///
+    /// Returns:
+    ///     dict with keys:
+    ///     ``atoms`` (list of dicts: ``idx``, ``element`` (symbol string),
+    ///     ``x``, ``y``, ``label`` (``None`` when suppressed), ``color``
+    ///     (CSS hex string), ``charge``) and ``bonds`` (list of dicts:
+    ///     ``idx``, ``atom1``, ``atom2``, ``kind`` — one of ``"Single"``,
+    ///     ``"Double"``, ``"Triple"``, ``"Aromatic"``, ``"Up"``, ``"Down"``).
+    ///
+    /// Example::
+    ///
+    ///     mol = chematic.from_smiles("CCO")
+    ///     data = mol.depict_data()
+    ///     for atom in data["atoms"]:
+    ///         print(atom["element"], atom["x"], atom["y"])
+    fn depict_data<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let data = chematic_depict::compute_depict_data(&self.inner);
+
+        let atoms = data
+            .atoms
+            .iter()
+            .map(|a| {
+                let ad = PyDict::new(py);
+                ad.set_item("idx", a.idx.0)?;
+                ad.set_item("element", a.element.symbol())?;
+                ad.set_item("x", a.pos.x)?;
+                ad.set_item("y", a.pos.y)?;
+                ad.set_item("label", a.label.as_deref())?;
+                ad.set_item("color", &a.color)?;
+                ad.set_item("charge", a.charge)?;
+                Ok::<_, PyErr>(ad)
+            })
+            .collect::<PyResult<Vec<_>>>()?;
+
+        let bond_kind = |k: &chematic_depict::DepictBondKind| match k {
+            chematic_depict::DepictBondKind::Single => "Single",
+            chematic_depict::DepictBondKind::Double => "Double",
+            chematic_depict::DepictBondKind::Triple => "Triple",
+            chematic_depict::DepictBondKind::Aromatic => "Aromatic",
+            chematic_depict::DepictBondKind::Up => "Up",
+            chematic_depict::DepictBondKind::Down => "Down",
+        };
+
+        let bonds = data
+            .bonds
+            .iter()
+            .map(|b| {
+                let bd = PyDict::new(py);
+                bd.set_item("idx", b.idx.0)?;
+                bd.set_item("atom1", b.atom1.0)?;
+                bd.set_item("atom2", b.atom2.0)?;
+                bd.set_item("kind", bond_kind(&b.kind))?;
+                Ok::<_, PyErr>(bd)
+            })
+            .collect::<PyResult<Vec<_>>>()?;
+
+        let d = PyDict::new(py);
+        d.set_item("atoms", atoms)?;
+        d.set_item("bonds", bonds)?;
+        Ok(d)
+    }
+
     /// Export the 2D structure as an EPS string.
     ///
     /// Generates a self-contained PostScript EPS document.


### PR DESCRIPTION
## Summary

Fixes issue #347's `chematic-depict` 2D auto-layout defects, plus its Python coordinate-binding gap.

- **Long-chain drift/wrap-around**: `dfs_zigzag` alternated its ±30° deflection using a neighbor's position within its own parent's unplaced-neighbor list, which is always `0` for an ordinary single-successor chain step. A plain chain therefore drifted monotonically at -30°/bond instead of zigzagging — a 13-carbon chain's first and last atoms landed on identical coordinates. Now threads an explicit `sign: f64` through the DFS stack that flips every step.
- **Ring-substituent misangle**: `best_outgoing_direction` had its own coarser 6-point 60° candidate grid with a last-wins tie-break, missing the correct outward bisector at a ring junction by up to ~30° (issue #347 repro 2: -30°/90° ring bonds → correct bisector 210°, old code returned 180°). Now shares `suggest_bond_direction`'s richer 12-point 30° grid plus bond-relative sp2/sp3/anti offsets via a new `ranked_candidates` helper.
- **New: positional collision guard**. Found during review — angular separation from an atom's own bonds doesn't guard against the chosen ray landing on a *different*, already-placed atom elsewhere in the layout. `best_outgoing_direction` now walks its ranked candidates best-first and skips any whose resulting position lands within `BOND_LEN / 2.0` of an already-placed atom in the same connected component (scoped to `component`, matching the existing `used_angles` filter — an earlier version of this fix scanned all of `placed` and was corrected before push, since it could pick up a different, unrelated fragment's in-progress coordinates for disconnected molecules like `"CCO.CCO"`). Falls back to the top-ranked candidate if every one collides.
- **New Python binding**: `Mol.depict_data()` in `chematic-py`, returning the full structured `DepictData` (atoms with element/position/label/color/charge, bonds with kind including wedge/hash stereo) as a native `dict` — mirrors `chematic-wasm`'s existing `depict_data_json` (shipped since v0.1.20). Previously Python could only get an SVG string (`svg()`) or a function taking coordinates as *input* (`to_mol_block_2d`), not raw layout data.
- One-line `README.md` fix: the "distance geometry and spring forces" claim was stale and contradicted `layout.rs`'s own doc block ("No physics simulation is used").

## Disclosed, out-of-scope finding

`three_substituent_rings_on_bridged_core_do_not_collide` (pre-existing test) still passes with its original strict collision-freedom bar — no test needed to be weakened. While isolating an intermediate interaction during development, confirmed the test's bridged-core molecule has a **separate, pre-existing, already-disclosed bug**: `find_shared_edge` only handles a 2-atom shared edge, not the 3-atom-shared case a true bridge produces. Concretely, this molecule's atom5–atom6 bond (a real bond) lands ~108 units apart instead of the expected `BOND_LEN` of 40. Left untouched — out of scope here, but the repro is now in the test's comment for whoever picks up `find_shared_edge` next.

## Known, intentional behavior change

Any MOL/SDF/CML output that relies on `chematic`'s auto-generated 2D coordinates (i.e. the caller supplies none) will differ from before, since the previous coordinates were wrong. No fixture in this repo pins the old (buggy) auto-layout output as a golden value.

## Test plan

- [x] `cargo test -p chematic-depict` — 75 tests + 1 doctest, all passing (16/16 in `layout::tests`, including 4 new regression tests for this fix)
- [x] `cargo check -p chematic-py` — clean (new `depict_data()` binding compiles)
- [x] `cargo check -p chematic-wasm --target wasm32-unknown-unknown` — clean
- [x] `cargo clippy -p chematic-depict -p chematic-py --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check --workspace --all-features` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)