### PR TITLE
fix(tautomer): reject shifts that produce an unkekulizable molecule (issue #415)

### DIFF
--- a/crates/chematic-chem/src/tautomer.rs
+++ b/crates/chematic-chem/src/tautomer.rs
@@ -678,7 +678,27 @@ fn transfer_hydrogen_aromatic(
     builder.copy_stereo_groups_from(mol);
     builder.copy_stereo_from(mol);
     builder.copy_bond_directions_from(mol);
-    Some(builder.build())
+    let next = builder.build();
+
+    // Issue #415: `acceptor` being individually valence-legal (has an
+    // available H slot in isolation) isn't sufficient in a fused/bridged
+    // ring -- it can be ring-adjacent to *another* atom that already carries
+    // an "extra" H, and two such atoms next to each other in one aromatic
+    // ring can't both correctly contribute a lone pair to the same ring's pi
+    // system. Confirmed via a real repro this exact function reaches
+    // (`Oc1[nH]ncc2c3cc(OCc4ccccc4)ccc3nc1-2`'s two ring nitrogens end up
+    // adjacent-both-protonated, an over-valent state RDKit itself rejects).
+    // Same general-purpose oracle used for the same reason in
+    // `transfer_hydrogen_exocyclic_lactam` below -- see that function's own
+    // comment for why `kekulize` (not `validate_valence`, which doesn't cap
+    // aromatic atoms to their primary valence and misses this) is the right
+    // check. Bounded cost: this function is only ever called on the (`max`,
+    // default 16) candidates `enumerate_direct_aromatic_forms_tracked`'s BFS
+    // frontier actually visits, not on every possible pair in the molecule.
+    if chematic_core::kekulize(&next).is_err() {
+        return None;
+    }
+    Some(next)
 }
 
 // ---------------------------------------------------------------------------
@@ -862,6 +882,27 @@ fn transfer_hydrogen_exocyclic_lactam(
         // see Phase 1's fragment-extraction stereo-corruption fix). Fail
         // closed rather than return a molecule that silently changed
         // something this transform must never touch.
+        return None;
+    }
+
+    // Second defense-in-depth layer (issue #415): the per-atom preconditions
+    // above (`implicit_hcount(mol, acceptor) == 0`, degree 2) are necessary
+    // but not sufficient in a fused/bridged ring system -- `find_sssr`'s own
+    // ring choice for such systems isn't always unique (a known, separate
+    // residual: the *same* physical molecule can get a different SSSR
+    // decomposition depending on atom-labeling order, which can change which
+    // ring this function's `ring_distance` check sees), and an acceptor that
+    // looks individually valid (0 H, degree 2) can still be ring-adjacent to
+    // *another* aromatic atom that already carries an "extra" H. Two such
+    // atoms next to each other in one aromatic ring cannot both correctly
+    // contribute a lone pair to the same ring's pi system -- confirmed via a
+    // real repro (`Oc1[nH]ncc2c3cc(OCc4ccccc4)ccc3nc1-2`) that this function
+    // previously accepted and which produced an over-valent `[nH2]` nitrogen
+    // RDKit itself rejects outright. `kekulize` is a general, already-used-
+    // elsewhere oracle for "is this aromatic system actually valid" that
+    // catches this (and would catch other, not-yet-evidenced pathological
+    // shapes too) without needing to hand-enumerate every such shape here.
+    if chematic_core::kekulize(&next).is_err() {
         return None;
     }
     Some(next)
@@ -3719,5 +3760,38 @@ mod tests {
             crate::cip::assign_cip(&out).get(stereocenter),
             "CIP label changed on the uninvolved stereocenter"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #415: canonical_tautomer must never produce an unkekulizable
+    // (chemically invalid) molecule, even for a fused/bridged ring system
+    // where `find_sssr`'s own ring choice can differ depending on atom
+    // labeling.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn issue415_fused_ring_shift_never_produces_invalid_molecule() {
+        // A phthalazinone-like fused bicyclic tautomer where re-labeling via
+        // a canonical-SMILES round trip used to make both the
+        // exocyclic-lactam-shift mechanism and the plain direct-aromatic
+        // 1,2-shift mechanism protonate a ring nitrogen that was already
+        // ring-adjacent to another protonated nitrogen -- an over-valent
+        // `[nH2]`-shaped state RDKit itself rejects outright (confirmed via
+        // `Chem.MolFromSmiles` at diagnosis time). Every candidate this
+        // molecule can reach through repeated standardize passes must stay
+        // kekulizable.
+        let smi = "Oc1[nH]ncc2c3cc(OCc4ccccc4)ccc3nc1-2";
+        let mol = parse(smi).unwrap();
+        let mut current = mol;
+        for pass in 0..6 {
+            let next = canonical_tautomer(&current);
+            assert!(
+                chematic_core::kekulize(&next).is_ok(),
+                "pass {pass}: canonical_tautomer produced an unkekulizable molecule: {}",
+                canonical_smiles(&next)
+            );
+            let reparsed = parse(&canonical_smiles(&next)).unwrap();
+            current = reparsed;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes issue #415: `canonical_tautomer`'s two H-shift mechanisms (`transfer_hydrogen_exocyclic_lactam` and `transfer_hydrogen_aromatic`) validated their acceptor atom in isolation (0 implicit H, correct degree, neutral charge) but not against the rest of the ring. In a fused/bridged bicyclic system, an acceptor that looks individually valence-legal can be ring-adjacent to **another** aromatic atom that already carries an "extra" H -- and two such atoms next to each other in one aromatic ring can't both correctly contribute a lone pair to the same ring's pi system.

## Repro and root cause

`Oc1[nH]ncc2c3cc(OCc4ccccc4)ccc3nc1-2` (found during issue #407's own corpus re-measurement, initially mis-attributed to issue #402 -- see #402's tracking comment for the correction): re-labeling this molecule via a canonical-SMILES round trip made both mechanisms protonate a ring nitrogen already adjacent to another protonated nitrogen, producing an `[nH2]`-shaped, over-valent state RDKit's own parser rejects outright:

```
>>> Chem.MolFromSmiles("c-13c(=O)[nH2]ncc-1c4cc(ccc4n3)OCc2ccccc2")
Explicit valence for atom # 3 N, 5, is greater than permitted
```

`find_sssr`'s own ring choice for such fused systems isn't always unique, which is why the *same physical molecule* reached this invalid state on a second standardize pass but not the first -- a separate, deeper, not-fully-solved order-dependence residual. This fix doesn't chase that down; it stops the resulting corruption.

## Fix

Both mechanisms now validate their output with `kekulize` before accepting it -- a general "is this aromatic system actually valid" check, chosen over `validate_valence` (which doesn't cap aromatic atoms to their primary valence and doesn't catch this specific shape -- confirmed empirically: `validate_valence` returns zero errors on the same `[nH2]` molecule `kekulize` correctly rejects). This rejects the pathological shape without needing to hand-enumerate every way it could occur.

Bounded cost: `transfer_hydrogen_aromatic` is only ever called on the (default 16) candidates `enumerate_direct_aromatic_forms_tracked`'s BFS actually visits, not on every possible pair in the molecule.

## What this does and doesn't change

- The known corpus residual this molecule was already causing (`descriptor_census_corpus.smi`, ceiling at 1 since issue #407's own re-measurement) stays at **1**, unchanged in count -- this molecule still isn't byte-identical after one standardize pass vs two. It now **converges to a valid tautomer by the second pass** instead of producing invalid chemistry on the first pass -- severity reduced, residual itself not newly closed.
- No API signature changes; purely internal behavior (rejecting more candidates that would have produced invalid molecules).

## Verification

- [x] New regression test `issue415_fused_ring_shift_never_produces_invalid_molecule` -- runs 6 repeated standardize passes on the repro molecule, asserts every intermediate result stays kekulizable
- [x] `cargo test -p chematic-chem --lib tautomer::` -- 89 passed, 2 pre-existing unrelated ignores, 0 failed
- [x] `cargo test -p chematic-chem --lib` -- 820 passed, 0 failed
- [x] `cargo test -p chematic-chem --test canonical_idempotency_corpus_standardized` -- all 3 corpora pass (chembl_accuracy 0, descriptor_census 1 unchanged -- same molecule, less severe -- NCI first_5K 0)
- [x] `cargo test -p chematic-chem --test standardize_stereo_table_preservation` / `--test metal_disconnect_holdout` / `--test canonical_stereo_d0_cip_multiset_invariance` -- all unaffected
- [x] `cargo check -p chematic-py -p chematic-wasm` -- clean (both crates expose `canonical_tautomer`/`tautomer_parent`, no signature change)
- [x] `cargo fmt --check` / `cargo clippy -p chematic-chem --lib -- -D warnings` -- clean