### PR TITLE
feat(chematic-py): Python bindings for the A2 conformer ensemble core (A2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `chematic-py` (A2.1: Python bindings for the conformer ensemble core)
+
+- `Mol.conformer_ensemble_v2(config)`: a new, separate Python method
+  exposing `chematic_3d::embed_ensemble_v2` (A2, PR #373) — a deterministic
+  multi-conformer generator built as a new outer loop over
+  `embed_pipeline_v2`, with energy-ranked selection scoped within each
+  force field actually used and full per-attempt provenance. Added
+  alongside the existing `Mol.conformer_ensemble()`, not in place of it —
+  see below.
+- `EnsembleV2Config(per_conformer, count, base_seed, rmsd_threshold=0.5,
+  use_symmetric_rmsd_pruning=True, ensemble_timeout_ms=None)`: seed,
+  attempt count, ensemble-wide timeout, and RMSD pruning threshold are all
+  explicit, required-or-defaulted arguments — no hidden global state.
+  Construction is infallible; an invalid `rmsd_threshold` (negative, `NaN`,
+  infinite) is rejected with `ValueError` at `conformer_ensemble_v2()` call
+  time, matching where the Rust core itself validates it.
+- The returned dict never raises just because zero conformers were kept —
+  every per-attempt outcome (kept, pruned as a near-duplicate, or a typed
+  failure) is reported in `attempts`, and `conformers`/`conformer_provenance`
+  are simply empty in that case. This is the opposite convention from
+  `Mol.embed_pipeline_v2()`, which does raise on a failed embed — documented
+  explicitly on the new method, since "no exception raised" does not imply
+  "got at least one conformer" here.
+- MMFF94 and UFF energies are never cross-compared: kept conformers in
+  `conformers` are ordered group-by-group (by force field actually used),
+  ascending energy only *within* each group, and `mixed_force_field`
+  discloses when more than one group has a kept member. No flattened,
+  globally energy-sorted field is exposed — that would silently reintroduce
+  the cross-scale comparison this design avoids.
+- `Mol.conformer_ensemble()` (the legacy, `etkdg`-backed multi-conformer
+  method) is unchanged in this release — no behavior or return-type change,
+  no removal. Its docstring now carries a deprecation note pointing at
+  `conformer_ensemble_v2` and naming the concrete reasons (no seed, no
+  energy ranking, silent `Err(_) => []` on internal failure, and the live
+  MMFF94-zero-energy defect from PR #369). The docstring's own duplicated
+  intro paragraph (a pre-existing copy-paste artifact, unrelated to this
+  change) was cleaned up in the same edit.
+- Not done this round, by design: no WASM bindings for `embed_ensemble_v2`,
+  no version bump, and no best-of-N-vs-RDKit benchmark arm — those are the
+  explicitly planned next steps, not part of this change.
+
 ### Fixed — documentation (correction to a v0.19.0 changelog entry)
 
 - v0.19.0's own benchmark-refresh entry below states 3D conformer quality

--- a/crates/chematic-py/src/ensemble_v2.rs
+++ b/crates/chematic-py/src/ensemble_v2.rs
@@ -1,0 +1,311 @@
+//! Python binding for `chematic_3d::embed_ensemble_v2` (A2.1).
+//!
+//! Calls `embed_ensemble_v2` directly on the caller's own `Mol.inner` --
+//! never canonicalizes/reparses first, same convention as
+//! `embed_pipeline_v2` (see `pipeline_v2.rs`'s module doc, issue #172).
+//!
+//! # Error asymmetry with `embed_pipeline_v2`
+//!
+//! `embed_pipeline_v2` fails the whole call when a single embed doesn't
+//! work out. `embed_ensemble_v2` is different: every per-attempt outcome --
+//! including an ensemble where every attempt failed and zero conformers
+//! were kept -- is a normal, fully-diagnosable `Ok(EnsembleV2Result)`, with
+//! per-attempt detail in `attempts`. Its `Result` only rejects a config
+//! that could never succeed regardless of the molecule or how many
+//! attempts run (currently: an invalid `rmsd_threshold`). So there is no
+//! `EnsembleV2Error` exception type here -- a rejected config just raises a
+//! plain `ValueError` (mirrors `parse_stereo_policy` et al. in
+//! `pipeline_v2.rs`, which do the same for bad policy strings). A Python
+//! caller must not assume "no exception raised" implies "got at least one
+//! conformer" -- check `len(result["conformers"])`.
+//!
+//! # Never cross-comparing MMFF94 vs UFF energy
+//!
+//! `embed_ensemble_v2` itself already scopes energy ranking and duplicate
+//! pruning to within each `actual_force_field_used` group, and reports
+//! `mixed_force_field` when kept conformers span more than one group (see
+//! that function's own module doc in `chematic-3d` for the full
+//! rationale). This binding deliberately adds no top-level "best
+//! conformer" or flattened, globally energy-sorted field on top of that --
+//! doing so would silently reintroduce the exact cross-group comparison
+//! `embed_ensemble_v2` was built to avoid. `result["conformers"]` is
+//! already correctly ordered (group-then-energy); per-conformer energy and
+//! force-field context lives in the parallel `result["conformer_provenance"]`
+//! list, and the full untrimmed record lives in `result["attempts"]`.
+
+use chematic_3d::{ConformerAttempt, ConformerDisposition, EnsembleV2Result, embed_ensemble_v2};
+use chematic_core::Molecule;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+use crate::pipeline_v2::{
+    PyPipelineV2Config, coords_to_vec, failure_to_dict, force_field_bridge_error_dict,
+    force_field_policy_str, snake_case_debug,
+};
+
+// ---------------------------------------------------------------------------
+// EnsembleV2Config
+// ---------------------------------------------------------------------------
+
+/// Configuration for `Mol.conformer_ensemble_v2()`. Unlike
+/// `PipelineV2Config`, this constructor is infallible: the Rust
+/// `EnsembleV2Config` struct has no invariant of its own to parse or
+/// reject at construction time (its one fallible field, `rmsd_threshold`,
+/// is validated by `embed_ensemble_v2` itself, at call time -- see this
+/// module's doc for why that raises a plain `ValueError` rather than a
+/// dedicated exception type).
+#[pyclass(name = "EnsembleV2Config", from_py_object)]
+#[derive(Clone)]
+pub struct PyEnsembleV2Config {
+    pub(crate) inner: chematic_3d::EnsembleV2Config,
+}
+
+#[pymethods]
+impl PyEnsembleV2Config {
+    /// `per_conformer`: a `PipelineV2Config`, reused verbatim for every
+    /// attempt except its `embed_seed`, which is overridden per-attempt by
+    /// a value derived from `base_seed`.
+    ///
+    /// `count`: number of independent embedding attempts (before RMSD
+    /// pruning) -- the kept ensemble may have fewer conformers than this.
+    ///
+    /// `base_seed`: attempt `i` uses a seed deterministically derived from
+    /// this value. The same `base_seed` always reproduces the same
+    /// ensemble.
+    ///
+    /// `rmsd_threshold` (default 0.5 Å): minimum RMSD between kept
+    /// conformers within the same force-field group. `0.0` disables
+    /// pruning. Must be `0.0` or a positive, finite value -- an invalid
+    /// value is accepted here but rejected with `ValueError` when
+    /// `conformer_ensemble_v2()` is actually called.
+    ///
+    /// `use_symmetric_rmsd_pruning` (default `True`): automorphism-aware
+    /// RMSD (correct on molecules with interchangeable substituents, e.g.
+    /// -CF3, at the cost of enumerating automorphisms per comparison). Set
+    /// `False` for cheaper plain Kabsch RMSD.
+    ///
+    /// `ensemble_timeout_ms` (default `None`): wall-clock budget across
+    /// all `count` attempts combined, checked between attempts only.
+    /// Distinct from `per_conformer`'s own `total_timeout_ms`, which
+    /// budgets a single attempt.
+    #[new]
+    #[pyo3(signature = (
+        per_conformer,
+        count,
+        base_seed,
+        rmsd_threshold = 0.5,
+        use_symmetric_rmsd_pruning = true,
+        ensemble_timeout_ms = None,
+    ))]
+    fn new(
+        per_conformer: &PyPipelineV2Config,
+        count: usize,
+        base_seed: u64,
+        rmsd_threshold: f64,
+        use_symmetric_rmsd_pruning: bool,
+        ensemble_timeout_ms: Option<u64>,
+    ) -> Self {
+        Self {
+            inner: chematic_3d::EnsembleV2Config {
+                per_conformer: per_conformer.inner.clone(),
+                count,
+                base_seed,
+                rmsd_threshold,
+                use_symmetric_rmsd_pruning,
+                ensemble_timeout_ms,
+            },
+        }
+    }
+
+    #[getter]
+    fn count(&self) -> usize {
+        self.inner.count
+    }
+    #[getter]
+    fn base_seed(&self) -> u64 {
+        self.inner.base_seed
+    }
+    #[getter]
+    fn rmsd_threshold(&self) -> f64 {
+        self.inner.rmsd_threshold
+    }
+    #[getter]
+    fn use_symmetric_rmsd_pruning(&self) -> bool {
+        self.inner.use_symmetric_rmsd_pruning
+    }
+    #[getter]
+    fn ensemble_timeout_ms(&self) -> Option<u64> {
+        self.inner.ensemble_timeout_ms
+    }
+    #[getter]
+    fn per_conformer(&self) -> PyPipelineV2Config {
+        PyPipelineV2Config {
+            inner: self.inner.per_conformer.clone(),
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "EnsembleV2Config(count={}, base_seed={}, rmsd_threshold={}, \
+             use_symmetric_rmsd_pruning={}, ensemble_timeout_ms={:?})",
+            self.count(),
+            self.base_seed(),
+            self.rmsd_threshold(),
+            self.use_symmetric_rmsd_pruning(),
+            self.ensemble_timeout_ms(),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Result -> PyDict conversion
+// ---------------------------------------------------------------------------
+
+fn conformer_disposition_dict<'py>(
+    py: Python<'py>,
+    d: &ConformerDisposition,
+) -> PyResult<Bound<'py, PyDict>> {
+    let dict = PyDict::new(py);
+    match d {
+        ConformerDisposition::Kept { conformer_index } => {
+            dict.set_item("kind", "kept")?;
+            dict.set_item("conformer_index", conformer_index)?;
+        }
+        ConformerDisposition::PrunedAsDuplicate {
+            representative_attempt_index,
+            rmsd,
+            symmetric,
+        } => {
+            dict.set_item("kind", "pruned_as_duplicate")?;
+            dict.set_item("representative_attempt_index", representative_attempt_index)?;
+            dict.set_item("rmsd", rmsd)?;
+            dict.set_item("symmetric", symmetric)?;
+        }
+        // `ConformerDisposition` is `#[non_exhaustive]`: a new variant is a
+        // real gap in this binding, not something to paper over silently.
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "unhandled ConformerDisposition variant in Python binding: {other:?}"
+            )));
+        }
+    }
+    Ok(dict)
+}
+
+fn conformer_attempt_dict<'py>(
+    py: Python<'py>,
+    a: &ConformerAttempt,
+) -> PyResult<Bound<'py, PyDict>> {
+    let dict = PyDict::new(py);
+    dict.set_item("attempt_index", a.attempt_index)?;
+    dict.set_item("seed", a.seed)?;
+    match &a.outcome {
+        Ok(success) => {
+            dict.set_item("outcome", "success")?;
+            let success_dict = PyDict::new(py);
+            success_dict.set_item("energy", success.energy)?;
+            success_dict.set_item(
+                "actual_force_field_used",
+                force_field_policy_str(success.actual_force_field_used),
+            )?;
+            match &success.fallback_reason {
+                Some(e) => success_dict
+                    .set_item("fallback_reason", force_field_bridge_error_dict(py, e)?)?,
+                None => success_dict.set_item("fallback_reason", py.None())?,
+            }
+            success_dict.set_item(
+                "disposition",
+                conformer_disposition_dict(py, &success.disposition)?,
+            )?;
+            dict.set_item("success", success_dict)?;
+            dict.set_item("failure", py.None())?;
+        }
+        Err(failure) => {
+            dict.set_item("outcome", "failure")?;
+            dict.set_item("success", py.None())?;
+            dict.set_item("failure", failure_to_dict(py, failure)?)?;
+        }
+    }
+    Ok(dict)
+}
+
+fn ensemble_v2_result_dict<'py>(
+    py: Python<'py>,
+    r: &EnsembleV2Result,
+) -> PyResult<Bound<'py, PyDict>> {
+    let conformer_count = r.ensemble.conformer_count();
+    let conformers: Vec<Vec<Vec<f64>>> = (0..conformer_count)
+        .map(|i| {
+            coords_to_vec(
+                r.ensemble
+                    .get_conformer(i)
+                    .expect("index is within conformer_count()"),
+            )
+        })
+        .collect();
+
+    // Reverse-map Kept{conformer_index} -> the attempt that produced it, so
+    // callers never have to manually scan `attempts` to find out what a
+    // given `conformers[i]` actually is.
+    let mut provenance_by_index: Vec<Option<Bound<'py, PyDict>>> = (0..conformer_count)
+        .map(|_| None::<Bound<'py, PyDict>>)
+        .collect();
+    for attempt in &r.attempts {
+        if let Ok(success) = &attempt.outcome
+            && let ConformerDisposition::Kept { conformer_index } = &success.disposition
+        {
+            let entry = PyDict::new(py);
+            entry.set_item("attempt_index", attempt.attempt_index)?;
+            entry.set_item("seed", attempt.seed)?;
+            entry.set_item("energy", success.energy)?;
+            entry.set_item(
+                "actual_force_field_used",
+                force_field_policy_str(success.actual_force_field_used),
+            )?;
+            provenance_by_index[*conformer_index] = Some(entry);
+        }
+    }
+    let conformer_provenance: Vec<Bound<'py, PyDict>> = provenance_by_index
+        .into_iter()
+        .enumerate()
+        .map(|(i, entry)| {
+            entry.unwrap_or_else(|| {
+                panic!(
+                    "conformer {i} of {conformer_count} has no Kept disposition in `attempts` \
+                     -- embed_ensemble_v2's own invariant is broken, not a case to paper over"
+                )
+            })
+        })
+        .collect();
+
+    let attempts: Vec<Bound<'py, PyDict>> = r
+        .attempts
+        .iter()
+        .map(|a| conformer_attempt_dict(py, a))
+        .collect::<PyResult<Vec<_>>>()?;
+
+    let dict = PyDict::new(py);
+    dict.set_item("conformers", conformers)?;
+    dict.set_item("conformer_provenance", conformer_provenance)?;
+    dict.set_item("attempts", attempts)?;
+    dict.set_item("mixed_force_field", r.mixed_force_field)?;
+    dict.set_item("termination", snake_case_debug(&r.termination))?;
+    dict.set_item("requested_count", r.requested_count)?;
+    Ok(dict)
+}
+
+// ---------------------------------------------------------------------------
+// Entry point called from `Mol::conformer_ensemble_v2` in mol_methods.rs
+// ---------------------------------------------------------------------------
+
+pub fn run_embed_ensemble_v2<'py>(
+    py: Python<'py>,
+    mol: &Molecule,
+    config: &PyEnsembleV2Config,
+) -> PyResult<Bound<'py, PyDict>> {
+    match embed_ensemble_v2(mol, &config.inner) {
+        Ok(result) => ensemble_v2_result_dict(py, &result),
+        Err(e) => Err(PyValueError::new_err(e.to_string())),
+    }
+}

