### PR TITLE
release: v0.21.0 -- MCS charge/isotope matching + McsOutcome, 4 correctness fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] — 2026-08-27
+
+Minor release: `McsConfig` gains new fields (`match_charge`/`match_isotope`) and
+`McsOutcome` (additive, non-breaking public API), plus four correctness fixes —
+MCS branch-and-bound completeness, and issues #403/#407/#415 (metal-complex
+charge neutralization, zwitterion proton transfer, tautomer valence validity).
+No breaking API changes.
+
 ### Added — `chematic-smarts` (`McsConfig`: `match_charge`/`match_isotope`, typed timeout outcome)
 
 - `McsConfig` gained `match_charge`/`match_isotope` fields, mirroring the
@@ -70,6 +78,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hand-built metal-complex holdout added (11 fixtures spanning Ni, Co, Al,
   Zn, Cr, Fe, Mg, Mn, Hg, Cd, Pd with varied ligand shapes plus an
   ionic-salt negative control), all pass. Existing dev corpora unaffected.
+
+### Fixed — `chematic-chem` (issue #407: `normalize_zwitterion` invented a proton for non-transferable charge pairs)
+
+- The active proton-transfer path unconditionally neutralized the negative
+  atom (+1 charge, +1 H) but only neutralized the paired positive atom if
+  it had an available H. For a permanently charge-separated group with no
+  transferable proton on either side (e.g. a diazo-N,N'-dioxide,
+  `[N+]([O-])=[N+]...[O-]`, structurally similar to a nitro group), this
+  invented a hydrogen on the negative atom from nowhere, silently changing
+  the molecule's formula and net charge.
+- `has_zwitterion`'s "some + and some - charge exists somewhere" check is
+  necessary but not sufficient for a real protonation-state zwitterion.
+  Rather than hand-classifying every non-transferable functional-group
+  family (nitro, diazo N-oxide, mesoionic, ...), fixed by gating the
+  transfer on the invariant that actually matters: a proton can only move
+  if the chosen donor has one to give. If the positive atom has no
+  available H, neither atom is modified — the pair is left untouched.
+- Verified: `descriptor_census_corpus.smi` standardize-path idempotency
+  4 → **1** residual (the 3 known molecules for this issue now pass; the 1
+  remaining is an unrelated `canonical_tautomer` interaction, confirmed
+  standing alone — see issue #402/#415). New property-based tests (atom/
+  element/H-count conservation, net-charge conservation, idempotency, a
+  genuine-zwitterion positive control, nitro/pyridine-N-oxide negative
+  controls, and an atom-permutation invariance check) rather than
+  spot-checking one hardcoded expected string per molecule.
+
+### Fixed — `chematic-chem` (issue #415: `canonical_tautomer` could produce an unkekulizable molecule)
+
+- Both of `canonical_tautomer`'s aromatic H-shift mechanisms
+  (`transfer_hydrogen_exocyclic_lactam`, `transfer_hydrogen_aromatic`)
+  validated their acceptor atom in isolation (0 implicit H, correct
+  degree) but not against the rest of the ring. In a fused/bridged ring
+  system, an acceptor that looks individually valence-legal can be
+  ring-adjacent to *another* aromatic atom that already carries an "extra"
+  H — two such atoms next to each other in one aromatic ring can't both
+  correctly contribute a lone pair to the same ring's pi system. Confirmed
+  via a real repro (`Oc1[nH]ncc2c3cc(OCc4ccccc4)ccc3nc1-2`) that this
+  produced an `[nH2]`-shaped, over-valent nitrogen RDKit's own parser
+  rejects outright.
+- Fixed by validating both mechanisms' output with `kekulize` before
+  accepting it (`validate_valence` doesn't cap aromatic atoms to their
+  primary valence and doesn't catch this shape). `find_sssr`'s own ring
+  choice for such fused systems isn't always unique, which is why the same
+  physical molecule reached this state on a second standardize pass but
+  not the first — a separate, deeper, not-fully-solved order-dependence
+  residual this fix doesn't chase down; it stops the resulting corruption.
+- The known corpus residual this molecule was already causing
+  (`descriptor_census_corpus.smi`, ceiling 1) is unchanged in count — the
+  molecule still isn't byte-identical after one standardize pass vs two —
+  but now converges to a valid tautomer by the second pass instead of
+  producing invalid chemistry on the first.
 
 ## [0.20.1] — 2026-08-26
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,5 +23,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.20.1
+version: 0.21.0
 date-released: "2026-08-12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.20.1"
+version = "0.21.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.20.1
+# chematic v0.21.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-07-17, v0.4.29 vs RDKit 2026.03.3 --
@@ -447,6 +447,14 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +1
 
 ## Recent Development
 
+**v0.21.0** (2026-08-27): **`McsConfig` charge/isotope matching + typed timeout outcome, four correctness fixes**
+- `chematic-smarts`: `McsConfig` gains `match_charge`/`match_isotope` fields (mirroring the existing `match_chiral_tag`, default `false`) and a new `McsOutcome` enum (`Exhaustive`/`TimedOut`) via `find_mcs_with_config_checked`, reporting whether a timeout cut the search short rather than silently returning a possibly-non-optimal result — purely additive, `find_mcs`/`find_mcs_with_config` unchanged
+- `chematic-smarts`: `find_mcs`'s branch-and-bound search was incomplete — `grow()` only ever tried the first frontier atom with no way to exclude it and try another, silently missing a strictly larger common substructure in some cases (minimal repro: `OC(N)N` vs `NC(N)` returned 2 atoms instead of the true 3); fixed via standard include/exclude branch-and-bound
+- `chematic-chem`: `disconnect_metals` left a dative-bond-derived formal charge unneutralized after severing the metal bond (issue #403) — 34/4999 molecules in RDKit's own bundled NCI Diversity Set holdout were non-idempotent; fixed by recomputing the affected atom's H count via valence inference immediately after disconnection; NCI holdout 34 → 0 failures, new 11-fixture metal-complex holdout added
+- `chematic-chem`: `normalize_zwitterion` invented a proton on the negative atom of a permanently charge-separated group with no transferable proton anywhere (e.g. a diazo-N,N'-dioxide), silently changing the molecule's formula (issue #407) — fixed by gating the transfer on both atoms actually having a proton to move; dev-corpus residual 4 → 1 (the remaining one is unrelated, see issue #402/#415)
+- `chematic-chem`: `canonical_tautomer` could produce a chemically invalid, over-valent nitrogen in a fused/bridged ring system (issue #415) — both aromatic H-shift mechanisms now validate their output via kekulization before accepting it
+- Full details in `CHANGELOG.md`'s `[0.21.0]` section
+
 **v0.20.1** (2026-08-26): **Three canonical-SMILES/standardization correctness fixes (patch release, no breaking changes)**
 - `chematic-smiles`: coupled E/Z canonicalization could silently change geometry on re-canonicalization (issue #390) — two independent defects in the canonical writer's E/Z marker machinery, both required to reproduce the filed witness; fixed together, verified against a real 290-compound corpus (290/290 idempotent, 290/290 matching independent RDKit InChIKeys, up from 289/290)
 - `chematic-chem`: `standardize()` silently dropped stereo tables on several rebuild paths (issue #399) — 8 functions in `standardize.rs` rebuilt the molecule via a bare `MoleculeBuilder` without carrying `stereo_neighbor_order`/`bond_directions`/`stereo_groups` forward, flipping `@`/`@@` depending on ring-open/close role; dev-corpus standardize-path idempotency 615/519 → 68/60 (the exact pre-#392 baseline), NCI holdout (4,999 unused real molecules, run once) 0 stereo-related failures
@@ -616,7 +624,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v0.20.1)
+├── Cargo.toml                    workspace root (v0.21.0)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)
@@ -670,7 +678,7 @@ If you use chematic in academic or research work, please cite:
   author    = {kent-tokyo},
   title     = {chematic: A pure-Rust cheminformatics toolkit},
   url       = {https://github.com/kent-tokyo/chematic},
-  version   = {0.20.1},
+  version   = {0.21.0},
   year      = {2026},
 }
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -125,7 +125,7 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.20.1
+# chematic v0.21.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-06, v0.4.22 vs RDKit 2026.03.3 --
@@ -303,6 +303,14 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi      
 ---
 
 ## 最近の開発
+
+**v0.21.0**（2026-08-27）: **`McsConfig`の電荷/同位体マッチングと型付きtimeout結果、正確性修正4件**
+- `chematic-smarts`：`McsConfig`に`match_charge`/`match_isotope`フィールドを追加（既存の`match_chiral_tag`と同様、デフォルト`false`）。また新規`McsOutcome` enum（`Exhaustive`/`TimedOut`）を`find_mcs_with_config_checked`経由で提供し、timeoutで探索が打ち切られたかを明示的に報告（最適とは限らない結果をexhaustiveなものと区別できずに返す状態を解消）——純粋に追加のみ、`find_mcs`/`find_mcs_with_config`は無変更
+- `chematic-smarts`：`find_mcs`のbranch-and-bound探索が不完全だった問題——`grow()`が各探索ノードでfrontierの最初の候補しか試さず、除外して別候補を試す手段がなかったため、真に大きい共通部分構造を見逃すケースがあった（最小反例：`OC(N)N` vs `NC(N)`は真の3原子ではなく2原子を返していた）。標準的なinclude/exclude branch-and-boundで修正
+- `chematic-chem`：`disconnect_metals`が金属結合切断後にdative結合由来の形式電荷を中和せず放置していた問題（issue #403）——RDKit同梱のNCI Diversity Setホールドアウトで4,999件中34件が非冪等だった。切断直後に価電子推論でH数を再計算するよう修正。NCIホールドアウト34件→0件、新規11件の金属錯体ホールドアウトも追加
+- `chematic-chem`：`normalize_zwitterion`が、移動可能なプロトンがどちらの原子にもない永続的な電荷分離構造（例：diazo-N,N'-dioxide）に対し、負電荷側原子にプロトンを無から生成し分子式を静かに変えていた問題（issue #407）——両原子が実際にプロトンをやり取りできる場合のみ移動するよう修正。開発用corpusの残差は4→1（残る1件は無関係、issue #402/#415参照）
+- `chematic-chem`：`canonical_tautomer`が、融合・架橋環系で化学的に不正な過剰原子価窒素を生成しうる問題（issue #415）——2つの芳香族水素移動機構双方に、受理前のkekulization検証を追加
+- 詳細は`CHANGELOG.md`の`[0.21.0]`section参照
 
 **v0.20.1**（2026-08-26）: **canonical SMILES／standardizeの正確性修正3件（パッチリリース、破壊的変更なし）**
 - `chematic-smiles`：coupled E/Zのcanonicalizationが再canonicalize時に幾何をsilentlyに変えてしまう問題（issue #390）——canonical writerのE/Zマーカー機構における独立した2つのバグ、再現には両方の修正が必要。修正後、実際の290化合物コーパスで検証（idempotency 290/290、独立したRDKit InChIKeyとの一致290/290、修正前の289/290から改善）

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.20.1 | Yes | Current release — active support |
+| v0.21.0 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.20.1) receives all security updates.  
+**Active Support**: Latest release (v0.21.0) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -17,12 +17,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.20.1" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.20.1" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.20.1" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.21.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.21.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.21.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.21.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.21.0" }
 serde_json          = "1.0"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #219); web-time

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -17,14 +17,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.21.0" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.1" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.1" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.20.1" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.1" }
-chematic-cip        = { path = "../chematic-cip",        version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.21.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.21.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.21.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.21.0" }
+chematic-cip        = { path = "../chematic-cip",        version = "0.21.0" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.21.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-crystal/Cargo.toml
+++ b/crates/chematic-crystal/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 serde = ["dep:serde"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.1" }
+chematic-core = { path = "../chematic-core", version = "0.21.0" }
 serde         = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -23,10 +23,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.20.1" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.20.1" }
+chematic-core = { path = "../chematic-core", version = "0.21.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.21.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.21.0" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.1" }
+chematic-core = { path = "../chematic-core", version = "0.21.0" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.21.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -23,13 +23,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.1" }
+chematic-core = { path = "../chematic-core", version = "0.21.0" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.20.1" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.20.1" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.21.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.21.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.21.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -19,10 +19,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.20.1", path = "../chematic-core" }
-chematic-smiles = { version = "0.20.1", path = "../chematic-smiles" }
-chematic-chem = { version = "0.20.1", path = "../chematic-chem" }
-chematic-rxn = { version = "0.20.1", path = "../chematic-rxn" }
+chematic-core = { version = "0.21.0", path = "../chematic-core" }
+chematic-smiles = { version = "0.21.0", path = "../chematic-smiles" }
+chematic-chem = { version = "0.21.0", path = "../chematic-chem" }
+chematic-rxn = { version = "0.21.0", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.21.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -18,15 +18,15 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.1" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.20.1", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.20.1" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.1" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.20.1" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.1" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.20.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.21.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.21.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.21.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.21.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.21.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.21.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.21.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.21.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
 
 [dev-dependencies]
 # Real JSON Schema 2020-12 validator, used only in tests to independently

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -25,11 +25,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 crystal = ["dep:chematic-crystal"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.20.1" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.20.1" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.20.1" }
-chematic-smiles      = { path = "../chematic-smiles",      version = "0.20.1" }
-chematic-crystal     = { path = "../chematic-crystal",     version = "0.20.1", optional = true }
+chematic-core        = { path = "../chematic-core",        version = "0.21.0" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.21.0" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.21.0" }
+chematic-smiles      = { path = "../chematic-smiles",      version = "0.21.0" }
+chematic-crystal     = { path = "../chematic-crystal",     version = "0.21.0", optional = true }
 serde_json           = "1.0"
 
 [dev-dependencies]

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.1" }
+chematic-core = { path = "../chematic-core", version = "0.21.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,17 +25,17 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.20.1" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.20.1" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.20.1", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.20.1", features = ["crystal"] }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.1" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.1" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.1" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.20.1" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.20.1" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.20.1" }
-chematic-crystal    = { path = "../chematic-crystal",    version = "0.20.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.21.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.21.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.21.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.21.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.21.0", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.21.0", features = ["crystal"] }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.21.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.21.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.21.0" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.21.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.21.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.21.0" }
+chematic-crystal    = { path = "../chematic-crystal",    version = "0.21.0" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -23,9 +23,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 perf-instrumentation = []
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.20.1" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.20.1" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.20.1" }
+chematic-core   = { path = "../chematic-core",   version = "0.21.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.21.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.21.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
+chematic-core = { path = "../chematic-core", version = "0.21.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
 rustc-hash = "2"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #221); web-time

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.20.1" }
+chematic-core = { path = "../chematic-core", version = "0.21.0" }
 # Production use: `compute_stereo_alkene_ends` (canonical.rs) needs SSSR ring
 # membership to exclude endocyclic small-ring double bonds from marker-carrier
 # candidacy (issue #149's ring-constrained residual, see
@@ -27,7 +27,7 @@ chematic-core = { path = "../chematic-core", version = "0.20.1" }
 # graph, only test binaries. Was previously a dev-only dependency of this
 # crate for a different reason (re-aromatizing test fixtures); now also a
 # real one.
-chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
+chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
 
 [features]
 # Feature-gated internal work counters for the orbit-pruning canonical

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -32,16 +32,16 @@ web-sys = { version = "0.3", features = ["console"] }
 js-sys = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.20.1" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.1" }
-chematic-perception = { path = "../chematic-perception", version = "0.20.1" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.20.1", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.20.1" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.20.1", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.20.1" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.1" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.20.1" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.20.1" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.1" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.1" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.20.1" }
+chematic-core       = { path = "../chematic-core",       version = "0.21.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.21.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.21.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.21.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.21.0", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.21.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.21.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.21.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.21.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.21.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.21.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.21.0" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -54,16 +54,16 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.20.1", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.20.1", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.20.1", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.20.1", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.20.1", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.20.1", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.20.1", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.20.1", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.20.1", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.20.1", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.20.1", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.20.1", optional = true }
-chematic-crystal    = { path = "../chematic-crystal",    version = "0.20.1", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.21.0", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.21.0", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.21.0", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.21.0", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.21.0", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.21.0", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.21.0", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.21.0", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.21.0", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.21.0", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.21.0", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.21.0", optional = true }
+chematic-crystal    = { path = "../chematic-crystal",    version = "0.21.0", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Version bump 0.20.1 -> 0.21.0 (minor release). All changes already independently reviewed/merged as separate PRs (#411, #412, #416, #414, #417, #418) -- this PR is purely the version-bump mechanics (`scripts/bump_version.py` output) plus CHANGELOG/README restructuring.

**New public API** (additive, non-breaking): `McsConfig` gains `match_charge`/`match_isotope` fields and `McsOutcome` (`Exhaustive`/`TimedOut`) via `find_mcs_with_config_checked`.

**Correctness fixes bundled**:
- `find_mcs`'s branch-and-bound search was incomplete (frontier[0]-only, no exclude branch) -- could silently miss a strictly larger common substructure.
- issue #403: `disconnect_metals` left a dative-bond-derived formal charge unneutralized after severing the metal bond -- 34/4999 molecules in RDKit's own bundled NCI Diversity Set holdout were non-idempotent, now 0/4999.
- issue #407: `normalize_zwitterion` invented a proton on the negative atom of a permanently charge-separated group with no transferable proton anywhere, silently changing the molecule's formula.
- issue #415: `canonical_tautomer` could produce a chemically invalid, over-valent nitrogen in a fused/bridged ring system -- both aromatic H-shift mechanisms now validate their output via kekulization.

Full details in `CHANGELOG.md`'s `[0.21.0]` section.

## Verification

- [x] `python3 scripts/check_publish_graph.py` -- OK (19 publishable crates)
- [x] Version consistency check (README.md/README_ja.md/CITATION.cff/SECURITY.md/demo/pkg/package.json/all path-dependency Cargo.tomls) -- all consistent at 0.21.0
- [x] `cargo fmt --all -- --check` -- clean
- [x] `cargo clippy --workspace --all-targets --exclude chematic-py --exclude chematic-wasm -- -D warnings` -- clean
- [x] `cargo check -p chematic-py -p chematic-wasm` -- clean
- [x] `cargo test --workspace --lib --exclude chematic-py --exclude chematic-wasm` -- clean
- [x] `cargo test --workspace --tests --exclude chematic-py --exclude chematic-wasm --no-fail-fast` -- 594 passed, 1 failed in chematic-3d (the known, pre-existing `uff_only_rescue_now_preserves_stereo_for_atorvastatin_fragment` flake, unrelated to any change in this release), every other test binary across the workspace fully green