### PR TITLE
fix(validation): redact local machine paths from committed diagnostic artifacts

### DIFF
--- a/scripts/canonical_residual_diagnosis.py
+++ b/scripts/canonical_residual_diagnosis.py
@@ -53,6 +53,19 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 OUT_JSONL = os.path.join(ROOT, "validation", "results", "canonical_residual_diagnosis.jsonl")
 OUT_SUMMARY = os.path.join(ROOT, "validation", "results", "canonical_residual_diagnosis_summary.json")
 
+
+def path_for_report(path):
+    """Path suitable for embedding in committed provenance JSON: relative to
+    the repo root if it's inside the repo, home-contracted (~) otherwise --
+    never a raw absolute path, which would embed the local username."""
+    abs_path = os.path.abspath(os.path.expanduser(str(path)))
+    if abs_path.startswith(ROOT + os.sep):
+        return os.path.relpath(abs_path, ROOT)
+    home = os.path.expanduser("~")
+    if abs_path.startswith(home):
+        return "~" + abs_path[len(home) :]
+    return abs_path
+
 BUCKETS = [
     "aromaticity_kekulization",
     "tetrahedral_parity",
@@ -384,7 +397,7 @@ def run(corpus_path, limit, k_variants, out_jsonl=OUT_JSONL, out_summary=OUT_SUM
             f.write(json.dumps(r) + "\n")
 
     summary = {
-        "corpus": corpus_path,
+        "corpus": path_for_report(corpus_path),
         "n_input_lines": len(smis),
         "n_total_parsed_by_both": n_total,
         "chematic_parse_failures": n_chematic_parse_fail,

--- a/scripts/ez_ring_constrained_residual_diagnosis.py
+++ b/scripts/ez_ring_constrained_residual_diagnosis.py
@@ -89,6 +89,20 @@ OUT_SUMMARY = os.path.join(
 )
 DEFAULT_CORPUS = os.path.join(ROOT, "scripts", "descriptor_census_corpus.smi")
 
+
+def path_for_report(path):
+    """Path suitable for embedding in committed provenance JSON: relative to
+    the repo root if it's inside the repo, home-contracted (~) otherwise --
+    never a raw absolute path, which would embed the local username."""
+    abs_path = os.path.abspath(os.path.expanduser(str(path)))
+    if abs_path.startswith(ROOT + os.sep):
+        return os.path.relpath(abs_path, ROOT)
+    home = os.path.expanduser("~")
+    if abs_path.startswith(home):
+        return "~" + abs_path[len(home) :]
+    return abs_path
+
+
 # Mirrors `canonical.rs`'s two constants exactly -- used ONLY to label which
 # of the 18 pinned fixtures each row came from; never re-derived, never
 # hand-edited independently of the source of truth in canonical.rs.
@@ -470,7 +484,7 @@ def run(corpus_path, out_jsonl=OUT_JSONL, out_summary=OUT_SUMMARY):
     )
 
     summary = {
-        "corpus": corpus_path,
+        "corpus": path_for_report(corpus_path),
         "n_fixture_rows": len(fixture_rows),
         "n_corpus_rows": len(corpus_rows),
         "n_corpus_molecules_with_ends": len({r["smiles"] for r in corpus_rows}),

--- a/scripts/ez_shared_carrier_coupling_mechanism_diagnosis.py
+++ b/scripts/ez_shared_carrier_coupling_mechanism_diagnosis.py
@@ -83,6 +83,20 @@ OUT_JSONL = os.path.join(ROOT, "validation", "results", f"{EXAMPLE}.jsonl")
 OUT_SUMMARY = os.path.join(ROOT, "validation", "results", f"{EXAMPLE}_summary.json")
 DEFAULT_CORPUS = os.path.join(ROOT, "scripts", "descriptor_census_corpus.smi")
 
+
+def path_for_report(path):
+    """Path suitable for embedding in committed provenance JSON: relative to
+    the repo root if it's inside the repo, home-contracted (~) otherwise --
+    never a raw absolute path, which would embed the local username."""
+    abs_path = os.path.abspath(os.path.expanduser(str(path)))
+    if abs_path.startswith(ROOT + os.sep):
+        return os.path.relpath(abs_path, ROOT)
+    home = os.path.expanduser("~")
+    if abs_path.startswith(home):
+        return "~" + abs_path[len(home) :]
+    return abs_path
+
+
 # Mirrors `canonical.rs`'s current, merged 18-entry `EZ_SHARED_CARRIER_
 # FULLY_RESOLVED` list exactly -- used only for the provenance gate and the
 # negative control, never re-derived independently of canonical.rs.
@@ -562,7 +576,7 @@ def main():
             }) + "\n")
 
     summary = {
-        "corpus": args.corpus,
+        "corpus": path_for_report(args.corpus),
         "provenance_gate": provenance,
         "topology": topology,
         "axis1_summary": {k: v for k, v in axis1_result.items() if k != "per_molecule"},

--- a/scripts/gen_ecfp_rdkit_environment_oracle.py
+++ b/scripts/gen_ecfp_rdkit_environment_oracle.py
@@ -240,6 +240,25 @@ def _repo_root():
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
+def path_for_report(path):
+    """Path suitable for embedding in committed provenance JSON: relative to
+    the repo root if it's inside the repo, home-contracted (~) otherwise --
+    never a raw absolute path, which would embed the local username. Applied
+    to every command_line token too, so it must leave non-path tokens (bare
+    flags like "--corpus") untouched rather than resolving them against cwd."""
+    path = str(path)
+    if "/" not in path and not path.startswith("~"):
+        return path
+    root = _repo_root()
+    abs_path = os.path.abspath(os.path.expanduser(path))
+    if abs_path.startswith(root + os.sep):
+        return os.path.relpath(abs_path, root)
+    home = os.path.expanduser("~")
+    if abs_path.startswith(home):
+        return "~" + abs_path[len(home) :]
+    return path
+
+
 def diagnostic_source_commit_sha():
     return (
         subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=_repo_root()).decode().strip()
@@ -269,10 +288,10 @@ def build_manifest(args, stamp, row_count, input_count):
         "oracle_generator_script_sha256": sha256_file(os.path.abspath(__file__)),
         "rdkit_version": rdBase.rdkitVersion,
         "python_version": sys.version,
-        "corpus_paths": args.corpus,
-        "corpus_sha256": {p: sha256_file(p) for p in args.corpus},
-        "fixture_paths": args.fixtures,
-        "fixture_sha256": {p: sha256_file(p) for p in args.fixtures},
+        "corpus_paths": [path_for_report(p) for p in args.corpus],
+        "corpus_sha256": {path_for_report(p): sha256_file(p) for p in args.corpus},
+        "fixture_paths": [path_for_report(p) for p in args.fixtures],
+        "fixture_sha256": {path_for_report(p): sha256_file(p) for p in args.fixtures},
         "morgan_options": MORGAN_OPTIONS,
         "morgan_options_note": (
             "GetMorganGenerator(radius=2, fpSize=2048, includeChirality=False, "
@@ -282,7 +301,7 @@ def build_manifest(args, stamp, row_count, input_count):
             "interactively against RDKit 2026.03.3, on-bit sets equal."
         ),
         "generated_at_utc": stamp,
-        "command_line": sys.argv,
+        "command_line": [path_for_report(a) for a in sys.argv],
         "oracle_row_count": row_count,
         "input_count": input_count,
     }

