### PR TITLE
fix(chematic-chem): standardize.rs stereo table loss on identity-preserving rebuild (#399)

### DIFF
--- a/crates/chematic-chem/src/standardize.rs
+++ b/crates/chematic-chem/src/standardize.rs
@@ -826,6 +826,17 @@ pub fn normalize_groups(mol: &Molecule) -> Molecule {
         }
     }
 
+    // Every atom above is copied 1:1 in original index order (never
+    // filtered), so `remap` is the identity and bond indices are assigned in
+    // the same relative order too -- `copy_stereo_from`/
+    // `copy_bond_directions_from`'s verbatim-clone semantics are exactly
+    // valid here. Without this, any stereocenter/declared-E-Z-bond
+    // surviving nitro/azide/sulfoxide normalization silently lost its
+    // `stereo_neighbor_order`/`bond_directions` entry -- issue #399's root
+    // cause, the same defect class #392 fixed in `remove_hydrogens`.
+    builder.copy_stereo_from(mol);
+    builder.copy_bond_directions_from(mol);
+    builder.copy_stereo_groups_from(mol);
     builder.build()
 }
 
@@ -1019,6 +1030,11 @@ pub fn normalize_zwitterion(mol: &Molecule) -> Molecule {
         remap.insert(old_idx, new_idx);
     }
     copy_bonds(mol, &mut builder, &remap);
+    // Identity-preserving rebuild (every atom carried forward at the same
+    // relative order, remap is the identity) -- see issue #399.
+    builder.copy_stereo_from(mol);
+    builder.copy_bond_directions_from(mol);
+    builder.copy_stereo_groups_from(mol);
     builder.build()
 }
 
@@ -1092,6 +1108,10 @@ pub fn neutralize_charges(mol: &Molecule) -> Molecule {
         remap.insert(old_idx, new_idx);
     }
     copy_bonds(mol, &mut builder, &remap);
+    // Identity-preserving rebuild -- see issue #399.
+    builder.copy_stereo_from(mol);
+    builder.copy_bond_directions_from(mol);
+    builder.copy_stereo_groups_from(mol);
     builder.build()
 }
 
@@ -1110,6 +1130,10 @@ pub fn remove_isotopes(mol: &Molecule) -> Molecule {
         remap.insert(old_idx, new_idx);
     }
     copy_bonds(mol, &mut builder, &remap);
+    // Identity-preserving rebuild -- see issue #399.
+    builder.copy_stereo_from(mol);
+    builder.copy_bond_directions_from(mol);
+    builder.copy_stereo_groups_from(mol);
     builder.build()
 }
 
@@ -1210,14 +1234,10 @@ pub fn prefer_organic(mol: &Molecule) -> Molecule {
     let target_component = largest_organic.or_else(|| components.first());
 
     if let Some(component) = target_component {
-        let mut builder = MoleculeBuilder::new();
-        let mut remap: HashMap<AtomIdx, AtomIdx> = HashMap::new();
-        for &old_idx in component {
-            let new_idx = builder.add_atom(mol.atom(old_idx).clone());
-            remap.insert(old_idx, new_idx);
-        }
-        copy_bonds(mol, &mut builder, &remap);
-        builder.build()
+        // extract_fragment remaps stereo_neighbor_order/bond_directions/
+        // stereo_groups correctly for a genuine atom-subset extraction; a
+        // fresh MoleculeBuilder copy here would silently drop them (#399).
+        extract_fragment(mol, component)
     } else {
         MoleculeBuilder::new().build()
     }
@@ -1291,6 +1311,10 @@ pub fn reionize(mol: &Molecule) -> Molecule {
     }
 
     copy_bonds(mol, &mut builder, &remap);
+    // Identity-preserving rebuild -- see issue #399.
+    builder.copy_stereo_from(mol);
+    builder.copy_bond_directions_from(mol);
+    builder.copy_stereo_groups_from(mol);
     builder.build()
 }
 
@@ -1317,6 +1341,10 @@ pub fn uncharge(mol: &Molecule) -> Molecule {
     }
 
     copy_bonds(mol, &mut builder, &remap);
