### PR TITLE
fix(mmff94): add missing C5B (type 64) angle eq_level row (3D coverage gap)

### DIFF
--- a/crates/chematic-3d/src/minimize.rs
+++ b/crates/chematic-3d/src/minimize.rs
@@ -3531,6 +3531,71 @@ mod policy_bridge_tests {
         assert_eq!(report.total_missing(), 0);
     }
 
+    /// RDKit/COSMolKit/OpenEye advantage directive, Phase 4 (3D coverage
+    /// gap): 11 of the 265-molecule strict corpus's coverage failures were
+    /// exactly the same `Angle C(3)-C(2)-C(64)` gap (bis-indolylmaleimide
+    /// scaffold, C5B indole-ring carbon exocyclic to a maleimide ring),
+    /// closed by adding type 64's `MMFF94_EQ_LEVEL` row
+    /// (`chematic-ff/src/mmff94_energy/angle.rs`). End-to-end confirmation
+    /// through this crate's own real coverage-check path (not just the
+    /// isolated `chematic-ff` angle-lookup unit test).
+    #[test]
+    fn issue_c5b_angle_gap_bis_indolylmaleimide_scaffold_now_covered() {
+        let smiles = [
+            "Cn1cc(C2=C(c3cn(CCCSC(=N)N)c4ccccc34)C(=O)NC2=O)c2ccccc21", // chembl_tier_b_0180
+            "Cn1cc(C2=C(c3cn(CCC[N+](C)(C)C)c4ccccc34)C(=O)NC2=O)c2ccccc21", // _0184
+            "Cn1cc(C2=C(c3cn(CCCCC(=N)N)c4ccccc34)C(=O)NC2=O)c2ccccc21", // _0185
+            "CN(C)CCCn1cc(C2=C(c3cn(C)c4ccccc34)C(=O)NC2=O)c2ccccc21",   // _0186
+            "Cn1cc(C2=C(c3cn(CCCN)c4ccccc34)C(=O)NC2=O)c2ccccc21",       // _0187
+            "Cn1cc(C2=C(c3cn(CCCN=C(N)N)c4ccccc34)C(=O)NC2=O)c2ccccc21", // _0190
+            "Cn1cc(C2=C(c3cn(CCO)c4ccccc34)C(=O)NC2=O)c2ccccc21",        // _0195
+            "Cn1cc(C2=C(c3cn(CCCO)c4ccccc34)C(=O)NC2=O)c2ccccc21",       // _0196
+            "Cn1cc(C2=C(c3cn(CCCCO)c4ccccc34)C(=O)NC2=O)c2ccccc21",      // _0197
+            "Cn1cc(C2=C(c3cn(CCCCCO)c4ccccc34)C(=O)NC2=O)c2ccccc21",     // _0198
+            "CNCCCn1cc(C2=C(c3cn(C)c4ccccc34)C(=O)NC2=O)c2ccccc21",      // _0199
+        ];
+        for smi in smiles {
+            let mol = parse(smi).unwrap_or_else(|e| panic!("failed to parse '{smi}': {e}"));
+            let (types, mmff_mol) =
+                assign_mmff94_numeric_types_with_view(&mol).unwrap_or_else(|e| {
+                    panic!("assign_mmff94_numeric_types_with_view failed for '{smi}': {e:?}")
+                });
+            let report = compute_mmff94_coverage(&mmff_mol, &types);
+            assert!(
+                report.angles_missing.is_empty(),
+                "'{smi}': expected no missing angle parameters, got {:?}",
+                report.angles_missing
+            );
+        }
+    }
+
+    /// Negative control: `chembl_tier_b_0022`'s `(angle_type=0, 43, 18, 63)`
+    /// triple is a separate, already-diagnosed, deliberately-unresolved case
+    /// (see `angle_empirical_fails_closed_for_undefined_eq_level_substitution`
+    /// in `chematic-ff`) -- this fix (type 64 only) must not accidentally
+    /// change its behavior.
+    #[test]
+    fn issue_type_63_case_unaffected_by_type_64_fix() {
+        let smi = "COc1cc2nc(N3CCN(S(=O)(=O)c4cccs4)CC3)nc(N)c2cc1OC";
+        let mol = parse(smi);
+        // Sanity: this test only needs to hold if the fixture molecule still
+        // parses and still exhibits the known gap; if either assumption goes
+        // stale, fail loudly rather than silently asserting nothing.
+        let Ok(mol) = mol else {
+            panic!("chembl_tier_b_0022 fixture failed to parse: {smi}");
+        };
+        let (types, mmff_mol) = assign_mmff94_numeric_types_with_view(&mol)
+            .unwrap_or_else(|e| panic!("assign_mmff94_numeric_types_with_view failed: {e:?}"));
+        let report = compute_mmff94_coverage(&mmff_mol, &types);
+        assert!(
+            !report.angles_missing.is_empty(),
+            "chembl_tier_b_0022's known type-63 angle gap should still be present \
+             (unaffected by the type-64 fix) -- if this now passes, the fixture may have \
+             drifted from the real chembl_tier_b_0022 molecule; re-verify before treating \
+             this as a second fix landing for free"
+        );
+    }
+
     /// Was `chematic_ff_own_energy_function_is_blind_to_this_bond_stretch`,
     /// which pinned a real chematic-ff bug (`bond_type_for` using OR-logic
     /// with no bond-order check) found while building this bridge:

