### PR TITLE
fix(3d): candidate-ranked ring-entry direction for new-island topology (issue #256/#255)

### DIFF
--- a/crates/chematic-3d/src/dg.rs
+++ b/crates/chematic-3d/src/dg.rs
@@ -824,6 +824,100 @@ fn direction_away_from_centroid_xy(
     }
 }
 
+/// Candidate roll angles (around the incoming-bond axis) tried when choosing
+/// the entry direction for a newly-discovered ring system reached via a
+/// direct bond (see [`choose_ring_entry_direction_xy`]).
+const RING_ENTRY_CANDIDATE_COUNT: usize = 12;
+
+/// Choose the outgoing XY direction for the first ring atom of a
+/// newly-discovered ring system reached from `current` via a direct bond
+/// (issue #256/#255 Phase 2's "new-island" regression: a plain chain
+/// neighbor's single `i * 120°` roll has no reason to avoid the rest of the
+/// already-placed structure, and post-minimisation that shows up as real
+/// clashes for e.g. biphenyl/terphenyl).
+///
+/// Does not abandon the existing bend/dihedral scheme -- every candidate is
+/// still `dir_bent` rolled around `incoming_dir`, just at
+/// [`RING_ENTRY_CANDIDATE_COUNT`] angles instead of one. Ranked by: (1) XY
+/// distance from the centroid of everything placed so far (farther is
+/// better -- extend away from the existing structure, mirroring
+/// `chematic-depict::place_ring_anchored`'s own documented reason for using
+/// the whole-structure centroid rather than a single ring's own anchor,
+/// which degenerates to a tie); (2) on a tie, the minimum XY distance from
+/// the candidate entry position to any already-placed atom (larger is
+/// better -- more room); (3) a final deterministic tie-break seeded by
+/// `entry_atom`'s own `AtomIdx`, not candidate/array order -- an
+/// identity-less index tie-break is wrong here (see this crate's own
+/// permutation-invariance precedent).
+#[allow(clippy::too_many_arguments)]
+fn choose_ring_entry_direction_xy(
+    entry_atom: AtomIdx,
+    pos_current: Point3,
+    incoming_dir: Point3,
+    dir_bent: Point3,
+    bond_len: f64,
+    coords: &Coords3D,
+    placed: &[bool],
+) -> (f64, f64) {
+    let centroid = centroid_of_placed_xy(coords, placed);
+    let start = (entry_atom.0 as usize) % RING_ENTRY_CANDIDATE_COUNT;
+
+    let mut best_score: Option<(f64, f64)> = None; // (centroid_dist, min_clearance)
+    let mut best_dir = (1.0, 0.0);
+    for offset in 0..RING_ENTRY_CANDIDATE_COUNT {
+        let k = (start + offset) % RING_ENTRY_CANDIDATE_COUNT;
+        let dihedral = k as f64 * (2.0 * PI / RING_ENTRY_CANDIDATE_COUNT as f64);
+        let dir_final = rotate_around_axis(dir_bent, incoming_dir, dihedral);
+        let xy_len = (dir_final.x * dir_final.x + dir_final.y * dir_final.y).sqrt();
+        let dir_xy = if xy_len > 1e-9 {
+            (dir_final.x / xy_len, dir_final.y / xy_len)
+        } else {
+            (1.0, 0.0)
+        };
+        let entry_xy = (
+            pos_current.x + dir_xy.0 * bond_len,
+            pos_current.y + dir_xy.1 * bond_len,
+        );
+        let centroid_dist = match centroid {
+            Some((cx, cy)) => {
+                let dx = entry_xy.0 - cx;
+                let dy = entry_xy.1 - cy;
+                (dx * dx + dy * dy).sqrt()
+            }
+            None => 0.0,
+        };
+        let min_clearance = placed
+            .iter()
+            .enumerate()
+            .filter(|&(_, &p)| p)
+            .map(|(idx, _)| {
+                let p = coords.get(AtomIdx(idx as u32));
+                let dx = entry_xy.0 - p.x;
+                let dy = entry_xy.1 - p.y;
+                (dx * dx + dy * dy).sqrt()
+            })
+            .fold(f64::INFINITY, f64::min);
+
+        let is_better = match best_score {
+            None => true,
+            Some((best_centroid_dist, best_min_clearance)) => {
+                if centroid_dist > best_centroid_dist + 1e-9 {
+                    true
+                } else if centroid_dist < best_centroid_dist - 1e-9 {
+                    false
+                } else {
+                    min_clearance > best_min_clearance + 1e-9
+                }
+            }
+        };
+        if is_better {
+            best_score = Some((centroid_dist, min_clearance));
+            best_dir = dir_xy;
+        }
+    }
+    best_dir
+}
+
 /// Two consecutive-in-ring-order atoms that are both placed (the shared
 /// fusion edge), if any.
 fn find_shared_edge(ring: &[AtomIdx], placed: &[bool]) -> Option<(AtomIdx, AtomIdx)> {
@@ -1150,20 +1244,21 @@ fn dfs_place_connectivity_ordered(
             // guarded defensively rather than double-placed).
             continue;
         }
-        let dihedral = (i as f64) * (2.0 * PI / 3.0);
-        let dir_final = rotate_around_axis(dir_bent, incoming_dir, dihedral);
 
         if let Some(&sys_idx) = atom_to_system.get(&nb) {
             if system_placed[sys_idx] {
                 continue;
             }
-            let xy_len = (dir_final.x * dir_final.x + dir_final.y * dir_final.y).sqrt();
-            let dir_xy = if xy_len > 1e-9 {
-                (dir_final.x / xy_len, dir_final.y / xy_len)
-            } else {
-                (1.0, 0.0)
-            };
             let bond_len = ideal_bond_len(mol, current, nb);
+            let dir_xy = choose_ring_entry_direction_xy(
+                nb,
+                pos_current,
+                incoming_dir,
+                dir_bent,
+                bond_len,
+                coords,
+                placed,
+            );
             let entry_pos = Point3::new(
                 pos_current.x + dir_xy.0 * bond_len,
                 pos_current.y + dir_xy.1 * bond_len,
@@ -1187,6 +1282,8 @@ fn dfs_place_connectivity_ordered(
             continue;
         }
 
+        let dihedral = (i as f64) * (2.0 * PI / 3.0);
+        let dir_final = rotate_around_axis(dir_bent, incoming_dir, dihedral);
         let bond_len = ideal_bond_len(mol, current, nb);
         let new_pos = pos_current.add(&dir_final.scale(bond_len));
         coords.set(nb, new_pos);


### PR DESCRIPTION
## Summary

Fixes the one blocker Phase 2 (#387) identified before any #256/#255 Phase 3 routing decision: `dfs_place_connectivity_ordered`'s ring-entry branch picked its outgoing direction from a single, fixed `i * 120°` roll — the same one a plain chain neighbor gets — with no reason to avoid the rest of the already-placed structure. That showed up as a real post-UFF-minimization regression specific to "new-island" topology: rings joined by a single direct bond sharing no atom (biphenyl, terphenyl, 3-phenylpyridine, and 4 of the 17 `chembl_tier_b` molecules with the same motif).

New `choose_ring_entry_direction_xy` generates 12 candidate rolls of the *same* bend/dihedral scheme (not abandoned, just widened from one angle to twelve), ranked by:
1. XY distance from the centroid of everything placed so far (farther is better — extend away from the existing structure)
2. On a tie, minimum XY distance to any already-placed atom (larger is better — more room)
3. Final deterministic tie-break seeded by the entry atom's own `AtomIdx` (not candidate/array order)

This design was checked against `chematic-depict/layout.rs`'s own `place_ring_anchored` (lines 502-509), which documents *why* the whole-placed-structure centroid is the correct reference frame here, not a single ring's own local anchor (the latter degenerates to a tie at the shared-edge midpoint). Only the ring-entry branch changed — the plain-chain branch's `i * 120°` dihedral formula is byte-for-byte untouched.

## Measured results

Same 33-molecule population and harness as Phase 2 (`issue256_255_phase2_evaluation.rs`, `cargo test -p chematic-3d issue256_255_phase2_differential_evaluation --release -- --ignored --nocapture`). Checked against every criterion pre-registered before this fix was written, nothing loosened after seeing results:

| Criterion | Result |
|---|---|
| Raw soundness 33/33 maintained | ✅ unchanged |
| #277's 17/17 chembl molecules improved, no regressions | ✅ unchanged |
| RFC's 8 known-broken topologies, no regression | ✅ `regressed=[]` |
| Post-UFF success ≥ 32/33 | ✅ 32/33 (matches legacy; `chembl_tier_b_0143` is the one pre-existing, engine-independent UFF failure) |
| Every new-island molecule: `bond_violation_rate_15pct` ≤ legacy's own value | ✅ all 7 now hit exactly `0.0000`, matching legacy exactly (legacy's own value was 0.0000 on all 7 — the tightest possible reading of this gate) |
| Every new-island molecule: `gross_clash_count` ≤ legacy's own value | ✅ all 7 now hit exactly `0`, matching legacy |
| `mean_viol15` ≤ legacy's own baseline (0.0055) | ✅ **0.0000** — past matching legacy, to zero (pre-fix: 0.0458) |
| `mean_viol50` = 0 | ✅ **0.0000** (pre-fix: 0.0047) |
| No new stereo violation/unevaluable regression | ✅ unchanged, verified against the 3 declared-stereo chembl molecules |
| Determinism maintained | ✅ 33/33 identical |
| Atom-order-permutation robustness maintained | ✅ all 5 representative molecules × 2 relabelings, all SOUND |
| Unrelated topologies show zero diff from Phase 2's own baseline | ✅ legacy-side numbers byte-identical to Phase 2's recorded baseline; unaffected molecules (naphthalene, phenanthrene, pyrene, spiro_5_5_undecane) essentially unchanged |

Bonus, not required by the acceptance criteria: the 3 chain-bridged molecules (diphenylmethane/-propane/-butane) also reach the ring-entry branch at their terminal ring and show the same kind of improvement — a positive side effect, not a regression.

Full numbers and narrative in `ROADMAP.md` (gitignored, local notes only — not part of this diff).

## Verification

- `cargo test -p chematic-3d --lib dg::` — 46/46 pass
- `cargo test -p chematic-3d --lib` — 594/594 pass (1 test skipped, see below), 4 ignored
- `cargo clippy -p chematic-3d --all-targets -- -D warnings` — clean
- `cargo fmt --check -p chematic-3d` — clean
- Phase 2 differential-evaluation harness, release mode — see table above

**Investigated a local-only test issue, unrelated to this PR**: `minimize::policy_bridge_tests::uff_only_rescue_now_preserves_stereo_for_atorvastatin_fragment` (issue #210's own regression test) fails deterministically on this local machine across multiple re-run contexts (isolated, single-threaded, alongside `minimize::`'s other tests) — but GitHub Actions CI's own run of the exact same commit (`main@af62603`, PR #387's "Test" job) passed it cleanly, 595/595. Most likely a local-machine artifact (sustained heavy build load today), not a code issue. Reproduces identically with this PR's diff present or `git stash`-ed out, so confirmed unrelated either way. Full writeup and correction of an initial wrong theory posted to #210: https://github.com/kent-tokyo/chematic/issues/210#issuecomment-5408516179

## Issue status

Per this project's standing convention: #255/#256/#277 all stay **open** even after this merges. This fix clears the Phase 2 blocker but Phase 3's routing decision (whether/how `generate_coords` production callers ever reach this engine) is a separate, not-yet-authorized step.

Closes: none. Refs #255, #256, #277.