--- a/crates/chematic-py/src/lib.rs
+++ b/crates/chematic-py/src/lib.rs
@@ -18,6 +18,7 @@ type RdkitMorganDetail = (
 );
 
 mod crystal;
+mod ensemble_v2;
 mod formats;
 mod lammps;
 mod misc;
@@ -76,6 +77,7 @@ fn chematic(m: &Bound<'_, PyModule>) -> PyResult<()> {
         "PipelineV2Error",
         m.py().get_type::<pipeline_v2::PipelineV2Error>(),
     )?;
+    m.add_class::<ensemble_v2::PyEnsembleV2Config>()?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
 
     // bulk submodule

--- a/crates/chematic-py/src/mol_methods.rs
+++ b/crates/chematic-py/src/mol_methods.rs
@@ -2490,14 +2490,20 @@ impl Mol {
         coords.points.iter().map(|p| vec![p.x, p.y, p.z]).collect()
     }
 
-    /// Generate multiple conformers with RMSD-based pruning.
+    /// Generate a conformer ensemble using ETKDG + force-field minimization + RMSD pruning.
+    ///
+    /// .. deprecated::
+    ///     Prefer :meth:`conformer_ensemble_v2`, which is deterministic
+    ///     (explicit seed), energy-ranks kept conformers, reports full
+    ///     per-attempt provenance (kept / duplicate-pruned / failed), and
+    ///     avoids a known soundness defect in this method's underlying
+    ///     MMFF94 path (silently zero energy/gradient for atom-type pairs
+    ///     its tables don't cover -- see PR #369). Also, on any internal
+    ///     failure this method silently returns an empty list rather than
+    ///     raising. This method is unchanged and not scheduled for removal
+    ///     in this release.
     ///
     /// Returns a list of coordinate arrays — each is a ``[[x,y,z], ...]`` list.
