### PR TITLE
release: v0.22.0 -- embed_ensemble_v2_json WASM binding, canonicalization-hang fix, 3-membered-ring embedding fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] — 2026-08-29
+
+Minor release: new additive, non-breaking WASM API (`embed_ensemble_v2_json`), plus two
+correctness/robustness fixes — a `chematic-smiles` canonicalization hang (issue #421)
+and a `chematic-3d` distance-geometry embedding gap affecting every 3-membered-ring
+molecule. No breaking API changes.
+
 ### Fixed — `chematic-smiles` (canonical_smiles/canonical_atom_order could hang, issue #421)
 
 - `canonical_automorphism::extend_mapping`'s colored-graph automorphism

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,5 +23,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 0.21.0
+version: 0.22.0
 date-released: "2026-08-12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "0.21.0"
+version = "0.22.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["kent-tokyo <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.21.0
+# chematic v0.22.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-07-17, v0.4.29 vs RDKit 2026.03.3 --
@@ -447,6 +447,12 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi  # +1
 
 ## Recent Development
 
+**v0.22.0** (2026-08-29): **New WASM ensemble binding, canonicalization-hang fix, 3-membered-ring embedding fix**
+- `chematic-wasm`: new `embed_ensemble_v2_json` binding for `chematic_3d::embed_ensemble_v2`, mirroring the Python binding (`Mol.conformer_ensemble_v2()`) via the existing `pipeline_v2.rs` conventions (camelCase JSON keys, `schemaVersion: 1` envelope) — purely additive
+- `chematic-smiles`: `canonical_smiles`/`canonical_atom_order` could hang on molecules with several simultaneously-unresolved symmetric regions (issue #421) — the automorphism backtracking search had no internal step bound; fixed with an always-on step ceiling that safely falls back to "not proven automorphic" rather than searching unbounded
+- `chematic-3d`: 3-membered rings (cyclopropane/epoxide/aziridine/thiirane) failed closed at the distance-geometry embedding stage — a generic angle bound was overwriting the correct, tighter bond-length bound for a ring-closing pair that's simultaneously "1-3" and directly bonded; fixed by skipping the angle bound for any already-bonded neighbor pair; strict-MMFF94 3D corpus 252/265 → 263/265
+- Full details in `CHANGELOG.md`'s `[0.22.0]` section
+
 **v0.21.0** (2026-08-27): **`McsConfig` charge/isotope matching + typed timeout outcome, four correctness fixes**
 - `chematic-smarts`: `McsConfig` gains `match_charge`/`match_isotope` fields (mirroring the existing `match_chiral_tag`, default `false`) and a new `McsOutcome` enum (`Exhaustive`/`TimedOut`) via `find_mcs_with_config_checked`, reporting whether a timeout cut the search short rather than silently returning a possibly-non-optimal result — purely additive, `find_mcs`/`find_mcs_with_config` unchanged
 - `chematic-smarts`: `find_mcs`'s branch-and-bound search was incomplete — `grow()` only ever tried the first frontier atom with no way to exclude it and try another, silently missing a strictly larger common substructure in some cases (minimal repro: `OC(N)N` vs `NC(N)` returned 2 atoms instead of the true 3); fixed via standard include/exclude branch-and-bound
@@ -624,7 +630,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v0.21.0)
+├── Cargo.toml                    workspace root (v0.22.0)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)
@@ -678,7 +684,7 @@ If you use chematic in academic or research work, please cite:
   author    = {kent-tokyo},
   title     = {chematic: A pure-Rust cheminformatics toolkit},
   url       = {https://github.com/kent-tokyo/chematic},
-  version   = {0.21.0},
+  version   = {0.22.0},
   year      = {2026},
 }
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -125,7 +125,7 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v0.21.0
+# chematic v0.22.0
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-06, v0.4.22 vs RDKit 2026.03.3 --
@@ -303,6 +303,12 @@ cargo test -p chematic-inchi --features native-inchi --test standard_inchi      
 ---
 
 ## 最近の開発