--- a/crates/chematic-ff/src/mmff94_energy/angle.rs
+++ b/crates/chematic-ff/src/mmff94_energy/angle.rs
@@ -2360,10 +2360,34 @@ pub static MMFF94_ANGLE_ENERGY: &[(u8, u8, u8, u8, f64, f64)] = &[
 /// `eqLevel` columns, `Code/ForceField/MMFF/Params.cpp` at the pinned commit
 /// -- issue #227 Stage B). `[level2, level3, level4, level5]` per MMFF94
 /// numeric atom type; level1 is skipped, identical to level2 per MMFF.I note
-/// 68, page 519. 55 entries -- every numeric type this table doesn't list
-/// (rare/metal/exotic types outside chematic's supported corpus) is treated
-/// as its own identity substitution at every stage by [`eq_level`], matching
-/// what a real, valid MMFF94 molecule never needs to exercise in practice.
+/// 68, page 519. Every numeric type this table doesn't list (rare/metal/
+/// exotic types outside chematic's supported corpus) is treated as its own
+/// identity substitution at every stage by [`eq_level`].
+///
+/// **Type 64 (C5B) added 2026-08-28 (RDKit/COSMolKit/OpenEye advantage
+/// directive, Phase 4: 3D coverage gap)**:
+/// the table previously stopped at type 55, on the documented assumption
+/// that every type beyond it was "rare/exotic" and would never need a row
+/// in practice. Empirically false for type 64 specifically -- it's an
+/// aromatic 5-ring carbon (indole/pyrrole/furan/thiophene beta position),
+/// not rare at all, and 11 of the 265-molecule strict corpus's coverage
+/// failures were exactly this gap (`Angle C(3)-C(2)-C(64)`, e.g.
+/// `chembl_tier_b_0180`). Confirmed via the already-frozen
+/// `scripts/mmff94_provenance/rdkit_defaultMMFFDef.txt` (line 153: `C5B  64
+/// 64  2  1  0`) AND independently via a live RDKit oracle query
+/// (`MMFFGetMoleculeProperties(...).GetMMFFAngleBendParams`) on
+/// `chembl_tier_b_0180`'s own `(angle_type=2, 3, 2, 64)` triple, which
+/// returns real, defined values (`ka=0.893, theta0=118.456`) -- i.e. RDKit's
+/// real behavior resolves this deterministically, not the "returns nullptr,
+/// undefined behavior" situation type 63's own still-open, deliberately-
+/// unresolved case describes just below in this file
+/// (`angle_empirical_fails_closed_for_undefined_eq_level_substitution`).
+/// **Deliberately not added here**: any other type beyond 55 (63, 65-99,
+/// etc.) -- the frozen provenance file lists rows for those too, but none of
+/// them are evidenced by a concrete corpus failure this round; adding
+/// unverified rows risks resolving some future triple to a wrong value
+/// rather than correctly abstaining. See issue #415's own PR/ROADMAP note
+/// for this as flagged, deferred work, not silently dropped.
 static MMFF94_EQ_LEVEL: &[(u8, [u8; 4])] = &[
     (1, [1, 1, 1, 0]),
     (2, [2, 2, 1, 0]),
@@ -2420,6 +2444,7 @@ static MMFF94_EQ_LEVEL: &[(u8, [u8; 4])] = &[
     (53, [53, 42, 8, 0]),
     (54, [54, 9, 8, 0]),
     (55, [55, 10, 8, 0]),
+    (64, [64, 2, 1, 0]),
 ];
 
 /// `stage` in `0..4`, matching RDKit's Level 2/3/4/5. Falls back to `atom_type`
@@ -2745,7 +2770,7 @@ pub fn mmff94_angle_energy_resolved(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mmff94_energy::mmff94_bond_energy;
+    use crate::mmff94_energy::{mmff94_bond_energy, mmff94_bond_energy_resolved};
 
     #[test]
     fn eq_level_resolves_type_via_ladder_and_falls_back_to_identity() {
@@ -2829,6 +2854,42 @@ mod tests {
                 "plain mmff94_angle_energy must stay None for a ka==0.0 row"
             );
         }
+    }
+
+    #[test]
+    fn angle_type_3_2_64_resolves_via_new_c5b_eq_level_row() {
+        // RDKit/COSMolKit/OpenEye advantage directive, Phase 4 (3D coverage
+        // gap): 11 of the 265-molecule strict corpus's coverage failures
+        // were exactly this triple (`chembl_tier_b_0180` and 10 others,
+        // "Angle C(3)-C(2)-C(64)" -- an indole-ring C5B carbon beta to the
+        // ring N, exocyclic to a maleimide-type ring). Confirmed
+        // independently via a live RDKit oracle query on
+        // `chembl_tier_b_0180`'s own SMILES
+        // (`Cn1cc(C2=C(c3cn(CCCSC(=N)N)c4ccccc34)C(=O)NC2=O)c2ccccc21`):
+        // `MMFFGetMoleculeProperties(...).GetMMFFAngleBendParams` returns
+        // `(angleType=2, ka=0.893, theta0=118.456)` for this exact atom-type
+        // triple -- both values reproduced exactly here, resolved via the
+        // eqLevel ladder now that type 64 (C5B) has a row.
+        let r0_23 = mmff94_bond_energy_resolved(0, 2, 3).unwrap().0.r0;
+        let r0_264 = mmff94_bond_energy_resolved(0, 2, 64).unwrap().0.r0;
+        let (params, kind) = mmff94_angle_energy_resolved(2, 3, 2, 64, r0_23, r0_264, 0)
+            .expect("(angle_type=2, 3, 2, 64) must resolve now that type 64 has an eq_level row");
+        assert_eq!(kind, Mmff94Resolution::EquivalentType { level: 3 });
+        assert!(
+            (params.ka - 0.893).abs() < 1e-9,
+            "ka={} should be 0.893 (RDKit oracle value)",
+            params.ka
+        );
+        assert!(
+            (params.theta0 - 118.456).abs() < 1e-9,
+            "theta0={} should be 118.456 (RDKit oracle value)",
+            params.theta0
+        );
+        // Reversed i/k order must agree (angle bend is symmetric in i/k).
+        let (params_rev, _) = mmff94_angle_energy_resolved(2, 64, 2, 3, r0_264, r0_23, 0)
+            .expect("reversed (64, 2, 3) must also resolve");
+        assert_eq!(params_rev.ka, params.ka);
+        assert_eq!(params_rev.theta0, params.theta0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Phase 4 (3D coverage gap) of the RDKit/COSMolKit/OpenEye advantage directive: **241/265 → 252/265** strict-corpus success, closing 11 of the 24-molecule coverage gap. Still short of the 260+/265 target — see "Remaining gap" below.

**Root cause**: `chematic-ff`'s `MMFF94_EQ_LEVEL` table (the equivalence-class substitution ladder used to resolve MMFF94 angle-bend parameters not directly tabulated) stopped at atom type 55, on the documented assumption that every type beyond it was rare/exotic and outside chematic's supported corpus. That assumption is empirically false for type 64 (C5B — an aromatic 5-ring carbon beta to N, e.g. in indole/pyrrole/furan/thiophene): 11 molecules in the strict corpus, all sharing a bis-indolylmaleimide/staurosporine-like scaffold, hit `MissingParameters` on the exact same triple: `Angle C(3)-C(2)-C(64)`.

**Fix**: added type 64's row to `MMFF94_EQ_LEVEL`, sourced from the already-frozen `scripts/mmff94_provenance/rdkit_defaultMMFFDef.txt` (extracted verbatim from the pinned RDKit commit for prior MMFF94 work — not a fresh transcription) and independently cross-verified via a live RDKit oracle query on one of the failing molecules' own triple:

```
MMFFGetMoleculeProperties(...).GetMMFFAngleBendParams(mol, i, j, k)
-> (angleType=2, ka=0.893, theta0=118.456)
```

chematic now resolves the exact same values via the eqLevel ladder (`EquivalentType { level: 3 }`).

**Deliberately narrow scope**: does *not* add rows for any other type beyond 55 (63, 65–99, etc.), even though the frozen provenance file lists those too. `chembl_tier_b_0022`'s own type-63 case is a separate, already-diagnosed, deliberately-left-open residual (issue #227 Stage C — `angle_empirical_fails_closed_for_undefined_eq_level_substitution`, "per instruction... left fail-closed rather than guessed"). This PR must not (and, per a new negative-control test, does not) change that molecule's behavior.

## Remaining gap (not this PR)

Full classification of the 265-corpus's 24 failures (from `mmff94_bci_gap_227_state3_report.json` + `pipeline_v2_vs_rdkit_chematic_rows.jsonl`):
- **11 `BoundsConstructionFailed`** (embedding-stage, upstream of MMFF94 entirely) — likely the next-highest-value lever per the diagnosing pass, but genuinely unscoped; not investigated this round.
- **12 `MissingParameters`** — 11 fixed here, 1 (`chembl_tier_b_0022`, type 63) deliberately left open.
- **1 `UnsupportedAtomType`** — `force_field_unsupported_probe`, a deliberately-named synthetic 5-atom test fixture, not real coverage debt.

Also corrected a stale "251/265" baseline figure in `internal_docs/ROADMAP.md` (not tracked in git) — the real, already-measured baseline was 241/265, from `mmff94_bci_gap_227_phase2_report.md`.

## Test plan

- [x] New unit test in `chematic-ff`: `angle_type_3_2_64_resolves_via_new_c5b_eq_level_row` — exact match with RDKit oracle values, both atom orderings.
- [x] New integration test in `chematic-3d`: `issue_c5b_angle_gap_bis_indolylmaleimide_scaffold_now_covered` — all 11 real failing molecules now pass the actual production coverage-check path (`assign_mmff94_numeric_types_with_view` + `compute_mmff94_coverage`), not just the isolated angle-lookup.
- [x] Negative control: `issue_type_63_case_unaffected_by_type_64_fix` — `chembl_tier_b_0022` still shows the missing angle (unchanged).
- [x] `cargo test -p chematic-ff --lib` — 199 passed
- [x] `cargo test -p chematic-3d --lib --release` — 597 passed, 4 pre-existing ignored
- [x] `cargo fmt --check`, `cargo clippy -p chematic-ff -p chematic-3d --lib --tests -- -D warnings` — clean
- [x] `cargo build --workspace --exclude chematic-py --exclude chematic-wasm` — clean
- [x] `cargo check -p chematic-py -p chematic-wasm` — clean

Do not merge — held per the standing directive's governance (this session merges PRs from this round only on explicit instruction).