### PR TITLE
release: v0.20.0 -- stereo-safe 3D generation, connectivity-ordered coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,103 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] — 2026-08-25
+
+### Added — `chematic-3d`/`chematic-py`/`chematic-wasm` (stereo-safe 3D generation, issue #291)
+
+- `PipelineV2Config::expand_implicit_h_through_pipeline`: runs
+  `embed_pipeline_v2`'s whole pipeline on a temporary
+  `add_hydrogens`-expanded copy of the molecule instead of the original,
+  closing a real gap for ring-fused declared stereocenters (testosterone,
+  cholesterol, and similar) where `repair_tetrahedral_center` previously had
+  no coordinate to reflect an implicit H against. `PipelineV2Result::coords`/
+  `final_stereo` stay scoped to the caller's original atom count either way;
+  other diagnostic fields describe the expanded internal working state,
+  documented explicitly on the struct. Stage 2/3 (torsion knowledge) always
+  run against the *original* molecule, not the expanded one — `add_hydrogens`
+  appending real graph nodes would otherwise silently reclassify e.g. a
+  secondary amine's hybridization for torsion-rule purposes, an interaction
+  this design deliberately avoids rather than leaves unmeasured.
+- `PipelineV2Config::stereo_safe(force_field_policy)`: a new convenience
+  constructor bundling `stereo_policy: RepairAndVerify` +
+  `enforce_chirality: true` + `expand_implicit_h_through_pipeline: true` —
+  setting only some of these three together silently falls back to a
+  configuration already measured unsound for exactly this molecule class.
+  Exposed identically through `chematic-py` (`PipelineV2Config.stereo_safe(...)`
+  staticmethod) and `chematic-wasm` (`pipeline_v2_stereo_safe_config_json(...)`,
+  since JS has no static-method equivalent).
+- **Measured**, 29-molecule × 5-seed regression corpus: **144/145 (99.3%)
+  correct_and_ok, 0 silently_wrong, 0 loud_failure_stereo** — testosterone
+  and cholesterol both now succeed on every declared stereocenter, every
+  seed (5/5 each). The one remaining failure is cholesterol's pre-existing,
+  unrelated UFF `CatastrophicBondBlowup` issue (not a stereo defect).
+- Existing callers unaffected: the new flag defaults to `false` at every
+  layer (Rust/Python/WASM), and `expand_implicit_h_through_pipeline: true`
+  without `enforce_chirality: true` is rejected with a typed
+  `InvalidConfiguration` error rather than silently doing nothing.
+
+### Added — `chematic-3d` (connectivity-ordered 3D coordinate generation, issues #256/#255)
+
+- `generate_coords_connectivity_ordered` (new `chematic_3d::dg_connectivity_ordered`
+  module, also re-exported at the crate root): a parallel rule-based 3D
+  placement engine, structurally ported from `chematic-depict`'s proven 2D
+  technique — a single worklist discovers and places rings and chain atoms
+  in true connectivity order (never "all rings, then all chains"), unlike
+  the legacy `generate_coords`'s `place_rings`, which places every ring in a
+  component before walking any chain atom (issue #256) and can produce
+  distorted fusion-seam bonds via a fixed `+y` extension (issue #255).
+- **Measured**, 33-molecule differential corpus (issue #277's 17 real
+  ChEMBL molecules + 8 RFC known-broken topologies + positive controls):
+  raw-geometry soundness **10/33 → 33/33**, zero regressions, all 17 of
+  #277's real molecules improved. Post-UFF-minimization: an initial
+  "new-island" ring-entry-direction regression (rings joined by a single
+  direct bond, e.g. biphenyl) was found and fixed via a 12-candidate
+  centroid-away-plus-clearance ranking — the fixed engine's post-UFF
+  `mean_viol15` reaches **0.0000**, past even the legacy engine's own
+  0.0055 baseline. Determinism (33/33 identical across repeated runs) and
+  atom-order-permutation-invariant quality both confirmed.
+- **`generate_coords` itself is completely unchanged** — this ships as an
+  available, independently-selectable alternative (not a default-behavior
+  switch or topology-based routing), the conservative and fully reversible
+  of the three options considered. No existing caller (`generate_coords_etkdg`,
+  `embed_pipeline_v2`, ...) is routed to the new engine by this release.
+  Issues #255/#256/#277 stay open — availability as public API is not the
+  same as a production routing decision.
+- Not yet exposed through Python/WASM bindings — Rust core first, per this
+  project's established pattern; deferred to a follow-up.
+
+### Fixed — `chematic-3d` (UFF-rescue path did not enforce declared chirality, issue #210)
+
+- `rescue_with_distance_geometry_v2` (the bridge that retries embedding
+  after a UFF catastrophic-bond-length-blowup) embedded its retry with
+  `enforce_chirality: false` unconditionally — a constraint that no longer
+  needed to hold once `EmbedParameters::materialize_implicit_h_for_chirality`
+  became available (issue #291, above) at this same low-level embed API.
+- **Measured** against the 58-molecule corpus this bridge's own tests use:
+  zero regressions across the full corpus, and one of the 5 residual
+  molecules this issue names (`atorvastatin_fragment`) newly succeeds with
+  declared stereochemistry preserved.
+- `naproxen_S`/`ibuprofen_S`/`testosterone`/`cholesterol` remain unfixed by
+  this specific change — this bridge has no post-minimization
+  repair-and-reverify step the way `embed_pipeline_v2`'s own stage 11 does,
+  so a UFF-introduced post-embed violation still falls through to the
+  original (honest) failure. Issue #210 stays open, partial fix only.
+
+### Added — benchmark (`chematic-3d` best-of-N conformer generation vs. RDKit)
+
+- New benchmark arm, `chematic_pipeline_v2_uff_best_of_10`: `embed_ensemble_v2`
+  (`count=10`, `UffOnly`, `max_attempts=1`, `rmsd_threshold=0.0`), matched
+  against `docs/rfcs/pipeline_v2_vs_rdkit_etkdgv3_benchmark.md`'s existing
+  `rdkit_etkdgv3_best_of_n` arm so "10 attempts, best by energy" means the
+  same thing on both sides.
+- **Measured**: ~250/265 molecules successful on both sides; median paired
+  RMSD **2.147 Å**, median TFD **0.344** against RDKit's own best-of-10
+  `EmbedMultipleConfs`. This confirms `embed_ensemble_v2` (A2) works
+  robustly at this scale, but **does not** establish that chematic's
+  energy-based conformer *selection* picks the same conformer RDKit would
+  from the same pool — that's a separate, unestablished claim this
+  benchmark's numbers alone don't support.
+
 ### Fixed — `chematic-chem` `remove_hydrogens` (isotope labels silently destroyed)
 
 - `remove_hydrogens` previously removed *any* atom with `element == H`,
@@ -134,9 +231,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   MMFF94-zero-energy defect from PR #369). The docstring's own duplicated
   intro paragraph (a pre-existing copy-paste artifact, unrelated to this
   change) was cleaned up in the same edit.
-- Not done this round, by design: no WASM bindings for `embed_ensemble_v2`,
-  no version bump, and no best-of-N-vs-RDKit benchmark arm — those are the
-  explicitly planned next steps, not part of this change.
+- Not done this round, by design: no WASM bindings for `embed_ensemble_v2`.
+  The best-of-N-vs-RDKit benchmark arm planned as a next step here has
+  since landed — see "Added — benchmark" below.
 
 ### Fixed — documentation (correction to a v0.19.0 changelog entry)
 
@@ -155,6 +252,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   released changelog text itself, per this project's convention of never
   silently editing a shipped version's own historical record — see the
   entry below for what v0.19.0 originally said.
+
+### Known limitations in this release
+
+- `generate_coords` (the legacy 3D placement engine) is **not** routed to
+  the new connectivity-ordered engine — no existing caller's default
+  behavior changed. See "Added — connectivity-ordered 3D coordinate
+  generation" above.
+- Issue #210's remaining 4 residual molecules (`naproxen_S`, `ibuprofen_S`,
+  `testosterone`, `cholesterol`) are still unfixed via the UFF-rescue
+  bridge specifically — `stereo_safe` (this release's own headline feature,
+  above) already resolves them through `embed_pipeline_v2`'s own path.
+- Issue #390 (a single-molecule coupled/shared-bond E/Z correctness
+  residual, independent of every fix in this release) remains open.
+- The best-of-10 conformer benchmark establishes that `embed_ensemble_v2`
+  works robustly at scale; it does **not** establish RDKit conformer-
+  *selection* parity — see "Added — benchmark" above for the exact
+  distinction.
+- This release's evidence is drawn from measurements already taken during
+  development (29-molecule × 5-seed stereo sweep, 33-molecule connectivity
+  differential, 265-molecule best-of-10 benchmark, 58-molecule UFF-rescue
+  sweep, the 9.47M-compound downstream identity investigation) — no fresh
+  full-corpus re-measurement was run solely for this release, per this
+  project's own "minimize heavy measurements" policy.
 
 ## [0.19.0] — 2026-08-23
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,5 +23,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.19.0
+version: 0.20.0
 date-released: "2026-08-12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.19.0
+# chematic v0.20.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-07-17, v0.4.29 vs RDKit 2026.03.3 --
@@ -447,6 +447,15 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +1
 
 ## Recent Development
 
+**v0.20.0** (2026-08-25): **Stereo-safe 3D generation, a connectivity-ordered coordinate engine, and identity-correctness fixes for `remove_hydrogens`**
+- `chematic-3d`/`chematic-py`/`chematic-wasm`: `PipelineV2Config::stereo_safe(force_field_policy)` — a single-call configuration that resolves a real gap for ring-fused declared stereocenters (testosterone, cholesterol, and similar), where `repair_tetrahedral_center` previously had no coordinate to reflect an implicit H against. Measured on a 29-molecule × 5-seed corpus: 144/145 (99.3%) correct_and_ok, 0 silently wrong, testosterone/cholesterol both 5/5 seeds on every declared stereocenter
+- `chematic-3d`: `generate_coords_connectivity_ordered`, a new public alternative 3D placement engine (issues #256/#255) — places rings and chain atoms in true connectivity order rather than "all rings, then all chains." Measured: raw-geometry soundness 10/33 → 33/33 on a differential corpus with zero regressions, post-UFF bond-violation rate reaching 0.0000 (better than the legacy engine's own baseline). `generate_coords` itself is completely unchanged — ships as an available alternative, not a default-behavior switch; no existing caller is routed to it
+- `chematic-3d`: `rescue_with_distance_geometry_v2` (the UFF-catastrophic-blowup rescue bridge) now enforces declared chirality on retry (issue #210, partial fix) — zero regressions on its 58-molecule corpus, one of 5 named residual molecules newly succeeds; 4 residuals remain unfixed via this specific bridge (though resolved via `stereo_safe` above)
+- `chematic-chem`: `remove_hydrogens` no longer destroys isotope-labeled hydrogen (`[2H]`, `[3H]`) or silently drops declared stereo/E-Z information on every call — both were real, shipped correctness bugs found via a downstream consumer's 9.47M-compound real-world corpus scan, unaffected molecules confirmed unchanged, 289/290 of the originating investigation's identity mismatches resolved
+- `chematic-py`: `Mol.conformer_ensemble_v2(config)` exposes `embed_ensemble_v2` (deterministic multi-conformer generation, energy ranking scoped within force field, full per-attempt provenance) — added alongside the existing `conformer_ensemble()`, not replacing it. New best-of-10 benchmark arm confirms it works robustly at scale (~250/265 molecules, median RMSD 2.147 Å / TFD 0.344 vs. RDKit) — RDKit conformer-*selection* parity is a separate, unestablished claim
+- Known limitations: `generate_coords` not yet routed to the new engine; issue #210's 4 residuals remain open via that specific bridge; issue #390 (a single-molecule E/Z correctness residual, unrelated) remains open; no fresh full-corpus re-measurement was run solely for this release
+- Full details in `CHANGELOG.md`'s `[0.20.0]` section
+
 **v0.19.0** (2026-08-23): **Round 2C aromatic lactam/lactim tautomer fix, plus a benchmark/validation refresh**
 - `chematic-chem`: Tautomer & Parent Identity round 2C (ROADMAP.md Phase 2) — `canonical_tautomer`/`tautomer_parent` now canonicalize the aromatic lactam/lactim class for 2-pyridone, 4-pyridone, and uracil; cytosine, guanine, and hypoxanthine remain open (a distinct, documented ring-N-H position residual, RFC section 1.7 — diagnosed but not yet fixed), as does the unrelated nitroso/oxime defect (section 1.6). Phase 2 is **not** complete; `TautomerScoringConfig` and Python/WASM Parent-API bindings remain unimplemented
 - Benchmark/validation refresh: every number in `docs/benchmark.md`/`docs/validation.md` was pinned to chematic v0.4.29/RDKit 2026.03.3 (~14 releases stale) — re-measured fresh against RDKit 2026.03.4. The 4,999-mol accuracy corpus is now committed (`scripts/chembl_accuracy_corpus_4999.smi`, previously an uncommitted personal path); molecular weight has a real corpus-wide check for the first time (99.82%, not the previously-unmeasured "175-mol"/100% placeholder); CIP R/S/E/Z label agreement re-measured at 99.74–99.78% (up from a stale 96.30–96.83%); WASM bundle size rebuilt clean; the ECFP4 "diverse corpus" figure now has a reproducible source (`benchmark_vs_rdkit.py --corpus`, previously none existed); 3D conformer generation's "Good (ETKDG rules)" framing corrected to "Experimental," matching the migration guide's own honest characterization
@@ -600,7 +609,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v0.19.0)
+├── Cargo.toml                    workspace root (v0.20.0)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)
@@ -654,7 +663,7 @@ If you use chematic in academic or research work, please cite:
   author    = {kent-tokyo},
   title     = {chematic: A pure-Rust cheminformatics toolkit},
   url       = {https://github.com/kent-tokyo/chematic},
-  version   = {0.19.0},
+  version   = {0.20.0},
   year      = {2026},
 }
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -125,7 +125,7 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.19.0
+# chematic v0.20.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-06, v0.4.22 vs RDKit 2026.03.3 --
@@ -303,6 +303,15 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi      
 ---
 
 ## 最近の開発
+
+**v0.20.0**（2026-08-25）: **立体化学を保った3D構造生成、connectivity-ordered座標エンジン、`remove_hydrogens`の同一性正確性修正**
+- `chematic-3d`/`chematic-py`/`chematic-wasm`：`PipelineV2Config::stereo_safe(force_field_policy)`——環に組み込まれた宣言済み立体中心（テストステロン、コレステロール等）に対する実際のギャップを一括解決する設定。従来`repair_tetrahedral_center`は暗黙のHを反映すべき座標を持たなかった。29分子×5 seedコーパスで測定：144/145（99.3%）がcorrect_and_ok、silently wrongは0件、テストステロン・コレステロールとも全宣言立体中心・全seedで5/5成功
+- `chematic-3d`：`generate_coords_connectivity_ordered`——新しい公開の代替3D配置エンジン（issue #256/#255）。「まず全ての環、その後で鎖」ではなく、真の連結順序で環・鎖原子を配置。測定：raw geometryのsoundnessが差分コーパスで10/33→33/33（退行ゼロ）、post-UFFの結合長違反率は0.0000まで到達（旧エンジン自身の基準値より良好）。`generate_coords`自体は完全に無変更——デフォルト動作の切り替えではなく、選択可能な代替として提供。既存の呼び出し元はいずれも新エンジンへルーティングされていない
+- `chematic-3d`：`rescue_with_distance_geometry_v2`（UFF破局的破綻からの救済ブリッジ）が再試行時に宣言済みキラリティを強制するようになった（issue #210、部分修正）。58分子コーパスで退行ゼロ、既知の残存5分子のうち1件が新たに成功。このブリッジ単体では残り4分子は未解決（上記の`stereo_safe`では解決済み）
+- `chematic-chem`：`remove_hydrogens`が同位体標識水素（`[2H]`、`[3H]`）を破壊したり、呼び出しのたびに宣言済み立体・E/Z情報を静かに失ったりしなくなった——いずれも下流利用者の947万化合物規模の実世界コーパススキャンで発見された実際の出荷済みバグ。影響を受けない分子は変化しないことを確認済み、元の調査で見つかった同一性不一致290件中289件を解消
+- `chematic-py`：`Mol.conformer_ensemble_v2(config)`が`embed_ensemble_v2`（決定的な複数コンフォーマー生成、力場ごとにスコープされたエネルギーランキング、全試行のprovenance）を公開——既存の`conformer_ensemble()`を置き換えるのではなく併設。新しいbest-of-10ベンチマークにより大規模でも堅牢に動作することを確認（約250/265分子、RDKit比で中央値RMSD 2.147Å／TFD 0.344）——RDKitのコンフォーマー*選択*との一致は別の未確立の主張であることに注意
+- 既知の制約：`generate_coords`はまだ新エンジンへルーティングされていない、issue #210の残り4分子はこのブリッジ単体では未解決、issue #390（無関係の単一分子E/Z正確性残課題）は未解決、本リリース専用の新規全コーパス再測定は実施していない
+- 詳細は`CHANGELOG.md`の`[0.20.0]`section参照
 
 **v0.18.0**（2026-08-20）: **v0.17.0の7新形式へのPython/WASMバインディング、MMFF94 atom-typing修正、言語間一貫性の仕上げ**
 - `chematic-ff`：issue #337のアリールイソチオシアネート累積二重結合CSP炭素の誤タイプを修正（`getTotalDegree() == 2`、RDKitの実際のルールに合わせた厳密な上位集合）。残る6/8分子はRDKit自身のKekulization/MMFF芳香族性認識に起因する真正のアーティファクトと再診断し（negative-control fragmentsで直接検証）、誠実な残課題として開示

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.19.0 | Yes | Current release — active support |
+| v0.20.0 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.19.0) receives all security updates.  
+**Active Support**: Latest release (v0.20.0) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -17,12 +17,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.19.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.19.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.19.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.19.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.19.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.19.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.20.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.20.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.20.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.0" }
 serde_json          = "1.0"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #219); web-time

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -17,14 +17,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.19.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.19.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.19.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.19.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.19.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.19.0" }
-chematic-cip        = { path = "../chematic-cip",        version = "0.19.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.20.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.0" }
+chematic-cip        = { path = "../chematic-cip",        version = "0.20.0" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.19.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.19.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-crystal/Cargo.toml
+++ b/crates/chematic-crystal/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 serde = ["dep:serde"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.19.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.0" }
 serde         = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -23,10 +23,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.19.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.19.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.19.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.19.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.20.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.20.0" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.19.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.0" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.19.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.19.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -23,13 +23,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.19.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.0" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.19.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.19.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.19.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.19.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.20.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.20.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.20.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -19,10 +19,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.19.0", path = "../chematic-core" }
-chematic-smiles = { version = "0.19.0", path = "../chematic-smiles" }
-chematic-chem = { version = "0.19.0", path = "../chematic-chem" }
-chematic-rxn = { version = "0.19.0", path = "../chematic-rxn" }
+chematic-core = { version = "0.20.0", path = "../chematic-core" }
+chematic-smiles = { version = "0.20.0", path = "../chematic-smiles" }
+chematic-chem = { version = "0.20.0", path = "../chematic-chem" }
+chematic-rxn = { version = "0.20.0", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.19.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.19.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -18,15 +18,15 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.19.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.19.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.19.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.19.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.19.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.19.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.19.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.19.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.19.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.20.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.20.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.20.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.20.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
 
 [dev-dependencies]
 # Real JSON Schema 2020-12 validator, used only in tests to independently

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -25,11 +25,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 crystal = ["dep:chematic-crystal"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.19.0" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.19.0" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.19.0" }
-chematic-smiles      = { path = "../chematic-smiles",      version = "0.19.0" }
-chematic-crystal     = { path = "../chematic-crystal",     version = "0.19.0", optional = true }
+chematic-core        = { path = "../chematic-core",        version = "0.20.0" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.20.0" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.20.0" }
+chematic-smiles      = { path = "../chematic-smiles",      version = "0.20.0" }
+chematic-crystal     = { path = "../chematic-crystal",     version = "0.20.0", optional = true }
 serde_json           = "1.0"
 
 [dev-dependencies]

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.19.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,17 +25,17 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.19.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.19.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.19.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.19.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.19.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.19.0", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.19.0", features = ["crystal"] }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.19.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.19.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.19.0" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.19.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.19.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.19.0" }
-chematic-crystal    = { path = "../chematic-crystal",    version = "0.19.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.20.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.20.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.20.0", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.20.0", features = ["crystal"] }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.0" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.20.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.20.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.20.0" }
+chematic-crystal    = { path = "../chematic-crystal",    version = "0.20.0" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -23,9 +23,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 perf-instrumentation = []
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.19.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.19.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.19.0" }
+chematic-core   = { path = "../chematic-core",   version = "0.20.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.20.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.20.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.19.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.19.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
 rustc-hash = "2"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #221); web-time

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.19.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.0" }
 # Production use: `compute_stereo_alkene_ends` (canonical.rs) needs SSSR ring
 # membership to exclude endocyclic small-ring double bonds from marker-carrier
 # candidacy (issue #149's ring-constrained residual, see
@@ -27,7 +27,7 @@ chematic-core = { path = "../chematic-core", version = "0.19.0" }
 # graph, only test binaries. Was previously a dev-only dependency of this
 # crate for a different reason (re-aromatizing test fixtures); now also a
 # real one.
-chematic-perception = { path = "../chematic-perception", version = "0.19.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
 
 [features]
 # Feature-gated internal work counters for the orbit-pruning canonical

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -32,16 +32,16 @@ web-sys = { version = "0.3", features = ["console"] }
 js-sys = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.19.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.19.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.19.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.19.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.19.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.19.0", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.19.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.19.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.19.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.19.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.19.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.19.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.19.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.20.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.20.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.20.0", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.20.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.20.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.20.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.20.0" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -54,16 +54,16 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.19.0", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.19.0", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.19.0", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.19.0", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.19.0", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.19.0", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.19.0", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.19.0", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.19.0", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.19.0", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.19.0", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.19.0", optional = true }
-chematic-crystal    = { path = "../chematic-crystal",    version = "0.19.0", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.20.0", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.0", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.20.0", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.20.0", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.20.0", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.20.0", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.20.0", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.0", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.20.0", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.20.0", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.0", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.0", optional = true }
+chematic-crystal    = { path = "../chematic-crystal",    version = "0.20.0", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Version bump 0.19.0 → 0.20.0 and CHANGELOG/README consolidation, per user request. This PR is code-only preparation — **no git tag, no crates.io/PyPI/npm publish**. That remains a separate, deliberately not-yet-taken step (irreversible actions), pending explicit go-ahead.

## What's in this release

Four headline items that landed since v0.19.0 with no CHANGELOG coverage until this PR:

1. **Stereo-safe 3D generation** (issue #291) — `PipelineV2Config::stereo_safe`, Python/WASM bindings. 144/145 (99.3%) correct_and_ok on a 29-molecule × 5-seed corpus; testosterone/cholesterol both 5/5 seeds on every declared stereocenter.
2. **Connectivity-ordered 3D coordinate generation** (issues #256/#255) — `generate_coords_connectivity_ordered` promoted to public API. Raw soundness 10/33 → 33/33, post-UFF bond-violation rate reaching 0.0000. `generate_coords` itself unchanged — no existing caller routed to the new engine.
3. **UFF-rescue chirality enforcement** (issue #210, partial fix) — zero regressions on its 58-molecule corpus, one of 5 residuals newly fixed.
4. **Best-of-10 conformer benchmark vs. RDKit** — ~250/265 molecules, median RMSD 2.147 Å / TFD 0.344. Confirms `embed_ensemble_v2` works robustly at scale; does **not** establish RDKit conformer-selection parity (distinct, unestablished claim).

Plus the two `remove_hydrogens` correctness fixes already in `[Unreleased]` (isotope preservation, `stereo_neighbor_order`/`bond_directions` restoration) get folded into the versioned section.

## What this PR does

- `Cargo.toml` workspace version bump + `scripts/bump_version.py` propagation to every intra-workspace path-dependency pin, `CITATION.cff`, `SECURITY.md`, `demo/pkg/package.json`. (`chematic-py`'s `pyproject.toml` uses `dynamic = ["version"]` via maturin; `chematic-wasm`'s npm `package.json` is generated by `wasm-pack` from `Cargo.toml` at build time — neither needs a manual bump.)
- `CHANGELOG.md`: `[Unreleased]` → `[0.20.0] — 2026-08-25`, with the 4 new sections above added, a stale forward-reference corrected, and a new "Known limitations" section (legacy `generate_coords` not routed, issue #210's 4 remaining residuals, issue #390 unrelated E/Z residual, no fresh full-corpus re-measurement run solely for this release — per this project's "minimize heavy measurements" policy, reusing evidence already gathered during development). Fresh empty `[Unreleased]` added above it for future work.
- `README.md`/`README_ja.md`: matching "Recent Development" entries, following each file's own established prose-only convention — no code examples added, since both files consistently defer Rust/JS usage examples to the docs site across every prior release entry (`README.md`'s own text: "For Rust and JavaScript/TypeScript examples, see the documentation").

## Verification

- `python3 scripts/bump_version.py --old 0.19.0 --dry-run` then for real — all 24 target files updated as expected.
- `cargo check --workspace --exclude chematic-py` — clean, all crates build at 0.20.0.
- `bash scripts/check.sh` (fmt/clippy/full workspace tests/`cargo deny`/publish graph/version-consistency) — all green **except** one pre-existing, already-documented local-machine-only test flake (`atorvastatin_fragment`, issue #210) that reproduces identically with or without this PR's changes and passes cleanly in CI; confirmed via a separate `--skip` run that everything else passes (`cargo test --workspace --tests` clean).
- `python3 scripts/check_publish_graph.py` — OK, 19 publishable crates, safe order computed.
- `cargo deny --all-features check` — advisories/bans/licenses/sources all OK.
- Manual version-consistency check (the tail of `scripts/check.sh`) — all files consistent at 0.20.0, "Recent Development" top entry matches.
- `cargo doc -p chematic-3d --no-deps` — builds clean (37 pre-existing warnings, unrelated to this PR's changes, confirmed by diffing against `main`); new public items (`generate_coords_connectivity_ordered`, `dg_connectivity_ordered` module, `PipelineV2Config::stereo_safe`) render correctly, confirming docs.rs compatibility.

## Issue status

#255/#256/#277/#210/#390 all stay **open** per this project's standing convention — shipping code is not the same as resolving an issue's full scope.

## Not done in this PR (explicitly deferred, not forgotten)

- `cargo publish --dry-run` per-crate entry-point check, Python wheel build + fresh-venv smoke test, WASM build + Node smoke test — these are appropriate right before the actual tag/publish step, not before merge.
- Git tag, crates.io publish, PyPI publish, npm publish — explicitly held for a separate confirmation, since these are irreversible.