### PR TITLE
fix(ci): decouple MSRV Check's action ref from its Rust toolchain pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.88.0
+      # Pin the action's own code to @master (per dtolnay/rust-toolchain's
+      # own documented pattern) and set the actual Rust version under test
+      # via `toolchain:`, matching Cargo.toml's `rust-version`. Using the
+      # action ref itself as the version pin (e.g. `@1.88.0`) makes
+      # Dependabot treat this job's MSRV as a bumpable dependency -- it
+      # previously proposed bumping straight to a not-yet-released Rust
+      # version (1.100.0), breaking this job outright (PR #378).
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.88"
       - run: cargo check --workspace --all-features
 
   validate-citation:


### PR DESCRIPTION
## Summary

Fixes the root cause of the failing MSRV Check on #378 (Dependabot proposing a bump to a Rust version, 1.100.0, that doesn't exist yet, causing a 404 when `rustup` tries to download it).

## Root cause

`msrv` used `dtolnay/rust-toolchain@1.88.0` with no separate `toolchain:` input — the action's own version ref doubles as the Rust toolchain version it installs (a documented feature of that action). Dependabot has no way to know this ref is semantically "our MSRV," not an ordinary action-code dependency, so it treats it like any other version pin and proposes bumping it — which moved this job's tested Rust version straight to a not-yet-released one.

Every other job in this repo's workflows already uses the floating `@stable` ref, which Dependabot doesn't propose version bumps against. `msrv` can't just switch to `@stable` too, since its whole point is testing against a fixed minimum version (`Cargo.toml`'s `rust-version = "1.88"`), not whatever's currently newest.

## Fix

Per `dtolnay/rust-toolchain`'s own documented pattern for exactly this case: pin the action's own code to `@master`, and set the actual Rust version under test via an explicit `toolchain: "1.88"` input, matching `Cargo.toml`. Dependabot doesn't propose bumps against a branch ref, so this stops the same breakage from recurring on every future Rust release — not just a one-off fix for this specific bad bump.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — valid YAML.
- Confirmed via `dtolnay/rust-toolchain`'s own README: `@master` + `toolchain:` input is the documented way to pin an exact version while letting Dependabot manage the action's own code separately.
- This PR's own CI run is the live verification that the `msrv` job installs Rust 1.88 correctly under the new syntax.

## Related

Dependabot PR #378 (currently broken, proposing the bad `1.100.0` bump) should be closed once this merges — not done here, since closing another PR isn't this PR's job.