### PR TITLE
feat(3d,py,wasm): expose expand_implicit_h_through_pipeline + stereo_safe preset (issue #383)

### DIFF
--- a/crates/chematic-3d/src/pipeline_v2.rs
+++ b/crates/chematic-3d/src/pipeline_v2.rs
@@ -320,6 +320,37 @@ impl PipelineV2Config {
             expand_implicit_h_through_pipeline: false,
         }
     }
+
+    /// Convenience constructor for the "stereo-safe" configuration (issue
+    /// #291/#383): the exact 3-flag combination measured to close #291's
+    /// residual for ring-fused declared stereocenters (testosterone,
+    /// cholesterol, and similar) -- [`StereoPolicy::RepairAndVerify`],
+    /// `embed.enforce_chirality: true`, and
+    /// `expand_implicit_h_through_pipeline: true`, always set together.
+    /// These three only work correctly as a set (`expand_implicit_h_through_pipeline`
+    /// requires `enforce_chirality`, stage-1-validated elsewhere in this
+    /// module; `RepairAndVerify` is what actually uses the corrected
+    /// geometry) -- exposing them as independent flags risks a caller
+    /// setting some but not all of them, silently landing back on a
+    /// configuration issue #291's own measurement found unsound. Everything
+    /// else matches [`Self::minimal`]'s conservative defaults; override any
+    /// other field on the returned value the same way `minimal`'s own
+    /// callers already do. `max_attempts` is deliberately left at
+    /// `EmbedParameters::default()`'s `8` -- the exact value the 29-molecule
+    /// regression measurement (`crates/chematic-3d/examples/
+    /// issue291_repair_policy_measurement.rs`) validated (144/145 correct,
+    /// 0 silently wrong), not bumped speculatively.
+    pub fn stereo_safe(force_field_policy: ForceFieldPolicy) -> Self {
+        Self {
+            stereo_policy: StereoPolicy::RepairAndVerify,
+            embed: EmbedParameters {
+                enforce_chirality: true,
+                ..EmbedParameters::default()
+            },
+            expand_implicit_h_through_pipeline: true,
+            ..Self::minimal(force_field_policy)
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1624,6 +1655,33 @@ mod tests {
                     "atom {idx:?}: declared {code:?} but 3D-perceived {perceived_code:?} \
                      -- pipeline reported success with wrong chirality"
                 );
+            }
+        }
+    }
+
+    #[test]
+    fn stereo_safe_matches_the_hand_built_configuration_above() {
+        // issue #383: `stereo_safe` must be exactly the same as manually setting the
+        // 3 flags -- same testosterone happy-path, same seed, same expectations as
+        // `expand_implicit_h_through_pipeline_fixes_testosterone_with_correct_geometry`
+        // above, just built via the convenience constructor instead.
+        let mol = parse("C[C@]12CC[C@H]3[C@@H](CC[C@H]4CCC(=O)C=C34)[C@@H]1CC[C@@H]2O").unwrap();
+        let declared = chematic_chem::assign_cip(&mol);
+
+        let mut config = PipelineV2Config::stereo_safe(ForceFieldPolicy::Mmff94WithUffFallback);
+        assert!(config.embed.enforce_chirality);
+        assert!(config.expand_implicit_h_through_pipeline);
+        assert_eq!(config.stereo_policy, StereoPolicy::RepairAndVerify);
+        config.embed.random_seed = 0;
+
+        let result = embed_pipeline_v2(&mol, &config).expect("testosterone must succeed");
+        assert!(result.final_stereo.is_fully_satisfied());
+        assert_eq!(result.coords.atom_count(), mol.atom_count());
+
+        let perceived = crate::stereo3d::assign_stereo_from_3d(&mol, &result.coords);
+        for &(idx, code) in &declared.assignments {
+            if let Some(perceived_code) = perceived.get(idx) {
+                assert_eq!(perceived_code, code);
             }
         }
     }

--- a/crates/chematic-py/python/chematic/__init__.pyi
+++ b/crates/chematic-py/python/chematic/__init__.pyi
@@ -3111,6 +3111,7 @@ class PipelineV2Config:
         ring_torsion_policy: str,
         total_timeout_ms: Optional[int],
         enforce_chirality: bool = False,
