### PR TITLE
docs(tautomer): document that CIP labels can legitimately change (issue #402)

### DIFF
--- a/crates/chematic-chem/src/standardize.rs
+++ b/crates/chematic-chem/src/standardize.rs
@@ -1816,6 +1816,12 @@ fn is_metal(element: Element) -> bool {
 /// 4. If `canonical_tautomer`, convert to the canonical tautomer.
 ///
 /// Useful for cleaning pasted structures or database entries.
+///
+/// With `canonical_tautomer` enabled (the default), a stereocenter's CIP
+/// (R/S) label can legitimately change even though its real spatial
+/// configuration never moves -- see [`crate::tautomer::canonical_tautomer`]'s
+/// own doc comment (issue #402) before treating a pre- vs. post-standardize
+/// CIP-label difference as a bug on its own.
 pub fn standardize(mol: &Molecule, opts: &StandardizeOptions) -> Molecule {
     StandardizationPipeline::new(opts.clone()).run(mol).0
 }

--- a/crates/chematic-chem/src/tautomer.rs
+++ b/crates/chematic-chem/src/tautomer.rs
@@ -1423,6 +1423,21 @@ fn active_rules(config: &TautomerConfig) -> Vec<&'static TautomerRule> {
 /// by `tautomer_score` (O-H > N-H > S-H, aromatic-ring bonus), with
 /// canonical SMILES as the final tiebreaker.
 ///
+/// **A stereocenter's CIP (R/S) label can legitimately change across this
+/// shift, even at an atom this function never touches** (issue #402):
+/// `stereo_neighbor_order`/`chirality` are always carried forward verbatim
+/// for every atom not directly part of the transform (the real spatial
+/// configuration never moves), but a CIP label is *computed* from
+/// substituent priorities across the whole molecular graph, and a keto-enol
+/// (or similar) shift a few bonds away can change those priorities. Compare
+/// CIP labels only on the *same* tautomeric form on both sides -- comparing
+/// a pre-shift label to a post-shift label for "did stereo survive
+/// standardization" is not a valid check, and a difference there does not by
+/// itself indicate a bug. Confirmed via independent RDKit CIP oracle on two
+/// molecules where this shift changes a label: chematic's CIP on its own
+/// shifted structure matches RDKit's CIP on that identical structure exactly
+/// in both cases.
+///
 /// Uses [`TautomerConfig::default`] (all rules, max_iter=16).
 pub fn canonical_tautomer(mol: &Molecule) -> Molecule {
     canonical_tautomer_with_config(mol, &TautomerConfig::default())


### PR DESCRIPTION
## Summary

Closes out issue #402 as "working as intended, needed documentation" per this round's diagnosis: chematic's CIP assignment is correct and matches RDKit's own CIP engine exactly on `canonical_tautomer`'s shifted structure, in every case checked. The apparent pre/post-shift label difference is a legitimate consequence of the keto-enol shift altering a remote substituent's CIP priority -- not a stereo-preservation bug (`stereo_neighbor_order`/`chirality` are always carried forward verbatim for every atom the transform doesn't touch, confirmed directly).

Docs-only, no code change. Adds this to `canonical_tautomer`'s own doc comment, with a pointer from `standardize()`'s, so a future "CIP flipped after standardize(), is that a bug?" investigation doesn't have to redo this analysis from scratch.

## Test plan

- [x] `cargo build -p chematic-chem` / `cargo fmt --check -p chematic-chem` -- clean
- [x] Doc comment only, no behavior change