### PR TITLE
fix(3d): 3-membered rings no longer fail closed at the distance-geometry stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `chematic-3d` (3-membered rings no longer fail closed at the distance-geometry stage)
+
+- `dg_fft::build_bond_angle_bounds`'s angle-constraint loop treated every pair
+  of a center atom's neighbors as a generic 1-3 (through-center) relationship,
+  tightening their bound with the generic ~109.5°/120° ideal angle. In a
+  3-membered ring, that "1-3" pair is *also* a direct 1-2 bonded pair (the
+  ring closes one bond away), so the generic-angle bound overwrote the
+  correct, much shorter bond-length bound with a contradictory one
+  (cyclopropane's ring-closing C-C pair: bond constraint gave upper ≈ 1.59 Å,
+  the angle constraint then tightened lower to ≈ 2.41 Å) — `lower > upper`,
+  caught by `try_embed_once`'s pre-smoothing sanity check and failed closed
+  as `BoundsConstructionFailed`. This was a disclosed limitation affecting
+  every cyclopropane/epoxide/aziridine/thiirane-containing molecule (11/265
+  in the strict 3D corpus). Fixed by skipping the angle-derived bound for any
+  neighbor pair that is itself directly bonded — a 3-membered ring's three
+  bond-length constraints already fully determine its shape, so nothing is
+  lost. Every molecule without a 3-membered ring is provably unaffected (the
+  skip condition can only fire on a ring-closing bonded pair). Verified: all
+  11 previously-failing molecules now embed and pass the strict-MMFF94 arm
+  under its exact production config; `embed_pipeline_v2`'s strict-MMFF94
+  corpus result moves from 252/265 to 263/265.
+
 ## [0.21.0] — 2026-08-27
 
 Minor release: `McsConfig` gains new fields (`match_charge`/`match_isotope`) and