+        expand_implicit_h_through_pipeline: bool = False,
     ) -> None: ...
     @staticmethod
     def safe(
@@ -3131,6 +3132,7 @@ class PipelineV2Config:
         gate_mmff94_stretch_bend: bool = False,
         total_timeout_ms: Optional[int] = None,
         enforce_chirality: bool = False,
+        expand_implicit_h_through_pipeline: bool = False,
     ) -> "PipelineV2Config":
         """Convenience constructor.
 
@@ -3138,6 +3140,39 @@ class PipelineV2Config:
         still required, explicit arguments -- never hidden defaults --
         everything else takes a conservative default (every torsion-knowledge
         flag off, ``fail_on_unevaluable_stereo=False``, no timeouts).
+        """
+        ...
+    @staticmethod
+    def stereo_safe(
+        force_field: str,
+        ring_torsion_policy: str,
+        fail_on_unevaluable_stereo: bool = False,
+        embed_seed: int = ...,
+        max_attempts: int = 8,
+        embed_timeout_ms: Optional[int] = None,
+        use_exp_torsions: bool = False,
+        use_small_ring_torsions: bool = False,
+        use_macrocycle_torsions: bool = False,
+        use_macrocycle_14_bounds: bool = False,
+        include_legacy_torsion_heuristic: bool = False,
+        force_field_max_iterations: int = 200,
+        gate_mmff94_torsion_oop: bool = False,
+        gate_mmff94_stretch_bend: bool = False,
+        total_timeout_ms: Optional[int] = None,
+    ) -> "PipelineV2Config":
+        """Convenience constructor for the "stereo-safe" configuration (issue
+        #291/#383): sets ``stereo_policy="repair_and_verify"``,
+        ``enforce_chirality=True``, and
+        ``expand_implicit_h_through_pipeline=True`` together -- the exact
+        combination measured to correctly handle ring-fused declared
+        stereocenters (e.g. testosterone, cholesterol) that
+        ``enforce_chirality`` alone cannot repair. Prefer this over setting
+        those three individually via :meth:`safe`/the constructor: they only
+        work correctly as a set, and forgetting one silently falls back to a
+        configuration issue #291 measured as unsound for that molecule
+        class. ``force_field``/``ring_torsion_policy`` are still required,
+        explicit arguments; everything else takes the same conservative
+        defaults :meth:`safe` does.
         """
         ...
 