+
+**v0.22.0**（2026-08-29）: **WASM ensemble binding新規追加、canonicalizationハング修正、3員環embedding修正**
+- `chematic-wasm`：`chematic_3d::embed_ensemble_v2`向けの新規`embed_ensemble_v2_json` bindingを追加。Python binding（`Mol.conformer_ensemble_v2()`）を`pipeline_v2.rs`既存の規約（camelCase JSONキー、`schemaVersion: 1` envelope）に沿って踏襲——純粋に追加のみ
+- `chematic-smiles`：複数の対称領域が同時に未解決な分子で`canonical_smiles`/`canonical_atom_order`がハングしうる問題（issue #421）——automorphism backtracking探索に内部ステップ上限がなかった。常時有効なステップ上限を追加し、超過時は安全側（automorphismと証明できない扱い）にフォールバックするよう修正
+- `chematic-3d`：3員環（シクロプロパン/エポキシド/アジリジン/チイラン）がdistance-geometry embedding段階でfail closedしていた問題——リング閉環ペアが同時に「1-3」かつ直接結合している場合に、汎用角度制約が正しい（より厳しい）結合長制約を上書きしていた。既に結合済みの近傍ペアには角度制約をスキップするよう修正。strict-MMFF94 3Dコーパス 252/265 → 263/265
+- 詳細は`CHANGELOG.md`の`[0.22.0]`section参照
 
 **v0.21.0**（2026-08-27）: **`McsConfig`の電荷/同位体マッチングと型付きtimeout結果、正確性修正4件**
 - `chematic-smarts`：`McsConfig`に`match_charge`/`match_isotope`フィールドを追加（既存の`match_chiral_tag`と同様、デフォルト`false`）。また新規`McsOutcome` enum（`Exhaustive`/`TimedOut`）を`find_mcs_with_config_checked`経由で提供し、timeoutで探索が打ち切られたかを明示的に報告（最適とは限らない結果をexhaustiveなものと区別できずに返す状態を解消）——純粋に追加のみ、`find_mcs`/`find_mcs_with_config`は無変更

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,11 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
-| v0.21.0 | Yes | Current release — active support |
+| v0.22.0 | Yes | Current release — active support |
 | v0.4.22 | Limited | Security fixes only (limited) |
 | < v0.4.22 | No | Unsupported |
 
