### PR TITLE
docs: refresh stale WASM bundle size (719 KB gzip -> ~1.1 MB gzip)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Pure Rust · Zero C/C++ · Python · WebAssembly · [Live Demo](https://kent-tok
 | | chematic | RDKit (Python) | RDKit.js (WASM) |
 |---|---|---|---|
 | **Get started** | `pip install chematic` | conda / cmake required | no Python bindings |
-| **Browser bundle** | **719 KB** | not available | ~30 MB (~42× larger) |
+| **Browser bundle** | **~1.1 MB gzip** | not available | ~30 MB (~27× larger) |
 | **Batch fingerprints** | **~78 µs/mol** (2–3× faster) | ~160–235 µs/mol | — |
 | **Memory safety** | compiler-enforced (Rust) | C++ | C++ |
 | **Build from source** | `cargo build` only | cmake + clang + Boost | Emscripten SDK |
 
 All numbers are reproducible — see [benchmark details](https://kent-tokyo.github.io/chematic/benchmark/).  
-WASM sizes: chematic **719 KB** · RDKit.js ~30 MB · Indigo WASM ~40 MB
+WASM sizes: chematic **~1.1 MB gzip** · RDKit.js ~30 MB · Indigo WASM ~40 MB
 
 **Feature maturity at a glance:**
 
@@ -74,7 +74,7 @@ cmp.save("compare.html")
 | **Drug screening** | 190+ descriptors, ADMET, PAINS/Brenk, QED — batch over thousands of compounds |
 | **Molecule search** | ECFP4/MACCS fingerprints, Tanimoto, LSH approximate nearest-neighbour |
 | **AI agent / MCP** | Built-in MCP server — Claude Desktop can call chemistry tools directly |
-| **Browser app** | 719 KB WASM bundle, zero backend required, React/Vue/Svelte ready |
+| **Browser app** | ~1.1 MB gzip WASM bundle, zero backend required, React/Vue/Svelte ready |
 | **Jupyter notebook** | `mol` renders SVG inline; `descriptors_df()` returns a pandas DataFrame |
 | **Batch analysis** | Rayon-parallel descriptor/fingerprint/3D pipelines; SDF/CSV in, CSV out |
 | **Rust server** | Pure-Rust crates with no C/C++ toolchain; Axum/Actix compatible |
@@ -87,7 +87,7 @@ Full worked examples → [Use cases](https://kent-tokyo.github.io/chematic/use-c
 
 **Use chematic if:**
 
-- You want chemistry in the browser (WASM, 719 KB, no server required)
+- You want chemistry in the browser (WASM, ~1.1 MB gzip, no server required)
 - You need a pure Rust stack with no C++ toolchain dependencies
 - You deploy to environments where `pip install rdkit` is impractical (Cloudflare Workers, Lambda, embedded)
 - You build AI agents and want native MCP tool integration
@@ -275,7 +275,7 @@ safety at every call site chematic itself wrote.
 ### Anywhere
 
 Pure Rust compiles to `wasm32-unknown-unknown` natively — no Emscripten, no `cmake`,
-no `clang`. The npm package `@kent-tokyo/chematic` is **719 KB gzip** — ~42× smaller
+no `clang`. The npm package `@kent-tokyo/chematic` is **~1.1 MB gzip** — ~27× smaller
 than RDKit.js. One codebase runs on Linux, macOS, Windows, and in every browser.
 
 ---
@@ -290,7 +290,7 @@ than RDKit.js. One codebase runs on Linux, macOS, Windows, and in every browser.
 | LogP (Crippen) | **100% RDKit agreement**\* | 4,999-mol ChEMBL subset |
 | Stereocenter count | **99.96%** vs legacy†; 98.6% vs new CIP | 4,999-mol ChEMBL subset |
 | CIP R/S label agreement | **96.30%** vs modern `rdCIPLabeler`‡; 96.83% vs legacy | 5,000-mol ChEMBL subset |
-| WASM bundle | **719 KB** gzip | — |
+| WASM bundle | **~1.1 MB** gzip | — |
 
 \*LogP max Δ = 1.1×10⁻¹³ across 4,999 molecules — within float64 rounding error.  
 †Stereocenter count: ~99.96% vs legacy `CalcNumAtomStereoCenters` (a handful of molecules where chematic matches `FindPotentialStereo` and legacy under-counts); ~98.6% vs new-CIP `FindPotentialStereo` (cage/bridgehead molecules where both chematic and legacy correctly return fewer than the new oracle). chematic is calibrated between both extremes. This measures whether an atom is *flagged* as a stereocenter, not whether its R/S label is correct — see the next row.  
@@ -306,7 +306,7 @@ Full history → [benchmarks/](benchmarks/) · Methodology → [validation/](val
 | Feature                 | **chematic**                              | RDKit (rdkit-sys)  | OpenBabel FFI  | RDKit.js (WASM)    |
 |-------------------------|-------------------------------------------|--------------------|----------------|--------------------|
 | **C/C++ dependencies**  | **None (default)**†                       | Extensive C++      | Extensive C++  | C++ via Emscripten |
-| **WASM binary size**    | **~1.9 MB** (719 KB gzip)                 | N/A (no WASM)      | N/A (no WASM)  | ~30 MB             |
+| **WASM binary size**    | **~2.9 MB** (~1.1 MB gzip)                | N/A (no WASM)      | N/A (no WASM)  | ~30 MB             |
 | **Build requirement**   | `cargo build` only                        | cmake + clang      | cmake + clang  | Emscripten SDK     |
 | **WASM target support** | **Full (native)**                         | No                 | No             | Yes (Emscripten)   |
 | **Python bindings**     | **Yes** (`pip install chematic`, PyO3)    | Yes (rdkit-sys)    | Yes            | No                 |
@@ -371,7 +371,7 @@ Full history → [benchmarks/](benchmarks/) · Methodology → [validation/](val
 
 ## JavaScript / TypeScript (WebAssembly)
 
-**719 KB gzip — ~42× smaller than RDKit.js.** No Emscripten, no cmake. Drop-in for browser or Node.js.
+**~1.1 MB gzip — ~27× smaller than RDKit.js.** No Emscripten, no cmake. Drop-in for browser or Node.js.
 
 ```sh
 npm install @kent-tokyo/chematic

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -17,7 +17,7 @@ Full methodology and raw numbers: [`benchmarks/2026-07-17.md`](../benchmarks/202
 | Descriptor accuracy vs RDKit | **19 metrics ≥98.6%, most 100%** — MW/HBA/HBD/TPSA/LogP/ARC/RotB/Spiro/Bridge/… (4,999-mol) | baseline |
 | Install | `pip install chematic` | conda or cmake |
 | C/C++ dependencies | **Zero** | Required |
-| WASM binary size | **719 KB** | ~30 MB |
+| WASM binary size | **~1.1 MB gzip** | ~30 MB |
 
 The ECFP4 speedup is fixture-dependent: a small set of simple molecules repeated to fill
 the batch shows a larger ratio than a large, structurally diverse corpus. See
@@ -192,7 +192,7 @@ python scripts/bench5k.py path/to/SMILES.csv --detail
 | C/C++ compiler | Not required | Required (Boost) |
 | Docker image size delta | ~4 MB | ~200 MB+ |
 | GitHub Actions | Single pip line | Separate conda setup step |
-| JavaScript / WASM | `npm install @kent-tokyo/chematic` (719 KB) | No official package |
+| JavaScript / WASM | `npm install @kent-tokyo/chematic` (~1.1 MB gzip) | No official package |
 | Browser deployment | Yes | No |
 
 ---
@@ -206,7 +206,7 @@ python scripts/bench5k.py path/to/SMILES.csv --detail
 | MCP server (AI agent integration) | 20 tools (stdio only) | Not available |
 | LSH approximate nearest-neighbour index | Built-in | Not available |
 | IUPAC name generation | Built-in (offline) | Not available |
-| Browser / WASM deployment | Yes (719 KB) | No |
+| Browser / WASM deployment | Yes (~1.1 MB gzip) | No |
 | ECFP4 batch speed | 2–3× faster (diverse corpus) | Baseline |
 | SMARTS atom map `:N` | Yes | Yes |
 | Retrosynthesis (template-based) | 60 retro-SMIRKS built-in | External tool |

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ print(mol.admet())                   # BBB, Caco-2, hERG, CYP3A4 in one call
 |---|---|---|
 | Install | `pip install chematic` | conda or complex build |
 | C/C++ deps | **Zero** | Required |
-| WASM | **Yes** (719 KB) | No (30–50 MB) |
+| WASM | **Yes** (~1.1 MB gzip) | No (30–50 MB) |
 | pKa prediction | **Built-in** | External tool |
 | ADMET profile | **Built-in** | External tool |
 | Pure Python wheel | **Yes** | No |

--- a/docs/rdkit-comparison.md
+++ b/docs/rdkit-comparison.md
@@ -11,7 +11,7 @@ See also: [`rdkit-migration.md`](rdkit-migration.md) for a feature-by-feature Su
 | | chematic | RDKit |
 |---|---|---|
 | **Install** | `pip install chematic` | conda / cmake required |
-| **Browser / WASM** | Yes — 719 KB | No |
+| **Browser / WASM** | Yes — ~1.1 MB gzip | No |
 | **C++ dependency** | None (default) | Required |
 | **Batch fingerprint speed** | ~78 µs/mol (2–3× faster, diverse corpus) | ~160–235 µs/mol |
 | **AI agent integration** | MCP server built-in | None |
@@ -39,7 +39,7 @@ See also: [`rdkit-migration.md`](rdkit-migration.md) for a feature-by-feature Su
 
 | Library | Bundle size | Build toolchain |
 |---|---|---|
-| **chematic** | **719 KB gzip** | `wasm-pack build` only |
+| **chematic** | **~1.1 MB gzip** | `wasm-pack build` only |
 | RDKit.js | ~30 MB | Emscripten SDK + cmake |
 | Indigo WASM | ~40 MB | Emscripten SDK + cmake |
 
@@ -165,7 +165,7 @@ Most common operations map directly:
 
 **Choose chematic if:**
 
-- You want chemistry in the browser (WASM, 719 KB, no server)
+- You want chemistry in the browser (WASM, ~1.1 MB gzip, no server)
 - You need a pure Rust stack with no C++ toolchain
 - You deploy to Lambda, Cloudflare Workers, or other constrained environments
 - You build AI agents and want native MCP tool integration

--- a/docs/rdkit-migration.md
+++ b/docs/rdkit-migration.md
@@ -285,7 +285,7 @@ formats" claim.
 Python-style WASM bindings; RDKit.js is a separate community project.
 chematic ships `chematic-wasm` directly from the same Rust source as the
 Python bindings. Per `docs/benchmark.md`/README's badge table: chematic's
-WASM bundle is **719 KB**, versus RDKit.js's **~30 MB** (~42× smaller) —
+WASM bundle is **~1.1 MB gzip**, versus RDKit.js's **~30 MB** (~27× smaller) —
 cited because it is already measured and documented in this repository, not
 asserted fresh here. See [`format-capabilities.md`](format-capabilities.md)
 for exactly which formats are and are not exposed at the WASM layer (plain

--- a/docs/rdkit_cheatsheet.md
+++ b/docs/rdkit_cheatsheet.md
@@ -291,7 +291,7 @@ df = pd.DataFrame(chematic.bulk.descriptors(smiles_list))
 
 - **pKa prediction** — built-in, no external tools
 - **ADMET profile** — BBB, Caco-2, hERG, CYP3A4 in a single call
-- **WASM support** — runs in the browser (719 KB bundle)
+- **WASM support** — runs in the browser (~1.1 MB gzip bundle)
 - **MCP server** — direct integration with AI agents
 - **Pure Rust** — no conda, works in Docker / serverless / CI without extra setup
 - **Atropisomer detection** — `mol.atropisomers()` detects biaryl and allene axes


### PR DESCRIPTION
## Summary

Follow-up to PR #352 (playground's own stale numbers). While fixing the demo, discovered the docs' "719 KB gzip" WASM bundle-size claim — cited 15 times across `README.md` and 5 `docs/` pages — is also stale.

Directly re-measured with the exact CI recipe (`wasm-pack build --release` + `wasm-opt -O3`, matching `.github/workflows/pages.yml`) against current `main`:
- Raw binary: ~2.9 MB (2,942,069–2,943,754 bytes across two independent local builds, cross-checked against the **live deployed site's** ETag byte count, not just a local build)
- Gzip -9: ~1.1 MB (1,092,248–1,092,311 bytes)

Both figures reproduced consistently within build-nondeterminism noise (<0.1%).

**Root cause** (from `Cargo.toml`'s own comment): `[profile.release]` was switched from `opt-level = "z"` (size) to `opt-level = 3` (speed) at some point — very likely most of the ~1.5x growth; the rest is feature growth (LAMMPS, Cube, OpenDX, mmCIF, QCSchema, ORCA, etc. all shipped since 719 KB was last measured).

Also updated the derived "~42x smaller than RDKit.js" ratio to "~27x" everywhere it appears (30 MB / 1.1 MB), so the comparison stays internally consistent rather than only fixing the bare size figure. Still a real, substantial win — 27x smaller is not a regression story.

## Files changed

- `README.md` (8 occurrences)
- `docs/benchmark.md` (3)
- `docs/rdkit-comparison.md` (3)
- `docs/rdkit-migration.md` (1)
- `docs/rdkit_cheatsheet.md` (1)
- `docs/index.md` (1)

Docs-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)