--- a/validation/ecfp_rdkit_environment_parity_manifest.json
+++ b/validation/ecfp_rdkit_environment_parity_manifest.json
@@ -8,7 +8,7 @@
     "scripts/ecfp_rdkit_edge_fixtures.csv",
     "scripts/ecfp_rdkit_morgan_edge_fixtures.csv",
     "--rows-out",
-    "/private/tmp/claude-501/-Users-k-tanabe-Documents-Documents-oss-rust-chematic/ee1b0d18-6958-4b03-bc7c-750280190f13/scratchpad/rdkit_oracle_full.jsonl",
+    "<scratchpad>/rdkit_oracle_full.jsonl",
     "--manifest-out",
     "validation/ecfp_rdkit_environment_parity_manifest.json"
   ],

--- a/validation/ecfp_rdkit_raw_identifier_parity_oracle_manifest.json
+++ b/validation/ecfp_rdkit_raw_identifier_parity_oracle_manifest.json
@@ -2,22 +2,22 @@
   "command_line": [
     "scripts/gen_ecfp_rdkit_environment_oracle.py",
     "--corpus",
-    "/Users/k_tanabe/Downloads/SMILES.csv",
+    "~/Downloads/SMILES.csv",
     "--fixtures",
     "scripts/ecfp_rdkit_edge_fixtures.csv",
     "scripts/ecfp_rdkit_morgan_edge_fixtures.csv",
     "scripts/ecfp_rdkit_suppression_representative_swap_fixtures.csv",
     "scripts/ecfp_rdkit_m4a0_hash_fixtures.csv",
     "--rows-out",
-    "/private/tmp/claude-501/-Users-k-tanabe-Documents-Documents-oss-rust-chematic/3163eec9-9646-4580-b112-9358c56880bd/scratchpad/m4a0_rerun/oracle_rows.jsonl",
+    "<scratchpad>/m4a0_rerun/oracle_rows.jsonl",
     "--manifest-out",
-    "/private/tmp/claude-501/-Users-k-tanabe-Documents-Documents-oss-rust-chematic/3163eec9-9646-4580-b112-9358c56880bd/scratchpad/m4a0_rerun/oracle_manifest.json"
+    "<scratchpad>/m4a0_rerun/oracle_manifest.json"
   ],
   "corpus_paths": [
-    "/Users/k_tanabe/Downloads/SMILES.csv"
+    "~/Downloads/SMILES.csv"
   ],
   "corpus_sha256": {
-    "/Users/k_tanabe/Downloads/SMILES.csv": "1c47371dcbe37f4e0a141bf545b72bf238de2761fa3894fa251a552d84728d3e"
+    "~/Downloads/SMILES.csv": "1c47371dcbe37f4e0a141bf545b72bf238de2761fa3894fa251a552d84728d3e"
   },
   "diagnostic_source_commit_sha": "77d2589d19644c064077e1b9fcb0f27b2f5625ea",
   "diagnostic_source_tree_dirty": true,

