### PR TITLE
fix(smiles): bound automorphism-search backtracking to prevent hang (issue #421)

### DIFF
--- a/crates/chematic-smiles/src/canonical_automorphism.rs
+++ b/crates/chematic-smiles/src/canonical_automorphism.rs
@@ -28,6 +28,32 @@ use crate::canonical_partition::{CanonicalColoredGraph, Partition};
 /// search below is restricted to same-cell atoms and a singleton's only
 /// same-cell candidate is itself. That is exactly what "keep
 /// already-individualized singletons fixed" means in practice.
+/// Hard, always-on ceiling on total backtracking steps within one
+/// [`has_colored_automorphism_mapping`] call (issue #421). `extend_mapping`'s
+/// candidate-vertex backtracking has no depth bound of its own: `feasible`
+/// only checks edges to already-assigned neighbors (a purely local,
+/// one-hop-away consistency check), so on a molecule with several
+/// simultaneously-unresolved large symmetric regions (e.g. 3+ near-identical
+/// repeated substituent arms, all still non-singleton cells at the same
+/// search node) it can explore a combinatorially large space. Observed to
+/// still be running after 100+ seconds (never confirmed to terminate) on a
+/// real 94-atom ChEMBL molecule reordered into `canonical_atom_order`'s own
+/// output order -- the outer `SearchBudget` in `canonical_search.rs` only
+/// counts *calls* to this function, not work done *inside* one call, so it
+/// could not catch this.
+///
+/// Exceeding this ceiling makes [`extend_mapping`] return `false` (via
+/// `steps` below), which is always a *safe* fallback per this module's own
+/// documented invariant ("a false result may cost performance... a true
+/// result must always be a genuine automorphism"): it can only ever cost a
+/// missed prune (redundant-but-still-correct exploration one level up in
+/// `canonical_search.rs`), never a wrong canonical answer. Chosen generously
+/// relative to this crate's actual fixtures/corpus (the entire cage/cubane/
+/// coronene test suite in this module needs a tiny fraction of this per
+/// call) while still bounding wall-clock to a small fraction of a second even
+/// in an unoptimized debug build.
+const MAX_EXTEND_MAPPING_STEPS: usize = 200_000;
+
 pub(crate) fn has_colored_automorphism_mapping(
     graph: &CanonicalColoredGraph,
     coloring: &Partition,
@@ -50,7 +76,8 @@ pub(crate) fn has_colored_automorphism_mapping(
     image[from.0 as usize] = Some(to.0);
     used[to.0 as usize] = true;
 
-    if !extend_mapping(graph, coloring, &mut image, &mut used) {
+    let mut steps = 0usize;
+    if !extend_mapping(graph, coloring, &mut image, &mut used, &mut steps) {
         return false;
     }
 
@@ -62,7 +89,12 @@ fn extend_mapping(
     coloring: &Partition,
     image: &mut [Option<u32>],
     used: &mut [bool],
+    steps: &mut usize,
 ) -> bool {
+    *steps += 1;
+    if *steps > MAX_EXTEND_MAPPING_STEPS {
+        return false;
+    }
     let n = image.len();
     let Some(u) = (0..n).find(|&i| image[i].is_none()) else {
         return true;
@@ -98,7 +130,7 @@ fn extend_mapping(
         }
         image[u] = Some(v);
         used[v as usize] = true;
-        if extend_mapping(graph, coloring, image, used) {
+        if extend_mapping(graph, coloring, image, used, steps) {
             return true;
         }
         image[u] = None;

--- a/crates/chematic-smiles/src/canonical_search.rs
+++ b/crates/chematic-smiles/src/canonical_search.rs
@@ -610,6 +610,67 @@ mod tests {
         );
     }
 
+    /// Issue #421: on a real 94-atom ChEMBL molecule (3 near-identical
+    /// Boc-protected benzylamine arms off a symmetric polyamine core)
+    /// reordered into `canonical_atom_order`'s own output order,
+    /// `canonical_smiles` used to hang -- observed running past 2 minutes,
+    /// never confirmed to terminate. Root cause was in
+    /// `canonical_automorphism::extend_mapping`, not this module: an
+    /// unbounded backtracking search with no internal step cap, which the
+    /// `SearchBudget` here cannot see (it only counts *calls* to
+    /// `has_colored_automorphism_mapping`, not work done inside one call).
+    /// Fixed there via an always-on `MAX_EXTEND_MAPPING_STEPS` ceiling that
+    /// falls back to `false` (a documented-safe result -- see that module's
+    /// own invariant) rather than searching unbounded. This test pins both
+    /// that the fix actually bounds the search (a generous but finite node
+    /// budget suffices, where before it would not terminate at all) and
+    /// that atom-order invariance holds despite the internal fallback (the
+    /// reordered input must still canonicalize to the exact same string as
+    /// the original).
+    #[test]
+    fn issue421_reordered_symmetric_molecule_does_not_hang() {
+        use chematic_core::{AtomIdx, MoleculeBuilder};
+
+        let smi = "CC(C)(C)OC(=O)N(CCCCCN1CCCN(CCCCCN(Cc2ccccc2)C(=O)OC(C)(C)C)CCN(CCCCCN(Cc2ccccc2)C(=O)OC(C)(C)C)CCCN(CCCCCN(Cc2ccccc2)C(=O)OC(C)(C)C)CC1)Cc1ccccc1";
+        let mol = parse(smi).unwrap();
+        assert_eq!(mol.atom_count(), 94);
+
+        // Reorder atoms into canonical_atom_order's own output order -- the
+        // exact composition that triggered the hang.
+        let order = crate::canonical_atom_order(&mol);
+        let mut builder = MoleculeBuilder::new();
+        let mut remap = std::collections::HashMap::new();
+        for &old in &order {
+            let old_idx = AtomIdx(old as u32);
+            remap.insert(old_idx, builder.add_atom(mol.atom(old_idx).clone()));
+        }
+        for i in 0..mol.bond_count() {
+            let b = mol.bond(chematic_core::BondIdx(i as u32));
+            builder
+                .add_bond(remap[&b.atom1], remap[&b.atom2], b.order)
+                .unwrap();
+        }
+        let reordered = builder.build();
+
+        // Generous but finite budget: before the fix, no finite budget on
+        // either axis mattered because a single automorphism-test call
+        // itself never returned.
+        let limits = CanonicalizationLimits {
+            max_search_nodes: Some(10_000),
+            max_automorphism_tests: Some(1_000_000),
+        };
+        let reordered_result = canonical_smiles_with_limits(&reordered, &limits)
+            .expect("reordered molecule must canonicalize within a bounded search");
+
+        let original_result = canonical_smiles_with_limits(&mol, &limits)
+            .expect("original-order molecule must canonicalize within a bounded search");
+        assert_eq!(
+            reordered_result, original_result,
+            "canonical_smiles must be atom-order-invariant even when the internal \
+             automorphism-search step cap falls back to `false`"
+        );
+    }
+
     #[test]
     fn tiny_node_budget_fails_closed_not_empty_string() {
         let mol = parse("c1ccccc1").unwrap();


### PR DESCRIPTION
## Summary

Fixes issue #421: `canonical_smiles`/`canonical_atom_order` could hang (observed running past 2 minutes, never confirmed to terminate) on a real 94-atom ChEMBL molecule whose atom order already coincided with the algorithm's own canonical output order.

## Root cause

`canonical_automorphism::extend_mapping` is a recursive backtracking search for a colored-graph automorphism, with **no internal step bound of its own** — its `feasible()` pruning only checks edges to already-assigned neighbors, a purely local one-hop consistency check. On a molecule with several simultaneously-unresolved large symmetric regions (here: 3 near-identical Boc-protected benzylamine arms, all still non-singleton cells at the same search node), it can explore a combinatorially large space within a single call.

The outer `SearchBudget` in `canonical_search.rs` could not catch this: it only counts *calls* to `has_colored_automorphism_mapping`, not the work done *inside* one call. Confirmed via a bounded diagnostic: even `max_automorphism_tests: Some(10)` didn't stop the search within 100s, because the very first call itself never returned.

## Fix

An always-on `MAX_EXTEND_MAPPING_STEPS` ceiling (200,000) inside `extend_mapping`. Exceeding it returns `false`, which this module's own documented invariant already establishes as a **safe** fallback:

> "a `false` result may cost performance (a missed prune); a `true` result must always be a genuine automorphism"

So this can only ever cost a missed prune (redundant-but-still-correct extra exploration one level up in `canonical_search.rs`), never a wrong canonical answer. No new public API, no threading of budgets through call chains — a pure internal implementation detail.

## Verification

- The reordered repro molecule now canonicalizes in **~0.6s** (was 2+ minutes, unconfirmed to terminate) and produces the **exact same canonical SMILES** as the original ordering — atom-order invariance is preserved, not just "doesn't hang."
- New regression test `issue421_reordered_symmetric_molecule_does_not_hang` (`canonical_search.rs`) pins both the bound and the invariance property, using a generous-but-finite `CanonicalizationLimits` budget.
- Full `chematic-smiles` suite: **209 passed, 0 failed** — including the exhaustive `n<=8` brute-force automorphism oracle tests (`canonical_automorphism::tests::*`), confirming the step cap doesn't affect correctness on any case those oracles cover (200,000 steps is orders of magnitude beyond what any of them need).
- Full `chematic-chem` suite (foundational downstream consumer): **825 passed, 0 failed**.
- `cargo fmt --check` / `cargo clippy -p chematic-smiles --lib --tests -- -D warnings`: clean.
- `cargo build --workspace --exclude chematic-py --exclude chematic-wasm` / `cargo check -p chematic-py -p chematic-wasm`: clean.
- `has_colored_automorphism_mapping` is `pub(crate)`, only called from `canonical_search.rs`, with an unchanged signature — blast radius fully contained to this one file's internals.

## Test plan

- [x] `cargo test -p chematic-smiles --lib --release` (209 passed, 0 failed)
- [x] `cargo test -p chematic-chem --lib --release` (825 passed, 0 failed)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p chematic-smiles --lib --tests -- -D warnings`
- [x] `cargo build --workspace --exclude chematic-py --exclude chematic-wasm`
- [x] `cargo check -p chematic-py -p chematic-wasm`

Per this session's standing directive, **not merging** — opening for review only.

Closes #421