### PR TITLE
fix(demo): stop displaying hardcoded, stale version/WASM-size numbers

### DIFF
--- a/crates/chematic-wasm/src/lib.rs
+++ b/crates/chematic-wasm/src/lib.rs
@@ -45,6 +45,16 @@ pub fn start() {
     }));
 }
 
+/// The `chematic-wasm` crate version (matches the workspace release version).
+///
+/// Lets callers (e.g. the browser playground demo) display the running
+/// version without hardcoding it — `demo/index.html` previously had a
+/// static version string that silently went stale across releases.
+#[wasm_bindgen]
+pub fn chematic_version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
 // High-level workflow APIs
 pub mod workflow;
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -670,7 +670,7 @@ footer {
   <div class="header-inner">
     <span class="logo">chematic</span>
     <a href="https://github.com/kent-tokyo/chematic/blob/main/CHANGELOG.md" target="_blank" rel="noopener" style="margin-left: 0.5rem;">
-      <span class="version" style="background: linear-gradient(135deg, #34d399, #4f8ef7); color: white; border-color: #34d399; cursor: pointer;">v0.4.23</span>
+      <span class="version" id="version-badge" style="display:none;background: linear-gradient(135deg, #34d399, #4f8ef7); color: white; border-color: #34d399; cursor: pointer;"></span>
     </a>
     <span class="tagline" id="tagline"></span>
     <div class="lang-switcher">
@@ -703,7 +703,7 @@ footer {
     <!-- Descriptor Calculator -->
     <section id="section-descriptor">
       <h2 id="h-desc-title"></h2>
-      <p class="value-strip">Pure Rust &middot; WASM 504 KB &middot; 99.7% RDKit-accurate LogP &mdash; change the SMILES below or pick an example&nbsp;&darr;&nbsp;&nbsp;<a href="https://pypi.org/project/chematic/" target="_blank" rel="noopener" style="color:var(--accent)">pip install chematic</a></p>
+      <p class="value-strip">Pure Rust &middot; WASM <span id="wasm-size-badge">&hellip;</span> &middot; <a href="https://kent-tokyo.github.io/chematic/benchmark/" target="_blank" rel="noopener" style="color:var(--accent)">RDKit-accuracy benchmarks</a> &mdash; change the SMILES below or pick an example&nbsp;&darr;&nbsp;&nbsp;<a href="https://pypi.org/project/chematic/" target="_blank" rel="noopener" style="color:var(--accent)">pip install chematic</a></p>
       <div class="input-row">
         <input id="smiles-input" class="smiles-input" type="text"
                spellcheck="false" autocomplete="off">
@@ -754,9 +754,8 @@ footer {
         </table>
       </div>
       <p id="rdkit-note" style="display:none;font-size:.72rem;color:var(--muted);margin:.35rem 0 0">
-        &#10003; LogP <span style="color:var(--pass)">99.7%</span> &middot;
-        TPSA <span style="color:var(--pass)">98.9%</span>
-        agreement with RDKit on 4,999-molecule benchmark
+        &#10003; Benchmarked against RDKit on a 4,999-molecule corpus &mdash;
+        <a href="https://kent-tokyo.github.io/chematic/benchmark/" target="_blank" rel="noopener" style="color:var(--accent)">see full results &amp; methodology</a>
       </p>
       <div id="code-wrap" style="display:none;margin:.9rem 0 0">
         <div style="display:flex;gap:.5rem;align-items:center;flex-wrap:wrap">
@@ -2007,10 +2006,34 @@ let groupColorMap = {};
 // ============================================================
 // WASM init
 // ============================================================
+// Formats a byte count as a human-readable "X.X MB" / "XXX KB" string.
+function formatBytes(n) {
+  if (n >= 1024 * 1024) return (n / (1024 * 1024)).toFixed(1) + ' MB';
+  return Math.round(n / 1024) + ' KB';
+}
+
 async function initWasm() {
   try {
     const mod = await import('./pkg/chematic_wasm.js');
-    await mod.default('./pkg/chematic_wasm_bg.wasm');
+    // Fetch the WASM binary ourselves (rather than letting init() do it
+    // internally) so we can measure its real, current size and display it
+    // -- the actual bytes served, never a hardcoded number that goes stale
+    // across releases. init() accepts a Response directly, so this adds no
+    // extra network round-trip.
+    const wasmResp = await fetch('./pkg/chematic_wasm_bg.wasm');
+    const wasmBytes = (await wasmResp.clone().arrayBuffer()).byteLength;
+    await mod.default(wasmResp);
+    // chematic_version() may be absent on an older locally-built ./pkg (e.g.
+    // a fresh git clone before CI has rebuilt it) -- guarded the same way
+    // depict_svg_opts is a few lines down, so a stale pkg degrades this one
+    // badge instead of failing WASM init entirely.
+    const versionEl = document.getElementById('version-badge');
+    if (versionEl && typeof mod.chematic_version === 'function') {
+      versionEl.textContent = 'v' + mod.chematic_version();
+      versionEl.style.display = '';
+    }
+    const wasmSizeEl = document.getElementById('wasm-size-badge');
+    if (wasmSizeEl) wasmSizeEl.textContent = formatBytes(wasmBytes);
     parseSmilesWasm  = mod.parse_smiles;
     tanimotoEcfp4    = mod.tanimoto_ecfp4;
     tanimotoFcfp4    = mod.tanimoto_fcfp4;


### PR DESCRIPTION
## Summary

Playground Priority-1 fix: the header version badge, hero WASM-size claim, and RDKit-accuracy note in `demo/index.html` were static text last touched at the v0.4.x era, while CI (`.github/workflows/pages.yml`) has rebuilt a fresh WASM binary on every deploy since — the live site was showing numbers from several dozen releases ago with no visible way to tell.

- New `chematic_version()` WASM export (`crates/chematic-wasm/src/lib.rs`), `env!("CARGO_PKG_VERSION")` — same pattern already used elsewhere in this crate. `demo/index.html` calls this after WASM init to populate the header badge instead of hardcoding `v0.4.23`.
- WASM size is now measured live in the browser: `initWasm()` fetches the `.wasm` binary itself, reads the real byte count via `.clone().arrayBuffer()`, and passes the same, already-fetched `Response` into `init()` — no extra network round-trip, never stale since it's the actual bytes served.
- Dropped the LogP/TPSA percentage claims (`99.7%`/`98.9%`) entirely rather than auto-generating them: no reliable, continuously-refreshed, machine-readable source exists for these in the repo (checked `validation/results/*.json` — both predate v0.17.0/v0.18.0), and the existing markdown docs already disagree with each other (README.md cites both 99.7% and 100% for TPSA depending on the table). Replaced with a link to `docs/benchmark.md`, the actively-maintained canonical source, rather than ship a second possibly-wrong number.

## A regression I caught before pushing

An earlier version called `mod.chematic_version()` unconditionally. That throws on the *committed* `demo/pkg/` (last rebuilt at the v0.4.x era — no such export), which is what a fresh `git clone` serves until CI next rebuilds `pkg/`. This would have broken the entire playground (not just the badge) for anyone browsing from a clone. Fixed with a `typeof` guard (same shape as the existing `depict_svg_opts ?? depict_svg` fallback a few lines down) — the version badge just stays hidden if the export isn't present; everything else still works. Verified both paths directly via Node (`wasm-bindgen --target web` output runs fine under Node's `fetch`/`WebAssembly`): stale `pkg/` degrades gracefully, fresh `pkg/` populates both badges correctly (`v0.18.0`, `2.8 MB`).

## On the WASM size jump (504 KB → ~2.8 MB)

Not a regression — the real number was simply never disclosed. Verified the *live* site's actual current binary directly (`curl -I`, ETag byte count) rather than trusting only my local build: **2,943,754 bytes**, matching my local release build (2,942,069, same `wasm-pack build --release` + `wasm-opt -O3` recipe as CI) within build-nondeterminism noise. Still ~10x smaller than RDKit.js's ~30 MB. The displayed figure is the raw (post-`wasm-opt`) binary size, not gzip-over-the-wire — gzip size can't be reliably measured client-side via `fetch`, and hardcoding it would just reintroduce the bug this PR fixes.

## Separately discovered, NOT addressed in this PR

`README.md` and 5 `docs/` pages cite **"719 KB gzip"** for the WASM bundle — also now substantially stale (actual gzip of the current binary measures ~1.07 MB, a ~50% increase). Root cause, from `Cargo.toml`'s own comment: `[profile.release]` was switched from `opt-level = "z"` (size) to `opt-level = 3` (speed) at some point, which is very likely most of the delta. Flagging this for a separate decision — whether to fix the docs numbers too, and whether to reconsider the size/speed tradeoff — rather than silently expanding this PR's scope.

## Test plan

- [x] `cargo test -p chematic-wasm` — 276/276 passed
- [x] `cargo clippy -p chematic-wasm --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check --workspace --all-features` — clean
- [x] Verified end-to-end via Node against both a freshly-built `pkg/` (has `chematic_version`) and the actual committed, stale `pkg/` (does not) — both paths work, no crash
- [x] Verified the live deployed WASM size directly against the local build's measurement (see above)
- No Playwright/browser test exists in this repo yet for the demo (noted as a separate, larger gap — not added here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)