### PR TITLE
fix(chematic-smiles): coupled E/Z canonicalization could silently change geometry (issue #390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,88 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   configuration, and Boc-protecting-group / fused-bicyclic-ring
   regression cases.
 
+### Fixed — `chematic-smiles` (issue #390: coupled E/Z canonicalization could silently change geometry)
+
+- Root cause, two independent defects in `CanonicalWriter`'s E/Z marker
+  machinery, both needed to reproduce the filed witness
+  (`O/N=C/C(C=N/O)=N\NC`, whose atom3=atom7 double bond was silently
+  written as E instead of the true Z — confirmed via independent RDKit
+  `MolToInchi`/`GetStereo()`, not just chematic's own self-consistency):
+  1. `resolve_ez_markers`'s carrier election for an ambiguous end could
+     elect a candidate bond whose sibling was raw-marked and load-bearing
+     for a *different*, unrelated double bond — demoting the sibling
+     silently under-specified that other double bond, while the elected
+     candidate simultaneously handed a *third*, genuinely undefined
+     double bond (confirmed via InChI's own `?` stereo descriptor for it)
+     a geometry it never had. Neither the demotion nor the promotion is
+     geometry-neutral, and picking between them at random (by whichever
+     canonical-numbering trial happened to explore first) is exactly how
+     the witness's true geometry got lost. Fixed by
+     `CanonicalWriter::is_load_bearing_elsewhere`: an election must not
+     demote a raw-marked candidate that is some other, non-ambiguous
+     double bond's only geometric anchor. Deliberately narrower than "has
+     a raw mark" — a candidate whose sibling is *itself* ambiguous (has
+     its own resolution path, e.g. a genuinely coupled/shared-carrier
+     system) is not protected, so legitimate coupled resolution is
+     unaffected.
+  2. Independently, `normalize_ez` decided a shared E/Z group's sign from
+     a value that had already been re-oriented for one specific DFS write
+     direction. Which end of a directional bond a given canonicalization
+     trial happens to write "forward" vs "backward" varies across
+     candidate atom numberings for reasons unrelated to that bond's own
+     geometry (a tie elsewhere in the molecule), so the seeded sign could
+     vary too, non-deterministically flipping an otherwise-correct group.
+     Fixed by splitting `normalize_ez` into a mol-relative propagation
+     step (always flips `effective_order`, the bond's own topology-fixed
+     `atom1`→`atom2` reading, never an already-write-oriented value) and a
+     write-perspective anchor-seeding step (the write atom decides the
+     group's shared sign exactly once, and only that — it never enters
+     propagation). Found and fixed second, after the first fix alone
+     restored correctness for the filed witness but broke canonical-form
+     stability (10 independently-rooted, InChI-confirmed-equivalent
+     respellings of the witness converged to only 1 string before this
+     defect existed in the code at all — introducing defect #1's fix
+     alone dropped that to 3 non-idempotent strings; both fixes together
+     restore 10/10 convergence).
+- An intermediate, never-shipped attempt at defect #2 (seeding purely
+  from write-perspective, dropping the mol-relative anchor entirely)
+  restored canonical-form stability but silently made canonicalization
+  *informationally lossy* for this shape — the witness's true-Z and a
+  hand-verified true-E mirror both canonicalized to the identical string,
+  each losing its own stereo identity in different directions. Caught by
+  a mirror-distinctness regression test before being combined with defect
+  #1's fix into what actually shipped; not a real intermediate state of
+  the code, called out here only because the failure mode (idempotent AND
+  self-consistent, yet wrong) is exactly the kind that hides behind a
+  weaker "does it round-trip" check alone.
+- Verified against the real 290-compound corpus from the originating
+  investigation (eMolecules, 9.47M compounds,
+  `renkin doctor stock reimport_idempotency`) two ways: idempotence
+  (**290/290**, up from 289/290 before this fix) and, independently, that
+  each record's chematic canonical form reparses in RDKit to the exact
+  InChIKey recorded for that record at investigation time (**290/290**) —
+  the corpus itself is not committed (see PR #389's own note on this), only
+  aggregate counts.
+- New tests: the witness's own geometry preserved and stable, its only
+  safe alternate-carrier candidate confirmed to have none available
+  (`alternate_ez_markings` returns empty — the sibling candidate is
+  load-bearing elsewhere, so no valid respelling moves the mark there),
+  mirror-image (E vs Z) distinctness, and full atom-order-permutation
+  invariance across 18 relabelings/markings via the same
+  `ez_carrier_test_variants` harness `EZ_SHARED_CARRIER_FULLY_RESOLVED`'s
+  own regression test uses.
+- Not addressed, not fixed, not blocking this PR: a synthetic edge case
+  found while writing this fix's own tests (not part of the filed issue,
+  the 290-corpus, or any pre-existing test) — an ambiguous end whose
+  *both* candidate bonds carry mutually-consistent raw marks, where one
+  candidate's sibling is itself adjacent to a genuinely undefined double
+  bond, produced a geometry mismatch between the raw input and a
+  canonicalize→reparse round-trip in this crate's own test-only
+  `up_of_reference` oracle. Not confirmed as a production defect (the
+  oracle is test-only scaffolding, not the production code path) or ruled
+  out as one — flagged here rather than silently dropped, deliberately
+  not filed as an issue without that confirmation.
+
 ### Added — `chematic-py` (A2.1: Python bindings for the conformer ensemble core)
 
 - `Mol.conformer_ensemble_v2(config)`: a new, separate Python method

--- a/crates/chematic-smiles/src/canonical.rs
+++ b/crates/chematic-smiles/src/canonical.rs
@@ -506,8 +506,14 @@ pub(crate) struct CanonicalWriter<'a> {
     ranks: &'a [u64],
     written: Vec<bool>,
     ring_bonds: HashSet<BondIdx>,
-    /// (ring_num, bond_order, ring_partner_atom, physical_bond)
-    atom_ring_nums: HashMap<AtomIdx, Vec<(u32, BondOrder, AtomIdx, BondIdx)>>,
+    /// (ring_num, is_open_side, ring_partner_atom, physical_bond). Deliberately
+    /// does NOT store a precomputed `BondOrder`: which endpoint of `bidx` is
+    /// "open" vs "close" is fixed at discovery time (`dfs_mark`), but the
+    /// actual `/`/`\` token can only be correctly computed once written --
+    /// see `normalize_ez`'s doc comment for why baking in a write-direction
+    /// re-orientation this early corrupts E/Z groups spanning bonds visited
+    /// in different directions (issue #390).
+    atom_ring_nums: HashMap<AtomIdx, Vec<(u32, bool, AtomIdx, BondIdx)>>,
     next_ring: u32,
     out: String,
     /// Union-find groups of directional (`/`/`\`) bonds that jointly encode
@@ -1061,6 +1067,17 @@ impl<'a> CanonicalWriter<'a> {
     ) -> Option<HashMap<BondIdx, BondOrder>> {
         let mut votes: HashMap<BondIdx, BondOrder> = HashMap::new();
         for (i, &end) in ordered.iter().enumerate() {
+            // A carrier election is not geometry-neutral when the losing
+            // (demoted) candidate is itself load-bearing for a *different*
+            // stereo double bond -- demoting it would silently strip that
+            // other double bond's own explicit geometry, and electing the
+            // winner would (via `build_ez_groups`) hand that other double
+            // bond's side a spurious value it never had (issue #390's actual
+            // root cause). See `is_load_bearing_elsewhere`.
+            let other_bidx = subs[i][1 - choice[i]].1;
+            if self.is_load_bearing_elsewhere(other_bidx, end) {
+                return None;
+            }
             for (bidx, value) in self.end_votes(end, &subs[i], pref[i], ref_up[i], choice[i]) {
                 match votes.get(&bidx) {
                     None => {
@@ -1072,6 +1089,55 @@ impl<'a> CanonicalWriter<'a> {
             }
         }
         Some(votes)
+    }
+
+    /// True if `bidx` (one of `owning_end`'s own two candidate substituent
+    /// bonds) carries a genuine raw input mark *and* also flanks a
+    /// *different* stereo double bond's end that is itself *not* ambiguous
+    /// (exactly one substituent, so `bidx` is its ONLY possible source of
+    /// geometric information) -- i.e. electing `owning_end`'s *other*
+    /// candidate as carrier would demote `bidx` to a plain bond, silently
+    /// stripping that other, unrelated double bond of the one explicit mark
+    /// it has no alternative way to recover.
+    ///
+    /// Deliberately excludes the case where the far end is itself ambiguous
+    /// (2 substituents, i.e. also in [`Self::compute_stereo_alkene_ends`]):
+    /// such an end has its own resolution machinery (possibly jointly, via
+    /// [`Self::coupling_components`]/[`Self::resolve_component_jointly`])
+    /// and is not solely dependent on this one candidate's raw mark --
+    /// forbidding its demotion here would block genuinely coupled,
+    /// resolvable systems (`EZ_SHARED_CARRIER_FULLY_RESOLVED`) for no
+    /// reason, since a real conflict there is already caught by
+    /// `evaluate_choice`'s own vote-consistency check.
+    ///
+    /// This is deliberately narrower than "does `bidx` have a raw mark":
+    /// demoting a raw-marked candidate that flanks nothing else (the common,
+    /// intended case `resolve_ez_markers` exists for -- picking whichever of
+    /// two candidates the canonical rank prefers, regardless of which one
+    /// the input happened to mark) must stay allowed. Only a candidate that
+    /// is *also* someone else's sole, non-ambiguous load-bearing mark is
+    /// protected.
+    fn is_load_bearing_elsewhere(&self, bidx: BondIdx, owning_end: AtomIdx) -> bool {
+        if self.raw_input_direction(bidx).is_none() {
+            return false;
+        }
+        let bond = self.mol.bond(bidx);
+        let Some(other_end) = bond.other(owning_end) else {
+            return false;
+        };
+        if Self::substituents(self.mol, other_end).len() != 1 {
+            return false; // other_end is itself ambiguous -- has its own resolution path
+        }
+        self.mol.neighbors(other_end).any(|(_, nb_bidx)| {
+            nb_bidx != bidx
+                && self.mol.bond(nb_bidx).order == BondOrder::Double
+                && Self::end_has_substituent(self.mol, other_end)
+                && self
+                    .mol
+                    .bond(nb_bidx)
+                    .other(other_end)
+                    .is_some_and(|far| Self::end_has_substituent(self.mol, far))
+        })
     }
 
     /// One end's own votes on its two candidate bonds, given its
@@ -1167,10 +1233,47 @@ impl<'a> CanonicalWriter<'a> {
         }
     }
 
-    /// Normalize a directional bond order so the first occurrence of each
-    /// E/Z system in canonical write order is always `Up` (`/`); every other
-    /// bond in the system is flipped consistently to preserve geometry.
-    fn normalize_ez(&mut self, bidx: BondIdx, order: BondOrder) -> BondOrder {
+    /// Normalize a directional bond so every member of its E/Z system is
+    /// flipped consistently -- in mol-relative (`atom1`->`atom2`) terms -- to
+    /// preserve geometry, with the group's shared sign pinned so the first
+    /// occurrence in canonical write order prints as `Up` (`/`).
+    ///
+    /// This function does two genuinely different jobs, on two different
+    /// frames, and conflating them is exactly how issue #390 happened:
+    ///
+    /// 1. **Propagation** (every call): flip [`Self::effective_order`] --
+    ///    mol-relative, topology-fixed -- by the group's shared bit.
+    ///    `build_ez_groups` unions bonds by molecule topology alone, so this
+    ///    MUST run in that same topology-fixed frame. A bond's `atom1`/
+    ///    `atom2` struct fields are fixed at parse/build time, but which
+    ///    endpoint a *specific* DFS write visits first varies per occurrence
+    ///    and per candidate canonical numbering; flipping an
+    ///    already-write-oriented value mixes bonds visited "forward" with
+    ///    bonds visited "backward" relative to their own storage, silently
+    ///    inverting the very same/different relationship this function
+    ///    exists to preserve whenever a group spans bonds with different
+    ///    write directions (confirmed against RDKit: a coupled system with
+    ///    one member's DFS direction reversed relative to another's produced
+    ///    a genuinely wrong, not just differently spelled, configuration).
+    /// 2. **Anchoring** (first call per group only): seed the group's shared
+    ///    bit from whether *this specific occurrence*, re-oriented for
+    ///    `from_atom` via [`Self::reorient_for_write`], would print as
+    ///    `Down` -- because the point of the bit is to pin a *printed*
+    ///    character, which only exists in write-perspective terms. Seeding
+    ///    it from the mol-relative value instead pins an artifact of
+    ///    whichever input text happened to be parsed (`atom1`/`atom2`
+    ///    ordering is parse-order, not a canonical property): a different
+    ///    spelling of the same molecule can swap `atom1`/`atom2`, seed a
+    ///    different bit, and sign-flip the entire group -- geometry still
+    ///    internally consistent (propagation was already fixed), but no
+    ///    longer canonical or idempotent. `from_atom` is used **only** here,
+    ///    never mixed into propagation.
+    ///
+    /// Every call site MUST separately apply [`Self::reorient_for_write`] to
+    /// this function's *return value* for its own occurrence -- passing
+    /// `from_atom` here does not do that; it only seeds the anchor.
+    fn normalize_ez(&mut self, bidx: BondIdx, from_atom: AtomIdx) -> BondOrder {
+        let order = self.effective_order(bidx);
         if !matches!(order, BondOrder::Up | BondOrder::Down) {
             return order;
         }
@@ -1184,7 +1287,15 @@ impl<'a> CanonicalWriter<'a> {
             }
             x
         };
-        let flip = *self.ez_flip.entry(root).or_insert(order == BondOrder::Down);
+        let flip = if let Some(&f) = self.ez_flip.get(&root) {
+            f
+        } else {
+            let bond_atom1 = self.mol.bond(bidx).atom1;
+            let printed = Self::reorient_for_write(bond_atom1, from_atom, order);
+            let seed = printed == BondOrder::Down;
+            self.ez_flip.insert(root, seed);
+            seed
+        };
         if flip {
             match order {
                 BondOrder::Up => BondOrder::Down,
@@ -1193,6 +1304,32 @@ impl<'a> CanonicalWriter<'a> {
             }
         } else {
             order
+        }
+    }
+
+    /// Re-orient a mol-relative (`atom1`->`atom2`) directional order for
+    /// reading "from `from_atom` toward the bond's other endpoint" -- the
+    /// per-occurrence step every [`Self::normalize_ez`] caller must apply to
+    /// its return value. Mirrors `crate::writer::direction_from` exactly
+    /// (kept as a second copy since this one only ever runs after
+    /// `normalize_ez`, which has no equivalent in the plain writer).
+    fn reorient_for_write(bond_atom1: AtomIdx, from_atom: AtomIdx, order: BondOrder) -> BondOrder {
+        match order {
+            BondOrder::Up => {
+                if bond_atom1 == from_atom {
+                    BondOrder::Up
+                } else {
+                    BondOrder::Down
+                }
+            }
+            BondOrder::Down => {
+                if bond_atom1 == from_atom {
+                    BondOrder::Down
+                } else {
+                    BondOrder::Up
+                }
+            }
+            other => other,
         }
     }
 
@@ -1311,54 +1448,22 @@ impl<'a> CanonicalWriter<'a> {
                 self.ring_bonds.insert(bidx);
                 let rn = self.next_ring;
                 self.next_ring += 1;
-                let bond = self.mol.bond(bidx);
-                // A ring bond forced to Aromatic (e.g. adjacent to an
-                // exocyclic C=N) may carry its true E/Z direction stashed
-                // separately rather than in `order` itself; a bond flanking
-                // a tri-/tetra-substituted stereo alkene may instead carry
-                // `resolve_ez_markers`'s resolved choice. `effective_order`
-                // checks both, in that priority, before falling back to the
-                // bond's own real order.
-                let effective_order = self.effective_order(bidx);
-                // Direction seen from `neighbor` (the open atom) going toward `atom`.
-                let order_at_open = match effective_order {
-                    BondOrder::Up => {
-                        if bond.atom1 == neighbor {
-                            BondOrder::Up
-                        } else {
-                            BondOrder::Down
-                        }
-                    }
-                    BondOrder::Down => {
-                        if bond.atom1 == neighbor {
-                            BondOrder::Down
-                        } else {
-                            BondOrder::Up
-                        }
-                    }
-                    other => other,
-                };
-                // Suppress stereo at the close atom to avoid conflicting
-                // ring-closure chars, falling back to the bond's own plain
-                // (non-directional) order: `Aromatic` unchanged for a
-                // stashed/resolved direction (implicit ring bond, no char),
-                // `Single` for a genuine literal directional single bond.
-                let order_at_close = match effective_order {
-                    BondOrder::Up | BondOrder::Down => Self::plain_order(bond.order),
-                    other => other,
-                };
-                self.atom_ring_nums.entry(neighbor).or_default().push((
-                    rn,
-                    order_at_open,
-                    atom,
-                    bidx,
-                )); // partner = close atom
-                self.atom_ring_nums.entry(atom).or_default().push((
-                    rn,
-                    order_at_close,
-                    neighbor,
-                    bidx,
-                )); // partner = open atom
+                // Discovery only decides ring numbering and which endpoint is
+                // "open" (carries the marker, written when `neighbor` is
+                // reached) vs "close" (suppressed, written when `atom` is
+                // reached) -- NOT the actual `/`/`\` token. That is computed
+                // later, in `write_chain`, from `normalize_ez`'s mol-relative
+                // result re-oriented for whichever atom is actually being
+                // written at consumption time (see `normalize_ez`'s doc
+                // comment and `atom_ring_nums`'s field comment).
+                self.atom_ring_nums
+                    .entry(neighbor)
+                    .or_default()
+                    .push((rn, true, atom, bidx)); // open side; partner = close atom
+                self.atom_ring_nums
+                    .entry(atom)
+                    .or_default()
+                    .push((rn, false, neighbor, bidx)); // close side; partner = open atom
             }
         }
 
@@ -1388,8 +1493,27 @@ impl<'a> CanonicalWriter<'a> {
 
         // Ring-closure digits.
         if let Some(rings) = self.atom_ring_nums.remove(&atom) {
-            for (rn, bond_order, _partner, bidx) in rings {
-                let bond_order = self.normalize_ez(bidx, bond_order);
+            for (rn, is_open, _partner, bidx) in rings {
+                // The open side carries the marker (normalize_ez's
+                // mol-relative result, re-oriented for `atom` -- the
+                // endpoint actually being written right now); the close
+                // side is always suppressed to its plain, non-directional
+                // order to avoid printing conflicting ring-closure chars at
+                // both ends of the same back-edge. Mirrors dfs_mark's
+                // former order_at_open/order_at_close split exactly, just
+                // computed now instead of at discovery time (see
+                // `normalize_ez`'s doc comment for why).
+                let bond_order = if is_open {
+                    let normalized = self.normalize_ez(bidx, atom);
+                    Self::reorient_for_write(self.mol.bond(bidx).atom1, atom, normalized)
+                } else {
+                    match self.effective_order(bidx) {
+                        BondOrder::Up | BondOrder::Down => {
+                            Self::plain_order(self.mol.bond(bidx).order)
+                        }
+                        other => other,
+                    }
+                };
                 let bond_order = suppress_standalone_wedge(self.mol, bidx, bond_order);
                 let atom_arom = self.mol.atom(atom).aromatic;
                 if !(bond_order == BondOrder::Aromatic && atom_arom)
@@ -1420,7 +1544,7 @@ impl<'a> CanonicalWriter<'a> {
         }
 
         // Tree-edge children, sorted canonically.
-        let mut children: Vec<(AtomIdx, BondIdx, BondOrder)> = self
+        let mut children: Vec<(AtomIdx, BondIdx)> = self
             .mol
             .neighbors(atom)
             .filter(|(nb, bidx)| {
@@ -1428,45 +1552,24 @@ impl<'a> CanonicalWriter<'a> {
                     && !self.written[nb.0 as usize]
                     && !self.ring_bonds.contains(bidx)
             })
-            .map(|(nb, bidx)| {
-                let bond = self.mol.bond(bidx);
-                // See the ring-closure site above: `effective_order` applies
-                // `resolve_ez_markers`'s resolved carrier choice and the
-                // aromatic-bond-direction stash, both ahead of the bond's
-                // own literal order.
-                let effective_order = self.effective_order(bidx);
-                // Direction seen from `atom` going toward `nb`.
-                let order = match effective_order {
-                    BondOrder::Up => {
-                        if bond.atom1 == atom {
-                            BondOrder::Up
-                        } else {
-                            BondOrder::Down
-                        }
-                    }
-                    BondOrder::Down => {
-                        if bond.atom1 == atom {
-                            BondOrder::Down
-                        } else {
-                            BondOrder::Up
-                        }
-                    }
-                    other => other,
-                };
-                (nb, bidx, order)
-            })
             .collect();
 
         // Sort children by canonical rank (ascending → highest rank = main chain).
         children.sort_by(|&(a, ..), &(b, ..)| self.canonical_cmp(a, b));
 
         let n = children.len();
-        for (i, (child, bidx, bond_order)) in children.into_iter().enumerate() {
-            // Normalized here (not in the map above) so the flip decision is
+        for (i, (child, bidx)) in children.into_iter().enumerate() {
+            // Normalized here (not before sorting) so the flip decision is
             // made in true left-to-right write order: this atom's earlier
             // (lower-rank) children have already fully recursed by the time
-            // a later sibling's direction is decided.
-            let bond_order = self.normalize_ez(bidx, bond_order);
+            // a later sibling's direction is decided. `effective_order`
+            // applies `resolve_ez_markers`'s resolved carrier choice and the
+            // aromatic-bond-direction stash, both ahead of the bond's own
+            // literal order; `normalize_ez` (mol-relative) must run before
+            // re-orienting for `atom`'s write direction, never after -- see
+            // its doc comment.
+            let normalized = self.normalize_ez(bidx, atom);
+            let bond_order = Self::reorient_for_write(self.mol.bond(bidx).atom1, atom, normalized);
             let bond_order = suppress_standalone_wedge(self.mol, bidx, bond_order);
             let is_last = i == n - 1;
             let parent_arom = self.mol.atom(atom).aromatic;
@@ -3584,6 +3687,149 @@ mod tests {
                  E/Z geometry fact"
             );
         }
+    }
+
+    /// Issue #390 witness: `O/N=C/C(C=N/O)=N\NC`. A prior version of
+    /// `normalize_ez` silently changed this molecule's atom3=atom7 double
+    /// bond from Z to E -- confirmed genuinely wrong (not just a different,
+    /// equally valid spelling) via an independent RDKit `MolToInchi`/
+    /// `GetStereo()` check, before any fix existed.
+    ///
+    /// Root cause, in two parts:
+    /// 1. `resolve_ez_markers`'s carrier election for the ambiguous end
+    ///    (2 candidates: the bond toward the atom1=atom2 double bond's own
+    ///    side, raw-marked and load-bearing for atom1=atom2's geometry; the
+    ///    bond toward the atom4=atom5 double bond's side, unmarked --
+    ///    atom4=atom5 is itself genuinely undefined in this molecule, only
+    ///    one of its two flanking bonds ever carries a mark, confirmed via
+    ///    InChI's own `?` stereo descriptor for it) could elect the
+    ///    unmarked candidate. That demotes the marked one -- silently
+    ///    under-specifying atom1=atom2 -- while handing atom4=atom5 a
+    ///    geometry it never had. Neither move is neutral. Fixed by
+    ///    [`Self::is_load_bearing_elsewhere`]: an election must not demote a
+    ///    raw-marked candidate that is some other, non-ambiguous double
+    ///    bond's only geometric anchor.
+    /// 2. Independently, `build_ez_groups`/`normalize_ez` chained the
+    ///    elected carrier's group together with atom4=atom5's own group
+    ///    (both touch the same connecting bond), and the group's sign was
+    ///    seeded from a value that had already been re-oriented for one
+    ///    specific DFS write direction -- which bond within a group gets
+    ///    visited "forward" vs "backward" varies across candidate canonical
+    ///    numberings for reasons unrelated to this bond's own geometry, so
+    ///    the seeded sign could vary too. Fixed by splitting `normalize_ez`
+    ///    into a mol-relative propagation step (always operates on
+    ///    [`Self::effective_order`], never an already-write-oriented value)
+    ///    and a write-perspective anchor-seeding step (uses the write atom
+    ///    ONLY to decide the group's shared sign once, never to decide what
+    ///    gets propagated).
+    #[test]
+    fn issue390_witness_geometry_preserved_and_stable() {
+        let smi = "O/N=C/C(C=N/O)=N\\NC";
+        let mol = parse(smi).unwrap();
+        let canon = canonical_smiles(&mol);
+        assert_eq!(
+            canon, smi,
+            "canonical form must match this already-canonically-written input exactly"
+        );
+
+        let reparsed = parse(&canon).unwrap();
+        let canon_twice = canonical_smiles(&reparsed);
+        assert_eq!(
+            canon, canon_twice,
+            "canonical(canonical(x)) must equal canonical(x)"
+        );
+
+        let before_geo = geometry_fingerprint(&mol);
+        let after_geo = geometry_fingerprint(&reparsed);
+        assert_eq!(
+            before_geo, after_geo,
+            "E/Z geometry must be preserved by canonicalization"
+        );
+        assert!(
+            before_geo.iter().any(|f| f.is_some()),
+            "test setup sanity: witness must have at least one defined E/Z fact"
+        );
+    }
+
+    /// The issue #390 witness's ambiguous end has exactly one *safe*
+    /// candidate: the bond toward atom1=atom2, which is load-bearing for
+    /// that unrelated double bond's own geometry. Its sibling (toward
+    /// atom4=atom5, itself undefined) is therefore NOT a valid
+    /// geometry-preserving alternate carrier -- moving the mark there would
+    /// silently strip atom1=atom2's geometry, exactly the corruption
+    /// [`Self::is_load_bearing_elsewhere`] exists to forbid.
+    /// [`alternate_ez_markings`] independently verifies geometry
+    /// preservation before offering an alternate, so it returning none here
+    /// is itself a direct, positive confirmation the fix is in effect --
+    /// not a vacuous negative.
+    #[test]
+    fn issue390_witness_has_no_valid_alternate_marking() {
+        let mol = parse("O/N=C/C(C=N/O)=N\\NC").unwrap();
+        let alternates = alternate_ez_markings(&mol);
+        assert!(
+            alternates.is_empty(),
+            "the only other candidate is load-bearing for atom1=atom2's own geometry; \
+             moving the mark there must not be offered as a valid alternate"
+        );
+    }
+
+    /// Mirror/stereoisomer distinctness: the issue #390 witness's E and Z
+    /// forms must remain genuinely distinguishable after canonicalization,
+    /// never collapse into the same string. Direct regression test for a
+    /// mid-investigation defect (never shipped) where an earlier attempted
+    /// fix made canonicalization informationally lossy for this coupled
+    /// shape -- both the true-Z and true-E spellings canonicalized to
+    /// identical output regardless of which geometry was actually input.
+    #[test]
+    fn issue390_mirror_stereoisomers_stay_distinct() {
+        let z = canonical_smiles(&parse("O/N=C/C(C=N/O)=N\\NC").unwrap());
+        let e = canonical_smiles(&parse("O/N=C/C(C=N/O)=N/NC").unwrap());
+        assert_ne!(
+            z, e,
+            "genuinely different E/Z witnesses must not canonicalize to the same string"
+        );
+    }
+
+    /// Atom-order permutation invariance for the issue #390 witness: every
+    /// deterministic relabeling [`ez_carrier_test_variants`] produces
+    /// (identity, reversed, 16 seeded Fisher-Yates shuffles, plus any
+    /// geometry-preserving alternate markings) must canonicalize to the
+    /// identical string, and that string must be idempotent and preserve
+    /// the input's own E/Z geometry.
+    #[test]
+    fn issue390_witness_permutation_invariant() {
+        let mol = parse("O/N=C/C(C=N/O)=N\\NC").unwrap();
+        let variants = ez_carrier_test_variants(&mol);
+        assert!(
+            variants.len() >= 18,
+            "sanity: at least 16 deterministic + 2 fixed relabelings"
+        );
+
+        let outputs: Vec<String> = variants.iter().map(canonical_smiles).collect();
+        let unique: HashSet<&String> = outputs.iter().collect();
+        assert_eq!(
+            unique.len(),
+            1,
+            "expected ONE canonical output across {} relabelings/markings, got {}: {:?}",
+            variants.len(),
+            unique.len(),
+            unique
+        );
+
+        let canon = outputs[0].clone();
+        let reparsed = parse(&canon).unwrap_or_else(|e| panic!("reparse of '{canon}': {e}"));
+        assert_eq!(
+            canonical_smiles(&reparsed),
+            canon,
+            "canonical(canonical(x)) must equal canonical(x)"
+        );
+
+        let before_geo = geometry_fingerprint(&mol);
+        let after_geo = geometry_fingerprint(&reparsed);
+        assert_eq!(
+            before_geo, after_geo,
+            "E/Z geometry must be preserved across permutation + canonicalization"
+        );
     }
 
     /// Direct empirical check of the invariant [`Self::resolve_component_


### PR DESCRIPTION
## Summary

Fixes #390 — the last residual gap from the isotope (#389) / stereo_neighbor_order (#392) investigation.

Root-caused via bare `parse`/`canonical_smiles` (no `standardize`/`remove_hydrogens` involved — this is a separate, independent defect from #389/#392) to **two** distinct bugs in `CanonicalWriter`'s E/Z marker machinery, both required to reproduce and both fixed here:

1. **Carrier election could demote a load-bearing raw mark.** `resolve_ez_markers`'s election for an ambiguous end (2 candidate substituent bonds) could elect the candidate whose sibling was raw-marked and load-bearing for a *different*, unrelated double bond — silently under-specifying that other bond while simultaneously handing a third, genuinely undefined double bond (confirmed via InChI's own `?` descriptor) a geometry it never had. Fixed by `CanonicalWriter::is_load_bearing_elsewhere`, which forbids demoting such a candidate. Deliberately narrow: a sibling that is itself ambiguous (has its own resolution path) is not protected, so real coupled/shared-carrier systems (`EZ_SHARED_CARRIER_FULLY_RESOLVED`) still resolve correctly.
2. **`normalize_ez` seeded a shared group's sign from a write-oriented value.** Which end of a bond a given canonicalization trial visits "forward" vs "backward" varies across candidate atom numberings for reasons unrelated to that bond's own geometry (a tie elsewhere in the molecule) — so the seeded sign varied too, non-deterministically flipping an otherwise-correct group. Fixed by splitting `normalize_ez` into mol-relative propagation (always flips the topology-fixed `atom1→atom2` reading) and write-perspective anchor-seeding (decides the group's sign exactly once, never enters propagation).

Fixing defect #1 alone restored correctness for the filed witness but broke canonical-form stability (a set of 10 independently-rooted, RDKit-InChI-confirmed-equivalent respellings that converged to 1 string before either fix existed dropped to 3 non-idempotent strings). An intermediate attempt at #2 (write-perspective-only seeding, no mol-relative anchor) restored stability but made canonicalization *informationally lossy* for this shape — a witness and its hand-verified mirror (E vs Z) both collapsed to the identical string. Caught by a mirror-distinctness test before being combined with #1 into what's actually in this PR. Both fixes together are required.

## Verification

- Filed witness (`O/N=C/C(C=N/O)=N\NC`) now canonicalizes to itself exactly, matching independent RDKit `MolToInchi`/`GetStereo()` ground truth (previously silently written as the wrong stereoisomer).
- Mirror/stereoisomer distinctness: hand-verified E and Z inputs canonicalize to different strings.
- 18-way atom-order permutation invariance for the witness (identity + reversed + 16 seeded Fisher-Yates relabelings), via the same `ez_carrier_test_variants` harness `EZ_SHARED_CARRIER_FULLY_RESOLVED`'s own regression test uses.
- Fresh-process determinism: 10 separate process invocations, identical output.
- Full 290-record corpus from the originating investigation (eMolecules, 9.47M compounds, `renkin doctor stock reimport_idempotency`), verified two independent ways:
  - Idempotence: **290/290** (up from 289/290 before this fix).
  - Independent RDKit InChIKey cross-check (chematic's canonical output reparsed in RDKit, compared against the InChIKey recorded for that record at investigation time): **290/290**.
  - Corpus itself not committed (real eMolecules-derived data), only aggregate counts — matching this project's existing convention from PR #389.
- `cargo test -p chematic-smiles --lib`: 206/206 (202 pre-existing + 4 new).
- `cargo test -p chematic-chem --lib`: 819/819 (unaffected).
- `cargo test -p chematic-rxn --lib`: 180/180 (unaffected).
- `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings`: clean.

## Not addressed, not blocking this PR (update: ruled out as a production defect)

A synthetic edge case found while writing this fix's own tests (not part of the filed issue, the 290-corpus, or any pre-existing test): an ambiguous end whose *both* candidates carry mutually-consistent raw marks, where one candidate's sibling is itself adjacent to a genuinely undefined double bond, produced a mismatch between the raw input and a canonicalize→reparse round-trip **in this crate's own test-only `up_of_reference` oracle**. Isolated further after opening this PR: comparing the raw over-specified input and the canonicalized+reparsed output directly against RDKit (`MolToInchi`, per-bond `GetStereo()`) shows they encode the **exact same real molecule and configuration** — the production canonical output is correct. The mismatch is confined to `up_of_reference`'s own reference-substituent selection for this specific input shape (both candidates of an ambiguous end explicitly marked), not to `resolve_ez_markers`/`normalize_ez` or any other production code path. No production defect; no fix needed; not filed as an issue.

## Test plan

- [x] Filed witness matches RDKit ground truth
- [x] Mirror (E/Z) distinctness
- [x] `canon(x) == canon(canon(x))`
- [x] Raw-vs-canonical E/Z descriptor agreement (InChIKey cross-check)
- [x] Existing simple E/Z controls (`ez_canonical_smiles_is_idempotent`, `ez_geometry_preserved_through_canonicalization`)
- [x] Coupled E/Z controls (`ez_shared_carrier_fully_resolved_are_permutation_invariant`, previously regressed mid-fix, now passing)
- [x] Atom-order permutation invariance (18-way)
- [x] Fresh-process determinism
- [x] Full 290-case corpus, 0 mismatches (both idempotence and RDKit cross-check)