-**Active Support**: Latest release (v0.21.0) receives all security updates.  
+**Active Support**: Latest release (v0.22.0) receives all security updates.  
 **Limited Support**: Previous release receives critical security fixes only.  
 **End of Life**: Older versions receive no support.
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -17,12 +17,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.21.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.21.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.21.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.21.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.21.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.22.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.22.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.22.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.22.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.22.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.22.0" }
 serde_json          = "1.0"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #219); web-time

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -17,14 +17,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.21.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.22.0" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.21.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.21.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.21.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.21.0" }
-chematic-cip        = { path = "../chematic-cip",        version = "0.21.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.22.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.22.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.22.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.22.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.22.0" }
+chematic-cip        = { path = "../chematic-cip",        version = "0.22.0" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.21.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.22.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.22.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-crystal/Cargo.toml
+++ b/crates/chematic-crystal/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 serde = ["dep:serde"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.21.0" }
+chematic-core = { path = "../chematic-core", version = "0.22.0" }
 serde         = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -23,10 +23,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.21.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.21.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.21.0" }
+chematic-core = { path = "../chematic-core", version = "0.22.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.22.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.22.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.22.0" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.21.0" }
+chematic-core = { path = "../chematic-core", version = "0.22.0" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.21.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.22.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.22.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -23,13 +23,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.21.0" }
+chematic-core = { path = "../chematic-core", version = "0.22.0" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "0.21.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.21.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.21.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.22.0" }
+chematic-rxn = { path = "../chematic-rxn", version = "0.22.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.22.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.22.0" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -19,10 +19,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "0.21.0", path = "../chematic-core" }
-chematic-smiles = { version = "0.21.0", path = "../chematic-smiles" }
-chematic-chem = { version = "0.21.0", path = "../chematic-chem" }
-chematic-rxn = { version = "0.21.0", path = "../chematic-rxn" }
+chematic-core = { version = "0.22.0", path = "../chematic-core" }
+chematic-smiles = { version = "0.22.0", path = "../chematic-smiles" }
+chematic-chem = { version = "0.22.0", path = "../chematic-chem" }
+chematic-rxn = { version = "0.22.0", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.21.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.22.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.22.0" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -18,15 +18,15 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "0.21.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.21.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.21.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.21.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.21.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.21.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.21.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.21.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.22.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.22.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.22.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.22.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.22.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.22.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.22.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.22.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.22.0" }
 
 [dev-dependencies]
 # Real JSON Schema 2020-12 validator, used only in tests to independently

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -25,11 +25,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 crystal = ["dep:chematic-crystal"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "0.21.0" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "0.21.0" }
-chematic-perception  = { path = "../chematic-perception",  version = "0.21.0" }
-chematic-smiles      = { path = "../chematic-smiles",      version = "0.21.0" }
-chematic-crystal     = { path = "../chematic-crystal",     version = "0.21.0", optional = true }
+chematic-core        = { path = "../chematic-core",        version = "0.22.0" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "0.22.0" }
+chematic-perception  = { path = "../chematic-perception",  version = "0.22.0" }
+chematic-smiles      = { path = "../chematic-smiles",      version = "0.22.0" }
+chematic-crystal     = { path = "../chematic-crystal",     version = "0.22.0", optional = true }
 serde_json           = "1.0"
 
 [dev-dependencies]

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.21.0" }
+chematic-core = { path = "../chematic-core", version = "0.22.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -25,17 +25,17 @@ pyo3 = { version = "0.29", features = ["extension-module"] }
 numpy = "0.29"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "0.21.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.21.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.21.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "0.21.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.21.0", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "0.21.0", features = ["crystal"] }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.21.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.21.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.21.0" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.21.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.21.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.21.0" }
-chematic-crystal    = { path = "../chematic-crystal",    version = "0.21.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.22.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.22.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.22.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.22.0" }
+chematic-fp         = { path = "../chematic-fp",         version = "0.22.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.22.0", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "0.22.0", features = ["crystal"] }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.22.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.22.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.22.0" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.22.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.22.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.22.0" }
+chematic-crystal    = { path = "../chematic-crystal",    version = "0.22.0" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -23,9 +23,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 perf-instrumentation = []
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "0.21.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "0.21.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "0.21.0" }
+chematic-core   = { path = "../chematic-core",   version = "0.22.0" }
+chematic-smiles = { path = "../chematic-smiles", version = "0.22.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "0.22.0" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.21.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
+chematic-core = { path = "../chematic-core", version = "0.22.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.22.0" }
 rustc-hash = "2"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #221); web-time

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "0.21.0" }
+chematic-core = { path = "../chematic-core", version = "0.22.0" }
 # Production use: `compute_stereo_alkene_ends` (canonical.rs) needs SSSR ring
 # membership to exclude endocyclic small-ring double bonds from marker-carrier
 # candidacy (issue #149's ring-constrained residual, see
@@ -27,7 +27,7 @@ chematic-core = { path = "../chematic-core", version = "0.21.0" }
 # graph, only test binaries. Was previously a dev-only dependency of this
 # crate for a different reason (re-aromatizing test fixtures); now also a
 # real one.
-chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.22.0" }
 
 [features]
 # Feature-gated internal work counters for the orbit-pruning canonical

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -32,16 +32,16 @@ web-sys = { version = "0.3", features = ["console"] }
 js-sys = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "0.21.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.21.0" }
-chematic-perception = { path = "../chematic-perception", version = "0.21.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "0.21.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "0.21.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "0.21.0", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.21.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.21.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "0.21.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "0.21.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.21.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.21.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "0.21.0" }
+chematic-core       = { path = "../chematic-core",       version = "0.22.0" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.22.0" }
+chematic-perception = { path = "../chematic-perception", version = "0.22.0" }
+chematic-chem       = { path = "../chematic-chem",       version = "0.22.0", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "0.22.0" }
+chematic-depict     = { path = "../chematic-depict",     version = "0.22.0", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.22.0" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.22.0" }
+chematic-3d         = { path = "../chematic-3d",         version = "0.22.0" }
+chematic-mol        = { path = "../chematic-mol",        version = "0.22.0" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.22.0" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.22.0" }
+chematic-ff         = { path = "../chematic-ff",         version = "0.22.0" }

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -54,16 +54,16 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "0.21.0", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "0.21.0", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "0.21.0", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "0.21.0", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "0.21.0", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "0.21.0", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "0.21.0", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "0.21.0", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "0.21.0", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "0.21.0", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "0.21.0", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "0.21.0", optional = true }
-chematic-crystal    = { path = "../chematic-crystal",    version = "0.21.0", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "0.22.0", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "0.22.0", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "0.22.0", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "0.22.0", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "0.22.0", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "0.22.0", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "0.22.0", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "0.22.0", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "0.22.0", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "0.22.0", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "0.22.0", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "0.22.0", optional = true }
+chematic-crystal    = { path = "../chematic-crystal",    version = "0.22.0", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "kent-tokyo <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Minor release. New additive, non-breaking WASM API: `embed_ensemble_v2_json`
(`chematic_3d::embed_ensemble_v2`'s WASM half, mirroring the already-shipped
Python binding `Mol.conformer_ensemble_v2()`).

Fixes bundled:
- issue #421: `canonical_smiles`/`canonical_atom_order` could hang on
  molecules with several simultaneously-unresolved symmetric regions -- the
  automorphism backtracking search had no internal step bound; fixed with
  an always-on step ceiling that safely falls back to "not proven
  automorphic" rather than searching unbounded.
- `chematic-3d`: 3-membered rings (cyclopropane/epoxide/aziridine/thiirane)
  failed closed at the distance-geometry embedding stage -- a generic angle
  bound was overwriting the correct, tighter bond-length bound for a
  ring-closing pair that's simultaneously "1-3" and directly bonded; fixed
  by skipping the angle bound for any already-bonded neighbor pair.
  strict-MMFF94 3D corpus 252/265 -> 263/265, exceeding the 258/265+ target.

Full details in `CHANGELOG.md`'s `[0.22.0]` section.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo deny --all-features check`
- [x] `scripts/check_publish_graph.py`
- [x] Version-string consistency (README/README_ja/CITATION.cff/SECURITY.md/demo package.json/crate inter-deps)
- [ ] Full `cargo test --workspace` (unoptimized-debug run was too slow locally to wait out for this crate's numerical tests; deferred to CI's `Test` job, same as every other PR merged this session)