-    ///
-    /// Args:
-    ///     n: Number of conformers to attempt.
-    ///     rmsd_threshold: Minimum RMSD (Å) between conformers (default 0.5).
-    /// Generate a conformer ensemble using ETKDG + force-field minimization + RMSD pruning.
     ///
     /// Args:
     ///     n: Number of conformers to attempt.
@@ -2684,6 +2690,55 @@ impl Mol {
         config: &crate::pipeline_v2::PyPipelineV2Config,
     ) -> PyResult<Bound<'py, PyDict>> {
         crate::pipeline_v2::run_embed_pipeline_v2(py, &self.inner, config)
+    }
+
+    /// Generate a multi-conformer ensemble by calling the v2 embedding
+    /// pipeline (:meth:`embed_pipeline_v2`) ``config.count`` times, once
+    /// per deterministically derived seed, then selecting kept
+    /// representatives by ascending energy within each force-field group.
+    ///
+    /// Unlike :meth:`embed_pipeline_v2`, a call here does **not** raise
+    /// just because no conformer was kept -- every per-attempt outcome,
+    /// including an ensemble where every attempt failed, is a normal,
+    /// fully-diagnosable result. This only raises ``ValueError`` for a
+    /// ``config`` that could never succeed regardless of the molecule
+    /// (currently: an invalid ``rmsd_threshold``). Always check
+    /// ``len(result["conformers"])`` rather than relying on "no exception."
+    ///
+    /// Applied directly to this ``Mol``'s own atom order -- never
+    /// canonicalizes/reparses first (see issue #172).
+    ///
+    /// ``config``: an :class:`EnsembleV2Config`.
+    ///
+    /// Returns a dict with keys:
+    ///     conformers: kept conformers only, as ``[[[x,y,z], ...], ...]``,
+    ///         ordered group-by-group (by force field actually used),
+    ///         ascending energy within each group. Never a single
+    ///         cross-group energy sort -- MMFF94 and UFF energies are not
+    ///         on a comparable scale (see ``mixed_force_field`` below).
+    ///     conformer_provenance: one dict per entry of ``conformers``, same
+    ///         order: ``attempt_index``, ``seed``, ``energy``,
+    ///         ``actual_force_field_used``.
+    ///     attempts: every attempt, success or failure, in order. Each has
+    ///         ``attempt_index``, ``seed``, ``outcome`` (``"success"`` or
+    ///         ``"failure"``), and one of ``success``/``failure`` populated.
+    ///         A successful attempt's dict has ``energy``,
+    ///         ``actual_force_field_used``, ``fallback_reason``, and
+    ///         ``disposition`` (``{"kind": "kept", "conformer_index"}`` or
+    ///         ``{"kind": "pruned_as_duplicate", "representative_attempt_index",
+    ///         "rmsd", "symmetric"}``). A failed attempt's dict has the same
+    ///         shape :meth:`embed_pipeline_v2` raises on failure.
+    ///     mixed_force_field: ``True`` iff kept conformers span more than
+    ///         one force field actually used.
+    ///     termination: ``"completed"`` or ``"timed_out"``
+    ///         (``ensemble_timeout_ms`` exhausted before all attempts ran).
+    ///     requested_count: ``config.count`` at call time.
+    fn conformer_ensemble_v2<'py>(
+        &self,
+        py: Python<'py>,
+        config: &crate::ensemble_v2::PyEnsembleV2Config,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        crate::ensemble_v2::run_embed_ensemble_v2(py, &self.inner, config)
     }
 
     /// Scan a torsion dihedral (atoms i–j–k–l) over 360° in ``steps`` increments.

