### PR TITLE
fix(explorer): surface WASM load failure instead of hiding it

### DIFF
--- a/demo/explorer/app.js
+++ b/demo/explorer/app.js
@@ -53,6 +53,11 @@ async function initWasm() {
     wasmReady = true;
     $("loading-overlay")?.classList.add("hidden");
   } catch (e) {
+    // The loading overlay is a full-screen, high-z-index element that would
+    // otherwise permanently hide this message behind "Loading chematic
+    // (WASM)…" -- surface the failure where it's actually visible.
+    const overlay = $("loading-overlay");
+    if (overlay) overlay.textContent = "Failed to load chematic (WASM): " + String(e);
     showStatus("WASM failed to load: " + String(e));
     throw e;
   }


### PR DESCRIPTION
## Summary

Explorer hardening pass, in lieu of live browser testing (no browser automation tool was available this session). Reviewed the code paths for the 6 post-publish smoke-test scenarios agreed on for the Explorer: page load, sample dataset parsing, similarity search, CSV export, mixed valid/invalid SMILES, and mobile layout.

## Bug found and fixed

`initWasm()`'s failure path called `showStatus()`, but `#explorer-status` lives inside `<main>`, underneath the full-screen `#loading-overlay` (`position: fixed; inset: 0; z-index: 999`) — which is only ever hidden on the *success* path. If WASM genuinely fails to load (wrong deployment path, corrupted binary, etc.), the user would be stuck looking at "Loading chematic (WASM)…" forever, with the real error message rendered invisibly behind it.

Fix: write the failure message directly into the overlay's own text content, so it's actually visible instead of hidden behind itself.

## Other 5 scenarios — no issues found via code review

- **Sample dataset**: `loadSampleDataset()` → `fetch('./sample.csv')` → `parseCsvText`/`detectColumns`/`csvRowsToRawRecords` → `processRawRecords` traces correctly; already covered by an end-to-end Node integration check against the real WASM build (16/16 sample compounds).
- **Similarity search**: `runSimilaritySearch()` validates the reference SMILES first, resets stale similarity values, chunks through valid records, and enables the similarity sort/filter controls only after completion — matches the already-verified logic.
- **CSV export**: straightforward apply-filters → sort → `exportToCsv`/`downloadCsv`; no issues.
- **Mixed invalid SMILES**: `parseOneRecord` catches per-record and never throws out of the chunk loop; `table.js`'s error-row rendering (`colSpan`, error message) was already fixed for a column-count bug earlier and traces correctly.
- **Mobile layout**: the results table is wrapped in an `overflow-x: auto` container and the filter/sort/similarity sections use `flex-wrap`, which should keep the page itself from needing horizontal scroll at narrow viewports — but this, like everything above, is still **unverified in an actual browser**.

## Verification

- `node --check demo/explorer/app.js` — clean
- `node demo/explorer/tests/explorer.test.mjs` — all assertions pass (unaffected by this change; the fix only touches the WASM-init failure path, which the pure-function test suite doesn't exercise)

## Not done this session

No live-browser testing at all — no browser automation tool was available. This PR is purely a static code-review pass. A manual browser check of the 6 scenarios above (plus keyboard/drag-and-drop/light-dark, per the Explorer's own README) remains the recommended gate before treating the Explorer as fully hardened.

Draft only — no merge without a separate explicit instruction.

## Test plan

- [x] `node --check` clean
- [x] Explorer unit test suite still passes
- [ ] Manual browser smoke test of the 6 scenarios (not done this session)