### PR TITLE
feat(wasm): add embed_ensemble_v2_json binding (A2.1 WASM half)

### DIFF
--- a/crates/chematic-wasm/src/ensemble_v2.rs
+++ b/crates/chematic-wasm/src/ensemble_v2.rs
@@ -1,0 +1,515 @@
+//! WASM binding for `chematic_3d::embed_ensemble_v2` (A2.1).
+//!
+//! Mirrors the Python binding (`crates/chematic-py/src/ensemble_v2.rs`, already
+//! on `main`) as closely as JS/JSON allow, and reuses the WASM `pipeline_v2.rs`
+//! binding's own JSON conventions (envelope shape, camelCase keys, snake_case
+//! policy/force-field strings, `FiniteF64`, per-attempt failure shape) rather
+//! than inventing a second scheme.
+//!
+//! # Config JSON shape
+//!
+//! `{"perConformer": <the same object embed_pipeline_v2_json's config_json
+//! parses>, "count": <u32>, "baseSeed": <u64>, "rmsdThreshold": <f64>,
+//! "useSymmetricRmsdPruning": <bool>, "ensembleTimeoutMs": <u64 | null>}`.
+//! Every field is required (deny_unknown_fields, no silent defaults) --
+//! matches `PipelineV2ConfigJson`'s own closed-config convention in this
+//! crate rather than the Python binding's optional-keyword-argument defaults
+//! (`rmsd_threshold = 0.5`, etc.): this is a brand-new WASM API with no
+//! existing callers to preserve compatibility for, so it follows this
+//! crate's dominant "explicit, nothing silently defaulted" JSON convention
+//! instead. `ensembleTimeoutMs` uses the same "key must be present, value may
+//! be null" convention as `embedTimeoutMs`/`totalTimeoutMs`.
+//!
+//! # Error asymmetry with `embed_pipeline_v2_json`
+//!
+//! Same asymmetry as the Python binding: `embed_ensemble_v2` itself only
+//! rejects a config that could never succeed regardless of the molecule
+//! (currently: an invalid `rmsdThreshold`) -- an ensemble where every attempt
+//! failed and zero conformers were kept is still a normal `{"ok": true,
+//! "result": {...}}` response, with per-attempt detail in `result.attempts`.
+//! A caller must not assume `ok: true` implies `result.conformers.length >
+//! 0`.
+//!
+//! Every JSON output is a tagged union with `schemaVersion: 1`, same as
+//! `embed_pipeline_v2_json`. Never throws.
+
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+
+use chematic_3d::{
+    ConformerAttempt, ConformerDisposition, EnsembleV2Config, EnsembleV2Result, embed_ensemble_v2,
+};
+
+use crate::pipeline_v2::{
+    ErrorEnvelopeJson, FailureCauseJson, FiniteF64, ForceFieldBridgeErrorJson,
+    PipelineV2ConfigJson, coords_to_json, deserialize_present, error_envelope_json,
+    force_field_bridge_error_json, force_field_policy_str, snake_case_debug, wasm_input_error_json,
+};
+use crate::{MolHandle, WASM_MAX_ATOMS, WASM_MAX_INPUT_BYTES};
+
+const SCHEMA_VERSION: u32 = 1;
+
+// ---------------------------------------------------------------------------
+// Config: input JSON shape
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct EnsembleV2ConfigJson {
+    per_conformer: PipelineV2ConfigJson,
+    count: usize,
+    base_seed: u64,
+    rmsd_threshold: f64,
+    use_symmetric_rmsd_pruning: bool,
+    #[serde(deserialize_with = "deserialize_present")]
+    ensemble_timeout_ms: Option<Option<u64>>,
+}
+
+impl EnsembleV2ConfigJson {
+    fn into_ensemble_config(self) -> Result<EnsembleV2Config, String> {
+        let ensemble_timeout_ms = self.ensemble_timeout_ms.ok_or_else(|| {
+            "missing field `ensembleTimeoutMs` (must be present; value may be null)".to_string()
+        })?;
+        Ok(EnsembleV2Config {
+            per_conformer: self.per_conformer.into_pipeline_config()?,
+            count: self.count,
+            base_seed: self.base_seed,
+            rmsd_threshold: self.rmsd_threshold,
+            use_symmetric_rmsd_pruning: self.use_symmetric_rmsd_pruning,
+            ensemble_timeout_ms,
+        })
+    }
+}
+
+fn parse_ensemble_config(config_json: &str) -> Result<EnsembleV2Config, String> {
+    let parsed: EnsembleV2ConfigJson =
+        serde_json::from_str(config_json).map_err(|e| e.to_string())?;
+    parsed.into_ensemble_config()
+}
+
+// ---------------------------------------------------------------------------
+// Result: JSON shape
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum ConformerDispositionJson {
+    Kept {
+        #[serde(rename = "conformerIndex")]
+        conformer_index: usize,
+    },
+    PrunedAsDuplicate {
+        #[serde(rename = "representativeAttemptIndex")]
+        representative_attempt_index: usize,
+        rmsd: FiniteF64,
+        symmetric: bool,
+    },
+}
+
+fn conformer_disposition_json(d: &ConformerDisposition) -> ConformerDispositionJson {
+    match d {
+        ConformerDisposition::Kept { conformer_index } => ConformerDispositionJson::Kept {
+            conformer_index: *conformer_index,
+        },
+        ConformerDisposition::PrunedAsDuplicate {
+            representative_attempt_index,
+            rmsd,
+            symmetric,
+        } => ConformerDispositionJson::PrunedAsDuplicate {
+            representative_attempt_index: *representative_attempt_index,
+            rmsd: (*rmsd).into(),
+            symmetric: *symmetric,
+        },
+        // `ConformerDisposition` is `#[non_exhaustive]`: mirrors the Python
+        // binding's own refusal to paper over an unhandled future variant --
+        // there is no sensible JSON to emit for it, so this stays a hard
+        // panic. Not caught anywhere on this path -- same convention
+        // `embed_pipeline_v2_json` itself already uses for its own internal
+        // invariant violations (e.g. `result_to_json`'s
+        // `expect("index is within conformer_count()")` below), not a new
+        // failure mode introduced by this binding.
+        other => panic!("unhandled ConformerDisposition variant in WASM binding: {other:?}"),
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConformerSuccessJson {
+    energy: Option<FiniteF64>,
+    actual_force_field_used: String,
+    fallback_reason: Option<ForceFieldBridgeErrorJson>,
+    disposition: ConformerDispositionJson,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConformerAttemptJson {
+    attempt_index: usize,
+    seed: u64,
+    outcome: &'static str,
+    success: Option<ConformerSuccessJson>,
+    failure: Option<ErrorEnvelopeJson>,
+}
+
+fn conformer_attempt_json(a: &ConformerAttempt) -> ConformerAttemptJson {
+    match &a.outcome {
+        Ok(success) => ConformerAttemptJson {
+            attempt_index: a.attempt_index,
+            seed: a.seed,
+            outcome: "success",
+            success: Some(ConformerSuccessJson {
+                energy: success.energy.map(Into::into),
+                actual_force_field_used: force_field_policy_str(success.actual_force_field_used)
+                    .to_string(),
+                fallback_reason: success
+                    .fallback_reason
+                    .as_ref()
+                    .map(force_field_bridge_error_json),
+                disposition: conformer_disposition_json(&success.disposition),
+            }),
+            failure: None,
+        },
+        Err(failure) => ConformerAttemptJson {
+            attempt_index: a.attempt_index,
+            seed: a.seed,
+            outcome: "failure",
+            success: None,
+            failure: Some(error_envelope_json(failure)),
+        },
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConformerProvenanceJson {
+    attempt_index: usize,
+    seed: u64,
+    energy: Option<FiniteF64>,
+    actual_force_field_used: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EnsembleV2ResultJson {
+    conformers: Vec<Vec<[FiniteF64; 3]>>,
+    conformer_provenance: Vec<ConformerProvenanceJson>,
+    attempts: Vec<ConformerAttemptJson>,
+    mixed_force_field: bool,
+    termination: String,
+    requested_count: usize,
+}
+
+#[derive(Serialize)]
+struct SuccessEnvelopeJson {
+    #[serde(rename = "schemaVersion")]
+    schema_version: u32,
+    ok: bool,
+    result: EnsembleV2ResultJson,
+}
+
+/// Mirrors `run_embed_ensemble_v2::ensemble_v2_result_dict`'s
+/// `conformer_provenance` construction: reverse-maps each `Kept{conformer_index}`
+/// disposition back to the attempt that produced it, so a caller never has to
+/// scan `attempts` to find out what a given `result.conformers[i]` actually is.
+fn result_to_json(r: &EnsembleV2Result) -> String {
+    let conformer_count = r.ensemble.conformer_count();
+    let conformers: Vec<Vec<[FiniteF64; 3]>> = (0..conformer_count)
+        .map(|i| {
+            coords_to_json(
+                r.ensemble
+                    .get_conformer(i)
+                    .expect("index is within conformer_count()"),
+            )
+        })
+        .collect();
+
+    let mut provenance_by_index: Vec<Option<ConformerProvenanceJson>> =
+        (0..conformer_count).map(|_| None).collect();
+    for attempt in &r.attempts {
+        if let Ok(success) = &attempt.outcome
+            && let ConformerDisposition::Kept { conformer_index } = &success.disposition
+        {
+            provenance_by_index[*conformer_index] = Some(ConformerProvenanceJson {
+                attempt_index: attempt.attempt_index,
+                seed: attempt.seed,
+                energy: success.energy.map(Into::into),
+                actual_force_field_used: force_field_policy_str(success.actual_force_field_used)
+                    .to_string(),
+            });
+        }
+    }
+    let conformer_provenance: Vec<ConformerProvenanceJson> = provenance_by_index
+        .into_iter()
+        .enumerate()
+        .map(|(i, entry)| {
+            entry.unwrap_or_else(|| {
+                panic!(
+                    "conformer {i} of {conformer_count} has no Kept disposition in `attempts` \
+                     -- embed_ensemble_v2's own invariant is broken, not a case to paper over"
+                )
+            })
+        })
+        .collect();
+
+    let envelope = SuccessEnvelopeJson {
+        schema_version: SCHEMA_VERSION,
+        ok: true,
+        result: EnsembleV2ResultJson {
+            conformers,
+            conformer_provenance,
+            attempts: r.attempts.iter().map(conformer_attempt_json).collect(),
+            mixed_force_field: r.mixed_force_field,
+            termination: snake_case_debug(&r.termination),
+            requested_count: r.requested_count,
+        },
+    };
+    serde_json::to_string(&envelope).expect("success envelope must always serialize")
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Run `embed_ensemble_v2` on `mol`'s own atom order (never canonicalizes/
+/// reparses, same convention as `embed_pipeline_v2_json`). See the module doc
+/// for the config JSON shape and the success/failure envelope shape.
+///
+/// Never throws. Always returns a JSON string tagged `schemaVersion: 1` and
+/// `ok: true`/`false`. `ok: false` covers both a WASM-level rejection
+/// (oversized input, too many atoms, malformed/incomplete config JSON) and a
+/// config `embed_ensemble_v2` itself rejects (currently only an invalid
+/// `rmsdThreshold`) -- distinguished by `error.stage` /
+/// `error.cause.kind`, same as `embed_pipeline_v2_json`.
+#[wasm_bindgen]
+pub fn embed_ensemble_v2_json(mol: &MolHandle, config_json: &str) -> String {
+    if config_json.len() > WASM_MAX_INPUT_BYTES {
+        return wasm_input_error_json(FailureCauseJson::InputTooLarge {
+            limit_bytes: WASM_MAX_INPUT_BYTES,
+            actual_bytes: config_json.len(),
+        });
+    }
+    if mol.inner.atom_count() > WASM_MAX_ATOMS {
+        return wasm_input_error_json(FailureCauseJson::AtomLimitExceeded {
+            limit: WASM_MAX_ATOMS,
+            actual: mol.inner.atom_count(),
+        });
+    }
+
+    let config = match parse_ensemble_config(config_json) {
+        Ok(c) => c,
+        Err(message) => {
+            return wasm_input_error_json(FailureCauseJson::InvalidConfig { message });
+        }
+    };
+
+    match embed_ensemble_v2(&mol.inner, &config) {
+        Ok(result) => result_to_json(&result),
+        Err(e) => wasm_input_error_json(FailureCauseJson::InvalidConfig {
+            message: e.to_string(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mol_depict::parse_smiles;
+
+    fn safe_config_json(count: usize, base_seed: u64, ensemble_timeout_ms: &str) -> String {
+        format!(
+            r#"{{
+                "perConformer": {{
+                    "embedSeed": 7,
+                    "maxAttempts": 8,
+                    "embedTimeoutMs": null,
+                    "useExpTorsions": false,
+                    "useSmallRingTorsions": false,
+                    "useMacrocycleTorsions": false,
+                    "useMacrocycle14Bounds": false,
+                    "includeLegacyTorsionHeuristic": false,
+                    "stereoPolicy": "ignore",
+                    "failOnUnevaluableStereo": false,
+                    "forceFieldPolicy": "none",
+                    "forceFieldMaxIterations": 200,
+                    "gateMmff94TorsionOop": false,
+                    "gateMmff94StretchBend": false,
+                    "ringTorsionPolicy": "fail_closed",
+                    "totalTimeoutMs": null
+                }},
+                "count": {count},
+                "baseSeed": {base_seed},
+                "rmsdThreshold": 0.5,
+                "useSymmetricRmsdPruning": true,
+                "ensembleTimeoutMs": {ensemble_timeout_ms}
+            }}"#
+        )
+    }
+
+    #[test]
+    fn success_path_has_expected_envelope_shape() {
+        let mol = parse_smiles("CCCCCCCCCC").expect("decane");
+        let config = safe_config_json(3, 20260828, "null");
+        let json = embed_ensemble_v2_json(&mol, &config);
+        let value: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+
+        assert_eq!(value["schemaVersion"], 1);
+        assert_eq!(value["ok"], true);
+        let result = &value["result"];
+        for key in [
+            "conformers",
+            "conformerProvenance",
+            "attempts",
+            "mixedForceField",
+            "termination",
+            "requestedCount",
+        ] {
+            assert!(result.get(key).is_some(), "missing result.{key}");
+        }
+        assert_eq!(result["requestedCount"], 3);
+        assert_eq!(result["attempts"].as_array().unwrap().len(), 3);
+        assert_eq!(result["termination"], "completed");
+        let conformers = result["conformers"].as_array().unwrap();
+        assert!(!conformers.is_empty(), "decane should embed at least once");
+        assert_eq!(
+            conformers.len(),
+            result["conformerProvenance"].as_array().unwrap().len()
+        );
+        for conformer in conformers {
+            assert_eq!(conformer.as_array().unwrap().len(), 10, "decane atom count");
+        }
+    }
+
+    #[test]
+    fn same_base_seed_is_reproducible() {
+        let mol = parse_smiles("CC(=O)Oc1ccccc1C(=O)O").expect("aspirin");
+        let config = safe_config_json(4, 42, "null");
+        let a = embed_ensemble_v2_json(&mol, &config);
+        let b = embed_ensemble_v2_json(&mol, &config);
+        let av: serde_json::Value = serde_json::from_str(&a).unwrap();
+        let bv: serde_json::Value = serde_json::from_str(&b).unwrap();
+        assert_eq!(
+            av["result"]["conformers"], bv["result"]["conformers"],
+            "same base_seed must reproduce identical conformers"
+        );
+    }
+
+    #[test]
+    fn zero_count_returns_ok_with_empty_ensemble() {
+        let mol = parse_smiles("CC").expect("ethane");
+        let config = safe_config_json(0, 1, "null");
+        let json = embed_ensemble_v2_json(&mol, &config);
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["ok"], true);
+        assert_eq!(value["result"]["conformers"].as_array().unwrap().len(), 0);
+        assert_eq!(value["result"]["attempts"].as_array().unwrap().len(), 0);
+        assert_eq!(value["result"]["termination"], "completed");
+    }
+
+    #[test]
+    fn invalid_rmsd_threshold_rejected_as_typed_error_not_panic() {
+        let mol = parse_smiles("CC").expect("ethane");
+        let config = r#"{
+                "perConformer": {
+                    "embedSeed": 7, "maxAttempts": 8, "embedTimeoutMs": null,
+                    "useExpTorsions": false, "useSmallRingTorsions": false,
+                    "useMacrocycleTorsions": false, "useMacrocycle14Bounds": false,
+                    "includeLegacyTorsionHeuristic": false, "stereoPolicy": "ignore",
+                    "failOnUnevaluableStereo": false, "forceFieldPolicy": "none",
+                    "forceFieldMaxIterations": 200, "gateMmff94TorsionOop": false,
+                    "gateMmff94StretchBend": false, "ringTorsionPolicy": "fail_closed",
+                    "totalTimeoutMs": null
+                },
+                "count": 2, "baseSeed": 1, "rmsdThreshold": -1.0,
+                "useSymmetricRmsdPruning": true, "ensembleTimeoutMs": null
+            }"#;
+        let json = embed_ensemble_v2_json(&mol, config);
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["ok"], false);
+        assert_eq!(value["error"]["stage"], "wasm_input_validation");
+        assert_eq!(value["error"]["cause"]["kind"], "invalid_config");
+    }
+
+    #[test]
+    fn malformed_and_incomplete_config_json_rejected_never_throws() {
+        let mol = parse_smiles("CC").expect("ethane");
+        let cases = [
+            "{not valid json",
+            r#"{"perConformer": {}, "count": 1, "baseSeed": 1, "rmsdThreshold": 0.5, "useSymmetricRmsdPruning": true, "ensembleTimeoutMs": null, "notARealField": true}"#,
+        ];
+        for config in cases {
+            let json = embed_ensemble_v2_json(&mol, config);
+            let value: serde_json::Value =
+                serde_json::from_str(&json).expect("must be valid JSON, never throw");
+            assert_eq!(value["ok"], false);
+            assert_eq!(value["error"]["stage"], "wasm_input_validation");
+            assert_eq!(value["error"]["cause"]["kind"], "invalid_config");
+        }
+    }
+
+    #[test]
+    fn missing_present_but_nullable_ensemble_timeout_field_rejected() {
+        let mol = parse_smiles("CC").expect("ethane");
+        let config = r#"{
+            "perConformer": {
+                "embedSeed": 7, "maxAttempts": 8, "embedTimeoutMs": null,
+                "useExpTorsions": false, "useSmallRingTorsions": false,
+                "useMacrocycleTorsions": false, "useMacrocycle14Bounds": false,
+                "includeLegacyTorsionHeuristic": false, "stereoPolicy": "ignore",
+                "failOnUnevaluableStereo": false, "forceFieldPolicy": "none",
+                "forceFieldMaxIterations": 200, "gateMmff94TorsionOop": false,
+                "gateMmff94StretchBend": false, "ringTorsionPolicy": "fail_closed",
+                "totalTimeoutMs": null
+            },
+            "count": 1, "baseSeed": 1, "rmsdThreshold": 0.5,
+            "useSymmetricRmsdPruning": true
+        }"#;
+        let json = embed_ensemble_v2_json(&mol, config);
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["ok"], false);
+        assert_eq!(value["error"]["cause"]["kind"], "invalid_config");
+    }
+
+    #[test]
+    fn every_attempt_failing_is_still_ok_true_with_zero_kept_conformers() {
+        // Mirrors the module doc's documented error asymmetry: a config that
+        // makes every attempt fail (here: a near-zero per-attempt timeout) is
+        // still a normal `ok: true` ensemble result with zero kept conformers,
+        // never surfaced as a top-level failure.
+        let mol = parse_smiles("CC(=O)Oc1ccccc1C(=O)O").expect("aspirin");
+        let config = r#"{
+                "perConformer": {
+                    "embedSeed": 7, "maxAttempts": 8, "embedTimeoutMs": null,
+                    "useExpTorsions": false, "useSmallRingTorsions": false,
+                    "useMacrocycleTorsions": false, "useMacrocycle14Bounds": false,
+                    "includeLegacyTorsionHeuristic": false, "stereoPolicy": "ignore",
+                    "failOnUnevaluableStereo": false, "forceFieldPolicy": "none",
+                    "forceFieldMaxIterations": 200, "gateMmff94TorsionOop": false,
+                    "gateMmff94StretchBend": false, "ringTorsionPolicy": "fail_closed",
+                    "totalTimeoutMs": 0
+                },
+                "count": 2, "baseSeed": 1, "rmsdThreshold": 0.5,
+                "useSymmetricRmsdPruning": true, "ensembleTimeoutMs": null
+            }"#;
+        let json = embed_ensemble_v2_json(&mol, config);
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["ok"], true, "an all-failed ensemble is still ok:true");
+        assert_eq!(value["result"]["conformers"].as_array().unwrap().len(), 0);
+        let attempts = value["result"]["attempts"].as_array().unwrap();
+        assert_eq!(attempts.len(), 2);
+        for attempt in attempts {
+            assert_eq!(attempt["outcome"], "failure");
+            assert!(attempt["failure"].is_object());
+            assert_eq!(attempt["success"], serde_json::Value::Null);
+        }
+    }
+
+    #[test]
+    fn oversized_config_json_rejected_before_parsing() {
+        let mol = parse_smiles("CC").expect("ethane");
+        let padded = " ".repeat(WASM_MAX_INPUT_BYTES + 1);
+        let json = embed_ensemble_v2_json(&mol, &padded);
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["ok"], false);
+        assert_eq!(value["error"]["cause"]["kind"], "input_too_large");
+    }
+}

--- a/crates/chematic-wasm/src/lib.rs
+++ b/crates/chematic-wasm/src/lib.rs
@@ -16,6 +16,7 @@ const WASM_MAX_JSON_STRING_BYTES: usize = 100_000;
 /// Maximum SMARTS matches returned by WASM APIs.
 const WASM_MAX_SMARTS_MATCHES: usize = 10_000;
 
+mod ensemble_v2;
 mod format_io;
 mod mol_3d;
 mod mol_depict;
@@ -28,6 +29,7 @@ mod pipeline_v2;
 #[cfg(test)]
 mod tests;
 
+pub use ensemble_v2::embed_ensemble_v2_json;
 pub use format_io::*;
 pub use mol_3d::*;
 pub use mol_depict::*;

--- a/crates/chematic-wasm/src/pipeline_v2.rs
+++ b/crates/chematic-wasm/src/pipeline_v2.rs
@@ -44,7 +44,7 @@ const STAGE_WASM_INPUT_VALIDATION: &str = "wasm_input_validation";
 /// `null` rather than ever emitting a literal `NaN`/`Infinity` token, which would
 /// make the output invalid JSON and break `JSON.parse` on the JS side.
 #[derive(Debug, Clone, Copy)]
-struct FiniteF64(f64);
+pub(crate) struct FiniteF64(f64);
 
 impl From<f64> for FiniteF64 {
     fn from(v: f64) -> Self {
@@ -65,7 +65,7 @@ impl Serialize for FiniteF64 {
 /// `format!("{value:?}")` -> `snake_case`, for the many small fieldless enums in
 /// this pipeline (e.g. `EmbedFailureCause::BoundsSmoothingFailed` ->
 /// `"bounds_smoothing_failed"`). Matches the identical helper in the Python binding.
-fn snake_case_debug<T: std::fmt::Debug>(value: &T) -> String {
+pub(crate) fn snake_case_debug<T: std::fmt::Debug>(value: &T) -> String {
     let debug = format!("{value:?}");
     let mut out = String::with_capacity(debug.len() + 4);
     for (i, c) in debug.chars().enumerate() {
@@ -150,7 +150,7 @@ impl From<ForceFieldPolicyJson> for ForceFieldPolicy {
     }
 }
 
-fn force_field_policy_str(p: ForceFieldPolicy) -> &'static str {
+pub(crate) fn force_field_policy_str(p: ForceFieldPolicy) -> &'static str {
     match p {
         ForceFieldPolicy::Mmff94BondAngleStrict => "mmff94_bond_angle_strict",
         ForceFieldPolicy::Mmff94WithUffFallback => "mmff94_with_uff_fallback",
@@ -170,7 +170,7 @@ fn force_field_policy_str(p: ForceFieldPolicy) -> &'static str {
 /// requires rejecting for `embedTimeoutMs`/`totalTimeoutMs`, since Python's
 /// constructor requires both as explicit, always-present arguments too, even though
 /// their value can be `None`).
-fn deserialize_present<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+pub(crate) fn deserialize_present<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
 where
     D: serde::Deserializer<'de>,
     T: serde::Deserialize<'de>,
@@ -180,7 +180,7 @@ where
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
-struct PipelineV2ConfigJson {
+pub(crate) struct PipelineV2ConfigJson {
     embed_seed: u64,
     max_attempts: usize,
     #[serde(deserialize_with = "deserialize_present")]
@@ -226,7 +226,7 @@ struct PipelineV2ConfigJson {
 }
 
 impl PipelineV2ConfigJson {
-    fn into_pipeline_config(self) -> Result<pv2::PipelineV2Config, String> {
+    pub(crate) fn into_pipeline_config(self) -> Result<pv2::PipelineV2Config, String> {
         let embed_timeout_ms = self.embed_timeout_ms.ok_or_else(|| {
             "missing field `embedTimeoutMs` (must be present; value may be null)".to_string()
         })?;
@@ -276,7 +276,7 @@ fn parse_pipeline_config(config_json: &str) -> Result<pv2::PipelineV2Config, Str
 // Python binding's dict conversion in crates/chematic-py/src/pipeline_v2.rs)
 // ---------------------------------------------------------------------------
 
-fn coords_to_json(coords: &chematic_3d::coords::Coords3D) -> Vec<[FiniteF64; 3]> {
+pub(crate) fn coords_to_json(coords: &chematic_3d::coords::Coords3D) -> Vec<[FiniteF64; 3]> {
     coords
         .points
         .iter()
@@ -709,7 +709,7 @@ fn mmff94_coverage_json(r: &chematic_3d::minimize::Mmff94CoverageReport) -> Mmff
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-struct ForceFieldBridgeErrorJson {
+pub(crate) struct ForceFieldBridgeErrorJson {
     kind: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     message: Option<String>,
@@ -727,7 +727,7 @@ struct ForceFieldBridgeErrorJson {
     max_residual_force: Option<FiniteF64>,
 }
 
-fn force_field_bridge_error_json(
+pub(crate) fn force_field_bridge_error_json(
     e: &chematic_3d::minimize::ForceFieldBridgeError,
 ) -> ForceFieldBridgeErrorJson {
     use chematic_3d::minimize::ForceFieldBridgeError;
@@ -1020,7 +1020,7 @@ fn result_to_json(r: &pv2::PipelineV2Result) -> String {
 
 #[derive(Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
-enum FailureCauseJson {
+pub(crate) enum FailureCauseJson {
     InvalidConfiguration,
     BoundAdjustmentFailed,
     DistanceGeometry {
@@ -1060,7 +1060,7 @@ enum FailureCauseJson {
     },
 }
 
-fn failure_cause_json(cause: &pv2::PipelineV2FailureCause) -> FailureCauseJson {
+pub(crate) fn failure_cause_json(cause: &pv2::PipelineV2FailureCause) -> FailureCauseJson {
     use pv2::PipelineV2FailureCause;
     match cause {
         PipelineV2FailureCause::InvalidConfiguration => FailureCauseJson::InvalidConfiguration,
@@ -1089,7 +1089,7 @@ fn failure_cause_json(cause: &pv2::PipelineV2FailureCause) -> FailureCauseJson {
 
 #[derive(Serialize, Default)]
 #[serde(rename_all = "camelCase")]
-struct FailureDiagnosticsJson {
+pub(crate) struct FailureDiagnosticsJson {
     embed_stats: Option<EmbedStatsJson>,
     bound_adjustment_report: Option<Vec<BoundAdjustmentJson>>,
     torsion_knowledge_report: Option<TorsionKnowledgeReportJson>,
@@ -1106,7 +1106,7 @@ struct FailureDiagnosticsJson {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-struct ErrorEnvelopeJson {
+pub(crate) struct ErrorEnvelopeJson {
     stage: String,
     cause: FailureCauseJson,
     last_known_coords: Option<Vec<[FiniteF64; 3]>>,
@@ -1126,42 +1126,53 @@ struct FailureEnvelopeJson {
     error: ErrorEnvelopeJson,
 }
 
+/// Builds the `error` object of a failure envelope, without the outer
+/// `schemaVersion`/`ok` wrapper -- reused as-is by `ensemble_v2.rs` to embed a
+/// per-attempt failure inside its own top-level envelope (an ensemble's own
+/// `Result` only ever rejects a config that could never succeed; a single
+/// attempt's `PipelineV2Failure` is ordinary per-attempt evidence, not
+/// something that gets its own `schemaVersion`/`ok` pair nested inside
+/// another one).
+pub(crate) fn error_envelope_json(f: &pv2::PipelineV2Failure) -> ErrorEnvelopeJson {
+    ErrorEnvelopeJson {
+        stage: snake_case_debug(&f.stage),
+        cause: failure_cause_json(&f.cause),
+        last_known_coords: f.last_known_coords.as_ref().map(coords_to_json),
+        coords_are_diagnostic_only: true,
+        diagnostics: FailureDiagnosticsJson {
+            embed_stats: f.embed_stats.as_ref().map(embed_stats_json),
+            bound_adjustment_report: f
+                .bound_adjustment_report
+                .as_ref()
+                .map(|v| v.iter().map(bound_adjustment_json).collect()),
+            torsion_knowledge_report: f
+                .torsion_knowledge_report
+                .as_ref()
+                .map(torsion_knowledge_report_json),
+            ring_torsion_evidence: f
+                .ring_torsion_evidence
+                .as_ref()
+                .map(ring_torsion_evidence_json),
+            torsion_optimization_report: f
+                .torsion_optimization_report
+                .as_ref()
+                .map(torsion_optimization_report_json),
+            stereo_before: f.stereo_before.as_ref().map(stereo_verification_json),
+            stereo_repair: f.stereo_repair.as_ref().map(stereo_repair_summary_json),
+            stereo_after_repair: f.stereo_after_repair.as_ref().map(stereo_verification_json),
+            force_field: f.force_field.as_ref().map(policy_minimize_result_json),
+            final_stereo: f.final_stereo.as_ref().map(stereo_verification_json),
+            final_validation: f.final_validation.as_ref().map(final_validation_json),
+            elapsed_ms_by_stage: stage_timings_json(&f.elapsed_ms_by_stage),
+        },
+    }
+}
+
 fn failure_to_json(f: &pv2::PipelineV2Failure) -> String {
     let envelope = FailureEnvelopeJson {
         schema_version: SCHEMA_VERSION,
         ok: false,
-        error: ErrorEnvelopeJson {
-            stage: snake_case_debug(&f.stage),
-            cause: failure_cause_json(&f.cause),
-            last_known_coords: f.last_known_coords.as_ref().map(coords_to_json),
-            coords_are_diagnostic_only: true,
-            diagnostics: FailureDiagnosticsJson {
-                embed_stats: f.embed_stats.as_ref().map(embed_stats_json),
-                bound_adjustment_report: f
-                    .bound_adjustment_report
-                    .as_ref()
-                    .map(|v| v.iter().map(bound_adjustment_json).collect()),
-                torsion_knowledge_report: f
-                    .torsion_knowledge_report
-                    .as_ref()
-                    .map(torsion_knowledge_report_json),
-                ring_torsion_evidence: f
-                    .ring_torsion_evidence
-                    .as_ref()
-                    .map(ring_torsion_evidence_json),
-                torsion_optimization_report: f
-                    .torsion_optimization_report
-                    .as_ref()
-                    .map(torsion_optimization_report_json),
-                stereo_before: f.stereo_before.as_ref().map(stereo_verification_json),
-                stereo_repair: f.stereo_repair.as_ref().map(stereo_repair_summary_json),
-                stereo_after_repair: f.stereo_after_repair.as_ref().map(stereo_verification_json),
-                force_field: f.force_field.as_ref().map(policy_minimize_result_json),
-                final_stereo: f.final_stereo.as_ref().map(stereo_verification_json),
-                final_validation: f.final_validation.as_ref().map(final_validation_json),
-                elapsed_ms_by_stage: stage_timings_json(&f.elapsed_ms_by_stage),
-            },
-        },
+        error: error_envelope_json(f),
     };
     serde_json::to_string(&envelope).expect("failure envelope must always serialize")
 }
@@ -1170,7 +1181,7 @@ fn failure_to_json(f: &pv2::PipelineV2Failure) -> String {
 /// input, too many atoms, malformed/incomplete config JSON). Same envelope shape
 /// as a real `PipelineV2Failure`, with `diagnostics` entirely empty (nothing was
 /// computed) and `elapsedMsByStage` all-zero.
-fn wasm_input_error_json(cause: FailureCauseJson) -> String {
+pub(crate) fn wasm_input_error_json(cause: FailureCauseJson) -> String {
     let envelope = FailureEnvelopeJson {
         schema_version: SCHEMA_VERSION,
         ok: false,


### PR DESCRIPTION
## Summary

Completes A2.1 (Track A, `docs/rfcs/openeye_materials_advantage_rfc.md`). Python bindings for `chematic_3d::embed_ensemble_v2` already shipped (`Mol.conformer_ensemble_v2()`); this adds the WASM equivalent.

- New `embed_ensemble_v2_json(mol, config_json) -> String` in `crates/chematic-wasm/src/ensemble_v2.rs`, mirroring the Python binding's JSON shape via the existing `pipeline_v2.rs` WASM conventions (camelCase keys, `schemaVersion: 1` tagged-union envelope, `FiniteF64` for JSON-safe non-finite handling, snake_case policy/force-field strings).
- Reuses `pipeline_v2.rs`'s existing helpers rather than duplicating them (`FiniteF64`, `snake_case_debug`, `coords_to_json`, `force_field_policy_str`, `PipelineV2ConfigJson`, `ForceFieldBridgeErrorJson`, `FailureCauseJson`) — widened to `pub(crate)`, plus a new `error_envelope_json(f)` helper extracted from `failure_to_json` so a per-attempt `PipelineV2Failure` can be embedded inside the ensemble's own envelope without a nested `schemaVersion`/`ok` pair. This is a purely mechanical refactor: `failure_to_json`'s own output is byte-for-byte unchanged (verified by the existing 289-test suite staying green).

## Design notes

- Config JSON requires every field explicitly (`deny_unknown_fields`, no silent defaults) — matches this crate's dominant "closed, explicit config" convention for new WASM APIs (see `PipelineV2ConfigJson`), rather than the Python binding's optional-keyword-argument defaults (`rmsd_threshold = 0.5`, etc.). This is a brand-new WASM API with no existing callers to preserve compatibility for.
- `ensembleTimeoutMs` uses the same "key must be present, value may be `null`" convention as `embedTimeoutMs`/`totalTimeoutMs`.
- Preserves `embed_ensemble_v2`'s documented error asymmetry: an ensemble where every attempt fails and zero conformers are kept is still `{"ok": true, "result": {...}}`, with per-attempt failure detail in `result.attempts` — only a config that could never succeed (invalid `rmsdThreshold`) surfaces as `ok: false`.

## Verification

- 8 new native `#[test]`s: success envelope shape, seed reproducibility, `count: 0` early-return, invalid-`rmsdThreshold` typed rejection, malformed/incomplete config JSON (never throws), missing present-but-nullable `ensembleTimeoutMs`, all-attempts-failing-is-still-`ok:true`, oversized-input rejection.
- Full `cargo test -p chematic-wasm --lib`: **289 passed, 0 failed** (includes the pre-existing `pipeline_v2.rs` suite, confirming the refactor is behavior-preserving).
- `cargo fmt --check` / `cargo clippy -p chematic-wasm --lib --tests -- -D warnings`: clean.
- `cargo build --workspace --exclude chematic-py --exclude chematic-wasm` / `cargo check -p chematic-py -p chematic-wasm`: clean.

Not run: the JS-level `wasm-pack build` + `node` parity test (mirrors `crates/chematic-wasm/tests/pipeline_v2.test.mjs`'s own documented convention of being a manual, non-CI-wired check) — no Python-derived parity fixture file exists yet for ensembles (`pipeline_v2.test.mjs` reads one generated by `scripts/gen_pipeline_v2_wasm_parity_fixtures.py`); generating an equivalent for ensembles is a reasonable, larger follow-up, not required for this binding to be correct (native tests already exercise the real `embed_ensemble_v2` end to end).

## Test plan

- [x] `cargo test -p chematic-wasm --lib` (289 passed, 0 failed)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p chematic-wasm --lib --tests -- -D warnings`
- [x] `cargo build --workspace --exclude chematic-py --exclude chematic-wasm`
- [x] `cargo check -p chematic-py -p chematic-wasm`

Per this session's standing directive, **not merging** — opening for review only.