--- a/crates/chematic-py/src/pipeline_v2.rs
+++ b/crates/chematic-py/src/pipeline_v2.rs
@@ -90,7 +90,7 @@ fn parse_force_field_policy(s: &str) -> PyResult<ForceFieldPolicy> {
     }
 }
 
-fn force_field_policy_str(p: ForceFieldPolicy) -> &'static str {
+pub(crate) fn force_field_policy_str(p: ForceFieldPolicy) -> &'static str {
     match p {
         ForceFieldPolicy::Mmff94BondAngleStrict => "mmff94_bond_angle_strict",
         ForceFieldPolicy::Mmff94WithUffFallback => "mmff94_with_uff_fallback",
@@ -104,7 +104,7 @@ fn force_field_policy_str(p: ForceFieldPolicy) -> &'static str {
 /// this pipeline (e.g. `EmbedFailureCause::BoundsSmoothingFailed` ->
 /// `"bounds_smoothing_failed"`). Not used for enums with data-carrying variants
 /// (those get hand-written conversions above/below so the payload isn't lost).
-fn snake_case_debug<T: std::fmt::Debug>(value: &T) -> String {
+pub(crate) fn snake_case_debug<T: std::fmt::Debug>(value: &T) -> String {
     let debug = format!("{value:?}");
     let mut out = String::with_capacity(debug.len() + 4);
     for (i, c) in debug.chars().enumerate() {
@@ -364,7 +364,7 @@ impl PyPipelineV2Config {
 // Result / failure -> PyDict conversion
 // ---------------------------------------------------------------------------
 
-fn coords_to_vec(coords: &chematic_3d::coords::Coords3D) -> Vec<Vec<f64>> {
+pub(crate) fn coords_to_vec(coords: &chematic_3d::coords::Coords3D) -> Vec<Vec<f64>> {
     coords.points.iter().map(|p| vec![p.x, p.y, p.z]).collect()
 }
 
@@ -703,7 +703,7 @@ fn mmff94_coverage_dict<'py>(
     Ok(d)
 }
 
-fn force_field_bridge_error_dict<'py>(
+pub(crate) fn force_field_bridge_error_dict<'py>(
     py: Python<'py>,
     e: &chematic_3d::minimize::ForceFieldBridgeError,
 ) -> PyResult<Bound<'py, PyDict>> {
@@ -966,7 +966,10 @@ fn failure_cause_dict<'py>(
     Ok(d)
 }
 
-fn failure_to_dict<'py>(py: Python<'py>, f: &PipelineV2Failure) -> PyResult<Bound<'py, PyDict>> {
+pub(crate) fn failure_to_dict<'py>(
+    py: Python<'py>,
+    f: &PipelineV2Failure,
+) -> PyResult<Bound<'py, PyDict>> {
     let d = PyDict::new(py);
     d.set_item("cause", failure_cause_dict(py, &f.cause)?)?;
     d.set_item("stage", snake_case_debug(&f.stage))?;

--- a/crates/chematic-py/tests/test_conformer_ensemble_v2.py
+++ b/crates/chematic-py/tests/test_conformer_ensemble_v2.py
@@ -1,0 +1,224 @@
+"""Regression tests for `Mol.conformer_ensemble_v2()` (A2.1) -- the Python
+binding for `chematic_3d::embed_ensemble_v2` (A2, PR #373).
+
+`embed_ensemble_v2` calls `embed_pipeline_v2` under the hood, which is
+already proven (see `test_pipeline_v2.py`, issue #172) to generate directly
+on the caller's own atom order without reparsing. So this file needs only
+a light confirming sweep for atom-index consistency, not the full 6-fixture
+regression suite `test_conformer_ensemble.py` needed to catch that bug in
+the first place. The focus here is A2.1-specific: determinism, full
+attempt provenance (kept / duplicate-pruned / failed), the
+conformer<->provenance cross-reference, and the config-validation
+error path.
+"""
+import math
+
+import chematic
+
+
+MIN_BOND_LEN = 0.6
+MAX_BOND_LEN = 2.6
+MIN_INTERATOMIC_DIST = 0.4
+
+ASPIRIN = "CC(=O)Oc1ccccc1C(=O)O"
+BRANCHED = "CCC(C)C"
+DISCONNECTED = "CCO.CC(C)C"
+STEREO = "F[C@@](Cl)(Br)I"
+
+
+def _assert_consistent_indexing(mol, conformer):
+    assert len(conformer) == mol.heavy_atoms
+    for a1, a2, _btype, _arom in mol.bond_table:
+        d = math.dist(conformer[a1], conformer[a2])
+        assert MIN_BOND_LEN <= d <= MAX_BOND_LEN, (
+            f"bond {a1}-{a2} has length {d:.3f} -- outside sane range "
+            f"[{MIN_BOND_LEN}, {MAX_BOND_LEN}]; likely atom-index mismatch"
+        )
+    n = len(conformer)
+    for i in range(n):
+        for j in range(i + 1, n):
+            d = math.dist(conformer[i], conformer[j])
+            assert d >= MIN_INTERATOMIC_DIST, (
+                f"atoms {i},{j} are {d:.3f} A apart -- degenerate/clashing geometry"
+            )
+
+
+def _config(count=4, base_seed=1, rmsd_threshold=0.5, max_attempts=1, **overrides):
+    per_conformer = chematic.PipelineV2Config.safe(
+        force_field="dreiding",
+        stereo_policy="verify_only",
+        ring_torsion_policy="diagnostic_only",
+        max_attempts=max_attempts,
+    )
+    return chematic.EnsembleV2Config(
+        per_conformer,
+        count=count,
+        base_seed=base_seed,
+        rmsd_threshold=rmsd_threshold,
+        **overrides,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Atom-index consistency (light sweep -- see module doc for why this is
+# lighter than test_conformer_ensemble.py's own 6-fixture suite)
+# ---------------------------------------------------------------------------
+
+
+def test_atom_index_consistency_across_structural_classes():
+    for smiles in (ASPIRIN, BRANCHED, DISCONNECTED, STEREO):
+        mol = chematic.from_smiles(smiles)
+        result = mol.conformer_ensemble_v2(_config(count=3, base_seed=7))
+        assert len(result["conformers"]) >= 1, smiles
+        for conformer in result["conformers"]:
+            _assert_consistent_indexing(mol, conformer)
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_same_base_seed_is_deterministic():
+    mol = chematic.from_smiles(ASPIRIN)
+    config = _config(count=6, base_seed=42)
+    r1 = mol.conformer_ensemble_v2(config)
+    r2 = mol.conformer_ensemble_v2(config)
+    assert r1["conformers"] == r2["conformers"]
+    assert r1["conformer_provenance"] == r2["conformer_provenance"]
+
+
+def test_different_base_seeds_are_not_aliased():
+    mol = chematic.from_smiles(ASPIRIN)
+    r1 = mol.conformer_ensemble_v2(_config(count=1, base_seed=1))
+    r2 = mol.conformer_ensemble_v2(_config(count=1, base_seed=2))
+    assert len(r1["conformers"]) == 1
+    assert len(r2["conformers"]) == 1
+    assert r1["conformers"][0] != r2["conformers"][0]
+
+
+# ---------------------------------------------------------------------------
+# Full provenance shape
+# ---------------------------------------------------------------------------
+
+
+def test_every_attempt_recorded_with_exactly_one_outcome_populated():
+    mol = chematic.from_smiles(ASPIRIN)
+    result = mol.conformer_ensemble_v2(_config(count=5, base_seed=100))
+    assert len(result["attempts"]) == 5
+    assert result["requested_count"] == 5
+    assert result["termination"] == "completed"
+    for i, attempt in enumerate(result["attempts"]):
+        assert attempt["attempt_index"] == i
+        assert attempt["outcome"] in ("success", "failure")
+        if attempt["outcome"] == "success":
+            assert attempt["success"] is not None
+            assert attempt["failure"] is None
+            assert attempt["success"]["disposition"]["kind"] in (
+                "kept",
+                "pruned_as_duplicate",
+            )
+        else:
+            assert attempt["success"] is None
+            assert attempt["failure"] is not None
+
+
+def test_conformer_provenance_cross_references_kept_attempts():
+    mol = chematic.from_smiles(ASPIRIN)
+    result = mol.conformer_ensemble_v2(_config(count=8, base_seed=20260823))
+    provenance = result["conformer_provenance"]
+    assert len(provenance) == len(result["conformers"])
+
+    kept_attempt_indices = {
+        a["attempt_index"]
+        for a in result["attempts"]
+        if a["outcome"] == "success" and a["success"]["disposition"]["kind"] == "kept"
+    }
+    for entry in provenance:
+        assert entry["attempt_index"] in kept_attempt_indices
+        matching = result["attempts"][entry["attempt_index"]]
+        assert matching["outcome"] == "success"
+        assert matching["success"]["disposition"]["kind"] == "kept"
+        assert entry["seed"] == matching["seed"]
+        assert entry["energy"] == matching["success"]["energy"]
+
+
+def test_pruned_duplicate_points_back_at_a_kept_representative():
+    """Propane's heavy-atom skeleton (C-C-C) has no dihedral degree of
+    freedom, so a generous rmsd_threshold reliably collapses every attempt
+    to one kept representative -- exercising the real
+    PrunedAsDuplicate/Kept round trip end to end, not just its shape."""
+    mol = chematic.from_smiles("CCC")
+    result = mol.conformer_ensemble_v2(
+        _config(count=6, base_seed=99, rmsd_threshold=5.0)
+    )
+    kept = [
+        a
+        for a in result["attempts"]
+        if a["outcome"] == "success" and a["success"]["disposition"]["kind"] == "kept"
+    ]
+    pruned = [
+        a
+        for a in result["attempts"]
+        if a["outcome"] == "success"
+        and a["success"]["disposition"]["kind"] == "pruned_as_duplicate"
+    ]
+    assert len(kept) == 1, f"expected exactly one representative, got {len(kept)}"
+    assert pruned, "expected at least one pruned duplicate at this generous threshold"
+    kept_index = kept[0]["attempt_index"]
+    for a in pruned:
+        disposition = a["success"]["disposition"]
+        assert disposition["representative_attempt_index"] == kept_index
+        assert 0.0 <= disposition["rmsd"] < 5.0
+        assert disposition["symmetric"] is True
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_rmsd_threshold_raises_value_error_at_call_time():
+    mol = chematic.from_smiles("CCC")
+    per_conformer = chematic.PipelineV2Config.safe(
+        force_field="dreiding",
+        stereo_policy="verify_only",
+        ring_torsion_policy="diagnostic_only",
+        max_attempts=1,
+    )
+    for bad in (-1.0, float("nan"), float("inf")):
+        # Construction itself is infallible -- matches the Rust
+        # EnsembleV2Config struct, which has no invariant of its own.
+        config = chematic.EnsembleV2Config(per_conformer, count=1, base_seed=1, rmsd_threshold=bad)
+        try:
+            mol.conformer_ensemble_v2(config)
+            raise AssertionError(f"rmsd_threshold={bad} should have raised ValueError")
+        except ValueError:
+            pass
+
+
+def test_zero_rmsd_threshold_is_accepted_as_pruning_disabled():
+    mol = chematic.from_smiles("CCC")
+    result = mol.conformer_ensemble_v2(_config(count=2, base_seed=1, rmsd_threshold=0.0))
+    assert len(result["attempts"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Legacy API: deprecation note added, behavior unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_conformer_ensemble_docstring_has_deprecation_note():
+    doc = chematic.Mol.conformer_ensemble.__doc__ or ""
+    assert "deprecated" in doc.lower()
+    assert "conformer_ensemble_v2" in doc
+
+
+def test_conformer_ensemble_behavior_unchanged():
+    """Sanity check that the docstring-only edit didn't touch behavior."""
+    mol = chematic.from_smiles(ASPIRIN)
+    ensemble = mol.conformer_ensemble(3, 0.5, "dreiding", 30.0)
+    assert isinstance(ensemble, list)
+    assert len(ensemble) >= 1
+    for conformer in ensemble:
+        _assert_consistent_indexing(mol, conformer)


### PR DESCRIPTION
## Summary

A2.1: exposes `chematic_3d::embed_ensemble_v2` (A2, PR #373) to Python as a **new** method, `Mol.conformer_ensemble_v2(config)`, alongside the existing `Mol.conformer_ensemble()` — not a replacement, per explicit instruction.

- `EnsembleV2Config(per_conformer, count, base_seed, rmsd_threshold=0.5, use_symmetric_rmsd_pruning=True, ensemble_timeout_ms=None)` — seed, attempt count, ensemble-wide timeout, and RMSD threshold are all explicit. Construction is infallible; an invalid `rmsd_threshold` raises `ValueError` at `conformer_ensemble_v2()` call time (where the Rust core itself validates it), not at construction.
- The returned dict carries full per-attempt provenance in `attempts` (kept / pruned-as-duplicate / failed), plus `conformers` (kept coordinates only, group-then-energy ordered) and a parallel `conformer_provenance` list so callers never have to manually cross-reference `attempts` to know what a given `conformers[i]` is.
- MMFF94 and UFF energies are never cross-compared: ranking and pruning are scoped strictly within each force field actually used; `mixed_force_field` discloses when kept conformers span more than one group. No flattened, globally-sorted energy field is exposed.
- Unlike `embed_pipeline_v2`, a call here never raises just because zero conformers were kept — every per-attempt outcome is a normal, diagnosable result. Documented explicitly since "no exception" ≠ "got a conformer."
- `conformer_ensemble()` (legacy, `etkdg`-backed) is unchanged — no behavior/return-type change, no removal. Its docstring gains a deprecation note (pointing at the new method, naming concrete reasons: no seed, no energy ranking, silent `Err(_) => []`, the live MMFF94-zero-energy defect from PR #369), and its pre-existing duplicated intro paragraph is cleaned up in the same edit.
- Implementation reuses `pipeline_v2.rs`'s existing dict-conversion helpers (`coords_to_vec`, `force_field_policy_str`, `force_field_bridge_error_dict`, `failure_to_dict`, `snake_case_debug`), widened from private `fn` to `pub(crate) fn` (visibility only, no signature change) rather than duplicating them in the new `ensemble_v2.rs` module.

## Scope

Rust core (`chematic_3d::embed_ensemble_v2`) is unchanged — this PR is bindings only. No WASM bindings, no version bump, no best-of-N-vs-RDKit benchmark arm — those are the planned next steps, not part of this change.

## Test plan

- [x] `cargo test -p chematic-3d -p chematic-py --lib` — 560 + related crate tests, 0 failures
- [x] `cargo clippy -p chematic-py -p chematic-3d --lib -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] New `crates/chematic-py/tests/test_conformer_ensemble_v2.py` (10 tests): atom-index consistency across structural classes, determinism, full per-attempt provenance shape, `conformer_provenance` cross-reference to `attempts`, a real (not synthetic) pruned-duplicate round trip on propane, invalid-`rmsd_threshold` error path, `conformer_ensemble()` behavior-unchanged + deprecation-note-present checks
- [x] Full `bash scripts/check.sh` (fmt, clippy, all Rust crate tests, full 757-item pytest suite incl. the new file, cargo-deny, publish graph, version consistency) — all green, "All checks passed."