+    // Identity-preserving rebuild -- see issue #399.
+    builder.copy_stereo_from(mol);
+    builder.copy_bond_directions_from(mol);
+    builder.copy_stereo_groups_from(mol);
     builder.build()
 }
 
@@ -1674,18 +1702,29 @@ fn disconnect_metals(mol: &Molecule) -> Molecule {
         builder.add_atom(mol.atom(AtomIdx(i as u32)).clone());
     }
 
-    // Copy only non-metal bonds
+    // Copy only non-metal bonds. Atom indices are unchanged (identity remap,
+    // safe for copy_stereo_from/copy_stereo_groups_from below), but dropped
+    // metal bonds shift surviving bonds' indices, so bond_directions is
+    // remapped bond-by-bond here rather than cloned wholesale -- the same
+    // pattern as `Molecule::with_bond_removed` (see #399).
     for i in 0..mol.bond_count() {
-        let bond = mol.bond(BondIdx(i as u32));
+        let old_bidx = BondIdx(i as u32);
+        let bond = mol.bond(old_bidx);
         let atom1_is_metal = is_metal(mol.atom(bond.atom1).element);
         let atom2_is_metal = is_metal(mol.atom(bond.atom2).element);
 
         // Skip bonds where at least one atom is a metal
-        if !atom1_is_metal && !atom2_is_metal {
-            builder.add_bond(bond.atom1, bond.atom2, bond.order).ok();
+        if !atom1_is_metal
+            && !atom2_is_metal
+            && let Ok(new_bidx) = builder.add_bond(bond.atom1, bond.atom2, bond.order)
+            && let Some(direction) = mol.bond_direction(old_bidx)
+        {
+            builder.set_bond_direction(new_bidx, direction);
         }
     }
 
+    builder.copy_stereo_from(mol);
+    builder.copy_stereo_groups_from(mol);
     builder.build()
 }
 