--- a/crates/chematic-3d/examples/cf_integration_smoke_test.rs
+++ b/crates/chematic-3d/examples/cf_integration_smoke_test.rs
@@ -525,33 +525,25 @@ fn main() {
 
     // =========================================================================
     // 3-membered-ring probe: the frozen 58 contains ZERO 3-membered rings
-    // (Agent C's own module doc states this), so item 5's "confirm 3-rings
-    // never reach the minimizer" cannot be exercised by the main corpus loop
-    // above. Separate, explicit check on the exact molecules Agent C's own
-    // tests use for this known limitation.
+    // (Agent C's own module doc states this), so this is a separate, explicit
+    // check on the exact molecules Agent C's own tests use. FORMERLY these all
+    // failed closed with `BoundsConstructionFailed` (a bound-construction bug
+    // in `dg_fft::build_bond_angle_bounds`'s angle-constraint loop, now fixed --
+    // see `distance_geometry_v2::tests::three_membered_rings_embed_successfully`).
     // =========================================================================
     println!("\n=== 3-membered-ring probe (not part of the 58-molecule corpus) ===");
-    let mut three_ring_all_failed_closed = true;
+    let mut three_ring_all_embedded = true;
     for smiles in ["C1CC1", "C1CO1", "C1CN1", "C1CS1"] {
         let mol = parse(smiles).unwrap();
         let result = embed_distance_geometry_v2(&mol, &EmbedParameters::default());
-        let failed_as_expected = matches!(
-            result,
-            Err(chematic_3d::distance_geometry_v2::EmbedFailureCause::BoundsConstructionFailed)
-        );
-        println!(
-            "  {smiles:<8} embed result: {result:?} (never reaches minimize_with_policy -- no code path calls it on Err)"
-        );
-        three_ring_all_failed_closed &= failed_as_expected;
+        println!("  {smiles:<8} embed result: {}", result.is_ok());
+        three_ring_all_embedded &= result.is_ok();
     }
     assert!(
-        three_ring_all_failed_closed,
-        "expected every 3-membered ring to fail closed with BoundsConstructionFailed"
+        three_ring_all_embedded,
+        "expected every 3-membered ring to embed successfully"
     );
-    println!(
-        "VERIFIED: 3-membered rings fail at the embed stage and structurally never reach the \
-         minimizer (this smoke test's own control flow only calls minimize_with_policy on Ok(coords))."
-    );
+    println!("VERIFIED: 3-membered rings now embed successfully and reach the minimizer.");
 
     // =========================================================================
     // Seed-robustness spot check (item raised by review): the embedder is

--- a/crates/chematic-3d/examples/distance_geometry_v2_gap_check.rs
+++ b/crates/chematic-3d/examples/distance_geometry_v2_gap_check.rs
@@ -32,16 +32,17 @@
 //! agree with the model that constrained it?), not an external-oracle check like
 //! the bond-length one. Reported separately, never mixed into the same table.
 //!
-//! # Known limitation: 3-membered rings
+//! # Formerly a known limitation: 3-membered rings
 //!
-//! Every 3-membered ring (cyclopropane, epoxide, aziridine, thiirane, ...) fails
-//! closed with `EmbedFailureCause::BoundsConstructionFailed` -- see
-//! `distance_geometry_v2::tests::{three_membered_rings_fail_closed_not_silently,
-//! cyclopropane_exact_bound_contradiction_verified}` for the exact numbers and root
-//! cause (in `dg_fft::build_bound_matrix`'s angle-constraint loop, not this module).
-//! **The frozen 58-molecule corpus below contains zero 3-membered rings**, so the
-//! "58/58" gate result never exercises this path -- stated explicitly so the gate
-//! doesn't read as broader coverage than it has.
+//! Every 3-membered ring (cyclopropane, epoxide, aziridine, thiirane, ...) used to
+//! fail closed with `EmbedFailureCause::BoundsConstructionFailed`, root-caused to
+//! `dg_fft::build_bond_angle_bounds`'s angle-constraint loop treating a ring-closing
+//! bonded pair as a generic 1-3 (through-center) relationship. Fixed by skipping the
+//! angle-derived bound for any neighbor pair that is itself directly bonded -- see
+//! `distance_geometry_v2::tests::three_membered_rings_embed_successfully`.
+//! **The frozen 58-molecule corpus below still contains zero 3-membered rings**, so
+//! the "58/58" gate result never exercised this path either way -- stated explicitly
+//! so the gate doesn't read as broader coverage than it has.
 //!
 //! # 4-layer acceptance gate
 //!

--- a/crates/chematic-3d/examples/torsion_knowledge_v2_gap_check.rs
+++ b/crates/chematic-3d/examples/torsion_knowledge_v2_gap_check.rs
@@ -10,16 +10,17 @@
 //! bounds are ever actually applied to a working bounds copy, simulating
 //! what a future Coordinator integration would do.
 //!
-//! # Known limitation: 3-membered rings still fail to embed
+//! # Formerly a known limitation: 3-membered rings used to fail to embed
 //!
-//! `embed_distance_geometry_v2` fails closed with `BoundsConstructionFailed`
-//! for every 3-membered ring (documented in
-//! `distance_geometry_v2::tests::three_membered_rings_fail_closed_not_silently`
-//! -- a `dg_fft::build_bound_matrix` bug this PR does not fix, since this PR
-//! does not edit `dg_fft.rs`/`distance_geometry_v2.rs`). This means
-//! cyclopropane (and any 3-membered ring) cannot reach the coordinate-level
-//! arms (A-D) below. Rather than silently dropping it from the corpus, this
-//! harness splits its fixtures into two layers:
+//! `embed_distance_geometry_v2` used to fail closed with
+//! `BoundsConstructionFailed` for every 3-membered ring (a
+//! `dg_fft::build_bond_angle_bounds` bug, since fixed -- see
+//! `distance_geometry_v2::tests::three_membered_rings_embed_successfully`),
+//! which meant cyclopropane (and any 3-membered ring) could not reach the
+//! coordinate-level arms (A-D) below. The split is kept anyway (harmless now
+//! that the embed succeeds -- the coordinate layer just stops emitting an
+//! `[embed-failed: ...]` row for these) rather than silently dropping it from
+//! the corpus. This harness splits its fixtures into two layers:
 //! - **Knowledge layer** (rule matching, ring classification, 1-4 pair
 //!   selection): every required fixture, cyclopropane included, runs here
 //!   -- no coordinates needed.

--- a/crates/chematic-3d/src/dg_fft.rs
+++ b/crates/chematic-3d/src/dg_fft.rs
@@ -81,6 +81,21 @@ pub(crate) fn build_bond_angle_bounds(mol: &Molecule) -> (Vec<Vec<f64>>, Vec<Vec
             for j in (i + 1)..neighbors.len() {
                 let a = neighbors[i];
                 let b = neighbors[j];
+
+                // `a` and `b` are both bonded to `center`; if they are ALSO bonded to
+                // each other, `center`-`a`-`b` is a 3-membered ring, not a genuine 1-3
+                // (through-center) relationship. The generic ~109.5°/120° angle below
+                // is wrong for a ring this tight (true angle ~60°) and, left in place,
+                // overwrites the already-correct 1-2 bond-length bound set above for
+                // this same pair with a contradictory one (see
+                // `distance_geometry_v2::tests::cyclopropane_exact_bound_contradiction_verified`).
+                // A 3-membered ring's three bond lengths already fix its shape (a
+                // triangle's side lengths determine it up to reflection), so skipping
+                // the angle bound here drops a wrong constraint, not a needed one.
+                if mol.bond_between(a, b).is_some() {
+                    continue;
+                }
+
                 let bond_len_1 = ideal_bond_length(mol, center, a);
                 let bond_len_2 = ideal_bond_length(mol, center, b);
                 let angle = ideal_bond_angle(mol, center);

--- a/crates/chematic-3d/src/distance_geometry_v2.rs
+++ b/crates/chematic-3d/src/distance_geometry_v2.rs
@@ -1166,26 +1166,19 @@ mod tests {
             .fold(0.0_f64, f64::max)
     }
 
-    /// KNOWN LIMITATION (documented, not fixed by this module -- see PR body):
-    /// every 3-membered ring fails closed with `BoundsConstructionFailed`. Root
-    /// cause is in `dg_fft::build_bound_matrix` (not this module's code): its
-    /// angle-constraint loop treats every pair of a center atom's neighbors as a
-    /// 1-3 (through-center) relationship and unconditionally tightens their bound
-    /// using the *generic* ideal angle (~109.5°/120°, `ideal_bond_angle` has no
-    /// notion of ring strain) -- but in a 3-membered ring, that "1-3" pair is
-    /// *also* a direct 1-2 bonded pair (the ring closes one bond away), so the
-    /// angle constraint's generic-angle-derived bound overwrites the correct,
-    /// much shorter bond-length bound with a value inconsistent with it
-    /// (concretely, for cyclopropane's ring-closing C-C pair: bond constraint
-    /// gives upper ≈ 1.59 Å, the angle constraint then tightens lower to ≈ 2.41 Å
-    /// using the generic ~109.5° angle instead of the real ~60° ring angle,
-    /// producing `lower > upper` for the same pair). This module's own
-    /// pre-smoothing sanity check (`try_embed_once`) catches exactly this and
-    /// fails closed with a typed error -- correct behavior, just a real, disclosed
-    /// gap for a common drug-discovery motif (cyclopropane/epoxide/aziridine
-    /// rings), not silently mishandled.
+    /// FORMERLY a known limitation (`dg_fft::build_bound_matrix`'s angle-constraint
+    /// loop treated every pair of a center atom's neighbors as a 1-3
+    /// (through-center) relationship and unconditionally tightened their bound with
+    /// the *generic* ideal angle (~109.5°/120°) -- but in a 3-membered ring, that
+    /// "1-3" pair is *also* a direct 1-2 bonded pair, so the generic-angle bound
+    /// overwrote the correct, much shorter bond-length bound with a contradictory
+    /// one). Fixed by skipping the angle-derived bound for any neighbor pair that
+    /// is itself directly bonded (`dg_fft::build_bond_angle_bounds`): a 3-membered
+    /// ring's three bond-length constraints already fully determine its shape, so
+    /// nothing is lost. See `cyclopropane_ring_closing_bond_uses_bond_length_bound_not_angle`
+    /// for the exact numbers this replaced.
     #[test]
-    fn three_membered_rings_fail_closed_not_silently() {
+    fn three_membered_rings_embed_successfully() {
         for smiles in [
             "C1CC1",         // cyclopropane
             "C1CO1",         // epoxide
@@ -1196,12 +1189,10 @@ mod tests {
         ] {
             let mol = parse(smiles).unwrap();
             let params = EmbedParameters::default();
-            let err = embed_distance_geometry_v2(&mol, &params).unwrap_err();
-            assert_eq!(
-                err,
-                EmbedFailureCause::BoundsConstructionFailed,
-                "{smiles}: expected a typed BoundsConstructionFailed, not a silent success or a different error"
-            );
+            let coords = embed_distance_geometry_v2(&mol, &params)
+                .unwrap_or_else(|e| panic!("{smiles}: expected a successful embed, got {e:?}"));
+            let worst = worst_bond(&mol, &coords);
+            assert!(worst < 2.0, "{smiles}: worst bond length {worst}");
         }
         // Controls: 4- and 5-membered rings are unaffected (this is specific to
         // 3-membered rings, not "any small ring").
@@ -1216,29 +1207,28 @@ mod tests {
     }
 
     #[test]
-    fn cyclopropane_exact_bound_contradiction_verified() {
-        // Verifies the exact numbers cited in the doc comment above (and in the PR
-        // body's Known Limitations) rather than trusting them from memory.
+    fn cyclopropane_ring_closing_bond_uses_bond_length_bound_not_angle() {
+        // The ring-closing C-C pair must keep the tight bond-length bound (upper
+        // ≈ 1.59 Å) rather than being overwritten by the generic ~109.5°-angle-
+        // derived bound (which previously forced lower ≈ 2.414 Å > upper, the
+        // exact contradiction `three_membered_rings_embed_successfully` used to
+        // fail closed on).
         let mol = parse("C1CC1").unwrap();
         let (lower, upper) = crate::dg_fft::build_bound_matrix(&mol);
         let mut found = false;
         for (_, bond) in mol.bonds() {
             let i = bond.atom1.0 as usize;
             let j = bond.atom2.0 as usize;
-            if lower[i][j] > upper[i][j] {
-                println!(
-                    "cyclopropane ring-closing pair ({i},{j}): lower={:.3} upper={:.3}",
-                    lower[i][j], upper[i][j]
-                );
-                assert!((lower[i][j] - 2.414).abs() < 0.01, "lower={}", lower[i][j]);
-                assert!((upper[i][j] - 1.590).abs() < 0.01, "upper={}", upper[i][j]);
-                found = true;
-            }
+            assert!(
+                lower[i][j] <= upper[i][j],
+                "bonded pair ({i},{j}): lower={} > upper={}",
+                lower[i][j],
+                upper[i][j]
+            );
+            assert!((upper[i][j] - 1.590).abs() < 0.01, "upper={}", upper[i][j]);
+            found = true;
         }
-        assert!(
-            found,
-            "expected at least one bonded pair with lower > upper in cyclopropane's bound matrix"
-        );
+        assert!(found, "cyclopropane has no bonds?");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a real, previously-documented limitation: every molecule containing a 3-membered ring (cyclopropane, epoxide, aziridine, thiirane) failed closed with `BoundsConstructionFailed` at the distance-geometry embedding stage — before ever reaching MMFF94/UFF/DREIDING minimization.

## Root cause

`dg_fft::build_bond_angle_bounds`'s angle-constraint loop treats every pair of a center atom's neighbors as a generic 1-3 (through-center) relationship, tightening their distance bound with the generic ~109.5°/120° ideal angle. In a 3-membered ring, that "1-3" pair is *also* a direct 1-2 bonded pair (the ring closes one bond away) — so the generic-angle-derived bound overwrote the correct, much shorter bond-length bound with a contradictory one.

Concretely, for cyclopropane's ring-closing C-C pair: the bond-length constraint gives `upper ≈ 1.59 Å`, but the angle constraint (using the generic ~109.5° instead of the real ~60° ring angle) then tightened `lower` to `≈ 2.41 Å` — `lower > upper`, caught by `try_embed_once`'s pre-smoothing sanity check and failed closed as `BoundsConstructionFailed`.

## Fix

Skip the angle-derived bound for any neighbor pair that is itself directly bonded (`dg_fft.rs`, one `if mol.bond_between(a, b).is_some() { continue; }`). A 3-membered ring's three bond-length constraints already fully determine its shape (a triangle's side lengths fix it up to reflection), so nothing is lost.

Every molecule *without* a 3-membered ring is provably unaffected: two neighbors of a common center can only be directly bonded to each other if `center`-`a`-`b` forms a 3-membered ring, so the new skip condition can never fire for any other molecule — that code path is byte-identical to before for the other 254/265 corpus molecules.

## Verification

- Updated the two existing tests that had asserted the old (broken) behavior (`three_membered_rings_embed_successfully`, `cyclopropane_ring_closing_bond_uses_bond_length_bound_not_angle`) to assert the fix instead.
- Full `cargo test -p chematic-3d --lib --release`: 597 passed, 0 failed, 4 ignored.
- `cargo fmt --check` / `cargo clippy -p chematic-3d --lib --tests --examples -- -D warnings` / `cargo build --workspace --exclude chematic-py --exclude chematic-wasm` / `cargo check -p chematic-py -p chematic-wasm`: all clean.
- Measured via the exact production `chematic_pipeline_v2_mmff94_strict` arm config against all 11 previously-failing corpus molecules (each containing a cyclopropane/epoxide/aziridine): all 11 now embed and pass. `embed_pipeline_v2`'s strict-MMFF94 265-molecule corpus result moves from **252/265 to 263/265**.
- Refreshed three stale "known limitation" doc comments in `crates/chematic-3d/examples/{cf_integration_smoke_test,distance_geometry_v2_gap_check,torsion_knowledge_v2_gap_check}.rs` that referenced the old behavior.
- Added a CHANGELOG.md Unreleased entry.

## Test plan

- [x] `cargo test -p chematic-3d --lib --release` (597 passed, 0 failed)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p chematic-3d --lib --tests --examples -- -D warnings`
- [x] `cargo build --workspace --exclude chematic-py --exclude chematic-wasm`
- [x] `cargo check -p chematic-py -p chematic-wasm`
- [x] Targeted recheck of all 11 previously-failing corpus molecules through the production `chematic_pipeline_v2_mmff94_strict` config

Per this investigation's standing directive, **not merging** — opening for review only.