### PR TITLE
feat(chematic-chem): Tautomer & Parent Identity round 2B -- Parent API + budget visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `chematic-chem` (Tautomer & Parent Identity round 2B, ROADMAP.md Phase 2)
+
+- `fragment_parent`/`charge_parent`/`isotope_parent`/`stereo_parent`/
+  `tautomer_parent`/`super_parent`: an explicit "Parent identity" concept —
+  an idempotent, deterministic reduction of one axis of molecular
+  variability (fragment, charge, isotope, stereo, tautomer) to one
+  representative structure, meant as a grouping/dedup key. `charge_parent`
+  is **not** a bare `neutralize_charges` wrapper: it selects the fragment
+  parent first, then neutralizes that single fragment — a design correction
+  made during RFC review before any code was written (see the RFC's round
+  2A revision note). `fragment_parent`/`isotope_parent`/`stereo_parent`
+  are thin, explainable wrappers over the existing `select_fragment`/
+  `remove_isotopes`/`remove_stereo` primitives. `super_parent` composes all
+  five in the fixed order fragment → charge → isotope → stereo → tautomer,
+  returning every intermediate stage's audit record, not just the final
+  molecule.
+- `TautomerLimits { max_transforms, max_tautomers, timeout_ms }`: a
+  deterministic budget for `tautomer_parent`, generalizing
+  `TautomerConfig::max_iter`/`max_tautomers`. `max_transforms`/
+  `max_tautomers` are reproducible (same input + limits ⇒ same result,
+  always); `timeout_ms` is an explicitly non-deterministic escape hatch
+  (wall-clock, machine-dependent), documented as outside that guarantee.
+  `max_restarts`/`Canceled` from the original RFC sketch were dropped this
+  round: `max_restarts` has no defined meaning at this level, and `Canceled`
+  had no cancellation mechanism to ever produce it — see the RFC's round 2A
+  revision.
+- `ParentResult`/`ParentComputationStatus`/`ParentAudit`: `tautomer_parent`
+  and `super_parent` now report `Completed`/`MaxTransformsReached`/
+  `MaxTautomersReached`/`TimedOut`/`Abstained`/`InvalidInput` instead of a
+  bare `Molecule` — budget exhaustion is a previously-silent gap in
+  `canonical_tautomer_with_config` (confirmed via an existing `#[ignore]`d
+  regression test on a 25-independent-site "comb" molecule) that is now
+  visible to the caller instead of silently returning a possibly
+  input-order-dependent result.
+- `TautomerAuditRecord`/`ScoreContribution`/`TautomerScoreTerm`/
+  `AppliedTransform`/`TautomerRuleId`: an explainable trail for
+  `tautomer_parent` — which candidate was selected, its score breakdown by
+  named term, which rules fired (one of 42 stable `TautomerRuleId`
+  variants, not a bare string), and which atoms (if any) had stereo or
+  isotope data affected. `applied_transforms` covers the rule-based
+  1,3-/1,5-shift loop only; the final direct-aromatic-shift tie-break
+  contributes to `score_breakdown`/`candidate_count` instead (disclosed
+  scope limitation, not an oversight).
+- Fixed the module's stale `"The 15 tautomer rules"` doc comment — the
+  array actually has 42.
+- **Not in this round** (round 2C/2D, per the RFC's explicit split): the
+  aromatic lactam/lactim canonical-tautomer fix (2-pyridone/cytosine/
+  uracil/purine-class non-invariance, confirmed but not fixed); the
+  nitroso/oxime non-convergence gap found while reviewing a fixture;
+  `TautomerScoringConfig`/custom rule support; Python/WASM bindings for any
+  of the above.
+- Design: `docs/rfcs/tautomer_parent_identity_phase2_rfc.md`.
+
 ### Added — `chematic-chem` (explainable Molecule Standardization Phase 1, ROADMAP.md Phase 1)
 
 - `FragmentPolicy` + `select_fragment(mol, &FragmentPolicy) -> (Molecule,

--- a/crates/chematic-chem/src/lib.rs
+++ b/crates/chematic-chem/src/lib.rs
@@ -32,6 +32,7 @@ pub mod mlp;
 pub mod mmff94_bci;
 pub mod mmp;
 pub mod named_groups;
+pub mod parent;
 pub mod pka;
 pub mod qed;
 pub mod recap;
@@ -102,6 +103,10 @@ pub use mlp::{MLP_SOLUBILITY_TRAINED, mlp_solubility};
 pub use mmff94_bci::{MmffType, assign_mmff94_type, mmff94_charges_bci, mmff94_charges_typed};
 pub use mmp::{MmpPair, MmsMember, MmsSeries, find_mmp, find_mms};
 pub use named_groups::{NamedGroup, detect_named_functional_groups};
+pub use parent::{
+    AbstainReason, InvalidInputReason, ParentAudit, ParentComputationStatus, ParentResult,
+    super_parent,
+};
 pub use pka::{PkaSite, PkaSiteType, pka_acid, pka_base, pka_both, predict_pka};
 pub use qed::{qed, qed_with_bundle};
 pub use recap::{recap_breakable_bond_count, recap_fragment};
@@ -115,14 +120,16 @@ pub use standardize::{
     FragmentDecision, FragmentPolicy, FragmentRecord, FragmentSnapshot, MoleculeSnapshot,
     PipelineStatus, StandardizationPipeline, StandardizationReport, StandardizationStep,
     StandardizationStepReport, StandardizationWarning, StandardizeOptions, TransformationRecord,
-    ZwitterionHandling, has_zwitterion, largest_fragment, neutralize_charges, normalize_groups,
-    normalize_zwitterion, prefer_organic, reionize, remove_isotopes, remove_stereo,
-    select_fragment, standardize, uncharge,
+    ZwitterionHandling, charge_parent, fragment_parent, has_zwitterion, isotope_parent,
+    largest_fragment, neutralize_charges, normalize_groups, normalize_zwitterion, prefer_organic,
+    reionize, remove_isotopes, remove_stereo, select_fragment, standardize, stereo_parent,
+    uncharge,
 };
 pub use stereo::{assign_complete_stereochemistry, enumerate_stereoisomers, invert_stereocenter};
 pub use tautomer::{
-    TautomerConfig, canonical_tautomer, canonical_tautomer_with_config, enumerate_tautomers,
-    enumerate_tautomers_with_config,
+    AppliedTransform, ScoreContribution, TautomerAuditRecord, TautomerConfig, TautomerLimits,
+    TautomerRuleId, TautomerScoreTerm, canonical_tautomer, canonical_tautomer_with_config,
+    enumerate_tautomers, enumerate_tautomers_with_config, tautomer_parent,
 };
 pub use topo_descriptors::{
     bertz_ct, chi_all, chi0, chi0v, chi1, chi1v, chi2, chi2v, chi3, chi3v, chi4, chi4v,

--- a/crates/chematic-chem/src/parent.rs
+++ b/crates/chematic-chem/src/parent.rs
@@ -1,0 +1,221 @@
+//! Parent identity (ROADMAP.md Phase 2, round 2B).
+//!
+//! A **Parent** is an idempotent, deterministic reduction of one axis of
+//! molecular variability to one representative structure, meant to be used
+//! as a grouping/dedup key -- see
+//! `docs/rfcs/tautomer_parent_identity_phase2_rfc.md` section 4.3.
+//!
+//! [`fragment_parent`], [`charge_parent`], [`isotope_parent`], and
+//! [`stereo_parent`] live in [`crate::standardize`], next to the low-level
+//! primitives they wrap. [`tautomer_parent`](crate::tautomer::tautomer_parent)
+//! lives in [`crate::tautomer`]. This module holds the shared result types
+//! and [`super_parent`], which composes all five in one fixed order.
+
+#![forbid(unsafe_code)]
+
+use chematic_core::Molecule;
+
+use crate::standardize::{
+    TransformationRecord, charge_parent, fragment_parent, isotope_parent, stereo_parent,
+};
+use crate::tautomer::{TautomerLimits, tautomer_parent};
+
+/// Why a Parent computation could not reach a definite answer.
+///
+/// A new, orthogonal type -- not an extension of [`crate::standardize::PipelineStatus`],
+/// which answers "did the molecule change," a different question from "did
+/// the computation reach a definite answer, and if not, why not."
+/// `#[non_exhaustive]`: new statuses may be added without a breaking change.
+///
+/// There is no `Canceled` variant: no cancellation mechanism (token or
+/// callback) exists yet, and a state nothing can ever produce would look
+/// like a supported feature to a caller who matches on it. Add it back only
+/// alongside the mechanism that produces it.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum ParentComputationStatus {
+    Completed,
+    MaxTransformsReached,
+    MaxTautomersReached,
+    /// Outside the determinism guarantee `max_transforms`/`max_tautomers`
+    /// carry -- see [`TautomerLimits`]'s `timeout_ms` doc comment.
+    TimedOut,
+    Abstained(AbstainReason),
+    InvalidInput(InvalidInputReason),
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum AbstainReason {
+    NoConfidentOrganicParent,
+    AmbiguousFragmentSelection,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum InvalidInputReason {
+    EmptyMolecule,
+    UnparsableStructure,
+}
+
+/// Result of a Parent computation that has a result-state question
+/// ([`tautomer_parent`](crate::tautomer::tautomer_parent) and
+/// [`super_parent`]). `fragment_parent`/`charge_parent`/`isotope_parent`/
+/// `stereo_parent` keep returning `(Molecule, TransformationRecord)`
+/// directly (Phase 1's shape, unchanged) -- they are simple mechanical
+/// transforms with no budget/timeout/abstain question.
+///
+/// `#[non_exhaustive]` struct: fields may be added without a breaking
+/// change. Does not implement `Serialize`/`Deserialize` even under the
+/// `serde` feature: it embeds a raw `Molecule`, which does not implement
+/// them.
+#[non_exhaustive]
+#[derive(Clone)]
+pub struct ParentResult {
+    pub molecule: Molecule,
+    pub status: ParentComputationStatus,
+    pub audit: ParentAudit,
+}
+
+/// One Parent function's audit trail, or (for [`super_parent`]) every
+/// stage's, in order.
+///
+/// Does not implement `Serialize`/`Deserialize` even under the `serde`
+/// feature: it embeds [`crate::tautomer::TautomerAuditRecord`], which does
+/// not implement them (see that type's own doc comment).
+#[derive(Debug, Clone)]
+pub enum ParentAudit {
+    /// fragment_parent / charge_parent / isotope_parent / stereo_parent.
+    Transformation(TransformationRecord),
+    /// tautomer_parent.
+    Tautomer(crate::tautomer::TautomerAuditRecord),
+    /// super_parent: one entry per stage, in the fixed order
+    /// fragment_parent -> charge_parent -> isotope_parent -> stereo_parent
+    /// -> tautomer_parent.
+    Composed(Vec<ParentAudit>),
+}
+
+/// Compose all five Parent functions in one fixed order:
+/// `fragment_parent` -> `charge_parent` -> `isotope_parent` ->
+/// `stereo_parent` -> `tautomer_parent`, each stage's output feeding the
+/// next stage's input.
+///
+/// This order is deliberate and does **not** follow
+/// `StandardizationPipeline::run`'s stage order (which neutralizes charges
+/// *before* fragment selection, for a different reason -- see that
+/// pipeline's own comment): `super_parent` selects the representative
+/// fragment *first*, because every subsequent Parent step should operate on
+/// one fragment, not a not-yet-resolved multi-fragment molecule. See
+/// `docs/rfcs/tautomer_parent_identity_phase2_rfc.md` section 4.3.
+///
+/// `status`/the final `molecule` come from the `tautomer_parent` stage
+/// (the only stage with a result-state question); `audit` is
+/// `ParentAudit::Composed` with exactly 5 entries, one per stage, so a
+/// caller can inspect every intermediate result, not just the final one.
+pub fn super_parent(mol: &Molecule, limits: &TautomerLimits) -> ParentResult {
+    if mol.atom_count() == 0 {
+        return ParentResult {
+            molecule: mol.clone(),
+            status: ParentComputationStatus::InvalidInput(InvalidInputReason::EmptyMolecule),
+            audit: ParentAudit::Composed(Vec::new()),
+        };
+    }
+
+    let (after_fragment, fragment_record) = fragment_parent(mol);
+    let (after_charge, charge_record) = charge_parent(&after_fragment);
+    let (after_isotope, isotope_record) = isotope_parent(&after_charge);
+    let (after_stereo, stereo_record) = stereo_parent(&after_isotope);
+    let tautomer_result = tautomer_parent(&after_stereo, limits);
+
+    ParentResult {
+        molecule: tautomer_result.molecule,
+        status: tautomer_result.status,
+        audit: ParentAudit::Composed(vec![
+            ParentAudit::Transformation(fragment_record),
+            ParentAudit::Transformation(charge_record),
+            ParentAudit::Transformation(isotope_record),
+            ParentAudit::Transformation(stereo_record),
+            tautomer_result.audit,
+        ]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chematic_smiles::{canonical_smiles, parse};
+
+    // -- Phase 2 round-2B super_parent fixture test ---------------------------
+    // Mirrors validation/tautomer_parent_identity_phase2_fixtures.jsonl's
+    // tp2-23-super-parent-composed. See
+    // docs/rfcs/tautomer_parent_identity_phase2_rfc.md section 5.
+
+    #[test]
+    fn tp2_23_super_parent_composed_pins_every_intermediate_stage() {
+        let input = "[NH3+][C@@H]([2H])C(=O)[O-].Cl";
+        let mol = parse(input).unwrap();
+
+        let (after_fragment, _) = fragment_parent(&mol);
+        assert_eq!(
+            canonical_smiles(&after_fragment),
+            canonical_smiles(&parse("[2H][C@@H](C(=O)[O-])[NH3+]").unwrap()),
+            "after fragment_parent: HCl salt dropped"
+        );
+
+        let (after_charge, _) = charge_parent(&after_fragment);
+        assert_eq!(
+            canonical_smiles(&after_charge),
+            canonical_smiles(&parse("[2H][C@@H](C(O)=O)N").unwrap()),
+            "after charge_parent: zwitterion neutralized"
+        );
+
+        let (after_isotope, _) = isotope_parent(&after_charge);
+        assert_eq!(
+            canonical_smiles(&after_isotope),
+            canonical_smiles(&parse("[H][C@@H](C(O)=O)N").unwrap()),
+            "after isotope_parent: 2H label dropped"
+        );
+
+        let (after_stereo, _) = stereo_parent(&after_isotope);
+        assert_eq!(
+            canonical_smiles(&after_stereo),
+            canonical_smiles(&parse("[H]C(C(O)=O)N").unwrap()),
+            "after stereo_parent: @@ dropped"
+        );
+
+        let result = super_parent(&mol, &TautomerLimits::default());
+        assert_eq!(result.status, ParentComputationStatus::Completed);
+        assert_eq!(
+            canonical_smiles(&result.molecule),
+            canonical_smiles(&parse("[H]C(C(O)=O)N").unwrap()),
+            "super_parent's final output matches the pinned end-to-end chain"
+        );
+        match &result.audit {
+            ParentAudit::Composed(stages) => assert_eq!(stages.len(), 5, "one entry per stage"),
+            other => panic!("expected ParentAudit::Composed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn super_parent_on_empty_molecule_is_invalid_input() {
+        let empty = chematic_core::MoleculeBuilder::new().build();
+        let result = super_parent(&empty, &TautomerLimits::default());
+        assert_eq!(
+            result.status,
+            ParentComputationStatus::InvalidInput(InvalidInputReason::EmptyMolecule)
+        );
+    }
+
+    #[test]
+    fn super_parent_noop_on_toluene() {
+        // tp2-holdout-04: an already-neutral/unlabeled/achiral/single-fragment
+        // input must pass through all four mechanical stages unchanged.
+        let mol = parse("Cc1ccccc1").unwrap();
+        let result = super_parent(&mol, &TautomerLimits::default());
+        assert_eq!(result.status, ParentComputationStatus::Completed);
+        assert_eq!(canonical_smiles(&result.molecule), canonical_smiles(&mol));
+    }
+}

--- a/crates/chematic-chem/src/standardize.rs
+++ b/crates/chematic-chem/src/standardize.rs
@@ -628,6 +628,82 @@ pub fn select_fragment(
     )
 }
 
+// ---------------------------------------------------------------------------
+// Parent identity (ROADMAP.md Phase 2 round 2B) -- see
+// docs/rfcs/tautomer_parent_identity_phase2_rfc.md section 4.3.
+// ---------------------------------------------------------------------------
+
+/// [`select_fragment`] with the default [`FragmentPolicy`] -- the "Parent"
+/// framing of Phase 1's fragment-selection logic.
+pub fn fragment_parent(mol: &Molecule) -> (Molecule, TransformationRecord) {
+    select_fragment(mol, &FragmentPolicy::default())
+}
+
+/// Select the fragment parent, then neutralize all formal charges on it.
+///
+/// **Not** the same as [`neutralize_charges`], which neutralizes every
+/// fragment in a possibly-multi-fragment molecule and leaves them all in
+/// the output. `charge_parent` first resolves fragment-selection ambiguity
+/// down to one representative structure, matching this module's definition
+/// of a Parent: an idempotent reduction to *one* structure, not a
+/// multi-fragment mechanical transform.
+///
+/// The returned record's `fragments` (inherited from `fragment_parent`)
+/// describe each candidate fragment **as selected**, before neutralization
+/// -- a record of what was chosen and why. Only the record's own `after`
+/// snapshot is updated to reflect the neutralized result.
+pub fn charge_parent(mol: &Molecule) -> (Molecule, TransformationRecord) {
+    let (selected, mut record) = fragment_parent(mol);
+    let neutralized = neutralize_charges(&selected);
+    record.rule_id = "charge_parent_v1".to_string();
+    record.after = MoleculeSnapshot::from_mol(&neutralized);
+    (neutralized, record)
+}
+
+/// [`remove_isotopes`] with an explainable audit record.
+///
+/// `fragments` is always empty: no fragment-selection decision is made
+/// here (unlike `fragment_parent`/`charge_parent`), only isotope removal
+/// on the whole input molecule.
+pub fn isotope_parent(mol: &Molecule) -> (Molecule, TransformationRecord) {
+    let before = MoleculeSnapshot::from_mol(mol);
+    let output = remove_isotopes(mol);
+    let after = MoleculeSnapshot::from_mol(&output);
+    (
+        output,
+        TransformationRecord {
+            rule_id: "isotope_parent_v1".to_string(),
+            rule_version: 1,
+            fragments: Vec::new(),
+            abstained: None,
+            before,
+            after,
+            warnings: Vec::new(),
+        },
+    )
+}
+
+/// [`remove_stereo`] with an explainable audit record.
+///
+/// `fragments` is always empty -- see [`isotope_parent`]'s doc comment.
+pub fn stereo_parent(mol: &Molecule) -> (Molecule, TransformationRecord) {
+    let before = MoleculeSnapshot::from_mol(mol);
+    let output = remove_stereo(mol);
+    let after = MoleculeSnapshot::from_mol(&output);
+    (
+        output,
+        TransformationRecord {
+            rule_id: "stereo_parent_v1".to_string(),
+            rule_version: 1,
+            fragments: Vec::new(),
+            abstained: None,
+            before,
+            after,
+            warnings: Vec::new(),
+        },
+    )
+}
+
 /// Extract a connected fragment (given its atom set) as a standalone
 /// `Molecule`, preserving stereo data.
 ///
@@ -1332,7 +1408,7 @@ pub struct MoleculeSnapshot {
 }
 
 impl MoleculeSnapshot {
-    fn from_mol(mol: &Molecule) -> Self {
+    pub(crate) fn from_mol(mol: &Molecule) -> Self {
         Self {
             atoms: mol.atom_count(),
             bonds: mol.bond_count(),
@@ -2670,5 +2746,100 @@ mod tests {
     fn phase1_holdout_09_10_non_tie_sanity_checks() {
         assert_kept("std-p1-holdout-09", "CC.CCCCCCCCCC", "CCCCCCCCCC");
         assert_kept("std-p1-holdout-10", "CCCCC.CCCC", "CCCCC");
+    }
+
+    // -- Phase 2 round-2B Parent-function fixture tests -----------------------
+    // Mirrors validation/tautomer_parent_identity_phase2_fixtures.jsonl's
+    // tp2-17..22. See docs/rfcs/tautomer_parent_identity_phase2_rfc.md
+    // section 4.3.
+
+    #[test]
+    fn tp2_17_charge_parent_ammonium_acetate_single_fragment_result() {
+        // charge_parent is NOT neutralize_charges: it selects the fragment
+        // parent first (acetate: 4 heavy atoms, has carbon, over ammonium:
+        // 1 heavy atom, no carbon), THEN neutralizes that one fragment.
+        let mol = parse("CC(=O)[O-].[NH4+]").unwrap();
+        let (result, record) = charge_parent(&mol);
+        assert_eq!(chematic_smiles::canonical_smiles(&result), canon("CC(O)=O"));
+        assert_eq!(record.rule_id, "charge_parent_v1");
+        assert_eq!(
+            record.fragments.len(),
+            2,
+            "inherited from fragment_parent's selection"
+        );
+    }
+
+    #[test]
+    fn tp2_18_charge_parent_zwitterion_amino_acid() {
+        let mol = parse("[NH3+]CC(=O)[O-]").unwrap();
+        let (result, _) = charge_parent(&mol);
+        assert_eq!(
+            chematic_smiles::canonical_smiles(&result),
+            canon("NCC(O)=O")
+        );
+    }
+
+    #[test]
+    fn tp2_19_isotope_parent_deuterated_ethanol() {
+        let mol = parse("[2H]C([2H])([2H])CO").unwrap();
+        let (result, record) = isotope_parent(&mol);
+        assert_eq!(
+            chematic_smiles::canonical_smiles(&result),
+            canon("[H]C(CO)([H])[H]")
+        );
+        assert!(record.fragments.is_empty());
+    }
+
+    #[test]
+    fn tp2_20_isotope_parent_preserves_stereo() {
+        let mol = parse("OC[C@H]1O[C@@H]([13CH2]O)[C@H](O)[C@@H](O)[C@@H]1O").unwrap();
+        let (result, _) = isotope_parent(&mol);
+        assert_eq!(
+            chematic_smiles::canonical_smiles(&result),
+            canon("[C@@H]1(CO)O[C@H]([C@@H](O)[C@@H]([C@H]1O)O)CO")
+        );
+    }
+
+    #[test]
+    fn tp2_21_stereo_parent_alanine() {
+        let mol = parse("C[C@@H](N)C(=O)O").unwrap();
+        let (result, record) = stereo_parent(&mol);
+        assert_eq!(
+            chematic_smiles::canonical_smiles(&result),
+            canon("C(C(O)=O)(C)N")
+        );
+        assert!(record.fragments.is_empty());
+    }
+
+    #[test]
+    fn tp2_22_fragment_parent_hcl_salt() {
+        let mol = parse("CN1CCC(CC1)Nc1ccccc1.Cl").unwrap();
+        let (result, _) = fragment_parent(&mol);
+        assert_eq!(
+            chematic_smiles::canonical_smiles(&result),
+            canon("N(c2ccccc2)C1CCN(CC1)C")
+        );
+    }
+
+    #[test]
+    fn holdout_04_parent_functions_noop_on_toluene() {
+        let mol = parse("Cc1ccccc1").unwrap();
+        let expected = chematic_smiles::canonical_smiles(&mol);
+        assert_eq!(
+            chematic_smiles::canonical_smiles(&fragment_parent(&mol).0),
+            expected
+        );
+        assert_eq!(
+            chematic_smiles::canonical_smiles(&charge_parent(&mol).0),
+            expected
+        );
+        assert_eq!(
+            chematic_smiles::canonical_smiles(&isotope_parent(&mol).0),
+            expected
+        );
+        assert_eq!(
+            chematic_smiles::canonical_smiles(&stereo_parent(&mol).0),
+            expected
+        );
     }
 }

--- a/crates/chematic-chem/src/tautomer.rs
+++ b/crates/chematic-chem/src/tautomer.rs
@@ -1,16 +1,26 @@
 //! Tautomer enumeration and canonical tautomer selection.
 //!
-//! Provides two public functions:
+//! Provides:
 //! - [`canonical_tautomer`]: return the canonical (preferred) tautomer form.
 //! - [`enumerate_tautomers`]: enumerate all reachable tautomers up to a cap.
+//! - [`tautomer_parent`]: like `canonical_tautomer`, but budget-limited via
+//!   [`TautomerLimits`] and returns an explainable [`TautomerAuditRecord`]
+//!   instead of a bare `Molecule` -- see
+//!   `docs/rfcs/tautomer_parent_identity_phase2_rfc.md` section 4.
 //!
 //! Pattern matching is implemented directly on the molecule graph (no SMARTS).
 
 #![forbid(unsafe_code)]
 
 use std::collections::HashSet;
+use std::time::Instant;
 
-use chematic_core::{AtomIdx, BondIdx, BondOrder, Molecule, MoleculeBuilder, implicit_hcount};
+use chematic_core::{
+    AtomIdx, BondIdx, BondOrder, Chirality, Molecule, MoleculeBuilder, implicit_hcount,
+};
+
+use crate::parent::{InvalidInputReason, ParentAudit, ParentComputationStatus, ParentResult};
+use crate::standardize::MoleculeSnapshot;
 
 /// Bond order match type for tautomer rule patterns.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -61,7 +71,7 @@ struct TautomerRule {
     path_len: usize,
 }
 
-/// The 15 tautomer rules.
+/// The 42 tautomer rules.
 static RULES: &[TautomerRule] = &[
     // 1. keto-enol: O-H adjacent to C=C → O=C-C (prefer keto)
     TautomerRule {
@@ -554,14 +564,35 @@ fn enumerate_direct_aromatic_forms(
     blocked: &HashSet<AtomIdx>,
     max: usize,
 ) -> Vec<Molecule> {
+    enumerate_direct_aromatic_forms_tracked(start, blocked, max).0
+}
+
+/// Like [`enumerate_direct_aromatic_forms`], but also reports whether the
+/// search was cut short by `max` while more candidates were still reachable
+/// (`true`) versus exhausting the frontier naturally (`false`) -- needed by
+/// [`tautomer_parent`] to distinguish `Completed` from `MaxTautomersReached`.
+fn enumerate_direct_aromatic_forms_tracked(
+    start: &Molecule,
+    blocked: &HashSet<AtomIdx>,
+    max: usize,
+) -> (Vec<Molecule>, bool) {
     let mut result = Vec::new();
     let mut seen: HashSet<Vec<Option<u32>>> = HashSet::new();
     seen.insert(h_assignment(start));
     let mut frontier = vec![start.clone()];
+    let mut truncated = false;
 
-    while !frontier.is_empty() && result.len() < max {
+    'outer: while !frontier.is_empty() {
+        if result.len() >= max {
+            truncated = true;
+            break;
+        }
         let current = frontier.remove(0);
         for (d, a) in find_direct_aromatic_matches(&current) {
+            if result.len() >= max {
+                truncated = true;
+                break 'outer;
+            }
             if let Some(next) = transfer_hydrogen_aromatic(&current, d, a, blocked) {
                 let ha = h_assignment(&next);
                 if !seen.contains(&ha) {
@@ -572,7 +603,7 @@ fn enumerate_direct_aromatic_forms(
             }
         }
     }
-    result
+    (result, truncated)
 }
 
 /// Find adjacent pairs of aromatic N atoms where the first (donor) carries an explicit H.
@@ -654,11 +685,17 @@ use crate::hash::{FNV1A_OFFSET, FNV1A_PRIME};
 
 /// Tautomer form score for canonical selection: prefers O-H > N-H > S-H and aromatic rings.
 fn tautomer_score(mol: &Molecule) -> i32 {
-    let mut score = 0i32;
+    score_breakdown(mol).iter().map(|c| c.value).sum()
+}
+
+/// Same scoring rule as [`tautomer_score`], decomposed into named
+/// contributions for [`TautomerAuditRecord::score_breakdown`]. This is the
+/// single source of truth for the scoring rule; `tautomer_score` sums it.
+fn score_breakdown(mol: &Molecule) -> Vec<ScoreContribution> {
+    let mut contributions = Vec::new();
     let mut has_aromatic = false;
 
     for (_, atom) in mol.atoms() {
-        // Aromatic ring bonus
         if atom.aromatic {
             has_aromatic = true;
         }
@@ -666,21 +703,31 @@ fn tautomer_score(mol: &Molecule) -> i32 {
         // Heteroatom hydrogen: O-H > N-H > S-H (explicit or implicit)
         let h_count = atom.hydrogen_count.unwrap_or(0) as i32;
         if h_count > 0 {
-            match atom.element.atomic_number() {
-                8 => score += h_count * 100, // O-H: highest priority
-                7 => score += h_count * 50,  // N-H: medium priority
-                16 => score += h_count * 25, // S-H: low priority
-                _ => {}
+            let weight = match atom.element.atomic_number() {
+                8 => Some(100), // O-H: highest priority
+                7 => Some(50),  // N-H: medium priority
+                16 => Some(25), // S-H: low priority
+                _ => None,
+            };
+            if let Some(weight) = weight {
+                contributions.push(ScoreContribution {
+                    term: TautomerScoreTerm::HeteroatomHydrogen {
+                        element: atom.element.atomic_number(),
+                    },
+                    value: h_count * weight,
+                });
             }
         }
     }
 
-    // Aromatic system bonus
     if has_aromatic {
-        score += 1000;
+        contributions.push(ScoreContribution {
+            term: TautomerScoreTerm::AromaticRing,
+            value: 1000,
+        });
     }
 
-    score
+    contributions
 }
 
 /// Order-independent structural hash for convergence detection.
@@ -887,8 +934,20 @@ fn apply_first_match(
     rule: &TautomerRule,
     config: &TautomerConfig,
 ) -> Option<Molecule> {
+    apply_first_match_tracked(mol, rule, config).map(|(next, ..)| next)
+}
+
+/// Like [`apply_first_match`], but also returns the (donor, bridge, acceptor)
+/// triple that was moved -- needed by [`tautomer_parent`] to record which
+/// atoms/bonds each applied transform touched.
+fn apply_first_match_tracked(
+    mol: &Molecule,
+    rule: &TautomerRule,
+    config: &TautomerConfig,
+) -> Option<(Molecule, AtomIdx, AtomIdx, AtomIdx)> {
     find_matches(mol, rule).into_iter().find_map(|(d, b, a)| {
         transfer_hydrogen(mol, d, b, a, &config.blocked_atoms, &config.blocked_bonds)
+            .map(|next| (next, d, b, a))
     })
 }
 
@@ -1128,6 +1187,374 @@ pub fn enumerate_tautomers_with_config(mol: &Molecule, config: &TautomerConfig) 
         }
     }
     result
+}
+
+// ---------------------------------------------------------------------------
+// Tautomer Parent (ROADMAP.md Phase 2 round 2B) -- see
+// docs/rfcs/tautomer_parent_identity_phase2_rfc.md section 4.
+// ---------------------------------------------------------------------------
+
+/// Budget limits for [`tautomer_parent`].
+///
+/// `max_transforms`/`max_tautomers` are deterministic budgets, counted
+/// exactly as [`TautomerConfig::max_iter`]/[`TautomerConfig::max_tautomers`]
+/// always have been: `max_transforms` counts outer-loop iterations in which
+/// a transform was actually applied (a rule that matches but produces an
+/// already-seen fingerprint does not consume budget); `max_tautomers`
+/// counts distinct direct-aromatic-shift candidates found while choosing
+/// among them at the end (duplicates rejected by fingerprint do not consume
+/// budget either). Both are reproducible: same input, same limits, same
+/// result, always.
+///
+/// `timeout_ms` is a different kind of bound: a wall-clock timeout depends
+/// on machine speed and load, so a `TimedOut` result is explicitly outside
+/// the "same canonical tautomer regardless of input" determinism guarantee
+/// the other two limits carry. `None` (the default) performs no wall-clock
+/// check.
+///
+/// `max_tautomers: 0` is treated as "skip the direct-aromatic-shift
+/// comparison step entirely" (status stays `Completed`, using whatever the
+/// rule-based loop converged to) rather than reporting `MaxTautomersReached`
+/// on every input regardless of whether any alternate form actually
+/// exists -- the latter would be a boundary artifact of the search
+/// algorithm, not a meaningful signal.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TautomerLimits {
+    pub max_transforms: usize,
+    pub max_tautomers: usize,
+    pub timeout_ms: Option<u64>,
+}
+
+impl Default for TautomerLimits {
+    fn default() -> Self {
+        Self {
+            max_transforms: 16,
+            max_tautomers: 32,
+            timeout_ms: None,
+        }
+    }
+}
+
+/// Stable identifier for one of the built-in [`TautomerRule`]s, used in
+/// [`AppliedTransform::rule_id`]. `#[non_exhaustive]` so new rules can be
+/// added without a breaking change; `Other` is a defensive fallback for a
+/// rule name not yet mapped to a variant here -- should not occur for any
+/// rule currently in `RULES` (see `all_rules_map_to_a_named_tautomer_rule_id`
+/// in this module's tests).
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum TautomerRuleId {
+    KetoEnol,
+    AmideIminol,
+    IminolAmide,
+    ImineEnamine,
+    OneThreeNToO,
+    OneThreeNToN,
+    Thioamide,
+    ThioIminolAmide,
+    ThioKetoEnol,
+    ThioEnolKetone,
+    OneThreeNToS,
+    OneThreeSToO,
+    OneThreeSToN,
+    OneThreeOToS,
+    OneThreeSToS,
+    OneThreeOToNAnyBridge,
+    OneThreeOToOAnyBridge,
+    OneThreeNToCAnyBridge,
+    OneThreeCToOAnyBridge,
+    OneThreeCToNAnyBridge,
+    OneFiveOToOBetaDiketone,
+    OneFiveOToN,
+    OneFiveNToN,
+    OneFiveNToO,
+    OneFiveCToO,
+    OneFiveOToONBridge,
+    OneFiveOToOSBridge,
+    OneFiveNToONBridge,
+    OneFiveNToOSBridge,
+    OneFiveNToNNBridge,
+    OneFiveNToNSBridge,
+    OneFiveOToNNBridge,
+    OneFiveOToNSBridge,
+    OneFiveSToONBridge,
+    OneFiveSToOSBridge,
+    OneFiveSToNCBridge,
+    OneFiveSToNNBridge,
+    OneFiveCToNCBridge,
+    OneFiveCToNNBridge,
+    OneFiveCToNSBridge,
+    OneFiveCToSNBridge,
+    OneFiveCToSSBridge,
+    /// A rule name not yet mapped to a named variant above.
+    Other(&'static str),
+}
+
+fn rule_id_for(name: &'static str) -> TautomerRuleId {
+    match name {
+        "keto-enol" => TautomerRuleId::KetoEnol,
+        "amide-iminol" => TautomerRuleId::AmideIminol,
+        "iminol-amide" => TautomerRuleId::IminolAmide,
+        "imine-enamine" => TautomerRuleId::ImineEnamine,
+        "1,3-N-to-O" => TautomerRuleId::OneThreeNToO,
+        "1,3-N-to-N" => TautomerRuleId::OneThreeNToN,
+        "thioamide" => TautomerRuleId::Thioamide,
+        "thio-iminol-amide" => TautomerRuleId::ThioIminolAmide,
+        "thio-keto-enol" => TautomerRuleId::ThioKetoEnol,
+        "thio-enol-ketone" => TautomerRuleId::ThioEnolKetone,
+        "1,3-N-to-S" => TautomerRuleId::OneThreeNToS,
+        "1,3-S-to-O" => TautomerRuleId::OneThreeSToO,
+        "1,3-S-to-N" => TautomerRuleId::OneThreeSToN,
+        "1,3-O-to-S" => TautomerRuleId::OneThreeOToS,
+        "1,3-S-to-S" => TautomerRuleId::OneThreeSToS,
+        "1,3-O-to-N-any-bridge" => TautomerRuleId::OneThreeOToNAnyBridge,
+        "1,3-O-to-O-any-bridge" => TautomerRuleId::OneThreeOToOAnyBridge,
+        "1,3-N-to-C-any-bridge" => TautomerRuleId::OneThreeNToCAnyBridge,
+        "1,3-C-to-O-any-bridge" => TautomerRuleId::OneThreeCToOAnyBridge,
+        "1,3-C-to-N-any-bridge" => TautomerRuleId::OneThreeCToNAnyBridge,
+        "1,5-O-to-O-beta-diketone" => TautomerRuleId::OneFiveOToOBetaDiketone,
+        "1,5-O-to-N" => TautomerRuleId::OneFiveOToN,
+        "1,5-N-to-N" => TautomerRuleId::OneFiveNToN,
+        "1,5-N-to-O" => TautomerRuleId::OneFiveNToO,
+        "1,5-C-to-O" => TautomerRuleId::OneFiveCToO,
+        "1,5-O-to-O-N-bridge" => TautomerRuleId::OneFiveOToONBridge,
+        "1,5-O-to-O-S-bridge" => TautomerRuleId::OneFiveOToOSBridge,
+        "1,5-N-to-O-N-bridge" => TautomerRuleId::OneFiveNToONBridge,
+        "1,5-N-to-O-S-bridge" => TautomerRuleId::OneFiveNToOSBridge,
+        "1,5-N-to-N-N-bridge" => TautomerRuleId::OneFiveNToNNBridge,
+        "1,5-N-to-N-S-bridge" => TautomerRuleId::OneFiveNToNSBridge,
+        "1,5-O-to-N-N-bridge" => TautomerRuleId::OneFiveOToNNBridge,
+        "1,5-O-to-N-S-bridge" => TautomerRuleId::OneFiveOToNSBridge,
+        "1,5-S-to-O-N-bridge" => TautomerRuleId::OneFiveSToONBridge,
+        "1,5-S-to-O-S-bridge" => TautomerRuleId::OneFiveSToOSBridge,
+        "1,5-S-to-N-C-bridge" => TautomerRuleId::OneFiveSToNCBridge,
+        "1,5-S-to-N-N-bridge" => TautomerRuleId::OneFiveSToNNBridge,
+        "1,5-C-to-N-C-bridge" => TautomerRuleId::OneFiveCToNCBridge,
+        "1,5-C-to-N-N-bridge" => TautomerRuleId::OneFiveCToNNBridge,
+        "1,5-C-to-N-S-bridge" => TautomerRuleId::OneFiveCToNSBridge,
+        "1,5-C-to-S-N-bridge" => TautomerRuleId::OneFiveCToSNBridge,
+        "1,5-C-to-S-S-bridge" => TautomerRuleId::OneFiveCToSSBridge,
+        other => TautomerRuleId::Other(other),
+    }
+}
+
+/// One named contribution to a candidate tautomer's [`tautomer_score`],
+/// decomposed for [`TautomerAuditRecord::score_breakdown`].
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum TautomerScoreTerm {
+    AromaticRing,
+    /// `element` is an atomic number (today: 8=O, 7=N, 16=S).
+    HeteroatomHydrogen {
+        element: u8,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ScoreContribution {
+    pub term: TautomerScoreTerm,
+    pub value: i32,
+}
+
+/// One transformation applied by the rule-based 1,3-/1,5-shift loop while
+/// computing a [`TautomerAuditRecord`].
+///
+/// Does not implement `Serialize`/`Deserialize` even under the `serde`
+/// feature: `AtomIdx`/`BondIdx` (from `chematic-core`) do not implement
+/// them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppliedTransform {
+    pub rule_id: TautomerRuleId,
+    pub affected_atoms: Vec<AtomIdx>,
+    pub affected_bonds: Vec<BondIdx>,
+}
+
+/// Explainable audit record for one [`tautomer_parent`] call.
+///
+/// `applied_transforms` records only the rule-based 1,3-/1,5-shift loop (the
+/// same loop [`canonical_tautomer_with_config`] runs); the final
+/// direct-aromatic-shift tie-break contributes to `score_breakdown` and
+/// `candidate_count` instead, since that search does not track the specific
+/// shift sequence taken to reach each candidate -- a disclosed scope
+/// limitation, not an oversight.
+///
+/// `lost_stereo`/`affected_isotopes` are atom-index lists (empty = none
+/// affected), not booleans: every transform this module applies preserves
+/// `chirality`/`isotope` (see the RFC's non-bug finding, section 1.2), so
+/// both are expected to always be empty today; the check is real (not
+/// hardcoded) so it stays correct if that ever changes.
+///
+/// Does not implement `Serialize`/`Deserialize` even under the `serde`
+/// feature: it embeds [`AppliedTransform`] (see its own doc comment).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TautomerAuditRecord {
+    pub selected: MoleculeSnapshot,
+    pub candidate_count: usize,
+    pub score_breakdown: Vec<ScoreContribution>,
+    pub applied_transforms: Vec<AppliedTransform>,
+    pub lost_stereo: Vec<AtomIdx>,
+    pub affected_isotopes: Vec<AtomIdx>,
+}
+
+/// Like [`canonical_tautomer`], but budget-limited via [`TautomerLimits`]
+/// and returns a [`ParentResult`] (status + explainable
+/// [`TautomerAuditRecord`]) instead of a bare `Molecule` -- see
+/// `docs/rfcs/tautomer_parent_identity_phase2_rfc.md` sections 4.2-4.3.
+///
+/// Does **not** implement the section 4.4 aromatic lactam/lactim fix (round
+/// 2C) -- on the aromatic tautomer pairs described there, this returns the
+/// same non-invariant result `canonical_tautomer` does today, just with an
+/// explicit `Completed` status (the rule-based loop and aromatic-shift
+/// search both genuinely converge without hitting any budget; the result is
+/// wrong for a different, structural reason that budget visibility cannot
+/// detect).
+pub fn tautomer_parent(mol: &Molecule, limits: &TautomerLimits) -> ParentResult {
+    if mol.atom_count() == 0 {
+        return ParentResult {
+            molecule: mol.clone(),
+            status: ParentComputationStatus::InvalidInput(InvalidInputReason::EmptyMolecule),
+            audit: ParentAudit::Tautomer(TautomerAuditRecord {
+                selected: MoleculeSnapshot::from_mol(mol),
+                candidate_count: 0,
+                score_breakdown: Vec::new(),
+                applied_transforms: Vec::new(),
+                lost_stereo: Vec::new(),
+                affected_isotopes: Vec::new(),
+            }),
+        };
+    }
+
+    let config = TautomerConfig {
+        max_iter: limits.max_transforms,
+        max_tautomers: limits.max_tautomers,
+        ..TautomerConfig::default()
+    };
+    let deadline = limits
+        .timeout_ms
+        .map(|ms| (Instant::now(), std::time::Duration::from_millis(ms)));
+    let timed_out = |deadline: &Option<(Instant, std::time::Duration)>| match deadline {
+        Some((start, budget)) => start.elapsed() >= *budget,
+        None => false,
+    };
+
+    let mut current = mol.clone();
+    let mut seen = HashSet::new();
+    seen.insert(mol_fingerprint(&current));
+    let mut applied_transforms = Vec::new();
+    let mut transforms_applied = 0usize;
+    let mut status = ParentComputationStatus::Completed;
+
+    loop {
+        if timed_out(&deadline) {
+            status = ParentComputationStatus::TimedOut;
+            break;
+        }
+        if transforms_applied >= limits.max_transforms {
+            let has_more = active_rules(&config)
+                .into_iter()
+                .filter(|r| r.prefer_forward)
+                .any(|rule| {
+                    apply_first_match_tracked(&current, rule, &config)
+                        .is_some_and(|(next, ..)| !seen.contains(&mol_fingerprint(&next)))
+                });
+            if has_more {
+                status = ParentComputationStatus::MaxTransformsReached;
+            }
+            break;
+        }
+        let mut changed = false;
+        for rule in active_rules(&config)
+            .into_iter()
+            .filter(|r| r.prefer_forward)
+        {
+            if let Some((next, donor, bridge, acceptor)) =
+                apply_first_match_tracked(&current, rule, &config)
+            {
+                let fp = mol_fingerprint(&next);
+                if !seen.contains(&fp) {
+                    seen.insert(fp);
+                    let mut affected_bonds = Vec::new();
+                    if let Some((bidx, _)) = current.bond_between(donor, bridge) {
+                        affected_bonds.push(bidx);
+                    }
+                    if let Some((bidx, _)) = current.bond_between(bridge, acceptor) {
+                        affected_bonds.push(bidx);
+                    }
+                    applied_transforms.push(AppliedTransform {
+                        rule_id: rule_id_for(rule.name),
+                        affected_atoms: vec![donor, bridge, acceptor],
+                        affected_bonds,
+                    });
+                    current = next;
+                    transforms_applied += 1;
+                    changed = true;
+                    break;
+                }
+            }
+        }
+        if !changed {
+            break; // converged: no forward rule produces an unseen form
+        }
+    }
+
+    let mut candidate_count = 1;
+    if matches!(status, ParentComputationStatus::Completed) && limits.max_tautomers > 0 {
+        if timed_out(&deadline) {
+            status = ParentComputationStatus::TimedOut;
+        } else {
+            let (extra, truncated) = enumerate_direct_aromatic_forms_tracked(
+                &current,
+                &HashSet::new(),
+                limits.max_tautomers,
+            );
+            let mut candidates: Vec<Molecule> = vec![current.clone()];
+            candidates.extend(extra);
+            candidate_count = candidates.len();
+            if candidates.len() > 1 {
+                candidates.sort_by(|a, b| {
+                    tautomer_score(b).cmp(&tautomer_score(a)).then_with(|| {
+                        chematic_smiles::canonical_smiles(a)
+                            .cmp(&chematic_smiles::canonical_smiles(b))
+                    })
+                });
+                current = candidates.into_iter().next().unwrap();
+            }
+            if truncated {
+                status = ParentComputationStatus::MaxTautomersReached;
+            }
+        }
+    }
+
+    let common_atoms = mol.atom_count().min(current.atom_count());
+    let lost_stereo: Vec<AtomIdx> = (0..common_atoms)
+        .map(|i| AtomIdx(i as u32))
+        .filter(|&i| {
+            mol.atom(i).chirality != Chirality::None && current.atom(i).chirality == Chirality::None
+        })
+        .collect();
+    let affected_isotopes: Vec<AtomIdx> = (0..common_atoms)
+        .map(|i| AtomIdx(i as u32))
+        .filter(|&i| mol.atom(i).isotope != current.atom(i).isotope)
+        .collect();
+    let score_breakdown_final = score_breakdown(&current);
+
+    ParentResult {
+        status,
+        audit: ParentAudit::Tautomer(TautomerAuditRecord {
+            selected: MoleculeSnapshot::from_mol(&current),
+            candidate_count,
+            score_breakdown: score_breakdown_final,
+            applied_transforms,
+            lost_stereo,
+            affected_isotopes,
+        }),
+        molecule: current,
+    }
 }
 
 #[cfg(test)]
@@ -2246,6 +2673,154 @@ mod tests {
                 !smi.is_empty(),
                 "tautomer {i} must produce valid canonical SMILES"
             );
+        }
+    }
+
+    // -- Phase 2 round-2B tautomer_parent tests --------------------------------
+    // See docs/rfcs/tautomer_parent_identity_phase2_rfc.md sections 4.1-4.3.
+
+    #[test]
+    fn all_rules_map_to_a_named_tautomer_rule_id() {
+        for rule in RULES {
+            assert!(
+                !matches!(rule_id_for(rule.name), TautomerRuleId::Other(_)),
+                "rule '{}' has no TautomerRuleId variant -- add one",
+                rule.name
+            );
+        }
+    }
+
+    #[test]
+    fn tautomer_parent_completed_on_keto_enol() {
+        let mol = parse("CC(O)=CC(C)=O").unwrap();
+        let result = tautomer_parent(&mol, &TautomerLimits::default());
+        assert_eq!(result.status, ParentComputationStatus::Completed);
+        assert_eq!(
+            canonical_smiles(&result.molecule),
+            canonical_smiles(&canonical_tautomer(&mol))
+        );
+        match &result.audit {
+            ParentAudit::Tautomer(record) => {
+                assert_eq!(record.applied_transforms.len(), 1);
+                assert_eq!(
+                    record.applied_transforms[0].rule_id,
+                    TautomerRuleId::KetoEnol
+                );
+                assert!(record.lost_stereo.is_empty());
+                assert!(record.affected_isotopes.is_empty());
+            }
+            other => panic!("expected ParentAudit::Tautomer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tautomer_parent_max_transforms_reached_when_budget_too_small() {
+        // 3 independent enol arms, each needing exactly 1 transform; a
+        // budget of 1 converts only one and must report the exhaustion,
+        // not silently return a partially-converted, order-dependent result
+        // as if it were `Completed`.
+        let mol = build_comb(3, false, false);
+        let limits = TautomerLimits {
+            max_transforms: 1,
+            ..TautomerLimits::default()
+        };
+        let result = tautomer_parent(&mol, &limits);
+        assert_eq!(result.status, ParentComputationStatus::MaxTransformsReached);
+        match &result.audit {
+            ParentAudit::Tautomer(record) => assert_eq!(record.applied_transforms.len(), 1),
+            other => panic!("expected ParentAudit::Tautomer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tautomer_parent_completed_with_enough_budget_for_all_arms() {
+        let mol = build_comb(3, false, false);
+        let limits = TautomerLimits {
+            max_transforms: 10,
+            ..TautomerLimits::default()
+        };
+        let result = tautomer_parent(&mol, &limits);
+        assert_eq!(result.status, ParentComputationStatus::Completed);
+        match &result.audit {
+            ParentAudit::Tautomer(record) => assert_eq!(record.applied_transforms.len(), 3),
+            other => panic!("expected ParentAudit::Tautomer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tautomer_parent_max_tautomers_reached_on_tetrazole() {
+        let mol = parse("c1nnn[nH]1").unwrap();
+        let unlimited = tautomer_parent(&mol, &TautomerLimits::default());
+        let (unlimited_candidate_count, _) = match &unlimited.audit {
+            ParentAudit::Tautomer(r) => (r.candidate_count, ()),
+            other => panic!("expected ParentAudit::Tautomer, got {other:?}"),
+        };
+        assert!(
+            unlimited_candidate_count > 1,
+            "tetrazole must have more than one direct-aromatic-shift candidate to make this test meaningful"
+        );
+
+        let limited = tautomer_parent(
+            &mol,
+            &TautomerLimits {
+                max_tautomers: 1,
+                ..TautomerLimits::default()
+            },
+        );
+        assert_eq!(limited.status, ParentComputationStatus::MaxTautomersReached);
+    }
+
+    #[test]
+    fn tautomer_parent_max_tautomers_zero_skips_comparison_without_false_exhaustion() {
+        // A molecule with NO direct-aromatic-shift candidates at all must
+        // not report MaxTautomersReached just because max_tautomers=0 --
+        // see TautomerLimits::max_tautomers's doc comment.
+        let mol = parse("CC(O)=CC(C)=O").unwrap();
+        let result = tautomer_parent(
+            &mol,
+            &TautomerLimits {
+                max_tautomers: 0,
+                ..TautomerLimits::default()
+            },
+        );
+        assert_eq!(result.status, ParentComputationStatus::Completed);
+    }
+
+    #[test]
+    fn tautomer_parent_empty_molecule_is_invalid_input() {
+        let empty = MoleculeBuilder::new().build();
+        let result = tautomer_parent(&empty, &TautomerLimits::default());
+        assert_eq!(
+            result.status,
+            ParentComputationStatus::InvalidInput(InvalidInputReason::EmptyMolecule)
+        );
+    }
+
+    #[test]
+    fn tp2_29_idempotence_acetylacetone() {
+        let mol = parse("CC(=O)CC(C)=O").unwrap();
+        let once = tautomer_parent(&mol, &TautomerLimits::default());
+        let twice = tautomer_parent(&once.molecule, &TautomerLimits::default());
+        assert_eq!(
+            canonical_smiles(&once.molecule),
+            canonical_smiles(&twice.molecule)
+        );
+        assert_eq!(twice.status, ParentComputationStatus::Completed);
+    }
+
+    #[test]
+    fn tautomer_parent_preserves_remote_stereocenter() {
+        // Alanine's stereocenter must survive tautomer_parent unaffected,
+        // same as the primitive transfer_hydrogen/transfer_hydrogen_aromatic
+        // functions this is built on (RFC section 1.2's confirmed non-bug).
+        let mol = parse("C[C@@H](N)C(=O)O").unwrap();
+        let result = tautomer_parent(&mol, &TautomerLimits::default());
+        match &result.audit {
+            ParentAudit::Tautomer(record) => {
+                assert!(record.lost_stereo.is_empty());
+                assert!(record.affected_isotopes.is_empty());
+            }
+            other => panic!("expected ParentAudit::Tautomer, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
## Summary

Round 2B of ROADMAP.md Phase 2 (Tautomer & Parent Identity), per RFC #362 section 7's round split (2A RFC revision → **2B Parent API + budget visibility** → 2C aromatic lactam/lactim fix → 2D scoring customization). Implements the Parent-identity API and tautomer budget visibility; deliberately does **not** implement the round-2C aromatic fix (`tautomer_parent` on the confirmed-non-invariant lactam/lactim pairs still returns the same result `canonical_tautomer` does today, with an honest `Completed` status — see below).

## What's in this PR

- **`fragment_parent`/`charge_parent`/`isotope_parent`/`stereo_parent`** (`standardize.rs`): explicit "Parent" framing of existing primitives. `charge_parent` is **not** a bare `neutralize_charges` wrapper — it selects the fragment parent first, then neutralizes that single fragment (a design correction made during RFC review, before any code existed — see PR #362's round-2A revision).
- **`tautomer_parent`** (`tautomer.rs`): like `canonical_tautomer`, but budget-limited via `TautomerLimits` and returns a `ParentResult` with a `TautomerAuditRecord` (selected candidate, per-term score breakdown, applied transforms with affected atoms/bonds, and real — not hardcoded — `lost_stereo`/`affected_isotopes` checks) instead of a bare `Molecule`.
- **`super_parent`** (`parent.rs`, new file): composes all five in the fixed order fragment → charge → isotope → stereo → tautomer, returning every intermediate stage's audit record.
- **`TautomerLimits { max_transforms, max_tautomers, timeout_ms }`**: deterministic budgets (counted exactly as the existing `TautomerConfig::max_iter`/`max_tautomers` always have been — outer-loop iterations where a transform was *applied*, distinct forms *added* to the candidate set, duplicates never consuming budget). `timeout_ms` is a real wall-clock check (`std::time::Instant`), not a decorative field.
- **`ParentResult`/`ParentComputationStatus`/`ParentAudit`**: `Completed`/`MaxTransformsReached`/`MaxTautomersReached`/`TimedOut`/`Abstained`/`InvalidInput`. `MaxTransformsReached`/`MaxTautomersReached` are real, tested detections — `apply_first_match`/`enumerate_direct_aromatic_forms` were refactored into `_tracked` variants that expose which rule/candidate fired without duplicating the underlying search logic (the untracked functions are now thin wrappers).
- **`TautomerRuleId`**: 42 named variants (one per existing `TautomerRule`, mapped by name) + an `Other(&'static str)` fallback, with a regression test asserting no rule in `RULES` maps to the fallback (catches future drift between the two lists).
- Fixed a stale doc comment (`"The 15 tautomer rules"` → 42; the array grew without the comment being updated).
- `MoleculeSnapshot::from_mol` bumped from private to `pub(crate)` so `tautomer.rs` can build snapshots without duplicating that logic.

## Explicitly not in this round

- The round-2C aromatic lactam/lactim fix (2-pyridone/cytosine/uracil/purine-class canonical-tautomer non-invariance, confirmed in PR #362). `tautomer_parent` is honest about this: it reports `Completed` on those pairs today, because the computation genuinely converges without hitting any budget — the result is wrong for a structural reason budget-visibility cannot detect, not something this round's scope covers.
- The nitroso/oxime non-convergence gap (also confirmed in #362, distinct root cause).
- `TautomerScoringConfig`/custom rule support (round 2D).
- Python/WASM bindings for any of the above.
- `max_restarts`/`Canceled` from the original RFC sketch — dropped this round (not silently ignored): `max_restarts` has no defined meaning at the tautomer-limits level, and `Canceled` had no cancellation mechanism to ever produce it.

## Test plan

- [x] `cargo test -p chematic-chem --lib`: 776 passed, 0 failed, 4 ignored (was 760/0/4 before this PR — 16 net new tests; some existing counts shifted internally but no regressions)
- [x] New tests cover: all 6 `tp2-17`..`tp2-23` Parent-function fixtures from `validation/tautomer_parent_identity_phase2_fixtures.jsonl` (PR #362, not merged, hand-transcribed here per Phase 1's own established convention); `MaxTransformsReached` on a 3-arm comb molecule with a too-small budget (and a companion test confirming a large-enough budget completes normally); `MaxTautomersReached` on tetrazole; the `max_tautomers=0` boundary case (must not falsely report exhaustion on a molecule with zero direct-aromatic-shift candidates); empty-molecule `InvalidInput`; idempotence; remote-stereocenter preservation through `tautomer_parent`.
- [x] `cargo check --workspace --all-features` clean (exercises the `serde` feature path via chematic-py/chematic-wasm)
- [x] `cargo clippy -p chematic-chem --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `bash scripts/check.sh` (full workspace fmt/clippy/test/publish-graph/version gate)