@@ -2792,11 +2831,20 @@ mod tests {
 
     #[test]
     fn tp2_20_isotope_parent_preserves_stereo() {
+        // Expected value corrected under issue #399: `remove_isotopes`
+        // rebuilt the molecule via a bare `MoleculeBuilder` without carrying
+        // `stereo_neighbor_order` forward, so this test's original expected
+        // string had the anomeric-adjacent ring stereocenter silently
+        // flipped -- baked into the "golden" value instead of being caught.
+        // Independently verified via RDKit: parse the input, zero every
+        // atom's isotope, `AssignStereochemistry(cleanIt=True, force=True)`,
+        // and compare `MolToInchi` -- only the value below (not the old one)
+        // matches the isotope-free reference's InChI.
         let mol = parse("OC[C@H]1O[C@@H]([13CH2]O)[C@H](O)[C@@H](O)[C@@H]1O").unwrap();
         let (result, _) = isotope_parent(&mol);
         assert_eq!(
             chematic_smiles::canonical_smiles(&result),
-            canon("[C@@H]1(CO)O[C@H]([C@@H](O)[C@@H]([C@H]1O)O)CO")
+            canon("[C@@H]1(CO)O[C@@H]([C@@H](O)[C@@H]([C@H]1O)O)CO")
         );
     }
 

--- a/crates/chematic-chem/tests/canonical_idempotency_corpus_standardized.rs
+++ b/crates/chematic-chem/tests/canonical_idempotency_corpus_standardized.rs
@@ -82,27 +82,44 @@ fn assert_corpus_idempotent(label: &str, corpus: &str, max_known_failures: usize
 /// Current known-residual ceiling -- see this file's own doc comment. Must
 /// only ever move down, never up.
 ///
-/// **Correction**: an earlier version of this file set these to 60/68,
+/// **History**: an earlier version of this file set these to 60/68,
 /// labeled "re-measured against main@743b77b (after #392 merged)" -- that
 /// re-measurement never actually ran (a `git checkout` race silently
-/// clobbered the source file mid-build, and the resulting "no such test
-/// target" cargo error was mistaken for "0 additional failures" against an
-/// empty grep pattern). The 60/68 figures were in fact the *pre-#392*
-/// baseline, carried forward unverified. Honestly re-measured on
-/// `test/issue-393-canonical-idempotency-corpus`
-/// (`743b77b`, #392 included): the true count is dramatically higher,
-/// **615/519**, not 60/68. This is a real, confirmed, ~9x increase caused
-/// specifically by #392 -- not measurement noise, not a different corpus
-/// state, not platform-dependent (re-confirmed identically against CI's
-/// own Linux run). Root cause, and why #392 (a correct, real fix) is the
-/// trigger rather than the culprit: filed as issue #399, with a confirmed
-/// minimal repro (`CN1CCC[C@H]1c1cccnc1`, zero explicit H atoms --
-/// `remove_hydrogens` should be a pure no-op, yet the molecule is
-/// idempotent under bare `canonical_smiles` alone but not through
-/// `standardize()`). Do not lower these again without an honest full-corpus
-/// re-run, not an assumption.
-const DESCRIPTOR_CENSUS_KNOWN_FAILURES: usize = 519;
-const CHEMBL_ACCURACY_KNOWN_FAILURES: usize = 615;
+/// clobbered the source file mid-build). The 60/68 figures were in fact the
+/// *pre-#392* baseline, carried forward unverified. Honestly re-measured on
+/// `test/issue-393-canonical-idempotency-corpus` (`743b77b`, #392 included):
+/// the true count was **615/519** -- a real, confirmed ~9x increase caused
+/// by #392 exposing a pre-existing bug in `standardize.rs` (issue #399):
+/// `neutralize_charges`, `normalize_zwitterion`, `normalize_groups`,
+/// `remove_isotopes`, `reionize`, `uncharge`, `prefer_organic` and
+/// `disconnect_metals` each rebuilt the molecule via a bare
+/// `MoleculeBuilder` without carrying `stereo_neighbor_order`/
+/// `bond_directions`/`stereo_groups` forward, so any stereocenter surviving
+/// one of those stages lost its declared order and fell back to
+/// `remove_hydrogens`'s adjacency-based reconstruction -- correct for
+/// ring-closing stereocenters, transposed for ring-opening ones.
+///
+/// **#399 fix (this measurement)**: all 8 functions above now carry the
+/// three stereo side tables forward (a simple bulk copy for the 7 that
+/// preserve every atom/bond 1:1; `prefer_organic` now delegates to the
+/// already-correct `extract_fragment`; `disconnect_metals` remaps
+/// `bond_directions` bond-by-bond since it drops metal bonds). Re-measured:
+/// **68/60** -- back down to the exact pre-#392 baseline, i.e. the ~547/459
+/// failures #392 newly introduced are gone. The remaining 68/60 are
+/// confirmed, by direct trace of representative cases (stereo, E/Z, and
+/// plain-ring-fusion residuals), to be **unrelated to #399's root cause**:
+/// `stereo_neighbor_order`/`bond_directions` survive `standardize()` fully
+/// intact for these molecules, and disabling `remove_explicit_h` entirely
+/// does not change the outcome -- so neither defect this issue fixed is in
+/// play. ~76% of the residual lines share issue #395's exact syntactic
+/// signature (an explicit bond symbol directly preceding a ring-closure
+/// digit, e.g. `c1-2`); the rest are plain fused-ring systems with no
+/// stereocenter at all. Left for #395 (or a new issue if #395 doesn't fully
+/// explain them) rather than folded into this fix. Do not lower these again
+/// without an honest full-corpus re-run, not an assumption; do not raise
+/// them to hide a future regression either.
+const DESCRIPTOR_CENSUS_KNOWN_FAILURES: usize = 60;
+const CHEMBL_ACCURACY_KNOWN_FAILURES: usize = 68;
 
 #[test]
 fn descriptor_census_corpus_standardized_is_canonically_idempotent() {

--- a/crates/chematic-chem/tests/standardize_stereo_table_preservation.rs
+++ b/crates/chematic-chem/tests/standardize_stereo_table_preservation.rs
@@ -1,0 +1,218 @@
+//! Regression tests for issue #399: several `standardize.rs` functions
+//! rebuilt a molecule via a bare `MoleculeBuilder` without carrying
+//! `stereo_neighbor_order`/`bond_directions`/`stereo_groups` forward, so any
+//! surviving stereocenter/declared-E-Z-bond silently lost its recorded
+//! order -- `remove_hydrogens`'s adjacency-based fallback then reconstructed
+//! a *transposed* order for ring-opening stereocenters, flipping `@`/`@@` in
+//! the canonical writer, on a subsequent canonicalize pass. Each test below
+//! exercises one of the 8 fixed functions (or, for `disconnect_metals`, via
+//! `standardize()` itself since it is a private pipeline-only stage).
+//!
+//! Note on methodology: a naive "canonical form must be textually unchanged
+//! before/after `f`" check is wrong whenever `f` performs a real chemical
+//! transformation (nitro normalization, deprotonation, isotope removal,
+//! fragment/metal disconnection) -- those legitimately shift canonical rank
+//! and can legitimately flip a *written* `@`/`@@` character while preserving
+//! the same physical configuration, and a multi-fragment molecule's surviving
+//! organic component can legitimately get different ring-closure numbering
+//! than the same fragment parsed standalone. The property that actually
+//! matters for #399 is idempotency: `canonicalize(f(x))` must equal
+//! `canonicalize(f(reparse(canonicalize(f(x)))))` -- i.e. running `f` again
+//! on the reparsed *output* of `f` must reproduce the same result. That is
+//! what every test here checks.
+
+use chematic_chem::{
+    StandardizeOptions, neutralize_charges, normalize_groups, normalize_zwitterion, prefer_organic,
+    reionize, remove_isotopes, standardize, uncharge,
+};
+use chematic_core::Molecule;
+use chematic_smiles::{canonical_smiles, parse};
+
+#[track_caller]
+fn assert_f_idempotent(label: &str, smi: &str, f: impl Fn(&Molecule) -> Molecule) {
+    let mol = parse(smi).unwrap_or_else(|e| panic!("{label}: parse '{smi}' failed: {e}"));
+    let once = canonical_smiles(&f(&mol));
+    let reparsed =
+        parse(&once).unwrap_or_else(|e| panic!("{label}: re-parse '{once}' failed: {e}"));
+    let twice = canonical_smiles(&f(&reparsed));
+    assert_eq!(
+        once, twice,
+        "{label}: '{smi}' not idempotent through f+canonicalize: once='{once}' twice='{twice}'"
+    );
+}
+
+#[test]
+fn normalize_groups_idempotent_with_unrelated_stereocenter() {
+    assert_f_idempotent(
+        "normalize_groups",
+        "O=[N+]([O-])c1ccc([C@@H](N)C)cc1",
+        normalize_groups,
+    );
+}
+
+#[test]
+fn normalize_zwitterion_active_path_idempotent_with_unrelated_stereocenter() {
+    // A genuine zwitterion (ammonium/carboxylate) with an unrelated ring
+    // stereocenter elsewhere -- exercises the active proton-transfer path,
+    // not the has_zwitterion() early-return.
+    assert_f_idempotent(
+        "normalize_zwitterion",
+        "[NH3+][C@@H](CCCC(=O)[O-])c1ccccc1",
+        normalize_zwitterion,
+    );
+}
+
+#[test]
+fn neutralize_charges_noop_preserves_stereocenter() {
+    // The confirmed minimal repro for issue #399: zero charged atoms at all,
+    // so neutralize_charges makes no modifications -- a true no-op, so
+    // canonical form must be exactly unchanged (not just idempotent).
+    let smi = "CN1CCC[C@H]1c1cccnc1";
+    let mol = parse(smi).expect("parse");
+    let before = canonical_smiles(&mol);
+    let after = canonical_smiles(&neutralize_charges(&mol));
+    assert_eq!(
+        before, after,
+        "neutralize_charges: true no-op case changed canonical form ({before} -> {after})"
+    );
+}
+
+#[test]
+fn neutralize_charges_idempotent_with_unrelated_charge() {
+    assert_f_idempotent(
+        "neutralize_charges (with unrelated charge)",
+        "[O-]C(=O)c1ccc([C@@H](N)C)cc1",
+        neutralize_charges,
+    );
+}
+
+#[test]
+fn remove_isotopes_idempotent_with_unrelated_stereocenter() {
+    assert_f_idempotent(
+        "remove_isotopes",
+        "[13CH3][C@@H](N)c1ccccc1",
+        remove_isotopes,
+    );
+}
+
+#[test]
+fn reionize_idempotent_with_unrelated_stereocenter() {
+    assert_f_idempotent("reionize", "OC(=O)c1ccc([C@@H](N)C)cc1", reionize);
+}
+
+#[test]
+fn uncharge_idempotent_with_unrelated_stereocenter() {
+    assert_f_idempotent("uncharge", "[NH3+]CCc1ccc([C@@H](N)C)cc1", uncharge);
+}
+
+#[test]
+fn prefer_organic_idempotent_with_kept_fragment_stereocenter() {
+    assert_f_idempotent(
+        "prefer_organic",
+        "[Cl-].[NH3+][C@@H](C)c1ccccc1",
+        prefer_organic,
+    );
+}
+
+#[test]
+fn disconnect_metals_path_idempotent_with_organic_stereocenter() {
+    // disconnect_metals fires unconditionally inside standardize() whenever
+    // any atom is a metal; the organic stereocenter it doesn't touch must
+    // still survive a second standardize+canonicalize pass unperturbed.
+    let opts = StandardizeOptions::default();
+    let f = |m: &Molecule| standardize(m, &opts);
+    assert_f_idempotent(
+        "disconnect_metals (via standardize)",
+        "[Na+].[O-]C(=O)[C@@H](N)c1ccccc1",
+        f,
+    );
+}
+
+/// Standardize+canonicalize round trip must stay idempotent regardless of
+/// whether the stereocenter plays the ring-*closing* role (its ring bond is
+/// added to physical adjacency synchronously at parse time) or the
+/// ring-*opening* role (the bond is deferred until the matching digit is
+/// parsed) in the original SMILES text -- issue #399's defect 2 mechanism
+/// specifically depended on this role differing between the original text
+/// and the canonical rewrite.
+#[test]
+fn standardize_idempotent_for_both_ring_closing_and_ring_opening_stereocenter_roles() {
+    let opts = StandardizeOptions::default();
+    let cases = [
+        // Ring-closing role: N opens ring 1, [C@H] consumes (closes) it.
+        ("ring-closing", "CN1CCC[C@H]1c1cccnc1"),
+        // Ring-opening role: the stereocenter itself opens ring 1; N closes it.
+        ("ring-opening", "[C@@H]1(c2cccnc2)CCCN1C"),
+    ];
+    for (label, smi) in cases {
+        let mol = parse(smi).unwrap_or_else(|e| panic!("{label}: parse '{smi}' failed: {e}"));
+        let once = canonical_smiles(&standardize(&mol, &opts));
+        let reparsed =
+            parse(&once).unwrap_or_else(|e| panic!("{label}: re-parse '{once}' failed: {e}"));
+        let twice = canonical_smiles(&standardize(&reparsed, &opts));
+        assert_eq!(
+            once, twice,
+            "{label} ('{smi}'): standardize+canonicalize not idempotent: once='{once}' twice='{twice}'"
+        );
+    }
+}
+
+/// Mirror-image distinctness must survive `standardize()`: a genuine (R)/(S)
+/// pair (four distinct substituents -- unlike e.g. monosubstituted
+/// cyclopentane, whose two ring arms are homotopic and so is not actually a
+/// stereocenter, a pre-existing, unrelated characteristic of that fixture,
+/// not a regression) must never collapse to the same canonical form.
+#[test]
+fn standardize_preserves_mirror_image_distinctness() {
+    let opts = StandardizeOptions::default();
+    let pairs = [
+        ("N[C@@H](C)C(=O)O", "N[C@H](C)C(=O)O"), // L-/D-alanine
+        ("CN1CCC[C@H]1c1cccnc1", "CN1CCC[C@@H]1c1cccnc1"),
+        (
+            "[NH3+][C@@H](CCCC(=O)[O-])c1ccccc1",
+            "[NH3+][C@H](CCCC(=O)[O-])c1ccccc1",
+        ),
+    ];
+    for (r, s) in pairs {
+        let mr = parse(r).expect("parse R");
+        let ms = parse(s).expect("parse S");
+        let cr = canonical_smiles(&standardize(&mr, &opts));
+        let cs = canonical_smiles(&standardize(&ms, &opts));
+        assert_ne!(
+            cr, cs,
+            "mirror images '{r}' and '{s}' collapsed to the same canonical form after standardize: {cr}"
+        );
+    }
+}
+
+/// Atom-order permutation invariance through `standardize()`: the same
+/// molecule written starting from different atoms (different input
+/// traversal order) must converge to the same canonical form post-standardize.
+///
+/// Both alternative spellings below are independently verified (RDKit
+/// `MolToInchi` on both spellings agrees) rather than hand-derived --
+/// deriving stereo-tag parity for a rewritten traversal order by hand is
+/// genuinely error-prone (an earlier draft of this test got the second
+/// pair's tag backwards and would have asserted equality of two *opposite*
+/// enantiomers had it not been checked against RDKit first).
+#[test]
+fn standardize_atom_order_permutation_invariance() {
+    let opts = StandardizeOptions::default();
+    let pairs = [
+        ("CN1CCC[C@H]1c1cccnc1", "c1ccncc1[C@@H]1CCCN1C"),
+        (
+            "[NH3+][C@@H](CCCC(=O)[O-])c1ccccc1",
+            "c1ccccc1[C@@H]([NH3+])CCCC(=O)[O-]",
+        ),
+    ];
+    for (a, b) in pairs {
+        let ma = parse(a).expect("parse a");
+        let mb = parse(b).expect("parse b");
+        let ca = canonical_smiles(&standardize(&ma, &opts));
+        let cb = canonical_smiles(&standardize(&mb, &opts));
+        assert_eq!(
+            ca, cb,
+            "permutation invariance: '{a}' and '{b}' (same molecule, different traversal) diverged after standardize: {ca} vs {cb}"
+        );
+    }
+}

--- a/crates/chematic-core/src/molecule.rs
+++ b/crates/chematic-core/src/molecule.rs
@@ -784,6 +784,24 @@ impl Molecule {
     /// Returns `None` for atoms not parsed from SMILES or without stereo.
     /// The slice contains neighbor atom indices in SMILES text order;
     /// [`STEREO_H_SENTINEL`] (`u32::MAX`) marks the implicit bracket-H slot.
+    ///
+    /// # Invariant
+    ///
+    /// For any atom with `chirality != Chirality::None`, once this table is
+    /// populated it must stay populated and correct relative to that atom's
+    /// *current* neighbor set for as long as the chirality flag is set. A
+    /// function that rebuilds a `Molecule` while keeping the same surviving
+    /// atom/bond set (even if nothing actually changes) must carry this
+    /// table forward explicitly (`MoleculeBuilder::copy_stereo_from`, plus
+    /// `copy_bond_directions_from`/`copy_stereo_groups_from` for the other
+    /// two stereo side tables) rather than leaving a downstream consumer to
+    /// reconstruct it from raw adjacency — that reconstruction is only a
+    /// best-effort fallback and is provably wrong for ring-opening
+    /// stereocenters (see `chematic-chem`'s `hydrogen::declared_neighbor_order`
+    /// and issue #399). A function that genuinely removes atoms or bonds
+    /// must use the index-remap-with-sentinel-substitution pattern in
+    /// [`Self::with_atom_removed`]/[`Self::with_bond_removed`], not a bare
+    /// rebuild.
     pub fn stereo_neighbor_order(&self, idx: AtomIdx) -> Option<&[u32]> {
         self.stereo_neighbor_order.get(&idx.0).map(|v| v.as_slice())
     }


### PR DESCRIPTION
## Summary

Fixes issue #399: `standardize()` was non-idempotent through several charge/isotope/fragment-normalization stages because they rebuilt the molecule via a bare `MoleculeBuilder` without carrying `stereo_neighbor_order`/`bond_directions`/`stereo_groups` forward -- even when zero atoms were actually modified. Once #392 restored `remove_hydrogens`'s own table-copying, its adjacency-based fallback reconstruction (correct for ring-closing stereocenters, transposed for ring-opening ones) started firing on every stereocenter that passed through any of these 8 functions, flipping `@`/`@@` depending on which role a stereocenter played in the original text vs. the canonical rewrite.

## Root cause and fix

Full diagnosis (invariant, formalized coordinate frames, defect classification) posted to #399 before this PR: https://github.com/kent-tokyo/chematic/issues/399#issuecomment-5416853936

8 functions in `crates/chematic-chem/src/standardize.rs` fixed:
- `normalize_groups`, `normalize_zwitterion` (active path), `neutralize_charges`, `remove_isotopes`, `reionize`, `uncharge`: bulk `copy_stereo_from`/`copy_bond_directions_from`/`copy_stereo_groups_from` before `.build()` (all 7 preserve the full atom/bond set 1:1, so a wholesale copy is exactly correct).
- `prefer_organic`: delegated to the already-correct `extract_fragment` helper instead of its own bare rebuild (it genuinely drops atoms, so a naive bulk copy would be wrong).
- `disconnect_metals`: remaps `bond_directions` bond-by-bond (matching `Molecule::with_bond_removed`'s existing pattern) since it drops metal-adjacent bonds, shifting survivors' bond indices; atoms are unchanged so `stereo_neighbor_order`/`stereo_groups` are copied wholesale.

Added the stereo-preservation invariant as a doc comment on `Molecule::stereo_neighbor_order`.

Also corrected `tp2_20_isotope_parent_preserves_stereo`'s hardcoded expected value, which had baked in this exact bug (verified via RDKit `MolToInchi` which of the two candidates matches the isotope-free reference structure).

## Verification

**Dev corpora** (`chembl_accuracy_corpus_4999.smi` + `descriptor_census_corpus.smi`, 10,000 lines, iterated on freely per the agreed dev/holdout discipline):
- Standardize-path idempotency: 615/5000 + 519/5000 (post-#392 regression) → **68/5000 + 60/5000** -- back to the exact pre-#392 baseline. The remaining 128 are confirmed unrelated (stereo table survives `standardize()` fully intact; disabling `remove_explicit_h` doesn't change the outcome); ~76% share issue #395's syntactic signature.
- New regression suite `crates/chematic-chem/tests/standardize_stereo_table_preservation.rs` (12 tests): one idempotency test per fixed function + mirror-image-distinctness + atom-order-permutation-invariance through `standardize()`. Verified 2 of them fail on pre-fix code (i.e. they actually catch the bug).
- Independent RDKit oracle (`rdCIPLabeler`) on all 10,000: **0 stereocenter-count mismatches**. 3 CIP-label-multiset mismatches found and traced to a separate, pre-existing `canonical_tautomer` interaction (filed as #402), not this fix.
- Full workspace test suite: clean (excluding `chematic-py`/`chematic-wasm`, which have a pre-existing, unrelated `cargo test`-vs-PyO3 linker issue outside `maturin`).

**NCI `first_5K.smi` holdout** (4,999 real, completely unused molecules; run exactly once, reported unedited, per the agreed blind-holdout discipline):
- Idempotency: 34/4,999 not idempotent (99.32%). **Stereocenter-count mismatch (RDKit oracle): 0/4,999.**
- All 34 failures confirmed to be a separate, pre-existing bug (identical on `main` before this fix): metal-coordination complexes where `disconnect_metals` leaves a dative-bond-derived `[O+]`/`[N+]` unneutralized on the first pass -- zero stereocenters involved. Filed as #403.
- **For this issue's actual scope: 0/4,999 stereo-related idempotency failures on a genuinely blind, previously-unused real-molecule holdout.**

Full results posted to #399: https://github.com/kent-tokyo/chematic/issues/399#issuecomment-5417392487

## Out of scope (filed separately, not touched here)

- #395 (bare-parse ring-closure explicit-bond-order pattern) -- unrelated mechanism, unchanged.
- #402 (`canonical_tautomer` can change CIP labels at nearby stereocenters during a keto-enol shift) -- discovered during this verification, confirmed unrelated to `standardize.rs`'s rebuild-drops-the-table defect.
- #403 (`disconnect_metals`/`neutralize_charges` ordering leaves dative-bond charges unneutralized) -- discovered during the NCI holdout, confirmed pre-existing and unrelated to stereo.

## Test plan

- [x] `cargo test --workspace --release --exclude chematic-py --exclude chematic-wasm` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean
- [x] New regression suite verified to catch the bug (fails on pre-fix code)
- [x] Independent RDKit CIP oracle cross-check on both dev corpora
- [x] NCI `first_5K.smi` blind holdout, run once, reported as-is