### PR TITLE
fix(chematic-smiles): ring-closure bond marker ignored partner aromaticity (#395)

### DIFF
--- a/crates/chematic-smiles/src/canonical.rs
+++ b/crates/chematic-smiles/src/canonical.rs
@@ -1493,7 +1493,7 @@ impl<'a> CanonicalWriter<'a> {
 
         // Ring-closure digits.
         if let Some(rings) = self.atom_ring_nums.remove(&atom) {
-            for (rn, is_open, _partner, bidx) in rings {
+            for (rn, is_open, partner, bidx) in rings {
                 // The open side carries the marker (normalize_ez's
                 // mol-relative result, re-oriented for `atom` -- the
                 // endpoint actually being written right now); the close
@@ -1515,10 +1515,25 @@ impl<'a> CanonicalWriter<'a> {
                     }
                 };
                 let bond_order = suppress_standalone_wedge(self.mol, bidx, bond_order);
+                // Whether a ring-closure digit needs an explicit bond-order
+                // prefix depends on BOTH endpoints' aromaticity, exactly like
+                // a tree-edge's own `implicit` computation below: a bare
+                // digit between two aromatic atoms is read back as an
+                // *aromatic* bond by the parser, so a genuinely Single
+                // ring-closure bond between two aromatic atoms (e.g. a
+                // non-aromatic fusion bond joining two separately-aromatic
+                // ring systems, `c1-2`) must carry the `-` marker or it
+                // silently becomes aromatic on re-parse -- issue #395. The
+                // previous check only inspected `atom`'s own aromaticity,
+                // never the ring-closure partner's.
                 let atom_arom = self.mol.atom(atom).aromatic;
-                if !(bond_order == BondOrder::Aromatic && atom_arom)
-                    && bond_order != BondOrder::Single
-                {
+                let partner_arom = self.mol.atom(partner).aromatic;
+                let implicit = match bond_order {
+                    BondOrder::Single => !(atom_arom && partner_arom),
+                    BondOrder::Aromatic => atom_arom && partner_arom,
+                    _ => false,
+                };
+                if !implicit {
                     // Oriented from the atom being written right now, so a
                     // dative ring closure prints `->` at its donor end and
                     // `<-` at its acceptor end (the same bond read from
@@ -4403,6 +4418,60 @@ mod explicit_implicit_h_invariance {
                     "not idempotent starting from {smi}: {canon}"
                 );
             }
+        }
+    }
+
+    // ── Round 11: ring-closure explicit-bond-order aromaticity check (#395) ──
+    //
+    // `write_chain`'s ring-closure marker decision checked only the
+    // currently-written atom's own aromaticity, never its ring-closure
+    // partner's -- unlike the equivalent tree-edge decision, which correctly
+    // checks both endpoints. A bare ring-closure digit between two aromatic
+    // atoms is read back as an *aromatic* bond, so a genuinely `Single`
+    // ring-closure bond joining two atoms that each individually happen to
+    // be aromatic (e.g. a non-aromatic fusion bond between two separately-
+    // aromatic ring systems, `c1-2`) silently became aromatic on re-parse
+    // whenever the writer omitted the `-` marker. Confirmed via corpus sweep
+    // (130/10,000 molecules) and RDKit InChI cross-check.
+
+    #[test]
+    fn ring_closure_explicit_single_bond_between_aromatic_atoms_real_world_repro() {
+        // Smallest real-corpus repro from issue #395: the final atom closes
+        // both ring 1 (implicit aromatic, correct) and ring 2 (explicit
+        // `-2`, a non-aromatic fusion bond) at once.
+        let smi = "Oc1[nH]c(Br)nc2nnc(Br)c1-2";
+        let mol = parse(smi).unwrap();
+        let once = canonical_smiles(&mol);
+        let reparsed = parse(&once).unwrap();
+        let twice = canonical_smiles(&reparsed);
+        assert_eq!(
+            once, twice,
+            "explicit-bond-order ring closure not idempotent: {smi} -> once={once} twice={twice}"
+        );
+    }
+
+    #[test]
+    fn ring_closure_explicit_bond_order_survives_reparse_for_various_orders() {
+        // A minimal two-ring system where the fusion bond (ring digit `2`)
+        // is deliberately non-aromatic, exercised at each explicit bond
+        // order the writer can emit on a ring closure.
+        for smi in [
+            "c1ccc2c1-c1ccccc-21", // single fusion bond
+            "c1ccc2c1=CC=CC2",     // double fusion bond into a non-aromatic ring
+        ] {
+            let mol = match parse(smi) {
+                Ok(m) => m,
+                Err(_) => continue, // not every hand-written combination is valid; skip malformed ones
+            };
+            let once = canonical_smiles(&mol);
+            let reparsed = parse(&once).unwrap_or_else(|e| {
+                panic!("re-parse of canonical output '{once}' (from {smi}) failed: {e}")
+            });
+            let twice = canonical_smiles(&reparsed);
+            assert_eq!(
+                once, twice,
+                "not idempotent: {smi} -> once={once} twice={twice}"
+            );
         }
     }
 }

--- a/crates/chematic-smiles/tests/canonical_idempotency_corpus.rs
+++ b/crates/chematic-smiles/tests/canonical_idempotency_corpus.rs
@@ -15,25 +15,27 @@
 //! collect-all-failures-then-panic), scaled from a 50-molecule hand-picked
 //! list to the full 5,000-line corpora.
 //!
-//! **Known residual, tracked as issue #395, not a regression from this
-//! test's own addition.** Running this test against both corpora for the
+//! **Issue #395, fixed.** Running this test against both corpora for the
 //! first time found a real, previously-undetected defect, independent of
 //! #389/#392/#390: 73/5000 lines in `chembl_accuracy_corpus_4999.smi` and
-//! 57/5000 in `descriptor_census_corpus.smi` are not idempotent. Every one
-//! of the smallest failing examples shares an explicit-bond-order ring
+//! 57/5000 in `descriptor_census_corpus.smi` were not idempotent. Every one
+//! of the smallest failing examples shared an explicit-bond-order ring
 //! closure (SMILES `-N`/`=N` immediately preceding a ring-closure digit,
-//! e.g. `c1-2`) -- an unconfirmed lead, not a diagnosis; see #395. Per this
-//! project's own `_known_broken`-fixture convention (e.g. `dg.rs`'s ring-
-//! fusion tests) and its "gate fail != regression until redesigned"
-//! precedent (issue #70): rather than either (a) leaving this test
-//! hard-failing on `main` -- which would make every unrelated future PR's
-//! CI run red for a pre-existing, already-tracked defect it didn't cause --
-//! or (b) `#[ignore]`-ing it and losing the "visible and tracked, not
-//! silently ignored" property issue #393 explicitly asked for, this test
-//! pins the CURRENT failure count as a ceiling: it stays green as long as
-//! the count doesn't exceed what's measured today, and fails (loudly, with
-//! every failing line) the moment it gets worse. Fixing #395 should lower
-//! these constants, not raise them.
+//! e.g. `c1-2`).
+//!
+//! Root cause: `canonical.rs`'s `write_chain` decided whether a ring-closure
+//! digit needed an explicit bond-order prefix by checking only the
+//! currently-written atom's own aromaticity, never its ring-closure
+//! partner's -- unlike the equivalent decision for a tree-edge child, which
+//! correctly checks both endpoints (`parent_arom && child_arom`). A bare
+//! ring-closure digit between two aromatic atoms is read back by the parser
+//! as an *aromatic* bond, so a genuinely `Single`-order ring-closure bond
+//! between two atoms that each individually happen to be aromatic (e.g. a
+//! non-aromatic fusion bond joining two separately-aromatic ring systems,
+//! `c1-2`) silently became an aromatic bond on re-parse whenever the writer
+//! omitted its `-` marker. Fixed by checking both endpoints' aromaticity,
+//! mirroring the tree-edge `implicit` computation exactly. Both corpora are
+//! now **0/5000** failing -- a full fix, not a partial improvement.
 
 use chematic_smiles::{canonical_smiles, parse};
 
@@ -42,10 +44,13 @@ const DESCRIPTOR_CENSUS_CORPUS: &str =
 const CHEMBL_ACCURACY_CORPUS: &str =
     include_str!("../../../scripts/chembl_accuracy_corpus_4999.smi");
 
-/// Current known-residual ceiling (issue #395) -- see this file's own doc
-/// comment. Must only ever move down, never up.
-const DESCRIPTOR_CENSUS_KNOWN_FAILURES: usize = 57;
-const CHEMBL_ACCURACY_KNOWN_FAILURES: usize = 73;
+/// Known-residual ceiling -- see this file's own doc comment. Issue #395 is
+/// now fully fixed (both corpora measured at 0 failures); kept as named
+/// constants, not inlined `0`s, so a future regression here fails loudly
+/// with the same message shape as when this was a nonzero ceiling. Must
+/// only ever move down, never up.
+const DESCRIPTOR_CENSUS_KNOWN_FAILURES: usize = 0;
+const CHEMBL_ACCURACY_KNOWN_FAILURES: usize = 0;
 
 /// For every non-empty line in `corpus`: parse, canonicalize once, re-parse,
 /// canonicalize twice, check the two canonical strings are identical. Parse


### PR DESCRIPTION
## Summary

Fixes issue #395: 130/10,000 real-world-derived corpus molecules failed `canon(x) == canon(canon(x))` (bare `parse`/`canonical_smiles`, no `standardize()` involved). Root-caused and fixed.

## Root cause

`crates/chematic-smiles/src/canonical.rs`'s `write_chain` decides whether a ring-closure digit needs an explicit bond-order prefix (`-`, `=`, etc.) by checking only the currently-written atom's own aromaticity, never its ring-closure **partner**'s (available in the same tuple, but discarded as `_partner`). Compare the equivalent, correct decision for a plain tree-edge child a few lines down, which checks both endpoints (`parent_arom && child_arom`).

A bare ring-closure digit between two aromatic atoms is read back by the parser as an *aromatic* bond. So a genuinely `Single`-order ring-closure bond joining two atoms that each individually happen to be aromatic (a non-aromatic fusion bond connecting two separately-aromatic ring systems -- exactly `c1-2`'s shape, the pattern issue #395 was filed with) silently became aromatic on re-parse whenever the writer omitted its `-` marker.

## Fix

Mirror the tree-edge `implicit` computation exactly for ring closures, checking both `atom`'s and the ring-closure partner's aromaticity.

## Verification

- `canonical_idempotency_corpus.rs` (both real-world-derived dev corpora, 10,000 lines): **73/5000 + 57/5000 → 0/5000 + 0/5000** — a complete fix. Confirmed the test fails with the exact original counts when the fix is reverted.
- Independent RDKit oracle: for all 10,000 corpus lines, chematic's canonical output round-trips through RDKit (`MolFromSmiles` → `MolToInchi`) to the **exact same InChI** as the original input parsed directly by RDKit — 0 mismatches, 0 RDKit parse failures.
- 2 new targeted regression tests in `canonical.rs` (confirmed to fail against the pre-fix logic) alongside the existing corpus-scale test.
- Full workspace test suite: clean (excluding `chematic-py`/`chematic-wasm`'s pre-existing, unrelated `cargo test`-vs-PyO3 linker issue outside `maturin`).

Full diagnosis and results posted to #395: https://github.com/kent-tokyo/chematic/issues/395#issuecomment-5423686000

## Cross-issue note

This bug is exercised through `standardize()` too (same canonical writer) and turns out to be the majority cause of issue #399's own residual: this fix alone drops the standardize-path corpus test's failures from 615/519 to 571/481 on `main` (before #399's own fix, which is a separate, independent PR — different file, different mechanism). `canonical_idempotency_corpus_standardized.rs`'s ceiling constants are deliberately left untouched here to avoid double-counting/conflicting with that PR; whichever merges second should re-measure and set the final combined number.

## Test plan

- [x] `cargo test --workspace --release --exclude chematic-py --exclude chematic-wasm` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean
- [x] New regression tests verified to catch the bug (fail on pre-fix code)
- [x] Independent RDKit InChI oracle cross-check on both dev corpora (0 mismatches)