### PR TITLE
fix(chematic-chem): preserve isotope-labeled hydrogen in remove_hydrogens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `chematic-chem` `remove_hydrogens` (isotope labels silently destroyed)
+
+- `remove_hydrogens` previously removed *any* atom with `element == H`,
+  including deuterium (`[2H]`), tritium (`[3H]`), and any other
+  isotope-labeled hydrogen — collapsing an explicit isotopic-H atom into an
+  ordinary heavy atom's opaque `hydrogen_count` silently discards the
+  isotope label, since that representation has no way to record "N
+  implicit hydrogens, one of which is deuterium." Found via a downstream
+  consumer (RENKIN) whose stock-identity pipeline calls `standardize`
+  with `remove_explicit_h: true` (chematic's own default) on a
+  9.48M-compound real-world building-block corpus containing 12,688
+  explicitly-isotopic-hydrogen rows — every one of them lost its D/T
+  label on the very first canonicalization pass, exhaustively confirmed,
+  zero exceptions.
+- Now: only a *non-isotopic* explicit H (`element == H && isotope.is_none()`)
+  is removed. An isotope-labeled H is kept as an explicit atom node, like
+  any other heavy atom — its bond is preserved, and a heavy atom that
+  retains an isotopic-H neighbor still gets its `hydrogen_count` reset to
+  `None` so implicit H is recomputed from valence, which correctly
+  accounts for the kept neighbor's own bond (`valence_inferred_hcount`
+  counts every bonded neighbor by bond order, not by element identity, so
+  this needed no separate special-casing).
+- Heavy-atom isotopes (¹³C, ¹⁴C, ¹⁵N, ¹⁸O, ...) were never affected by
+  this bug in the first place (they're not `element == H` atoms at all)
+  and remain untouched — new regression tests pin this explicitly rather
+  than leaving it as an implicit assumption.
+- New tests: fully-deuterated methane, tritium, mixed deuterium+plain-H on
+  the same atom (confirms `hydrogen_count` recomputation is exactly
+  correct, not off-by-the-kept-neighbor), the four heavy-isotope no-op
+  cases, an isotope-labeled tetrahedral stereocenter (structural
+  soundness only — see below), a full `standardize()` round-trip, and a
+  canonical-round-trip (`canon(parse(canon(parse(s))))`) case matching
+  the exact re-canonicalization scenario that surfaced the bug.
+- **Does not** address the separate, independent finding from the same
+  investigation: `canonical_smiles` can pick a different, structurally-
+  identical-but-differently-parity'd traversal on a second canonicalization
+  pass for certain (typically ring-fused or otherwise symmetric-adjacent)
+  molecules, occasionally flipping a declared tetrahedral or E/Z
+  descriptor's *meaning* even though the literal token or overall
+  structure looks unchanged. That is a distinct root cause (this
+  function's own missing `stereo_neighbor_order` restoration, unlike
+  `add_hydrogens`, which explicitly does restore it) needing its own,
+  separate fix and issue — not addressed, not fixed, and not blocking
+  this PR.
+
 ### Added — `chematic-py` (A2.1: Python bindings for the conformer ensemble core)
 
 - `Mol.conformer_ensemble_v2(config)`: a new, separate Python method

--- a/crates/chematic-chem/src/hydrogen.rs
+++ b/crates/chematic-chem/src/hydrogen.rs
@@ -135,21 +135,53 @@ pub fn add_hydrogens(mol: &Molecule) -> Molecule {
     builder.build()
 }
 
-/// Return a new molecule in which explicit H atom nodes are removed and their
-/// bonds are converted back to implicit hydrogens.
+/// Whether atom `a` is a *removable* explicit hydrogen: element `H` with no
+/// isotope specified. An isotope-labeled hydrogen (`[2H]` deuterium, `[3H]`
+/// tritium, ...) is real, distinguishing chemical information -- akin to
+/// charge or element identity, not a notation choice -- so it is never
+/// removed by this function regardless of `element == H`. See
+/// [`remove_hydrogens`]'s own doc comment for the full rationale and the
+/// regression this guards (issue: isotope labels silently destroyed by
+/// unconditional H-node removal).
+fn is_removable_explicit_h(a: &Atom) -> bool {
+    a.element == Element::H && a.isotope.is_none()
+}
+
+/// Return a new molecule in which removable explicit H atom nodes (see
+/// [`is_removable_explicit_h`]) are removed and their bonds are converted
+/// back to implicit hydrogens.
 ///
-/// Only explicit hydrogen atoms (nodes with `element == H`) are removed.
-/// Chirality annotations and other atom properties are preserved.
+/// Only *non-isotopic* explicit hydrogen atoms are removed -- an
+/// isotope-labeled H (`[2H]`, `[3H]`, ...) is kept as an explicit atom node,
+/// exactly like any other heavy atom, since collapsing it into an ordinary
+/// atom's opaque `hydrogen_count` would silently discard the isotope label
+/// (there is no way to record "N implicit hydrogens, one of which is
+/// deuterium" in that compact representation). A heavy atom that retains an
+/// isotopic-H neighbor keeps that bond untouched; only bonds to a removed
+/// (non-isotopic) H are dropped. Chirality annotations and other atom
+/// properties are preserved.
 ///
-/// Heavy atoms that had explicit H neighbors will have `hydrogen_count` set
-/// to `None` so that implicit H is recomputed from valence.
+/// Heavy atoms that had *removable* explicit H neighbors will have
+/// `hydrogen_count` reset to `None` so implicit H is recomputed from
+/// valence -- correct even when the atom also keeps an explicit isotopic-H
+/// neighbor, since valence inference counts every bonded neighbor (isotopic
+/// or not) via its bond order, not by element identity (see
+/// `chematic_core::valence::valence_inferred_hcount`).
+///
+/// Declared tetrahedral/E-Z stereo *parity* is unaffected by this function
+/// either way (it lives on `Atom::chirality`/bond directions, copied
+/// verbatim); this function does not restore the parser-recorded
+/// `stereo_neighbor_order` side table for any atom, isotopic-H-bearing or
+/// not -- unlike [`add_hydrogens`], which explicitly does. That gap is
+/// pre-existing and out of scope here; see `chematic`'s canonical-SMILES
+/// stereo-round-trip issue tracker for the separate, broader fix.
 pub fn remove_hydrogens(mol: &Molecule) -> Molecule {
     let mut builder = MoleculeBuilder::new();
     let mut remap: HashMap<AtomIdx, AtomIdx> = HashMap::new();
 
     for i in 0..mol.atom_count() {
         let old_idx = AtomIdx(i as u32);
-        if mol.atom(old_idx).element == Element::H {
+        if is_removable_explicit_h(mol.atom(old_idx)) {
             continue;
         }
         let mut atom = mol.atom(old_idx).clone();
@@ -161,12 +193,12 @@ pub fn remove_hydrogens(mol: &Molecule) -> Molecule {
         remap.insert(old_idx, new_idx);
     }
 
-    // Copy heavy–heavy bonds only.
+    // Copy bonds, dropping only those touching a removed (non-isotopic) H.
     for i in 0..mol.bond_count() {
         let bond = mol.bond(BondIdx(i as u32));
-        let a1_is_h = mol.atom(bond.atom1).element == Element::H;
-        let a2_is_h = mol.atom(bond.atom2).element == Element::H;
-        if a1_is_h || a2_is_h {
+        let a1_removed = is_removable_explicit_h(mol.atom(bond.atom1));
+        let a2_removed = is_removable_explicit_h(mol.atom(bond.atom2));
+        if a1_removed || a2_removed {
             continue;
         }
         if let (Some(&na), Some(&nb)) = (remap.get(&bond.atom1), remap.get(&bond.atom2)) {
@@ -182,10 +214,247 @@ pub fn remove_hydrogens(mol: &Molecule) -> Molecule {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chematic_smiles::parse;
+    use chematic_smiles::{canonical_smiles, parse};
 
     fn mol(s: &str) -> Molecule {
         parse(s).unwrap_or_else(|e| panic!("parse '{s}': {e}"))
+    }
+
+    // ─── Isotopic-hydrogen preservation ────────────────────────────────────
+
+    fn h_isotopes(m: &Molecule) -> Vec<Option<u16>> {
+        let mut v: Vec<Option<u16>> = m
+            .atoms()
+            .filter(|(_, a)| a.element == Element::H)
+            .map(|(_, a)| a.isotope)
+            .collect();
+        v.sort();
+        v
+    }
+
+    #[test]
+    fn remove_hydrogens_keeps_fully_deuterated_methane() {
+        // CD4: 4 explicit D atom nodes, no plain H at all.
+        let orig = mol("[2H]C([2H])([2H])[2H]");
+        assert_eq!(orig.atom_count(), 5);
+        let result = remove_hydrogens(&orig);
+        assert_eq!(
+            result.atom_count(),
+            5,
+            "all 4 deuteriums must be kept as explicit atom nodes, not folded away"
+        );
+        assert_eq!(
+            h_isotopes(&result),
+            vec![Some(2), Some(2), Some(2), Some(2)]
+        );
+        let canon = canonical_smiles(&result);
+        assert_eq!(
+            canon.matches("[2H]").count(),
+            4,
+            "canonical SMILES must show all 4 deuteriums: {canon}"
+        );
+        assert!(
+            !canon.contains("[H]"),
+            "must not have degraded to plain explicit H: {canon}"
+        );
+    }
+
+    #[test]
+    fn remove_hydrogens_keeps_tritium() {
+        // Tritiated water analog: O bonded to one T and (implicitly) one
+        // ordinary H it never had explicitly -- OT.
+        let orig = mol("[3H]O");
+        let result = remove_hydrogens(&orig);
+        assert_eq!(
+            result.atom_count(),
+            2,
+            "the tritium atom must be kept, not removed"
+        );
+        assert_eq!(h_isotopes(&result), vec![Some(3)]);
+        let canon = canonical_smiles(&result);
+        assert!(canon.contains("[3H]"), "canonical SMILES lost T: {canon}");
+    }
+
+    #[test]
+    fn remove_hydrogens_mixed_deuterium_and_plain_hydrogen() {
+        // One explicit D + three explicit plain H on the same carbon
+        // (CHD3-style methane, fully explicit form). The plain H's must be
+        // removed (folded into hydrogen_count); the D must survive as an
+        // explicit neighbor; the carbon's total valence (4 bonds either way)
+        // must stay correct.
+        let orig = mol("[2H]C([H])([H])[H]");
+        assert_eq!(orig.atom_count(), 5);
+        let result = remove_hydrogens(&orig);
+        assert_eq!(
+            result.atom_count(),
+            2,
+            "C + the single kept deuterium; the 3 plain H must be removed"
+        );
+        assert_eq!(h_isotopes(&result), vec![Some(2)]);
+
+        let carbon = result
+            .atoms()
+            .find(|(_, a)| a.element == Element::C)
+            .map(|(idx, _)| idx)
+            .expect("carbon must survive");
+        // Valence must be satisfied by 1 explicit D bond + 3 recomputed
+        // implicit H -- not 4 implicit H (which would silently duplicate
+        // the D's own bond) and not 0 (which would under-saturate carbon).
+        assert_eq!(
+            chematic_core::implicit_hcount(&result, carbon),
+            3,
+            "carbon must recompute exactly 3 implicit H, correctly accounting for \
+             the kept deuterium's own bond -- not 4 (double-counting D) or fewer"
+        );
+
+        let canon = canonical_smiles(&result);
+        assert_eq!(canon.matches("[2H]").count(), 1, "{canon}");
+        assert!(!canon.contains("[H]"), "plain H must not survive: {canon}");
+        // total_formula() is deliberately isotope-blind (it keys purely by
+        // element symbol, per its own doc comment) -- 4 H-family atoms
+        // total either way (1 kept D + 3 recomputed implicit protium),
+        // matching the original explicit-everything form's own H count.
+        assert_eq!(result.total_formula(), orig.total_formula());
+        // formula_with_isotopes() *is* isotope-aware and must show the kept D.
+        assert!(
+            result.formula_with_isotopes().contains("2H"),
+            "isotope-aware formula must show the surviving deuterium: {}",
+            result.formula_with_isotopes()
+        );
+    }
+
+    #[test]
+    fn remove_hydrogens_heavy_isotopes_untouched_13c_14c_15n_18o() {
+        // None of these carry an isotope-tagged H at all -- confirms the
+        // fix's H-specific guard doesn't regress the already-correct
+        // heavy-atom-isotope behavior (unaffected before and after, since
+        // `element == H` was always false for these atoms).
+        for smi in ["[13CH4]", "[14CH4]", "[15NH3]", "[18OH2]"] {
+            let orig = mol(smi);
+            let before_isotope = orig
+                .atoms()
+                .find(|(_, a)| a.element != Element::H)
+                .and_then(|(_, a)| a.isotope);
+            let result = remove_hydrogens(&orig);
+            let after_isotope = result
+                .atoms()
+                .find(|(_, a)| a.element != Element::H)
+                .and_then(|(_, a)| a.isotope);
+            assert_eq!(
+                before_isotope, after_isotope,
+                "{smi}: heavy-atom isotope must be untouched by remove_hydrogens"
+            );
+            assert!(
+                result.atoms().all(|(_, a)| a.element != Element::H),
+                "{smi}: no explicit H atom node exists in bracket-implicit-H \
+                 form to begin with, so nothing should remain either way"
+            );
+        }
+    }
+
+    #[test]
+    fn remove_hydrogens_preserves_isotope_on_a_tetrahedral_stereocenter() {
+        // Alpha-deuterated alanine analog: a declared tetrahedral
+        // stereocenter with an explicit deuterium substituent (a real,
+        // common labeling pattern in metabolic-stability medicinal
+        // chemistry). Scope of this fix: the D atom and the stereocenter's
+        // atom-level `chirality` tag must both survive structurally sound
+        // (right atom/bond count, right element set) -- this test does NOT
+        // assert the exact `@`/`@@` parity is textually preserved, since
+        // `remove_hydrogens` does not restore the parser-recorded
+        // `stereo_neighbor_order` side table (a separate, pre-existing gap,
+        // out of scope for this isotope-only fix -- see the module doc
+        // comment on `remove_hydrogens`).
+        let orig = mol("N[C@@H]([2H])C(=O)O");
+        let stereocenter = orig
+            .atoms()
+            .find(|(_, a)| a.chirality != Chirality::None)
+            .map(|(idx, _)| idx)
+            .expect("a declared stereocenter must exist");
+        assert_ne!(orig.atom(stereocenter).chirality, Chirality::None);
+
+        let result = remove_hydrogens(&orig);
+        assert_eq!(h_isotopes(&result), vec![Some(2)], "the D must survive");
+        assert_eq!(
+            result.atom(stereocenter).chirality,
+            orig.atom(stereocenter).chirality,
+            "the stereocenter's own chirality tag (an Atom-level field, not \
+             the separate neighbor-order side table) must be copied verbatim"
+        );
+        assert!(
+            result
+                .neighbors(stereocenter)
+                .any(|(nb, _)| result.atom(nb).element == Element::H
+                    && result.atom(nb).isotope == Some(2)),
+            "the kept deuterium must still be bonded to the stereocenter"
+        );
+        // Structural soundness: same heavy-atom formula, same total H-family
+        // count (1 explicit D + whatever protium the other atoms need).
+        assert_eq!(result.total_formula(), orig.total_formula());
+    }
+
+    #[test]
+    fn standardize_round_trip_preserves_isotope() {
+        // The exact policy RENKIN's stock-identity pipeline uses
+        // (`remove_explicit_h: true`), run through the real, full
+        // `standardize()` entry point -- not just the bare `remove_hydrogens`
+        // helper -- to confirm the fix actually reaches consumers through
+        // that path, not only when called directly.
+        use crate::standardize::{StandardizeOptions, ZwitterionHandling, standardize};
+        let opts = StandardizeOptions {
+            canonical_tautomer: false,
+            neutralize_charges: false,
+            remove_explicit_h: true,
+            largest_fragment_only: false,
+            zwitterion_handling: ZwitterionHandling::Keep,
+        };
+        let orig = mol("[2H]C([2H])([2H])[2H]");
+        let result = standardize(&orig, &opts);
+        assert_eq!(
+            h_isotopes(&result),
+            vec![Some(2), Some(2), Some(2), Some(2)]
+        );
+        let canon = canonical_smiles(&result);
+        assert_eq!(canon.matches("[2H]").count(), 4, "{canon}");
+    }
+
+    #[test]
+    fn canonical_round_trip_preserves_isotope() {
+        // canon(parse(canon(parse(s)))) must still carry the isotope --
+        // the exact re-canonicalization scenario (RENKIN's `renkin doctor
+        // stock` reimport_idempotency check) that originally surfaced this
+        // bug: a real stock file's already-canonical line, canonicalized
+        // again, silently losing D/T on the very first pass, let alone a
+        // second one.
+        use crate::standardize::{StandardizeOptions, ZwitterionHandling, standardize};
+        let opts = StandardizeOptions {
+            canonical_tautomer: false,
+            neutralize_charges: false,
+            remove_explicit_h: true,
+            largest_fragment_only: false,
+            zwitterion_handling: ZwitterionHandling::Keep,
+        };
+        let stock_identity =
+            |s: &str| -> String { canonical_smiles(&standardize(&parse(s).unwrap(), &opts)) };
+
+        for smi in [
+            "[2H]C([2H])([2H])[2H]",
+            "[3H]O",
+            "[2H]C([2H])([2H])C(=O)N[C@H]1CCc2cc(OC)c(OC)c(OC)c2-c2ccc(OC)c(=O)cc21",
+        ] {
+            let once = stock_identity(smi);
+            let twice = stock_identity(&once);
+            assert_eq!(
+                once, twice,
+                "re-canonicalizing an already-canonical isotope-labeled SMILES \
+                 must be a no-op: {smi}"
+            );
+            assert!(
+                once.contains("[2H]") || once.contains("[3H]"),
+                "isotope must survive even one full standardize+canonicalize pass: \
+                 {smi} -> {once}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`remove_hydrogens` removed *any* atom with `element == H` unconditionally — including deuterium (`[2H]`), tritium (`[3H]`), or any other isotope-labeled hydrogen. Collapsing an explicit isotopic-H atom into an ordinary heavy atom's opaque `hydrogen_count` silently discards the isotope label, since that compact representation has no way to record "N implicit hydrogens, one of which is deuterium."

Found via a downstream consumer ([RENKIN](https://github.com/kent-tokyo/renkin)) whose stock-identity pipeline calls `standardize` with `remove_explicit_h: true` (this crate's own default) on a 9.48M-compound real-world building-block corpus. That corpus contains 12,688 rows with explicit isotopic hydrogen — **every one of them lost its D/T label on the very first canonicalization pass**, exhaustively confirmed (not sampled), zero exceptions. Reproduces identically on a fresh clone of `main` before this fix.

## Fix

Only a *non-isotopic* explicit H (`element == H && isotope.is_none()`) is now removed. An isotope-labeled H is kept as an explicit atom node, like any other heavy atom:

- Its bond is preserved (the bond-copy loop's H-skip predicate is updated to match).
- A heavy atom that retains an isotopic-H neighbor still gets `hydrogen_count` reset to `None` so implicit H is recomputed from valence — this correctly accounts for the kept neighbor's own bond, since `valence_inferred_hcount` counts every bonded neighbor by bond *order*, not by element identity. No extra special-casing was needed for this.
- Heavy-atom isotopes (¹³C, ¹⁴C, ¹⁵N, ¹⁸O, ...) were never affected by this bug in the first place — they're not `element == H` atoms at all — and remain untouched; new tests pin this explicitly rather than leaving it an implicit assumption.

## Tests added

- Fully-deuterated methane (`[2H]C([2H])([2H])[2H]`)
- Tritium (`[3H]O`)
- Mixed deuterium + plain H on the same atom — confirms `hydrogen_count` recomputation is exactly correct (not double-counting or under-counting the kept D neighbor)
- The 4 heavy-isotope no-op cases (¹³C/¹⁴C/¹⁵N/¹⁸O)
- An isotope-labeled tetrahedral stereocenter — structural soundness only (atom/bond count, element set, chirality tag preserved); does **not** assert exact `@`/`@@` parity survives, since that's the separate stereo issue below
- A full `standardize()` round-trip (the real, complete pipeline, not just the bare helper)
- A canonical-round-trip case (`canon(parse(canon(parse(s))))`) matching the exact re-canonicalization scenario that originally surfaced this bug

## Out of scope (separate, independent finding — not fixed here)

The same investigation also found that `canonical_smiles` can pick a different, structurally-identical-but-differently-parity'd traversal on a second canonicalization pass for certain (typically ring-fused or otherwise symmetric-adjacent) molecules, occasionally flipping a declared tetrahedral or E/Z descriptor's *meaning* — a distinct root cause (this function's own missing `stereo_neighbor_order` restoration, unlike `add_hydrogens`, which explicitly does restore it via `copy_stereo_from` + sentinel remapping). That needs its own fix and its own issue; deliberately not mixed into this PR since the cause and blast radius are unrelated.

## Verification

- `cargo test -p chematic-chem`: 937 passed, 0 failed (includes the 9 new tests above)
- `cargo check --workspace --exclude chematic-py --exclude chematic-wasm --exclude chematic-mcp`: clean (confirms no API/type-level regression anywhere else in the workspace)
- `cargo test -p chematic-rxn -p chematic-smiles -p chematic --lib`: 383 passed, 0 failed
- `cargo clippy -p chematic-chem -- -D warnings`: clean
- `cargo fmt --check`: clean
- `chematic-py`/`chematic-wasm` excluded from the broader workspace check due to a pre-existing, unrelated PyO3 linker environment issue on this machine (missing Python symbols during `cdylib` linking outside a proper `maturin` build) — confirmed unrelated to this change.

## CHANGELOG

Updated under `[Unreleased]`.