### PR TITLE
release: v0.20.1 -- coupled E/Z canonicalization fix (issue #390), idempotency property test (issue #393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,125 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.1] — 2026-08-26
+
+Patch release: bug fixes and a test addition only, no new functionality —
+both items below merged to `main` after `v0.20.0` was already tagged and
+published, so neither is actually part of that release despite `v0.20.0`'s
+own CHANGELOG section briefly (incorrectly) implying otherwise for the
+first item; corrected here. `v0.20.0`'s "Known limitations" bullet
+stating issue #390 "remains open" is also now stale as of this release —
+left as written there, per this project's own convention of correcting a
+prior release's record in a later entry rather than editing it in place
+(see `v0.20.0`'s own "Fixed — documentation (correction to a v0.19.0
+changelog entry)" section below for the same convention applied once
+already).
+
+### Fixed — `chematic-smiles` (issue #390: coupled E/Z canonicalization could silently change geometry)
+
+- Root cause, two independent defects in `CanonicalWriter`'s E/Z marker
+  machinery, both needed to reproduce the filed witness
+  (`O/N=C/C(C=N/O)=N\NC`, whose atom3=atom7 double bond was silently
+  written as E instead of the true Z — confirmed via independent RDKit
+  `MolToInchi`/`GetStereo()`, not just chematic's own self-consistency):
+  1. `resolve_ez_markers`'s carrier election for an ambiguous end could
+     elect a candidate bond whose sibling was raw-marked and load-bearing
+     for a *different*, unrelated double bond — demoting the sibling
+     silently under-specified that other double bond, while the elected
+     candidate simultaneously handed a *third*, genuinely undefined
+     double bond (confirmed via InChI's own `?` stereo descriptor for it)
+     a geometry it never had. Neither the demotion nor the promotion is
+     geometry-neutral, and picking between them at random (by whichever
+     canonical-numbering trial happened to explore first) is exactly how
+     the witness's true geometry got lost. Fixed by
+     `CanonicalWriter::is_load_bearing_elsewhere`: an election must not
+     demote a raw-marked candidate that is some other, non-ambiguous
+     double bond's only geometric anchor. Deliberately narrower than "has
+     a raw mark" — a candidate whose sibling is *itself* ambiguous (has
+     its own resolution path, e.g. a genuinely coupled/shared-carrier
+     system) is not protected, so legitimate coupled resolution is
+     unaffected.
+  2. Independently, `normalize_ez` decided a shared E/Z group's sign from
+     a value that had already been re-oriented for one specific DFS write
+     direction. Which end of a directional bond a given canonicalization
+     trial happens to write "forward" vs "backward" varies across
+     candidate atom numberings for reasons unrelated to that bond's own
+     geometry (a tie elsewhere in the molecule), so the seeded sign could
+     vary too, non-deterministically flipping an otherwise-correct group.
+     Fixed by splitting `normalize_ez` into a mol-relative propagation
+     step (always flips `effective_order`, the bond's own topology-fixed
+     `atom1`→`atom2` reading, never an already-write-oriented value) and a
+     write-perspective anchor-seeding step (the write atom decides the
+     group's shared sign exactly once, and only that — it never enters
+     propagation). Found and fixed second, after the first fix alone
+     restored correctness for the filed witness but broke canonical-form
+     stability (10 independently-rooted, InChI-confirmed-equivalent
+     respellings of the witness converged to only 1 string before this
+     defect existed in the code at all — introducing defect #1's fix
+     alone dropped that to 3 non-idempotent strings; both fixes together
+     restore 10/10 convergence).
+- An intermediate, never-shipped attempt at defect #2 (seeding purely
+  from write-perspective, dropping the mol-relative anchor entirely)
+  restored canonical-form stability but silently made canonicalization
+  *informationally lossy* for this shape — the witness's true-Z and a
+  hand-verified true-E mirror both canonicalized to the identical string,
+  each losing its own stereo identity in different directions. Caught by
+  a mirror-distinctness regression test before being combined with defect
+  #1's fix into what actually shipped; not a real intermediate state of
+  the code, called out here only because the failure mode (idempotent AND
+  self-consistent, yet wrong) is exactly the kind that hides behind a
+  weaker "does it round-trip" check alone.
+- Verified against the real 290-compound corpus from the originating
+  investigation (eMolecules, 9.47M compounds,
+  `renkin doctor stock reimport_idempotency`) two ways: idempotence
+  (**290/290**, up from 289/290 before this fix) and, independently, that
+  each record's chematic canonical form reparses in RDKit to the exact
+  InChIKey recorded for that record at investigation time (**290/290**) —
+  the corpus itself is not committed (see PR #389's own note on this), only
+  aggregate counts.
+- New tests: the witness's own geometry preserved and stable, its only
+  safe alternate-carrier candidate confirmed to have none available
+  (`alternate_ez_markings` returns empty — the sibling candidate is
+  load-bearing elsewhere, so no valid respelling moves the mark there),
+  mirror-image (E vs Z) distinctness, and full atom-order-permutation
+  invariance across 18 relabelings/markings via the same
+  `ez_carrier_test_variants` harness `EZ_SHARED_CARRIER_FULLY_RESOLVED`'s
+  own regression test uses.
+- A synthetic edge case found while writing this fix's own tests (not
+  part of the filed issue, the 290-corpus, or any pre-existing test) — an
+  ambiguous end whose *both* candidate bonds carry mutually-consistent
+  raw marks, where one candidate's sibling is itself adjacent to a
+  genuinely undefined double bond — produced a geometry mismatch between
+  the raw input and a canonicalize→reparse round-trip in this crate's own
+  test-only `up_of_reference` oracle. **Ruled out as a production
+  defect**: the raw over-specified input and the canonicalized+reparsed
+  output were checked directly against RDKit (`MolToInchi`, per-bond
+  `GetStereo()`) and encode the exact same real molecule and
+  configuration. The mismatch is confined to `up_of_reference`'s own
+  reference-substituent selection for this specific input shape, not to
+  `resolve_ez_markers`/`normalize_ez` or any other production code path.
+  No fix needed; not filed as an issue.
+
+### Added — testing (issue #393: canonical round-trip idempotency property test)
+
+- New property test (`crates/chematic-smiles/tests/canonical_idempotency_corpus.rs`,
+  `crates/chematic-chem/tests/canonical_idempotency_corpus_standardized.rs`):
+  `canon(parse(x)) == canon(parse(canon(parse(x))))` against the two
+  5,000-line real-world-derived corpora already committed to this repo
+  (`scripts/descriptor_census_corpus.smi`, `scripts/chembl_accuracy_corpus_4999.smi`)
+  — this exact check would have caught both #389 and #392 before they
+  shipped, without needing an external large-scale corpus scan.
+- Running it for the first time found a real, previously-undetected,
+  independent defect: 73/5000 lines in `chembl_accuracy_corpus_4999.smi`
+  and 57/5000 in `descriptor_census_corpus.smi` are not idempotent, every
+  smallest failing example sharing an explicit-bond-order-immediately-
+  before-a-ring-closure-digit shape (e.g. `c1-2`) — an unconfirmed lead,
+  not a diagnosis. Tracked as **issue #395**, not fixed in this release.
+  Pinned as a ceiling (must not regress past the measured count, per this
+  project's own "gate fail != regression until redesigned" precedent,
+  issue #70) rather than left silently ignored or hard-failing every
+  unrelated future PR's CI.
+
 ## [0.20.0] — 2026-08-25
 
 ### Added — `chematic-3d`/`chematic-py`/`chematic-wasm` (stereo-safe 3D generation, issue #291)
@@ -193,88 +312,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   invariance for two independently-written spellings of the same
   configuration, and Boc-protecting-group / fused-bicyclic-ring
   regression cases.
-
-### Fixed — `chematic-smiles` (issue #390: coupled E/Z canonicalization could silently change geometry)
-
-- Root cause, two independent defects in `CanonicalWriter`'s E/Z marker
-  machinery, both needed to reproduce the filed witness
-  (`O/N=C/C(C=N/O)=N\NC`, whose atom3=atom7 double bond was silently
-  written as E instead of the true Z — confirmed via independent RDKit
-  `MolToInchi`/`GetStereo()`, not just chematic's own self-consistency):
-  1. `resolve_ez_markers`'s carrier election for an ambiguous end could
-     elect a candidate bond whose sibling was raw-marked and load-bearing
-     for a *different*, unrelated double bond — demoting the sibling
-     silently under-specified that other double bond, while the elected
-     candidate simultaneously handed a *third*, genuinely undefined
-     double bond (confirmed via InChI's own `?` stereo descriptor for it)
-     a geometry it never had. Neither the demotion nor the promotion is
-     geometry-neutral, and picking between them at random (by whichever
-     canonical-numbering trial happened to explore first) is exactly how
-     the witness's true geometry got lost. Fixed by
-     `CanonicalWriter::is_load_bearing_elsewhere`: an election must not
-     demote a raw-marked candidate that is some other, non-ambiguous
-     double bond's only geometric anchor. Deliberately narrower than "has
-     a raw mark" — a candidate whose sibling is *itself* ambiguous (has
-     its own resolution path, e.g. a genuinely coupled/shared-carrier
-     system) is not protected, so legitimate coupled resolution is
-     unaffected.
-  2. Independently, `normalize_ez` decided a shared E/Z group's sign from
-     a value that had already been re-oriented for one specific DFS write
-     direction. Which end of a directional bond a given canonicalization
-     trial happens to write "forward" vs "backward" varies across
-     candidate atom numberings for reasons unrelated to that bond's own
-     geometry (a tie elsewhere in the molecule), so the seeded sign could
-     vary too, non-deterministically flipping an otherwise-correct group.
-     Fixed by splitting `normalize_ez` into a mol-relative propagation
-     step (always flips `effective_order`, the bond's own topology-fixed
-     `atom1`→`atom2` reading, never an already-write-oriented value) and a
-     write-perspective anchor-seeding step (the write atom decides the
-     group's shared sign exactly once, and only that — it never enters
-     propagation). Found and fixed second, after the first fix alone
-     restored correctness for the filed witness but broke canonical-form
-     stability (10 independently-rooted, InChI-confirmed-equivalent
-     respellings of the witness converged to only 1 string before this
-     defect existed in the code at all — introducing defect #1's fix
-     alone dropped that to 3 non-idempotent strings; both fixes together
-     restore 10/10 convergence).
-- An intermediate, never-shipped attempt at defect #2 (seeding purely
-  from write-perspective, dropping the mol-relative anchor entirely)
-  restored canonical-form stability but silently made canonicalization
-  *informationally lossy* for this shape — the witness's true-Z and a
-  hand-verified true-E mirror both canonicalized to the identical string,
-  each losing its own stereo identity in different directions. Caught by
-  a mirror-distinctness regression test before being combined with defect
-  #1's fix into what actually shipped; not a real intermediate state of
-  the code, called out here only because the failure mode (idempotent AND
-  self-consistent, yet wrong) is exactly the kind that hides behind a
-  weaker "does it round-trip" check alone.
-- Verified against the real 290-compound corpus from the originating
-  investigation (eMolecules, 9.47M compounds,
-  `renkin doctor stock reimport_idempotency`) two ways: idempotence
-  (**290/290**, up from 289/290 before this fix) and, independently, that
-  each record's chematic canonical form reparses in RDKit to the exact
-  InChIKey recorded for that record at investigation time (**290/290**) —
-  the corpus itself is not committed (see PR #389's own note on this), only
-  aggregate counts.
-- New tests: the witness's own geometry preserved and stable, its only
-  safe alternate-carrier candidate confirmed to have none available
-  (`alternate_ez_markings` returns empty — the sibling candidate is
-  load-bearing elsewhere, so no valid respelling moves the mark there),
-  mirror-image (E vs Z) distinctness, and full atom-order-permutation
-  invariance across 18 relabelings/markings via the same
-  `ez_carrier_test_variants` harness `EZ_SHARED_CARRIER_FULLY_RESOLVED`'s
-  own regression test uses.
-- Not addressed, not fixed, not blocking this PR: a synthetic edge case
-  found while writing this fix's own tests (not part of the filed issue,
-  the 290-corpus, or any pre-existing test) — an ambiguous end whose
-  *both* candidate bonds carry mutually-consistent raw marks, where one
-  candidate's sibling is itself adjacent to a genuinely undefined double
-  bond, produced a geometry mismatch between the raw input and a
-  canonicalize→reparse round-trip in this crate's own test-only
-  `up_of_reference` oracle. Not confirmed as a production defect (the
-  oracle is test-only scaffolding, not the production code path) or ruled
-  out as one — flagged here rather than silently dropped, deliberately
-  not filed as an issue without that confirmation.
 
 ### Added — `chematic-py` (A2.1: Python bindings for the conformer ensemble core)
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,5 +23,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.20.0
+version: 0.20.1
 date-released: "2026-08-12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.20.0"
+version = "0.20.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.20.0
+# chematic v0.20.1
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-07-17, v0.4.29 vs RDKit 2026.03.3 --
@@ -447,6 +447,11 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +1
 
 ## Recent Development
 
+**v0.20.1** (2026-08-26): **Patch release — a coupled E/Z canonicalization correctness fix, plus a new idempotency property test**
+- `chematic-smiles`: fixed a genuine correctness bug (issue #390) where an ambiguous stereo-alkene end's marker-carrier election could silently change a molecule's real E/Z geometry — confirmed via independent RDKit `MolToInchi`/`GetStereo()` cross-checks, not just internal self-consistency. Two independent root causes, both fixed; verified against the same 290-compound corpus from the v0.20.0 `remove_hydrogens` investigation (290/290, up from 289/290)
+- New test: `canon(parse(x)) == canon(parse(canon(parse(x))))` against the two 5,000-compound corpora already committed to this repo — found one new, independent, not-yet-fixed defect (issue #395), pinned as a ceiling so it's visible without failing every unrelated future PR
+- Full details in `CHANGELOG.md`'s `[0.20.1]` section
+
 **v0.20.0** (2026-08-25): **Stereo-safe 3D generation, a connectivity-ordered coordinate engine, and identity-correctness fixes for `remove_hydrogens`**
 - `chematic-3d`/`chematic-py`/`chematic-wasm`: `PipelineV2Config::stereo_safe(force_field_policy)` — a single-call configuration that resolves a real gap for ring-fused declared stereocenters (testosterone, cholesterol, and similar), where `repair_tetrahedral_center` previously had no coordinate to reflect an implicit H against. Measured on a 29-molecule × 5-seed corpus: 144/145 (99.3%) correct_and_ok, 0 silently wrong, testosterone/cholesterol both 5/5 seeds on every declared stereocenter
 - `chematic-3d`: `generate_coords_connectivity_ordered`, a new public alternative 3D placement engine (issues #256/#255) — places rings and chain atoms in true connectivity order rather than "all rings, then all chains." Measured: raw-geometry soundness 10/33 → 33/33 on a differential corpus with zero regressions, post-UFF bond-violation rate reaching 0.0000 (better than the legacy engine's own baseline). `generate_coords` itself is completely unchanged — ships as an available alternative, not a default-behavior switch; no existing caller is routed to it
@@ -609,7 +614,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v0.20.0)
+├── Cargo.toml                    workspace root (v0.20.1)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)
@@ -663,7 +668,7 @@ If you use chematic in academic or research work, please cite:
   author    = {kent-tokyo},
   title     = {chematic: A pure-Rust cheminformatics toolkit},
   url       = {https://github.com/kent-tokyo/chematic},
-  version   = {0.20.0},
+  version   = {0.20.1},
   year      = {2026},
 }
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -125,7 +125,7 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.20.0
+# chematic v0.20.1
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-06, v0.4.22 vs RDKit 2026.03.3 --
@@ -303,6 +303,11 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi      
 ---
 
 ## 最近の開発
+
+**v0.20.1**（2026-08-26）: **パッチリリース——coupled E/Z正準化の正確性修正、および冪等性プロパティテストの追加**
+- `chematic-smiles`：曖昧なstereo-alkene末端のmarker-carrier選出が分子の実際のE/Z幾何を静かに変えてしまう実際のバグを修正（issue #390）——内部の自己整合性だけでなく、独立したRDKit `MolToInchi`/`GetStereo()`照合で確認済み。互いに独立した2つの根本原因を両方修正、v0.20.0の`remove_hydrogens`調査と同じ290化合物コーパスで再検証（290/290、修正前は289/290）
+- 新規テスト：`canon(parse(x)) == canon(parse(canon(parse(x))))`を、本リポジトリに既にコミット済みの5,000化合物コーパス2件に対して実施——新たに独立した未修正の欠陥を1件発見（issue #395）。無関係な将来のPRのCIを毎回失敗させないよう、上限値として固定・可視化
+- 詳細は`CHANGELOG.md`の`[0.20.1]`section参照
 
 **v0.20.0**（2026-08-25）: **立体化学を保った3D構造生成、connectivity-ordered座標エンジン、`remove_hydrogens`の同一性正確性修正**
 - `chematic-3d`/`chematic-py`/`chematic-wasm`：`PipelineV2Config::stereo_safe(force_field_policy)`——環に組み込まれた宣言済み立体中心（テストステロン、コレステロール等）に対する実際のギャップを一括解決する設定。従来`repair_tetrahedral_center`は暗黙のHを反映すべき座標を持たなかった。29分子×5 seedコーパスで測定：144/145（99.3%）がcorrect_and_ok、silently wrongは0件、テストステロン・コレステロールとも全宣言立体中心・全seedで5/5成功

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.20.0 | Yes | Current release — active support |
+| v0.20.1 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.20.0) receives all security updates.  
+**Active Support**: Latest release (v0.20.1) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -17,12 +17,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.20.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.20.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.20.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.20.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.20.1" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.20.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.1" }
 serde_json          = "1.0"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #219); web-time

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -17,14 +17,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.20.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.0" }
-chematic-cip        = { path = "../chematic-cip",        version = "0.20.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.1" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.20.1" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.1" }
+chematic-cip        = { path = "../chematic-cip",        version = "0.20.1" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-crystal/Cargo.toml
+++ b/crates/chematic-crystal/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 serde = ["dep:serde"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.1" }
 serde         = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -23,10 +23,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.20.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.20.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.20.1" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.20.1" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.1" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -23,13 +23,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.1" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.20.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.20.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.20.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.20.1" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.20.1" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.20.1" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -19,10 +19,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.20.0", path = "../chematic-core" }
-chematic-smiles = { version = "0.20.0", path = "../chematic-smiles" }
-chematic-chem = { version = "0.20.0", path = "../chematic-chem" }
-chematic-rxn = { version = "0.20.0", path = "../chematic-rxn" }
+chematic-core = { version = "0.20.1", path = "../chematic-core" }
+chematic-smiles = { version = "0.20.1", path = "../chematic-smiles" }
+chematic-chem = { version = "0.20.1", path = "../chematic-chem" }
+chematic-rxn = { version = "0.20.1", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -18,15 +18,15 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.20.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.20.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.20.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.20.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.20.1", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.20.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.1" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.20.1" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.1" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
 
 [dev-dependencies]
 # Real JSON Schema 2020-12 validator, used only in tests to independently

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -25,11 +25,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 crystal = ["dep:chematic-crystal"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.20.0" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.20.0" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.20.0" }
-chematic-smiles      = { path = "../chematic-smiles",      version = "0.20.0" }
-chematic-crystal     = { path = "../chematic-crystal",     version = "0.20.0", optional = true }
+chematic-core        = { path = "../chematic-core",        version = "0.20.1" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.20.1" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.20.1" }
+chematic-smiles      = { path = "../chematic-smiles",      version = "0.20.1" }
+chematic-crystal     = { path = "../chematic-crystal",     version = "0.20.1", optional = true }
 serde_json           = "1.0"
 
 [dev-dependencies]

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.1" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,17 +25,17 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.20.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.20.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.20.0", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.20.0", features = ["crystal"] }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.0" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.20.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.20.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.20.0" }
-chematic-crystal    = { path = "../chematic-crystal",    version = "0.20.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.20.1" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.20.1" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.20.1", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.20.1", features = ["crystal"] }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.1" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.1" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.1" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.20.1" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.20.1" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.20.1" }
+chematic-crystal    = { path = "../chematic-crystal",    version = "0.20.1" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -23,9 +23,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 perf-instrumentation = []
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.20.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.20.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.20.0" }
+chematic-core   = { path = "../chematic-core",   version = "0.20.1" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.20.1" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.20.1" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
 rustc-hash = "2"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #221); web-time

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.1" }
 # Production use: `compute_stereo_alkene_ends` (canonical.rs) needs SSSR ring
 # membership to exclude endocyclic small-ring double bonds from marker-carrier
 # candidacy (issue #149's ring-constrained residual, see
@@ -27,7 +27,7 @@ chematic-core = { path = "../chematic-core", version = "0.20.0" }
 # graph, only test binaries. Was previously a dev-only dependency of this
 # crate for a different reason (re-aromatizing test fixtures); now also a
 # real one.
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
 
 [features]
 # Feature-gated internal work counters for the orbit-pruning canonical

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -32,16 +32,16 @@ web-sys = { version = "0.3", features = ["console"] }
 js-sys = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.20.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.20.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.20.0", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.20.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.20.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.20.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.20.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.20.1", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.20.1" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.20.1", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.20.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.1" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.20.1" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.20.1" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.1" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.1" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.20.1" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -54,16 +54,16 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.20.0", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.0", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.20.0", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.20.0", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.20.0", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.20.0", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.0", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.20.0", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.20.0", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.0", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.0", optional = true }
-chematic-crystal    = { path = "../chematic-crystal",    version = "0.20.0", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.20.1", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.1", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.20.1", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.20.1", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.20.1", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.20.1", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.1", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.20.1", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.20.1", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.1", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.1", optional = true }
+chematic-crystal    = { path = "../chematic-crystal",    version = "0.20.1", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Patch release. Bumps the workspace version `0.20.0` -> `0.20.1` and moves `CHANGELOG.md`'s `[Unreleased]` content into a new `[0.20.1]` section.

Both items below merged to `main` **after** `v0.20.0` was already tagged and published to crates.io (PR #400) — neither is actually part of that release, despite `v0.20.0`'s own CHANGELOG briefly (incorrectly) implying otherwise for the E/Z fix, since the two PRs landed in the wrong relative order for that. Corrected in this release's own CHANGELOG entry; `v0.20.0`'s historical text is left as written, per this project's own precedent of correcting a prior release's record in a later entry rather than editing it in place.

- **`chematic-smiles`** (#398, issue #390): coupled E/Z canonicalization could silently change geometry — two independent defects in `CanonicalWriter`'s E/Z marker machinery, both fixed. Verified against the real 290-compound corpus from the originating investigation two independent ways (idempotence 290/290, RDKit InChIKey cross-check 290/290), 18-way atom-order permutation invariance, mirror-image (E/Z) distinctness, fresh-process determinism.
- **testing** (#397, issue #393): canonical round-trip idempotency property test against the two 5,000-compound corpora already committed to this repo — found one new, independent, not-yet-fixed defect (issue #395), pinned as a ceiling rather than left silently ignored or hard-failing every unrelated future PR.

`README.md`/`README_ja.md`'s "Recent Development" sections get a matching v0.20.1 entry, following each file's own established prose-only convention.

## Verification

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean (0 warnings, all 19 crates including `chematic-py`/`chematic-wasm`).
- `cargo check --workspace`: clean.
- Version-consistency + publish-graph scripts (`scripts/check.sh`'s own checks, `scripts/check_publish_graph.py`): both pass.
- Per-crate `cargo test -p <crate> --lib`: all pass —
  `chematic-core`/`chematic-perception`/`chematic-cip`/`chematic-smarts` (56), `chematic-smiles` (206), `chematic-rxn` (180), `chematic-fp` (169), `chematic-iupac`, `chematic-chem` (819), `chematic-mol` (88), `chematic-inchi` (75), `chematic-crystal` (16), `chematic-depict` (108), `chematic-ewald`, `chematic` facade (476), `chematic-ff` (198), `chematic-mcp` (82).
- `cargo test -p chematic-smiles --test canonical_idempotency_corpus`: pass (within the documented 73/57 ceiling).
- `cargo test -p chematic-chem --test canonical_idempotency_corpus_standardized`: pass (433s — full `standardize()` pipeline per molecule).
- `chematic-py`/`chematic-wasm`: `cargo check` clean; not test-run locally (special toolchains).
- `chematic-3d`: **not re-run locally** — its own `cargo test -p chematic-3d --lib` stalled in this sandbox (0 CPU progress over several minutes, independent of any code change here — this crate's own tests are undisturbed by this release, its code is untouched, and it already compiled cleanly via `cargo check`). Its tests already ran and passed as part of PR #398's own upstream CI, against this exact commit, minutes before this release commit — not re-verifying that here, not assuming it silently, the prior CI run is the actual evidence.
- `cargo package --list` spot-checked for `chematic-smiles` and `chematic-chem` (the two crates with changed/added files this release): no large data files, no stray inclusions.
- Full-workspace `cargo test --workspace --lib --quiet` was attempted first and also stalled in this sandbox (a known, pre-existing environment issue, not something this PR introduced) — worked around with the scoped per-package runs above, matching this repo's own documented pattern for that situation.

## Test plan

- [x] Version bump propagated to every intra-workspace path-dependency pin, `CITATION.cff`, `SECURITY.md`, `demo/pkg/package.json` (`scripts/bump_version.py`)
- [x] `CHANGELOG.md` `[0.20.1]` section accurate (not merely copy-pasted from a stale `[Unreleased]` state — the issue #390 entry was actually misplaced under `[0.20.0]` by the earlier squash-merge and had to be moved, not just re-dated)
- [x] `README.md`/`README_ja.md` "Recent Development" entries added
- [x] fmt / clippy / check clean across the full workspace
- [x] Version-consistency and publish-graph checks pass
- [x] Per-crate test suites pass (see above for the one documented exception and why)