### PR TITLE
test: canonical round-trip idempotency corpus test (issue #393)

### DIFF
--- a/crates/chematic-chem/tests/canonical_idempotency_corpus_standardized.rs
+++ b/crates/chematic-chem/tests/canonical_idempotency_corpus_standardized.rs
@@ -1,0 +1,111 @@
+//! Canonical round-trip idempotency through `standardize`, full-corpus
+//! property test (issue #393).
+//!
+//! Sibling to `chematic-smiles`'s own `canonical_idempotency_corpus.rs`
+//! (bare `parse`/`canonical_smiles`, no `standardize` involved) -- this one
+//! specifically exercises `StandardizeOptions::default()` (`remove_explicit_h:
+//! true`), the exact real pipeline shape #389 and #392 were both found
+//! through (a downstream consumer's `standardize`-then-canonicalize stock-
+//! identity step). Checks
+//! `canon(standardize(x)) == canon(standardize(parse(canon(standardize(x)))))`
+//! for every line in the two real-world-derived corpora already committed to
+//! this repo (`scripts/*.smi`, 5,000 lines each).
+
+use chematic_chem::{StandardizeOptions, standardize};
+use chematic_smiles::{canonical_smiles, parse};
+
+const DESCRIPTOR_CENSUS_CORPUS: &str =
+    include_str!("../../../scripts/descriptor_census_corpus.smi");
+const CHEMBL_ACCURACY_CORPUS: &str =
+    include_str!("../../../scripts/chembl_accuracy_corpus_4999.smi");
+
+/// For every non-empty line in `corpus`: parse, standardize, canonicalize
+/// once, re-parse, standardize again, canonicalize twice, check the two
+/// canonical strings are identical. Parse failures (of either the original
+/// or the once-canonicalized form) count as failures too. Collects every
+/// failing line (not just the first) and panics with the full list if the
+/// count exceeds `max_known_failures` -- see
+/// `canonical_idempotency_corpus.rs` (the sibling bare-`parse` test in
+/// `chematic-smiles`) for why this is a ceiling, not a strict `== 0`
+/// assertion: the same reasoning applies here (a pre-existing, already-
+/// tracked residual must not make every unrelated future PR's CI red).
+fn assert_corpus_idempotent(label: &str, corpus: &str, max_known_failures: usize) {
+    let opts = StandardizeOptions::default();
+    let mut failures: Vec<String> = Vec::new();
+    let mut checked = 0usize;
+
+    for (line_no, line) in corpus.lines().enumerate() {
+        let smi = line.trim();
+        if smi.is_empty() {
+            continue;
+        }
+        checked += 1;
+
+        let mol = match parse(smi) {
+            Ok(m) => m,
+            Err(e) => {
+                failures.push(format!("line {}: PARSE FAILED '{smi}': {e}", line_no + 1));
+                continue;
+            }
+        };
+        let once = canonical_smiles(&standardize(&mol, &opts));
+        let reparsed = match parse(&once) {
+            Ok(m) => m,
+            Err(e) => {
+                failures.push(format!(
+                    "line {}: RE-PARSE FAILED '{smi}' (once='{once}'): {e}",
+                    line_no + 1
+                ));
+                continue;
+            }
+        };
+        let twice = canonical_smiles(&standardize(&reparsed, &opts));
+        if once != twice {
+            failures.push(format!(
+                "line {}: NOT IDEMPOTENT '{smi}': once='{once}' twice='{twice}'",
+                line_no + 1
+            ));
+        }
+    }
+
+    assert!(checked > 0, "{label}: corpus was empty, nothing checked");
+    assert!(
+        failures.len() <= max_known_failures,
+        "{label}: {}/{checked} corpus line(s) failed standardize+canonicalize round-trip \
+         idempotency (known ceiling: {max_known_failures}; this test must not regress past \
+         that count):\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}
+
+/// Current known-residual ceiling -- see this file's own doc comment. Must
+/// only ever move down, never up. Measured higher than the bare-`parse`
+/// sibling test's own ceiling (57/60, 73/68) because `standardize`'s
+/// default `remove_explicit_h: true` routes through `remove_hydrogens`,
+/// which (as of this measurement) does not yet restore
+/// `stereo_neighbor_order`/`bond_directions` -- the exact defect issue #392
+/// fixes, on an open, not-yet-merged PR at measurement time. Once #392
+/// merges, re-measure and lower these -- do not assume the delta closes to
+/// exactly zero without re-running, since #395's own residual (unrelated,
+/// still open) contributes to both counts too.
+const DESCRIPTOR_CENSUS_KNOWN_FAILURES: usize = 60;
+const CHEMBL_ACCURACY_KNOWN_FAILURES: usize = 68;
+
+#[test]
+fn descriptor_census_corpus_standardized_is_canonically_idempotent() {
+    assert_corpus_idempotent(
+        "descriptor_census_corpus.smi",
+        DESCRIPTOR_CENSUS_CORPUS,
+        DESCRIPTOR_CENSUS_KNOWN_FAILURES,
+    );
+}
+
+#[test]
+fn chembl_accuracy_corpus_standardized_is_canonically_idempotent() {
+    assert_corpus_idempotent(
+        "chembl_accuracy_corpus_4999.smi",
+        CHEMBL_ACCURACY_CORPUS,
+        CHEMBL_ACCURACY_KNOWN_FAILURES,
+    );
+}

--- a/crates/chematic-chem/tests/canonical_idempotency_corpus_standardized.rs
+++ b/crates/chematic-chem/tests/canonical_idempotency_corpus_standardized.rs
@@ -80,17 +80,29 @@ fn assert_corpus_idempotent(label: &str, corpus: &str, max_known_failures: usize
 }
 
 /// Current known-residual ceiling -- see this file's own doc comment. Must
-/// only ever move down, never up. Measured higher than the bare-`parse`
-/// sibling test's own ceiling (57/60, 73/68) because `standardize`'s
-/// default `remove_explicit_h: true` routes through `remove_hydrogens`,
-/// which (as of this measurement) does not yet restore
-/// `stereo_neighbor_order`/`bond_directions` -- the exact defect issue #392
-/// fixes, on an open, not-yet-merged PR at measurement time. Once #392
-/// merges, re-measure and lower these -- do not assume the delta closes to
-/// exactly zero without re-running, since #395's own residual (unrelated,
-/// still open) contributes to both counts too.
-const DESCRIPTOR_CENSUS_KNOWN_FAILURES: usize = 60;
-const CHEMBL_ACCURACY_KNOWN_FAILURES: usize = 68;
+/// only ever move down, never up.
+///
+/// **Correction**: an earlier version of this file set these to 60/68,
+/// labeled "re-measured against main@743b77b (after #392 merged)" -- that
+/// re-measurement never actually ran (a `git checkout` race silently
+/// clobbered the source file mid-build, and the resulting "no such test
+/// target" cargo error was mistaken for "0 additional failures" against an
+/// empty grep pattern). The 60/68 figures were in fact the *pre-#392*
+/// baseline, carried forward unverified. Honestly re-measured on
+/// `test/issue-393-canonical-idempotency-corpus`
+/// (`743b77b`, #392 included): the true count is dramatically higher,
+/// **615/519**, not 60/68. This is a real, confirmed, ~9x increase caused
+/// specifically by #392 -- not measurement noise, not a different corpus
+/// state, not platform-dependent (re-confirmed identically against CI's
+/// own Linux run). Root cause, and why #392 (a correct, real fix) is the
+/// trigger rather than the culprit: filed as issue #399, with a confirmed
+/// minimal repro (`CN1CCC[C@H]1c1cccnc1`, zero explicit H atoms --
+/// `remove_hydrogens` should be a pure no-op, yet the molecule is
+/// idempotent under bare `canonical_smiles` alone but not through
+/// `standardize()`). Do not lower these again without an honest full-corpus
+/// re-run, not an assumption.
+const DESCRIPTOR_CENSUS_KNOWN_FAILURES: usize = 519;
+const CHEMBL_ACCURACY_KNOWN_FAILURES: usize = 615;
 
 #[test]
 fn descriptor_census_corpus_standardized_is_canonically_idempotent() {

--- a/crates/chematic-smiles/tests/canonical_idempotency_corpus.rs
+++ b/crates/chematic-smiles/tests/canonical_idempotency_corpus.rs
@@ -1,0 +1,123 @@
+//! Canonical round-trip idempotency, full-corpus property test (issue #393).
+//!
+//! Motivation: #389 (isotope stripping) and #392 (tetrahedral stereo flip on
+//! re-canonicalization) were both real, shipped correctness bugs that none of
+//! chematic's existing tests caught, despite being simple to state and check:
+//! `canon(parse(x)) == canon(parse(canon(parse(x))))`. Both were only found
+//! via an external, large-scale (9.47M-compound) real-world corpus scan from
+//! a downstream consumer, not from anything in this repo's own test suite.
+//! This test runs that exact check against the two real-world-derived
+//! corpora already committed to this repo (`scripts/*.smi`, 5,000 lines
+//! each) -- no external download needed.
+//!
+//! Mirrors `chembl_roundtrip.rs`'s own established convention (parse ->
+//! canonicalize -> re-parse -> re-canonicalize -> assert stability,
+//! collect-all-failures-then-panic), scaled from a 50-molecule hand-picked
+//! list to the full 5,000-line corpora.
+//!
+//! **Known residual, tracked as issue #395, not a regression from this
+//! test's own addition.** Running this test against both corpora for the
+//! first time found a real, previously-undetected defect, independent of
+//! #389/#392/#390: 73/5000 lines in `chembl_accuracy_corpus_4999.smi` and
+//! 57/5000 in `descriptor_census_corpus.smi` are not idempotent. Every one
+//! of the smallest failing examples shares an explicit-bond-order ring
+//! closure (SMILES `-N`/`=N` immediately preceding a ring-closure digit,
+//! e.g. `c1-2`) -- an unconfirmed lead, not a diagnosis; see #395. Per this
+//! project's own `_known_broken`-fixture convention (e.g. `dg.rs`'s ring-
+//! fusion tests) and its "gate fail != regression until redesigned"
+//! precedent (issue #70): rather than either (a) leaving this test
+//! hard-failing on `main` -- which would make every unrelated future PR's
+//! CI run red for a pre-existing, already-tracked defect it didn't cause --
+//! or (b) `#[ignore]`-ing it and losing the "visible and tracked, not
+//! silently ignored" property issue #393 explicitly asked for, this test
+//! pins the CURRENT failure count as a ceiling: it stays green as long as
+//! the count doesn't exceed what's measured today, and fails (loudly, with
+//! every failing line) the moment it gets worse. Fixing #395 should lower
+//! these constants, not raise them.
+
+use chematic_smiles::{canonical_smiles, parse};
+
+const DESCRIPTOR_CENSUS_CORPUS: &str =
+    include_str!("../../../scripts/descriptor_census_corpus.smi");
+const CHEMBL_ACCURACY_CORPUS: &str =
+    include_str!("../../../scripts/chembl_accuracy_corpus_4999.smi");
+
+/// Current known-residual ceiling (issue #395) -- see this file's own doc
+/// comment. Must only ever move down, never up.
+const DESCRIPTOR_CENSUS_KNOWN_FAILURES: usize = 57;
+const CHEMBL_ACCURACY_KNOWN_FAILURES: usize = 73;
+
+/// For every non-empty line in `corpus`: parse, canonicalize once, re-parse,
+/// canonicalize twice, check the two canonical strings are identical. Parse
+/// failures (of either the original or the once-canonicalized form) count
+/// as failures too, not silently skipped -- a corpus line this test can't
+/// even parse is itself worth knowing about. Collects every failing line
+/// (not just the first) and panics with the full list if the count exceeds
+/// `max_known_failures` -- see this file's own doc comment for why this is
+/// a ceiling, not a strict `== 0` assertion.
+fn assert_corpus_idempotent(label: &str, corpus: &str, max_known_failures: usize) {
+    let mut failures: Vec<String> = Vec::new();
+    let mut checked = 0usize;
+
+    for (line_no, line) in corpus.lines().enumerate() {
+        let smi = line.trim();
+        if smi.is_empty() {
+            continue;
+        }
+        checked += 1;
+
+        let mol = match parse(smi) {
+            Ok(m) => m,
+            Err(e) => {
+                failures.push(format!("line {}: PARSE FAILED '{smi}': {e}", line_no + 1));
+                continue;
+            }
+        };
+        let once = canonical_smiles(&mol);
+        let reparsed = match parse(&once) {
+            Ok(m) => m,
+            Err(e) => {
+                failures.push(format!(
+                    "line {}: RE-PARSE FAILED '{smi}' (once='{once}'): {e}",
+                    line_no + 1
+                ));
+                continue;
+            }
+        };
+        let twice = canonical_smiles(&reparsed);
+        if once != twice {
+            failures.push(format!(
+                "line {}: NOT IDEMPOTENT '{smi}': once='{once}' twice='{twice}'",
+                line_no + 1
+            ));
+        }
+    }
+
+    assert!(checked > 0, "{label}: corpus was empty, nothing checked");
+    assert!(
+        failures.len() <= max_known_failures,
+        "{label}: {}/{checked} corpus line(s) failed canonical round-trip idempotency \
+         (known ceiling: {max_known_failures} -- see issue #395; this test must not regress \
+         past that count):\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}
+
+#[test]
+fn descriptor_census_corpus_is_canonically_idempotent() {
+    assert_corpus_idempotent(
+        "descriptor_census_corpus.smi",
+        DESCRIPTOR_CENSUS_CORPUS,
+        DESCRIPTOR_CENSUS_KNOWN_FAILURES,
+    );
+}
+
+#[test]
+fn chembl_accuracy_corpus_is_canonically_idempotent() {
+    assert_corpus_idempotent(
+        "chembl_accuracy_corpus_4999.smi",
+        CHEMBL_ACCURACY_CORPUS,
+        CHEMBL_ACCURACY_KNOWN_FAILURES,
+    );
+}


### PR DESCRIPTION
## Summary

Adds the property test issue #393 requested: `canon(x) == canon(canon(x))` checked against the full 5,000-line real-world-derived corpora already committed to this repo (`scripts/*.smi`), not just the existing 50-molecule hand-picked list in `chembl_roundtrip.rs`.

Two files, mirroring `chembl_roundtrip.rs`'s own established convention (parse → canonicalize → re-parse → re-canonicalize → assert stability, collect-all-failures-then-panic):

- `crates/chematic-smiles/tests/canonical_idempotency_corpus.rs` — bare `parse`/`canonical_smiles`, no `standardize`.
- `crates/chematic-chem/tests/canonical_idempotency_corpus_standardized.rs` — through `standardize(StandardizeOptions::default())` (`remove_explicit_h: true`), the exact pipeline shape #389/#392 were both found through.

## What running it found

Doing exactly what #393 asked for — running the idempotency check at real corpus scale — surfaced two real, previously-undetected, independent defects:

1. **Issue #395**: 130/10,000 lines non-idempotent under bare `parse`/`canonical_smiles` (no `standardize`). Every smallest failing example shares a common pattern (an explicit-bond-order ring closure, e.g. `c1-2`).
2. **Issue #399, found and corrected after this PR's CI first went red**: the `standardize`-path test's ceiling was originally set to 60/68, labeled as "re-measured after #392 merged" — that re-measurement never actually ran (a `git checkout` race silently clobbered the source file mid-build, and the resulting "no such test target" error was mistaken for "0 additional failures"). The honest, re-confirmed count (matching CI exactly) is **615/519** — a real ~9x increase caused specifically by #392: it correctly restores `stereo_neighbor_order` even for a `remove_hydrogens` no-op, which exposes a pre-existing, previously-masked bug in the canonical writer's stereo-reinterpretation logic. Minimal repro and full mechanism in #399. #392 did not introduce this bug — it removed the mask that was hiding it.

Neither #395 nor #399 is investigated or fixed here — per #393's own "not requesting" scope (no specific numeric target; this issue is about the test existing and being honest about what it measures).

## Why the tests aren't a strict `== 0` assertion

Landing these hard-failing on `main` would make every unrelated future PR's CI red for an already-tracked, pre-existing defect it didn't cause. `#[ignore]`-ing them instead would lose the "visible and tracked, not silently ignored" property #393 explicitly asked for. Following this project's own `_known_broken`-fixture convention (e.g. `dg.rs`'s ring-fusion tests) and its "gate fail != regression until redesigned" precedent (issue #70), both tests pin the **currently-measured failure count as a ceiling**: green as long as it doesn't get worse, loud with every failing line the moment it does.

- `chematic-smiles`: 57/5000 (`descriptor_census_corpus.smi`), 73/5000 (`chembl_accuracy_corpus_4999.smi`) — all attributable to issue #395.
- `chematic-chem` (standardized): **519/5000, 615/5000** — the honest, CI-confirmed baseline (see #399 above; corrected from an earlier, unverified 60/68).

## Verification

- `cargo test -p chematic-smiles --test canonical_idempotency_corpus` — 2/2 pass.
- `cargo test -p chematic-chem --test canonical_idempotency_corpus_standardized` — 2/2 pass, re-confirmed locally against the corrected ceiling.
- CI (this PR's own run) is the authoritative confirmation — it caught the original ceiling error directly, which is exactly why it's valuable.
- `cargo clippy -p chematic-smiles -p chematic-chem --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.

## Related

Refs #393. Found and filed #395, #399 (neither fixed here). Not part of issue #394's audit (separate PR/comment).