### PR TITLE
release: v0.20.1 -- three canonical-SMILES/standardization correctness fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,147 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.1] — 2026-08-26
+
+Patch release: three canonical-SMILES/standardization correctness fixes, all
+merged after the `v0.20.0` tag was cut (none of them are retroactively part of
+that release's own claims). No breaking API changes.
+
+### Fixed — `chematic-smiles` (issue #390: coupled E/Z canonicalization could silently change geometry)
+
+- Root cause, two independent defects in `CanonicalWriter`'s E/Z marker
+  machinery, both needed to reproduce the filed witness
+  (`O/N=C/C(C=N/O)=N\NC`, whose atom3=atom7 double bond was silently
+  written as E instead of the true Z — confirmed via independent RDKit
+  `MolToInchi`/`GetStereo()`, not just chematic's own self-consistency):
+  1. `resolve_ez_markers`'s carrier election for an ambiguous end could
+     elect a candidate bond whose sibling was raw-marked and load-bearing
+     for a *different*, unrelated double bond — demoting the sibling
+     silently under-specified that other double bond, while the elected
+     candidate simultaneously handed a *third*, genuinely undefined
+     double bond (confirmed via InChI's own `?` stereo descriptor for it)
+     a geometry it never had. Neither the demotion nor the promotion is
+     geometry-neutral, and picking between them at random (by whichever
+     canonical-numbering trial happened to explore first) is exactly how
+     the witness's true geometry got lost. Fixed by
+     `CanonicalWriter::is_load_bearing_elsewhere`: an election must not
+     demote a raw-marked candidate that is some other, non-ambiguous
+     double bond's only geometric anchor. Deliberately narrower than "has
+     a raw mark" — a candidate whose sibling is *itself* ambiguous (has
+     its own resolution path, e.g. a genuinely coupled/shared-carrier
+     system) is not protected, so legitimate coupled resolution is
+     unaffected.
+  2. Independently, `normalize_ez` decided a shared E/Z group's sign from
+     a value that had already been re-oriented for one specific DFS write
+     direction. Which end of a directional bond a given canonicalization
+     trial happens to write "forward" vs "backward" varies across
+     candidate atom numberings for reasons unrelated to that bond's own
+     geometry (a tie elsewhere in the molecule), so the seeded sign could
+     vary too, non-deterministically flipping an otherwise-correct group.
+     Fixed by splitting `normalize_ez` into a mol-relative propagation
+     step (always flips `effective_order`, the bond's own topology-fixed
+     `atom1`→`atom2` reading, never an already-write-oriented value) and a
+     write-perspective anchor-seeding step (the write atom decides the
+     group's shared sign exactly once, and only that — it never enters
+     propagation). Found and fixed second, after the first fix alone
+     restored correctness for the filed witness but broke canonical-form
+     stability (10 independently-rooted, InChI-confirmed-equivalent
+     respellings of the witness converged to only 1 string before this
+     defect existed in the code at all — introducing defect #1's fix
+     alone dropped that to 3 non-idempotent strings; both fixes together
+     restore 10/10 convergence).
+- An intermediate, never-shipped attempt at defect #2 (seeding purely
+  from write-perspective, dropping the mol-relative anchor entirely)
+  restored canonical-form stability but silently made canonicalization
+  *informationally lossy* for this shape — the witness's true-Z and a
+  hand-verified true-E mirror both canonicalized to the identical string,
+  each losing its own stereo identity in different directions. Caught by
+  a mirror-distinctness regression test before being combined with defect
+  #1's fix into what actually shipped; not a real intermediate state of
+  the code, called out here only because the failure mode (idempotent AND
+  self-consistent, yet wrong) is exactly the kind that hides behind a
+  weaker "does it round-trip" check alone.
+- Verified against the real 290-compound corpus from the originating
+  investigation (eMolecules, 9.47M compounds,
+  `renkin doctor stock reimport_idempotency`) two ways: idempotence
+  (**290/290**, up from 289/290 before this fix) and, independently, that
+  each record's chematic canonical form reparses in RDKit to the exact
+  InChIKey recorded for that record at investigation time (**290/290**) —
+  the corpus itself is not committed (see PR #389's own note on this), only
+  aggregate counts.
+- New tests: the witness's own geometry preserved and stable, its only
+  safe alternate-carrier candidate confirmed to have none available
+  (`alternate_ez_markings` returns empty — the sibling candidate is
+  load-bearing elsewhere, so no valid respelling moves the mark there),
+  mirror-image (E vs Z) distinctness, and full atom-order-permutation
+  invariance across 18 relabelings/markings via the same
+  `ez_carrier_test_variants` harness `EZ_SHARED_CARRIER_FULLY_RESOLVED`'s
+  own regression test uses.
+- Not addressed, not fixed, not blocking this PR: a synthetic edge case
+  found while writing this fix's own tests (not part of the filed issue,
+  the 290-corpus, or any pre-existing test) — an ambiguous end whose
+  *both* candidate bonds carry mutually-consistent raw marks, where one
+  candidate's sibling is itself adjacent to a genuinely undefined double
+  bond, produced a geometry mismatch between the raw input and a
+  canonicalize→reparse round-trip in this crate's own test-only
+  `up_of_reference` oracle. Not confirmed as a production defect (the
+  oracle is test-only scaffolding, not the production code path) or ruled
+  out as one — flagged here rather than silently dropped, deliberately
+  not filed as an issue without that confirmation.
+
+### Fixed — `chematic-chem` (issue #399: `standardize()` silently dropped stereo tables on several rebuild paths)
+
+- 8 functions in `standardize.rs` (`neutralize_charges`, `normalize_zwitterion`
+  active path, `normalize_groups`, `remove_isotopes`, `reionize`, `uncharge`,
+  `prefer_organic`, `disconnect_metals`) rebuilt the molecule via a bare
+  `MoleculeBuilder` without carrying `stereo_neighbor_order`/
+  `bond_directions`/`stereo_groups` forward — even when zero atoms were
+  actually modified. Once #392 (v0.20.0) restored `remove_hydrogens`'s own
+  table-copying, its adjacency-based fallback reconstruction (correct for
+  ring-closing stereocenters, transposed for ring-opening ones) started
+  firing on every stereocenter passing through any of these 8 functions,
+  flipping `@`/`@@` depending on which role a stereocenter played in the
+  original text vs. the canonical rewrite.
+- Fixed: a bulk `copy_stereo_from`/`copy_bond_directions_from`/
+  `copy_stereo_groups_from` for the 7 functions that preserve every
+  atom/bond 1:1; `prefer_organic` now delegates to the already-correct
+  `extract_fragment` (it genuinely drops atoms); `disconnect_metals` remaps
+  `bond_directions` bond-by-bond (it drops metal-adjacent bonds, shifting
+  survivors' indices). Added the stereo-preservation invariant as a doc
+  comment on `Molecule::stereo_neighbor_order`.
+- Also corrected `tp2_20_isotope_parent_preserves_stereo`'s hardcoded
+  expected value, which had baked in this exact bug (verified via RDKit
+  `MolToInchi` which of the two candidates matches the isotope-free
+  reference structure).
+- Verified: dev-corpus standardize-path idempotency 615/519 → 68/60 (the
+  exact pre-#392 baseline); NCI `first_5K.smi` blind holdout (4,999 unused
+  real molecules, run once): 0 stereo-related failures, 0 stereocenter-count
+  mismatches against an independent RDKit CIP oracle. New regression suite
+  (`standardize_stereo_table_preservation.rs`, 12 tests) verified to catch
+  the bug (fails on pre-fix code).
+
+### Fixed — `chematic-smiles` (issue #395: ring-closure bond marker ignored the closure partner's aromaticity)
+
+- The canonical writer's ring-closure marker decision checked only the
+  currently-written atom's own aromaticity, never its ring-closure
+  partner's — unlike the equivalent, correct decision for a plain tree-edge
+  child, which checks both endpoints. A bare ring-closure digit between two
+  aromatic atoms is read back by the parser as an *aromatic* bond, so a
+  genuinely `Single`-order ring-closure bond joining two atoms that each
+  individually happen to be aromatic (a non-aromatic fusion bond connecting
+  two separately-aromatic ring systems, e.g. `c1-2`) silently became
+  aromatic on re-parse whenever the writer omitted its `-` marker.
+- Fixed by mirroring the tree-edge `implicit` computation for ring closures,
+  checking both endpoints' aromaticity.
+- Verified: dev-corpus bare-parse idempotency 73/57 → **0/0**, a complete
+  fix, not a partial improvement. Independent RDKit oracle: all 10,000
+  corpus lines' canonical output now round-trips to the exact same InChI as
+  the original input — 0 mismatches. Combined with #399's fix, the
+  standardize-path corpus is now at 0/4 (the 4 residual failures traced to
+  two newly-filed, unfixed issues: #407, a `normalize_zwitterion`
+  proton-transfer asymmetry, and a `canonical_tautomer` interaction of the
+  same class as #402).
+
 ## [0.20.0] — 2026-08-25
 
 ### Added — `chematic-3d`/`chematic-py`/`chematic-wasm` (stereo-safe 3D generation, issue #291)
@@ -193,88 +334,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   invariance for two independently-written spellings of the same
   configuration, and Boc-protecting-group / fused-bicyclic-ring
   regression cases.
-
-### Fixed — `chematic-smiles` (issue #390: coupled E/Z canonicalization could silently change geometry)
-
-- Root cause, two independent defects in `CanonicalWriter`'s E/Z marker
-  machinery, both needed to reproduce the filed witness
-  (`O/N=C/C(C=N/O)=N\NC`, whose atom3=atom7 double bond was silently
-  written as E instead of the true Z — confirmed via independent RDKit
-  `MolToInchi`/`GetStereo()`, not just chematic's own self-consistency):
-  1. `resolve_ez_markers`'s carrier election for an ambiguous end could
-     elect a candidate bond whose sibling was raw-marked and load-bearing
-     for a *different*, unrelated double bond — demoting the sibling
-     silently under-specified that other double bond, while the elected
-     candidate simultaneously handed a *third*, genuinely undefined
-     double bond (confirmed via InChI's own `?` stereo descriptor for it)
-     a geometry it never had. Neither the demotion nor the promotion is
-     geometry-neutral, and picking between them at random (by whichever
-     canonical-numbering trial happened to explore first) is exactly how
-     the witness's true geometry got lost. Fixed by
-     `CanonicalWriter::is_load_bearing_elsewhere`: an election must not
-     demote a raw-marked candidate that is some other, non-ambiguous
-     double bond's only geometric anchor. Deliberately narrower than "has
-     a raw mark" — a candidate whose sibling is *itself* ambiguous (has
-     its own resolution path, e.g. a genuinely coupled/shared-carrier
-     system) is not protected, so legitimate coupled resolution is
-     unaffected.
-  2. Independently, `normalize_ez` decided a shared E/Z group's sign from
-     a value that had already been re-oriented for one specific DFS write
-     direction. Which end of a directional bond a given canonicalization
-     trial happens to write "forward" vs "backward" varies across
-     candidate atom numberings for reasons unrelated to that bond's own
-     geometry (a tie elsewhere in the molecule), so the seeded sign could
-     vary too, non-deterministically flipping an otherwise-correct group.
-     Fixed by splitting `normalize_ez` into a mol-relative propagation
-     step (always flips `effective_order`, the bond's own topology-fixed
-     `atom1`→`atom2` reading, never an already-write-oriented value) and a
-     write-perspective anchor-seeding step (the write atom decides the
-     group's shared sign exactly once, and only that — it never enters
-     propagation). Found and fixed second, after the first fix alone
-     restored correctness for the filed witness but broke canonical-form
-     stability (10 independently-rooted, InChI-confirmed-equivalent
-     respellings of the witness converged to only 1 string before this
-     defect existed in the code at all — introducing defect #1's fix
-     alone dropped that to 3 non-idempotent strings; both fixes together
-     restore 10/10 convergence).
-- An intermediate, never-shipped attempt at defect #2 (seeding purely
-  from write-perspective, dropping the mol-relative anchor entirely)
-  restored canonical-form stability but silently made canonicalization
-  *informationally lossy* for this shape — the witness's true-Z and a
-  hand-verified true-E mirror both canonicalized to the identical string,
-  each losing its own stereo identity in different directions. Caught by
-  a mirror-distinctness regression test before being combined with defect
-  #1's fix into what actually shipped; not a real intermediate state of
-  the code, called out here only because the failure mode (idempotent AND
-  self-consistent, yet wrong) is exactly the kind that hides behind a
-  weaker "does it round-trip" check alone.
-- Verified against the real 290-compound corpus from the originating
-  investigation (eMolecules, 9.47M compounds,
-  `renkin doctor stock reimport_idempotency`) two ways: idempotence
-  (**290/290**, up from 289/290 before this fix) and, independently, that
-  each record's chematic canonical form reparses in RDKit to the exact
-  InChIKey recorded for that record at investigation time (**290/290**) —
-  the corpus itself is not committed (see PR #389's own note on this), only
-  aggregate counts.
-- New tests: the witness's own geometry preserved and stable, its only
-  safe alternate-carrier candidate confirmed to have none available
-  (`alternate_ez_markings` returns empty — the sibling candidate is
-  load-bearing elsewhere, so no valid respelling moves the mark there),
-  mirror-image (E vs Z) distinctness, and full atom-order-permutation
-  invariance across 18 relabelings/markings via the same
-  `ez_carrier_test_variants` harness `EZ_SHARED_CARRIER_FULLY_RESOLVED`'s
-  own regression test uses.
-- Not addressed, not fixed, not blocking this PR: a synthetic edge case
-  found while writing this fix's own tests (not part of the filed issue,
-  the 290-corpus, or any pre-existing test) — an ambiguous end whose
-  *both* candidate bonds carry mutually-consistent raw marks, where one
-  candidate's sibling is itself adjacent to a genuinely undefined double
-  bond, produced a geometry mismatch between the raw input and a
-  canonicalize→reparse round-trip in this crate's own test-only
-  `up_of_reference` oracle. Not confirmed as a production defect (the
-  oracle is test-only scaffolding, not the production code path) or ruled
-  out as one — flagged here rather than silently dropped, deliberately
-  not filed as an issue without that confirmation.
 
 ### Added — `chematic-py` (A2.1: Python bindings for the conformer ensemble core)
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,5 +23,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.20.0
+version: 0.20.1
 date-released: "2026-08-12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.20.0"
+version = "0.20.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 A cheminformatics library for Python, Rust, and the browser.
 
 **Cheminformatics that's fast by default, safe by design.**  
-Pure Rust · Zero C/C++ · Python · WebAssembly · [Live Demo](https://kent-tokyo.github.io/chematic/playground/)
+Pure Rust · Zero C/C++ · Python · WebAssembly · [Website](https://chematic.io/) · [Live Demo](https://kent-tokyo.github.io/chematic/playground/)
 
 | | chematic | RDKit (Python) | RDKit.js (WASM) |
 |---|---|---|---|
@@ -199,7 +199,7 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.20.0
+# chematic v0.20.1
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-07-17, v0.4.29 vs RDKit 2026.03.3 --
@@ -447,6 +447,13 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +1
 
 ## Recent Development
 
+**v0.20.1** (2026-08-26): **Three canonical-SMILES/standardization correctness fixes (patch release, no breaking changes)**
+- `chematic-smiles`: coupled E/Z canonicalization could silently change geometry on re-canonicalization (issue #390) — two independent defects in the canonical writer's E/Z marker machinery, both required to reproduce the filed witness; fixed together, verified against a real 290-compound corpus (290/290 idempotent, 290/290 matching independent RDKit InChIKeys, up from 289/290)
+- `chematic-chem`: `standardize()` silently dropped stereo tables on several rebuild paths (issue #399) — 8 functions in `standardize.rs` rebuilt the molecule via a bare `MoleculeBuilder` without carrying `stereo_neighbor_order`/`bond_directions`/`stereo_groups` forward, flipping `@`/`@@` depending on ring-open/close role; dev-corpus standardize-path idempotency 615/519 → 68/60 (the exact pre-#392 baseline), NCI holdout (4,999 unused real molecules, run once) 0 stereo-related failures
+- `chematic-smiles`: canonical-writer ring-closure bond markers ignored the closure partner's aromaticity (issue #395) — a genuinely non-aromatic ring-closure "fusion" bond between two individually-aromatic atoms (e.g. `c1-2`) silently became aromatic on re-parse; dev-corpus bare-parse idempotency 73/57 → 0/0, a complete fix, independent RDKit InChI oracle 0 mismatches across all 10,000 corpus lines
+- Combined, the two standardize-path fixes bring that corpus to 0/4 residual — the 4 remaining failures are traced to two newly-filed, not-yet-fixed issues (#407, #402-class), not folded into this release
+- Full details in `CHANGELOG.md`'s `[0.20.1]` section
+
 **v0.20.0** (2026-08-25): **Stereo-safe 3D generation, a connectivity-ordered coordinate engine, and identity-correctness fixes for `remove_hydrogens`**
 - `chematic-3d`/`chematic-py`/`chematic-wasm`: `PipelineV2Config::stereo_safe(force_field_policy)` — a single-call configuration that resolves a real gap for ring-fused declared stereocenters (testosterone, cholesterol, and similar), where `repair_tetrahedral_center` previously had no coordinate to reflect an implicit H against. Measured on a 29-molecule × 5-seed corpus: 144/145 (99.3%) correct_and_ok, 0 silently wrong, testosterone/cholesterol both 5/5 seeds on every declared stereocenter
 - `chematic-3d`: `generate_coords_connectivity_ordered`, a new public alternative 3D placement engine (issues #256/#255) — places rings and chain atoms in true connectivity order rather than "all rings, then all chains." Measured: raw-geometry soundness 10/33 → 33/33 on a differential corpus with zero regressions, post-UFF bond-violation rate reaching 0.0000 (better than the legacy engine's own baseline). `generate_coords` itself is completely unchanged — ships as an available alternative, not a default-behavior switch; no existing caller is routed to it
@@ -609,7 +616,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v0.20.0)
+├── Cargo.toml                    workspace root (v0.20.1)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)
@@ -663,7 +670,7 @@ If you use chematic in academic or research work, please cite:
   author    = {kent-tokyo},
   title     = {chematic: A pure-Rust cheminformatics toolkit},
   url       = {https://github.com/kent-tokyo/chematic},
-  version   = {0.20.0},
+  version   = {0.20.1},
   year      = {2026},
 }
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -14,7 +14,7 @@
 Python・Rust・ブラウザ向けケモインフォマティクスライブラリ。
 
 **デフォルトで速く、設計で安全なケモインフォマティクス。**  
-Pure Rust · C/C++ ゼロ · Python · WebAssembly · [ライブデモ](https://kent-tokyo.github.io/chematic/playground/)
+Pure Rust · C/C++ ゼロ · Python · WebAssembly · [公式サイト](https://chematic.io/) · [ライブデモ](https://kent-tokyo.github.io/chematic/playground/)
 
 | | chematic | RDKit (Python) | RDKit.js (WASM) |
 |---|---|---|---|
@@ -125,7 +125,7 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.20.0
+# chematic v0.20.1
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-06, v0.4.22 vs RDKit 2026.03.3 --
@@ -303,6 +303,13 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi      
 ---
 
 ## 最近の開発
+
+**v0.20.1**（2026-08-26）: **canonical SMILES／standardizeの正確性修正3件（パッチリリース、破壊的変更なし）**
+- `chematic-smiles`：coupled E/Zのcanonicalizationが再canonicalize時に幾何をsilentlyに変えてしまう問題（issue #390）——canonical writerのE/Zマーカー機構における独立した2つのバグ、再現には両方の修正が必要。修正後、実際の290化合物コーパスで検証（idempotency 290/290、独立したRDKit InChIKeyとの一致290/290、修正前の289/290から改善）
+- `chematic-chem`：`standardize()`がいくつかの再構築経路でstereoテーブルをsilentlyに失う問題（issue #399）——`standardize.rs`の8関数が素の`MoleculeBuilder`で再構築する際に`stereo_neighbor_order`/`bond_directions`/`stereo_groups`を引き継いでおらず、ring-closing/ring-openingの役割次第で`@`/`@@`がフリップしていた。開発用corpusのstandardize経由idempotencyは615/519→68/60（#392以前の水準に正確に一致）、NCI holdout（未使用の実分子4,999件、一度だけ実行）でステレオ関連の失敗は0件
+- `chematic-smiles`：canonical writerのring-closure bond markerがclosure相手側の芳香族性を見ていなかった問題（issue #395）——個別には芳香族な2原子をつなぐ非芳香族の"fusion"結合（例：`c1-2`）が、再parse時にsilentlyに芳香族結合へ変わっていた。開発用corpusのbare-parse idempotencyは73/57→0/0（完全な修正）、独立したRDKit InChI oracleで全10,000件corpus一致（不一致0件）
+- 上記2件のstandardize経由修正を組み合わせた結果、そのcorpusの残差は0/4まで改善——残る4件は新規に発見・ファイルした2つの未修正issue（#407、#402系統）に起因し、本リリースには含めていない
+- 詳細は`CHANGELOG.md`の`[0.20.1]`section参照
 
 **v0.20.0**（2026-08-25）: **立体化学を保った3D構造生成、connectivity-ordered座標エンジン、`remove_hydrogens`の同一性正確性修正**
 - `chematic-3d`/`chematic-py`/`chematic-wasm`：`PipelineV2Config::stereo_safe(force_field_policy)`——環に組み込まれた宣言済み立体中心（テストステロン、コレステロール等）に対する実際のギャップを一括解決する設定。従来`repair_tetrahedral_center`は暗黙のHを反映すべき座標を持たなかった。29分子×5 seedコーパスで測定：144/145（99.3%）がcorrect_and_ok、silently wrongは0件、テストステロン・コレステロールとも全宣言立体中心・全seedで5/5成功

--- a/README_zh.md
+++ b/README_zh.md
@@ -14,7 +14,7 @@
 面向 Python、Rust 和浏览器的化学信息学库。
 
 **默认快速，设计安全的化学信息学库。**  
-纯 Rust · 零 C/C++ · Python · WebAssembly · [在线演示](https://kent-tokyo.github.io/chematic/playground/)
+纯 Rust · 零 C/C++ · Python · WebAssembly · [官方网站](https://chematic.io/) · [在线演示](https://kent-tokyo.github.io/chematic/playground/)
 
 | | chematic | RDKit (Python) | RDKit.js (WASM) |
 |---|---|---|---|

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.20.0 | Yes | Current release — active support |
+| v0.20.1 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.20.0) receives all security updates.  
+**Active Support**: Latest release (v0.20.1) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -17,12 +17,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.20.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.20.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.20.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.20.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.20.1" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.20.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.1" }
 serde_json          = "1.0"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #219); web-time

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -17,14 +17,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.20.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.0" }
-chematic-cip        = { path = "../chematic-cip",        version = "0.20.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.1" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.20.1" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.1" }
+chematic-cip        = { path = "../chematic-cip",        version = "0.20.1" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-crystal/Cargo.toml
+++ b/crates/chematic-crystal/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 serde = ["dep:serde"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.1" }
 serde         = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -23,10 +23,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.20.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.20.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.20.1" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.20.1" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.1" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -23,13 +23,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.1" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.20.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.20.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.20.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.20.1" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.20.1" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.20.1" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -19,10 +19,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.20.0", path = "../chematic-core" }
-chematic-smiles = { version = "0.20.0", path = "../chematic-smiles" }
-chematic-chem = { version = "0.20.0", path = "../chematic-chem" }
-chematic-rxn = { version = "0.20.0", path = "../chematic-rxn" }
+chematic-core = { version = "0.20.1", path = "../chematic-core" }
+chematic-smiles = { version = "0.20.1", path = "../chematic-smiles" }
+chematic-chem = { version = "0.20.1", path = "../chematic-chem" }
+chematic-rxn = { version = "0.20.1", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -18,15 +18,15 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.20.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.20.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.20.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.20.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.20.1", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.20.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.1" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.20.1" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.1" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
 
 [dev-dependencies]
 # Real JSON Schema 2020-12 validator, used only in tests to independently

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -25,11 +25,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 crystal = ["dep:chematic-crystal"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.20.0" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.20.0" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.20.0" }
-chematic-smiles      = { path = "../chematic-smiles",      version = "0.20.0" }
-chematic-crystal     = { path = "../chematic-crystal",     version = "0.20.0", optional = true }
+chematic-core        = { path = "../chematic-core",        version = "0.20.1" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.20.1" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.20.1" }
+chematic-smiles      = { path = "../chematic-smiles",      version = "0.20.1" }
+chematic-crystal     = { path = "../chematic-crystal",     version = "0.20.1", optional = true }
 serde_json           = "1.0"
 
 [dev-dependencies]

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.1" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,17 +25,17 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.20.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.20.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.20.0", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.20.0", features = ["crystal"] }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.0" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.20.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.20.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.20.0" }
-chematic-crystal    = { path = "../chematic-crystal",    version = "0.20.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.20.1" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.20.1" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.20.1", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.20.1", features = ["crystal"] }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.1" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.1" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.1" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.20.1" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.20.1" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.20.1" }
+chematic-crystal    = { path = "../chematic-crystal",    version = "0.20.1" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -23,9 +23,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 perf-instrumentation = []
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.20.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.20.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.20.0" }
+chematic-core   = { path = "../chematic-core",   version = "0.20.1" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.20.1" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.20.1" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
 rustc-hash = "2"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #221); web-time

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.0" }
+chematic-core = { path = "../chematic-core", version = "0.20.1" }
 # Production use: `compute_stereo_alkene_ends` (canonical.rs) needs SSSR ring
 # membership to exclude endocyclic small-ring double bonds from marker-carrier
 # candidacy (issue #149's ring-constrained residual, see
@@ -27,7 +27,7 @@ chematic-core = { path = "../chematic-core", version = "0.20.0" }
 # graph, only test binaries. Was previously a dev-only dependency of this
 # crate for a different reason (re-aromatizing test fixtures); now also a
 # real one.
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
 
 [features]
 # Feature-gated internal work counters for the orbit-pruning canonical

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -32,16 +32,16 @@ web-sys = { version = "0.3", features = ["console"] }
 js-sys = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.20.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.20.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.20.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.20.0", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.20.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.20.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.20.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.20.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.20.1", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.20.1" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.20.1", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.20.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.1" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.20.1" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.20.1" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.1" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.1" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.20.1" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -54,16 +54,16 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.20.0", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.0", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.20.0", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.20.0", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.20.0", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.20.0", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.20.0", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.0", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.20.0", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.20.0", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.0", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.0", optional = true }
-chematic-crystal    = { path = "../chematic-crystal",    version = "0.20.0", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.20.1", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.1", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.20.1", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.20.1", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.20.1", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.20.1", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.20.1", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.1", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.20.1", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.20.1", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.1", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.1", optional = true }
+chematic-crystal    = { path = "../chematic-crystal",    version = "0.20.1", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Patch release bundling three canonical-SMILES/standardization correctness fixes merged since `v0.20.0`, none retroactively part of that release's own claims:

- **issue #390** (PR #398): coupled E/Z canonicalization could silently change geometry -- two independent defects in `CanonicalWriter`'s E/Z marker machinery, both fixed. Verified against the real 290-compound corpus two independent ways (idempotence 290/290, RDKit InChIKey cross-check 290/290, up from 289/290).
- **issue #399** (PR #404): `standardize()` silently dropped stereo tables on several rebuild paths -- 8 functions in `standardize.rs` rebuilt via a bare `MoleculeBuilder` without carrying `stereo_neighbor_order`/`bond_directions`/`stereo_groups` forward. Dev-corpus standardize-path idempotency 615/519 -> 68/60 (the exact pre-#392 baseline); NCI holdout (4,999 unused real molecules, run once) 0 stereo-related failures.
- **issue #395** (PR #406): canonical writer's ring-closure bond marker ignored the closure partner's aromaticity -- a non-aromatic ring-closure "fusion" bond between two individually-aromatic atoms silently became aromatic on re-parse. Dev-corpus bare-parse idempotency 73/57 -> 0/0, a complete fix; independent RDKit InChI oracle 0 mismatches across all 10,000 corpus lines.

No breaking API changes.

## Also corrects

`CHANGELOG.md`'s `[0.20.0]` section had the #390 entry misplaced there by an earlier squash-merge race (its commit landed 21 minutes after the `v0.20.0` tag was cut). Moved to this new `[0.20.1]` section along with #399/#395's entries, rather than left as an inaccurate historical claim.

`README.md`/`README_ja.md`/`README_zh.md`: added a v0.20.1 "Recent Development" entry (each file's own established prose-only convention) and a link to the official site (chematic.io) alongside the existing live-demo link.

## Verification

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean (0 warnings, all 19 crates including `chematic-py`/`chematic-wasm` via `cargo check`).
- `cargo build --workspace --exclude chematic-py --exclude chematic-wasm`: clean (the two excluded crates have a known, pre-existing `cargo build`-vs-PyO3-linker issue unrelated to this change -- `cargo check` on them is clean).
- `cargo test --workspace --tests --no-fail-fast`: clean except the pre-existing, already-documented `atorvastatin_fragment` local-machine-only flake (confirmed unrelated to this release: passes in isolation under `--release`, same signature as prior releases; `chematic-3d` is untouched by this release).
- `scripts/check_publish_graph.py`: valid publish order for all 19 crates.
- Version-consistency checks (README.md/README_ja.md doctor() version, `Cargo.toml` Repository Structure comment, BibTeX citation, `CITATION.cff`, `SECURITY.md`, `demo/pkg/package.json`, all path-dependency Cargo.toml pins): all pass at `0.20.1`.

## Test plan

- [x] Version bump propagated everywhere `scripts/bump_version.py` touches
- [x] `CHANGELOG.md` `[0.20.1]` section accurate, `[0.20.0]`'s misplaced entry corrected
- [x] `README.md`/`README_ja.md`/`README_zh.md` "Recent Development" entries added
- [x] fmt / clippy / build clean across the full workspace
- [x] Version-consistency and publish-graph checks pass
- [x] Full workspace test suite clean (one pre-existing, unrelated local flake, confirmed)