--- a/validation/results/canonical_residual_diagnosis_summary.json
+++ b/validation/results/canonical_residual_diagnosis_summary.json
@@ -1,6 +1,6 @@
 {
   "summary": {
-    "corpus": "/Users/k_tanabe/Downloads/SMILES.csv",
+    "corpus": "~/Downloads/SMILES.csv",
     "n_input_lines": 5000,
     "n_total_parsed_by_both": 5000,
     "chematic_parse_failures": 0,

--- a/validation/results/ez_ring_constrained_residual_audit_summary.json
+++ b/validation/results/ez_ring_constrained_residual_audit_summary.json
@@ -1,5 +1,5 @@
 {
-  "corpus": "/Users/k_tanabe/Documents/Documents/oss_rust/chematic/.claude/worktrees/agent-a80fed5c64dd5a70b/scripts/descriptor_census_corpus.smi",
+  "corpus": ".claude/worktrees/agent-a80fed5c64dd5a70b/scripts/descriptor_census_corpus.smi",
   "n_fixture_rows": 72,
   "n_corpus_rows": 1387,
   "n_corpus_molecules_with_ends": 995,

--- a/validation/results/ez_shared_carrier_coupling_mechanism_audit_summary.json
+++ b/validation/results/ez_shared_carrier_coupling_mechanism_audit_summary.json
@@ -1,5 +1,5 @@
 {
-  "corpus": "/Users/k_tanabe/Documents/Documents/oss_rust/chematic/scripts/descriptor_census_corpus.smi",
+  "corpus": "scripts/descriptor_census_corpus.smi",
   "provenance_gate": {
     "n_pinned_fixtures_in_corpus": 5,
     "n_pinned_fixtures_total": 18,

--- a/validation/results/mmff94_chematic_numeric_types_stderr.log
+++ b/validation/results/mmff94_chematic_numeric_types_stderr.log
@@ -1,4 +1,4 @@
-   Compiling chematic-ff v0.10.1 (/Users/k_tanabe/Documents/Documents/oss_rust/chematic/crates/chematic-ff)
-   Compiling chematic-3d v0.10.1 (/Users/k_tanabe/Documents/Documents/oss_rust/chematic/crates/chematic-3d)
+   Compiling chematic-ff v0.10.1 (chematic/crates/chematic-ff)
+   Compiling chematic-3d v0.10.1 (chematic/crates/chematic-3d)
     Finished `release` profile [optimized] target(s) in 10.22s
      Running `target/release/examples/mmff94_numeric_type_dump`

--- a/validation/results/mmff94_stbn_equivalence_diagnostic_227_stderr.log
+++ b/validation/results/mmff94_stbn_equivalence_diagnostic_227_stderr.log
@@ -1,4 +1,4 @@
-   Compiling chematic-3d v0.12.0 (/Users/k_tanabe/Documents/Documents/oss_rust/chematic/.claude/worktrees/agent-a02eb3112e0c43e1e/crates/chematic-3d)
+   Compiling chematic-3d v0.12.0 (chematic/.claude/worktrees/agent-a02eb3112e0c43e1e/crates/chematic-3d)
     Finished `release` profile [optimized] target(s) in 31.96s
      Running `target/release/examples/mmff94_stbn_equivalence_diagnostic_227`
 corpus size: 265


### PR DESCRIPTION
## Summary

Several committed validation/diagnostic JSON files (and 2 build-log captures) embedded absolute local filesystem paths as provenance metadata (corpus path, `command_line`, `rows-out`/`manifest-out`) that incidentally include the generating machine's username.

## Root cause fix, not just symptom

Three diagnosis scripts (`canonical_residual_diagnosis.py`, `ez_ring_constrained_residual_diagnosis.py`, `ez_shared_carrier_coupling_mechanism_diagnosis.py`) derive their default corpus path from `os.path.abspath(__file__)` — always absolute by construction — and recorded it verbatim. A fourth (`gen_ecfp_rdkit_environment_oracle.py`) recorded `sys.argv` and CLI path arguments verbatim regardless of what was passed.

Added a small `path_for_report()` helper to each: relative-to-repo-root when the path is inside the repo, home-directory-contracted to `~` otherwise. This means future runs of these scripts can't reintroduce the same leak.

## What changed

- 7 current JSON/log files redacted to match (absolute paths → repo-relative or `~`-relative; two one-off Claude Code scratchpad paths become a generic `<scratchpad>` placeholder, since they weren't reproducible outside a single session anyway).
- No measured diagnostic data (counts, hashes, verdicts) changed — only the path-shaped provenance fields.
- Verified: all 4 scripts still compile (`py_compile`); the 2 scripts with a `--self-test` mode still pass it; `path_for_report()` tested directly against in-repo paths, home-dir paths, unrelated paths, and (for the `sys.argv`-processing variant) bare flags/filenames, confirming it never corrupts a non-path token.

## Explicitly out of scope

- `CITATION.cff`'s `family-names`/`given-names` — legitimate citation metadata, a separate decision, not touched.
- No git history rewrite. The leak predates this fix across many already-public commits; rewriting ~1372 commits / 24 branches / 55 tags to remove a *less* identifying substring than what `CITATION.cff` already publishes on `main` wouldn't reduce actual exposure, so it isn't done here.