@@ -3165,6 +3200,19 @@ class PipelineV2Config:
     composing the two repair mechanisms measurably improves correctness with
     no observed regressions). Default ``False``, matching the Rust
     ``EmbedParameters`` default -- existing callers are unaffected."""
+
+    expand_implicit_h_through_pipeline: bool
+    """Issue #291/#383: for declared stereocenters whose only non-ring
+    substituent is an implicit H (ring-fused steroid-like centers such as
+    testosterone/cholesterol), run the whole pipeline on a temporary
+    ``add_hydrogens``-expanded copy of the molecule instead of the original,
+    then map the result back onto the original atom count before returning.
+    Requires ``enforce_chirality=True`` (raises :class:`PipelineV2Error`
+    otherwise). Prefer :meth:`stereo_safe` over setting this flag alone --
+    it only works correctly combined with ``stereo_policy="repair_and_verify"``
+    and ``enforce_chirality=True``, which ``stereo_safe`` sets together so a
+    caller can't set one but forget another. Default ``False``, matching the
+    Rust ``PipelineV2Config`` default -- existing callers are unaffected."""
 
     def __repr__(self) -> str: ...
 

--- a/crates/chematic-py/src/pipeline_v2.rs
+++ b/crates/chematic-py/src/pipeline_v2.rs
@@ -157,6 +157,7 @@ impl PyPipelineV2Config {
         ring_torsion_policy,
         total_timeout_ms,
         enforce_chirality = false,
+        expand_implicit_h_through_pipeline = false,
     ))]
     fn new(
         embed_seed: u64,
@@ -184,6 +185,15 @@ impl PyPipelineV2Config {
         // `"repair_and_verify"` (raises `PipelineV2Error` at validate-config
         // otherwise).
         enforce_chirality: bool,
+        // Same trailing-defaulted precedent again (issue #291/#383). Requires
+        // `enforce_chirality=True` (raises `PipelineV2Error` at validate-config
+        // otherwise) -- see `PipelineV2Config::expand_implicit_h_through_pipeline`'s
+        // own Rust doc for what it does. Prefer `PipelineV2Config.stereo_safe(...)`
+        // over setting this flag alone: it only works correctly combined with
+        // `stereo_policy="repair_and_verify"` and `enforce_chirality=True`, and
+        // `stereo_safe` sets all three together so a caller can't set one but
+        // forget another.
+        expand_implicit_h_through_pipeline: bool,
     ) -> PyResult<Self> {
         Ok(Self {
             inner: pv2::PipelineV2Config {
@@ -208,10 +218,7 @@ impl PyPipelineV2Config {
                 gate_mmff94_stretch_bend,
                 ring_torsion_policy: parse_ring_torsion_policy(ring_torsion_policy)?,
                 total_timeout_ms,
-                // Issue #291 pipeline-level H-expansion: Rust-core-only for now
-                // (not yet exposed as a constructor argument here), same staging
-                // PR #380 used for the embed-level `materialize_implicit_h_for_chirality`.
-                expand_implicit_h_through_pipeline: false,
+                expand_implicit_h_through_pipeline,
             },
         })
     }
@@ -240,6 +247,7 @@ impl PyPipelineV2Config {
         gate_mmff94_stretch_bend = false,
         total_timeout_ms = None,
         enforce_chirality = false,
+        expand_implicit_h_through_pipeline = false,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn safe(
@@ -260,6 +268,7 @@ impl PyPipelineV2Config {
         gate_mmff94_stretch_bend: bool,
         total_timeout_ms: Option<u64>,
         enforce_chirality: bool,
+        expand_implicit_h_through_pipeline: bool,
     ) -> PyResult<Self> {
         Self::new(
             embed_seed,
@@ -279,7 +288,74 @@ impl PyPipelineV2Config {
             ring_torsion_policy,
             total_timeout_ms,
             enforce_chirality,
+            expand_implicit_h_through_pipeline,
         )
+    }
+
+    /// Convenience constructor for the "stereo-safe" configuration (issue
+    /// #291/#383): sets `stereo_policy="repair_and_verify"`,
+    /// `enforce_chirality=True`, and `expand_implicit_h_through_pipeline=True`
+    /// together -- the exact combination measured to correctly handle
+    /// ring-fused declared stereocenters (e.g. testosterone, cholesterol) that
+    /// `enforce_chirality` alone cannot repair. These three only work
+    /// correctly as a set; prefer this over setting them individually via
+    /// `safe(...)`/the constructor, where forgetting one silently falls back
+    /// to a configuration issue #291 measured as unsound for that molecule
+    /// class. `force_field`/`ring_torsion_policy` are still required,
+    /// explicit arguments; everything else takes the same conservative
+    /// defaults `safe(...)` does.
+    #[staticmethod]
+    #[pyo3(signature = (
+        force_field,
+        ring_torsion_policy,
+        fail_on_unevaluable_stereo = false,
+        embed_seed = 0xC0FF_EE42_D157_6E02,
+        max_attempts = 8,
+        embed_timeout_ms = None,
+        use_exp_torsions = false,
+        use_small_ring_torsions = false,
+        use_macrocycle_torsions = false,
+        use_macrocycle_14_bounds = false,
+        include_legacy_torsion_heuristic = false,
+        force_field_max_iterations = 200,
+        gate_mmff94_torsion_oop = false,
+        gate_mmff94_stretch_bend = false,
+        total_timeout_ms = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn stereo_safe(
+        force_field: &str,
+        ring_torsion_policy: &str,
+        fail_on_unevaluable_stereo: bool,
+        embed_seed: u64,
+        max_attempts: usize,
+        embed_timeout_ms: Option<u64>,
+        use_exp_torsions: bool,
+        use_small_ring_torsions: bool,
+        use_macrocycle_torsions: bool,
+        use_macrocycle_14_bounds: bool,
+        include_legacy_torsion_heuristic: bool,
+        force_field_max_iterations: usize,
+        gate_mmff94_torsion_oop: bool,
+        gate_mmff94_stretch_bend: bool,
+        total_timeout_ms: Option<u64>,
+    ) -> PyResult<Self> {
+        let mut inner = pv2::PipelineV2Config::stereo_safe(parse_force_field_policy(force_field)?);
+        inner.ring_torsion_policy = parse_ring_torsion_policy(ring_torsion_policy)?;
+        inner.fail_on_unevaluable_stereo = fail_on_unevaluable_stereo;
+        inner.embed.random_seed = embed_seed;
+        inner.embed.max_attempts = max_attempts;
+        inner.embed.timeout_ms = embed_timeout_ms;
+        inner.embed.use_exp_torsions = use_exp_torsions;
+        inner.embed.use_small_ring_torsions = use_small_ring_torsions;
+        inner.embed.use_macrocycle_torsions = use_macrocycle_torsions;
+        inner.embed.use_macrocycle_14_bounds = use_macrocycle_14_bounds;
+        inner.include_legacy_torsion_heuristic = include_legacy_torsion_heuristic;
+        inner.force_field_max_iterations = force_field_max_iterations;
+        inner.gate_mmff94_torsion_oop = gate_mmff94_torsion_oop;
+        inner.gate_mmff94_stretch_bend = gate_mmff94_stretch_bend;
+        inner.total_timeout_ms = total_timeout_ms;
+        Ok(Self { inner })
     }
 
     #[getter]
@@ -349,6 +425,10 @@ impl PyPipelineV2Config {
     #[getter]
     fn enforce_chirality(&self) -> bool {
         self.inner.embed.enforce_chirality
+    }
+    #[getter]
+    fn expand_implicit_h_through_pipeline(&self) -> bool {
+        self.inner.expand_implicit_h_through_pipeline
     }
 
     fn __repr__(&self) -> String {

--- a/crates/chematic-py/tests/test_pipeline_v2.py
+++ b/crates/chematic-py/tests/test_pipeline_v2.py
@@ -450,6 +450,77 @@ def test_enforce_chirality_with_repair_and_verify_is_allowed():
 
 
 # ---------------------------------------------------------------------------
+# expand_implicit_h_through_pipeline / stereo_safe (issue #291/#383)
+# ---------------------------------------------------------------------------
+
+TESTOSTERONE = "C[C@]12CC[C@H]3[C@@H](CC[C@H]4CCC(=O)C=C34)[C@@H]1CC[C@@H]2O"
+
+
+def test_expand_implicit_h_through_pipeline_requires_enforce_chirality():
+    mol = chematic.from_smiles(TESTOSTERONE)
+    config = _safe_config(
+        expand_implicit_h_through_pipeline=True,
+        enforce_chirality=False,
+    )
+    with pytest.raises(chematic.PipelineV2Error) as excinfo:
+        mol.embed_pipeline_v2(config)
+    diag = excinfo.value.diagnostics
+    assert diag["cause"] == {"kind": "invalid_configuration"}
+    assert diag["stage"] == "validate_config"
+
+
+def test_stereo_safe_sets_all_three_flags_together():
+    config = chematic.PipelineV2Config.stereo_safe(
+        force_field="mmff94_with_uff_fallback",
+        ring_torsion_policy="fail_closed",
+    )
+    assert config.stereo_policy == "repair_and_verify"
+    assert config.enforce_chirality is True
+    assert config.expand_implicit_h_through_pipeline is True
+
+
+def test_stereo_safe_fixes_testosterone_via_python_binding():
+    """Issue #291/#383: testosterone via the Python binding, same seed/
+    configuration already Rust-level tested and cross-checked against an
+    independent oracle in pipeline_v2.rs's own
+    stereo_safe_matches_the_hand_built_configuration_above test."""
+    mol = chematic.from_smiles(TESTOSTERONE)
+    config = chematic.PipelineV2Config.stereo_safe(
+        force_field="mmff94_with_uff_fallback",
+        ring_torsion_policy="diagnostic_only",
+        embed_seed=0,
+    )
+    result = mol.embed_pipeline_v2(config)
+    assert result["final_stereo"]["is_fully_satisfied"] is True
+    assert result["final_stereo"]["n_violations"] == 0
+    assert len(result["coords"]) == mol.heavy_atoms
+
+
+def test_expand_implicit_h_through_pipeline_is_noop_without_declared_stereo():
+    """A molecule with no declared stereo must give an identical result with
+    the flag on vs. off -- decane has no stereocenters at all."""
+    mol = chematic.from_smiles(DECANE)
+    base = mol.embed_pipeline_v2(
+        _safe_config(
+            force_field="mmff94_with_uff_fallback",
+            stereo_policy="repair_and_verify",
+            enforce_chirality=True,
+            embed_seed=0,
+        )
+    )
+    expanded = mol.embed_pipeline_v2(
+        _safe_config(
+            force_field="mmff94_with_uff_fallback",
+            stereo_policy="repair_and_verify",
+            enforce_chirality=True,
+            expand_implicit_h_through_pipeline=True,
+            embed_seed=0,
+        )
+    )
+    assert expanded["coords"] == base["coords"]
+
+
+# ---------------------------------------------------------------------------
 # .pyi stub existence check ("type stub test")
 # ---------------------------------------------------------------------------
 
@@ -479,6 +550,8 @@ def test_pyi_declares_the_new_public_surface():
     }
     assert "safe" in config_methods
     assert hasattr(chematic.PipelineV2Config, "safe")
+    assert "stereo_safe" in config_methods
+    assert hasattr(chematic.PipelineV2Config, "stereo_safe")
 
     mol_class = next(
         node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "Mol"

--- a/crates/chematic-wasm/README.md
+++ b/crates/chematic-wasm/README.md
@@ -122,11 +122,32 @@ const response = JSON.parse(embed_pipeline_v2_json(mol, JSON.stringify({
   forceFieldPolicy: "none",
   forceFieldMaxIterations: 200,
   gateMmff94TorsionOop: false,
+  gateMmff94StretchBend: false,
   ringTorsionPolicy: "fail_closed",
   totalTimeoutMs: null,
+  enforceChirality: false,
+  expandImplicitHThroughPipeline: false,
 })));
 // response.ok, response.result / response.error — same shape as
 // Mol.embed_pipeline_v2() in the Python binding.
+```
+
+For ring-fused declared stereocenters (e.g. testosterone, cholesterol) that
+`enforceChirality` alone can't repair, `stereoPolicy: "repair_and_verify"` +
+`enforceChirality: true` + `expandImplicitHThroughPipeline: true` are needed
+*together* (issue #291/#383) — `pipeline_v2_stereo_safe_config_json` builds
+that exact combination so a caller can't set one and forget another:
+
+```js
+const configResponse = JSON.parse(pipeline_v2_stereo_safe_config_json(
+  "mmff94_with_uff_fallback", "fail_closed"
+));
+// configResponse.ok, configResponse.config (or configResponse.error, same
+// shape as embed_pipeline_v2_json's own error) — modify configResponse.config
+// (e.g. a different embedSeed) before passing it to embed_pipeline_v2_json.
+const response = JSON.parse(
+  embed_pipeline_v2_json(mol, JSON.stringify(configResponse.config))
+);
 ```
 
 Verified working end-to-end under real WASM (both `wasm-pack --target nodejs`

--- a/crates/chematic-wasm/src/pipeline_v2.rs
+++ b/crates/chematic-wasm/src/pipeline_v2.rs
@@ -214,6 +214,15 @@ struct PipelineV2ConfigJson {
     // every existing arm's unchanged behavior).
     #[serde(default)]
     enforce_chirality: bool,
+    // #[serde(default)]: same precedent again (issue #291/#383). Requires
+    // `enforceChirality: true` (raises the same `invalid_configuration` error
+    // otherwise) -- see `PipelineV2Config::expand_implicit_h_through_pipeline`'s
+    // own Rust doc for what it does. Prefer `pipeline_v2_stereo_safe_config_json`
+    // over setting this field alone: it only works correctly combined with
+    // `stereoPolicy: "repair_and_verify"` and `enforceChirality: true`, which
+    // that helper sets together so a caller can't set one but forget another.
+    #[serde(default)]
+    expand_implicit_h_through_pipeline: bool,
 }
 
 impl PipelineV2ConfigJson {
@@ -246,10 +255,7 @@ impl PipelineV2ConfigJson {
             gate_mmff94_stretch_bend: self.gate_mmff94_stretch_bend,
             ring_torsion_policy: self.ring_torsion_policy.into(),
             total_timeout_ms,
-            // Issue #291 pipeline-level H-expansion: Rust-core-only for now (not
-            // yet exposed in this JSON config), same staging PR #380 used for the
-            // embed-level `materialize_implicit_h_for_chirality`.
-            expand_implicit_h_through_pipeline: false,
+            expand_implicit_h_through_pipeline: self.expand_implicit_h_through_pipeline,
         })
     }
 }
@@ -1231,6 +1237,75 @@ pub fn embed_pipeline_v2_json(mol: &MolHandle, config_json: &str) -> String {
     }
 }
 
+/// Returns a ready-to-use `embed_pipeline_v2_json` config JSON string for the
+/// "stereo-safe" configuration (issue #291/#383): `stereoPolicy:
+/// "repair_and_verify"`, `enforceChirality: true`, and
+/// `expandImplicitHThroughPipeline: true` together -- the exact combination
+/// measured to correctly handle ring-fused declared stereocenters (e.g.
+/// testosterone, cholesterol) that `enforceChirality` alone cannot repair.
+/// Mirrors `PipelineV2Config::stereo_safe`/the Python binding's
+/// `PipelineV2Config.stereo_safe(...)` -- prefer this over setting those three
+/// fields individually: they only work correctly as a set, and forgetting one
+/// silently falls back to a configuration issue #291 measured as unsound for
+/// that molecule class. `forceFieldPolicy`/`ringTorsionPolicy` are still
+/// required, explicit arguments; everything else takes the same conservative
+/// defaults `embed_pipeline_v2_json`'s own documented examples do. The caller
+/// may parse and further override individual fields before passing the result
+/// to `embed_pipeline_v2_json` (e.g. a different `embedSeed`).
+///
+/// Never throws, matching `embed_pipeline_v2_json`'s own convention: an
+/// unknown `force_field`/`ring_torsion_policy` string returns the same
+/// `{"ok": false, "error": {...}}` shape `embed_pipeline_v2_json` would for an
+/// invalid config, tagged `schemaVersion: 1`.
+#[wasm_bindgen]
+pub fn pipeline_v2_stereo_safe_config_json(force_field: &str, ring_torsion_policy: &str) -> String {
+    // Validate against the same closed enums `embed_pipeline_v2_json` itself
+    // parses with -- reuses their exact error messages, no hand-rolled match.
+    // The caller's own strings are re-serialized verbatim below (already
+    // proven to round-trip, since these enums serialize back to exactly the
+    // strings they deserialize from).
+    if let Err(e) = serde_json::from_value::<ForceFieldPolicyJson>(serde_json::Value::String(
+        force_field.to_string(),
+    )) {
+        return wasm_input_error_json(FailureCauseJson::InvalidConfig {
+            message: format!("forceFieldPolicy: {e}"),
+        });
+    }
+    if let Err(e) = serde_json::from_value::<RingTorsionPolicyJson>(serde_json::Value::String(
+        ring_torsion_policy.to_string(),
+    )) {
+        return wasm_input_error_json(FailureCauseJson::InvalidConfig {
+            message: format!("ringTorsionPolicy: {e}"),
+        });
+    }
+
+    serde_json::json!({
+        "schemaVersion": SCHEMA_VERSION,
+        "ok": true,
+        "config": {
+            "embedSeed": 0xC0FF_EE42_D157_6E02_u64,
+            "maxAttempts": 8,
+            "embedTimeoutMs": null,
+            "useExpTorsions": false,
+            "useSmallRingTorsions": false,
+            "useMacrocycleTorsions": false,
+            "useMacrocycle14Bounds": false,
+            "includeLegacyTorsionHeuristic": false,
+            "stereoPolicy": "repair_and_verify",
+            "failOnUnevaluableStereo": false,
+            "forceFieldPolicy": force_field,
+            "forceFieldMaxIterations": 200,
+            "gateMmff94TorsionOop": false,
+            "gateMmff94StretchBend": false,
+            "ringTorsionPolicy": ring_torsion_policy,
+            "totalTimeoutMs": null,
+            "enforceChirality": true,
+            "expandImplicitHThroughPipeline": true,
+        }
+    })
+    .to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1730,6 +1805,113 @@ mod tests {
         assert_eq!(
             value["result"]["finalStereo"]["isFullySatisfied"], true,
             "{json}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // expand_implicit_h_through_pipeline / pipeline_v2_stereo_safe_config_json
+    // (issue #291/#383) -- WASM parity
+    // -----------------------------------------------------------------------
+
+    const TESTOSTERONE: &str = "C[C@]12CC[C@H]3[C@@H](CC[C@H]4CCC(=O)C=C34)[C@@H]1CC[C@@H]2O";
+
+    #[test]
+    fn expand_implicit_h_through_pipeline_requires_enforce_chirality() {
+        let mol = parse_smiles(TESTOSTERONE).expect("testosterone");
+        let config = r#"{
+                "embedSeed": 0,
+                "maxAttempts": 8,
+                "embedTimeoutMs": null,
+                "useExpTorsions": false,
+                "useSmallRingTorsions": false,
+                "useMacrocycleTorsions": false,
+                "useMacrocycle14Bounds": false,
+                "includeLegacyTorsionHeuristic": false,
+                "stereoPolicy": "repair_and_verify",
+                "failOnUnevaluableStereo": false,
+                "forceFieldPolicy": "mmff94_with_uff_fallback",
+                "forceFieldMaxIterations": 200,
+                "gateMmff94TorsionOop": false,
+                "gateMmff94StretchBend": false,
+                "ringTorsionPolicy": "diagnostic_only",
+                "totalTimeoutMs": null,
+                "enforceChirality": false,
+                "expandImplicitHThroughPipeline": true
+            }"#;
+        let json = embed_pipeline_v2_json(&mol, config);
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["ok"], false, "{json}");
+        assert_eq!(
+            value["error"]["cause"]["kind"], "invalid_configuration",
+            "{json}"
+        );
+        assert_eq!(value["error"]["stage"], "validate_config", "{json}");
+    }
+
+    #[test]
+    fn stereo_safe_config_json_has_expected_shape() {
+        let json = pipeline_v2_stereo_safe_config_json("mmff94_with_uff_fallback", "fail_closed");
+        let value: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        assert_eq!(value["schemaVersion"], 1);
+        assert_eq!(value["ok"], true);
+        let config = &value["config"];
+        assert_eq!(config["stereoPolicy"], "repair_and_verify");
+        assert_eq!(config["enforceChirality"], true);
+        assert_eq!(config["expandImplicitHThroughPipeline"], true);
+        assert_eq!(config["forceFieldPolicy"], "mmff94_with_uff_fallback");
+        assert_eq!(config["ringTorsionPolicy"], "fail_closed");
+    }
+
+    #[test]
+    fn stereo_safe_config_json_rejects_unknown_force_field() {
+        let json = pipeline_v2_stereo_safe_config_json("not_a_real_force_field", "fail_closed");
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["ok"], false, "{json}");
+        assert_eq!(value["error"]["cause"]["kind"], "invalid_config", "{json}");
+    }
+
+    #[test]
+    fn stereo_safe_config_json_fixes_testosterone_via_wasm_binding() {
+        // Same seed/configuration already Rust-level tested and cross-checked
+        // against an independent oracle in pipeline_v2.rs's own
+        // stereo_safe_matches_the_hand_built_configuration_above test.
+        let mol = parse_smiles(TESTOSTERONE).expect("testosterone");
+        let generated =
+            pipeline_v2_stereo_safe_config_json("mmff94_with_uff_fallback", "diagnostic_only");
+        let mut config: serde_json::Value = serde_json::from_str(&generated).unwrap();
+        config["config"]["embedSeed"] = serde_json::json!(0);
+        let config_json = config["config"].to_string();
+
+        let json = embed_pipeline_v2_json(&mol, &config_json);
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["ok"], true, "{json}");
+        assert_eq!(
+            value["result"]["finalStereo"]["isFullySatisfied"], true,
+            "{json}"
+        );
+        assert_eq!(value["result"]["coords"].as_array().unwrap().len(), 20);
+    }
+
+    #[test]
+    fn expand_implicit_h_through_pipeline_is_noop_without_declared_stereo() {
+        let mol = parse_smiles("CCCCCCCCCC").expect("decane"); // no declared stereo
+        let base = embed_pipeline_v2_json(
+            &mol,
+            &enforce_chirality_config_json("repair_and_verify", true),
+        );
+        let expanded_config = {
+            let mut c: serde_json::Value =
+                serde_json::from_str(&enforce_chirality_config_json("repair_and_verify", true))
+                    .unwrap();
+            c["expandImplicitHThroughPipeline"] = serde_json::json!(true);
+            c.to_string()
+        };
+        let expanded = embed_pipeline_v2_json(&mol, &expanded_config);
+        let base_value: serde_json::Value = serde_json::from_str(&base).unwrap();
+        let expanded_value: serde_json::Value = serde_json::from_str(&expanded).unwrap();
+        assert_eq!(
+            base_value["result"]["coords"],
+            expanded_value["result"]["coords"]
         );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #291/#382, closing #383. Exposes
`PipelineV2Config::expand_implicit_h_through_pipeline` through the Python
and WASM bindings, plus a **`stereo_safe` convenience preset** so callers
don't have to remember to set `stereo_policy=repair_and_verify` +
`enforce_chirality=true` + `expand_implicit_h_through_pipeline=true`
*together* — setting only some of them silently falls back to a
configuration #291 measured as unsound for ring-fused declared
stereocenters (testosterone, cholesterol, and similar).

## Design

**Rust**: new `PipelineV2Config::stereo_safe(force_field_policy)`
constructor (mirrors the existing `::minimal()` shape) — single source of
truth for the 3-flag combination. Reused directly by the Python binding;
the WASM binding builds an equivalent JSON config via the same
policy-string enums the main parser already validates with.

**Python**: `PipelineV2Config.stereo_safe(force_field, ring_torsion_policy, ...)`
staticmethod, delegating to the Rust constructor and overriding only the
remaining optional fields — same signature shape as `safe()` minus the 3
hardcoded stereo fields. Raw `expand_implicit_h_through_pipeline` flag also
added as a trailing-defaulted constructor/`safe()` parameter (same
precedent as `enforce_chirality`) and getter. `.pyi` stub and the
type-stub-drift test updated to match.

**WASM**: `expandImplicitHThroughPipeline` added to the JSON config schema
(`#[serde(default)]` `false`, same precedent as `enforceChirality`). New
exported `pipeline_v2_stereo_safe_config_json(forceField, ringTorsionPolicy) -> String`
returns a ready-to-use config JSON (or a tagged
`{"ok":false,"error":{...}}` on an invalid policy string, matching
`embed_pipeline_v2_json`'s own never-throws convention) — JS has no
static-method equivalent, so this is a free function returning the config
object rather than a class method. README example updated (also picked up
two fields it was already missing — `gateMmff94StretchBend`,
`enforceChirality` — pre-existing staleness, not introduced by this PR).

## Tests

Per issue #383's acceptance criteria, in all 3 layers:

- Both bindings can specify the new setting (raw flag and the preset).
- `enforce_chirality=false` + the flag raises the same typed
  `InvalidConfiguration` error as the Rust core.
- Testosterone succeeds via each binding under the safe configuration.
- Returned coordinate count matches the original molecule's atom count.
- `final_stereo` has zero violations for that run.
- A molecule with no declared stereo gives an identical result with the
  flag on vs. off (no-op control).
- Default stays `false` — existing callers unaffected.

**Deliberately not re-running the full 29-molecule × 5-seed corpus through
the bindings** — already measured at the Rust core level (#291/#382, 144/145
correct, 0 silently wrong). Bindings tests only cover testosterone +
invalid-config + no-op control, per the issue's own acceptance criteria.

## Test plan

- [x] `cargo build --workspace --all-targets --exclude chematic-py` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p chematic-3d --lib --release` — 576 passed, 0 failed
- [x] `cargo test -p chematic-wasm --lib --release` — 281 passed, 0 failed
- [x] `python -m pytest crates/chematic-py/tests/` (via `maturin develop --release`) — 761 passed