### PR TITLE
feat(py,wasm): expose full McsConfig/McsOutcome to MCS bindings (Track A Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `chematic-py`/`chematic-wasm` (full `McsConfig`/`McsOutcome` exposed to MCS bindings)
+
+- Python's `find_mcs` previously exposed only 2 of `McsConfig`'s 11 fields
+  (`ring_matches_ring_only`/`complete_rings_only`); the rest were silently
+  hardcoded to their defaults. Extended to accept all 11 as keyword
+  arguments (`match_bonds`, `min_atoms`, `timeout_ms`, `atom_compare`,
+  `bond_compare`, `match_chiral_tag`, `match_charge`, `match_isotope`,
+  `maximize_bonds`, plus the existing two) — fully backward-compatible,
+  every new argument defaults to `McsConfig::default()`'s own value.
+- New `find_mcs_checked` (Python) and `mcs_smiles_json_with_config` (WASM,
+  camelCase JSON config in, `{"smiles": string|null, "wasTimedOut": bool}`
+  out) expose `McsOutcome`'s exhaustive/timed-out distinction for the first
+  time — previously always silently discarded via `find_mcs_with_config`
+  (never the `_checked` variant), so a caller using `timeout_ms` had no way
+  to tell a possibly-non-optimal result apart from a proven-optimal one.
+- The two pre-existing WASM `mcs_smiles_json`/`mcs_smiles_json_with_ring_config`
+  functions keep their exact signatures and behavior unchanged, refactored
+  to share one `QueryMolecule`-to-`Molecule` reconstruction helper (was
+  duplicated verbatim 2-3x per binding).
+
 ## [0.22.0] — 2026-08-29
 
 Minor release: new additive, non-breaking WASM API (`embed_ensemble_v2_json`), plus two

--- a/crates/chematic-py/python/chematic/__init__.pyi
+++ b/crates/chematic-py/python/chematic/__init__.pyi
@@ -3057,16 +3057,67 @@ def run_smirks(smirks: str, reactants: list[Mol]) -> list[list[Mol]]:
     """
     ...
 
-def find_mcs(mols: list[Mol]) -> Optional[Mol]:
+def find_mcs(
+    mols: list[Mol],
+    match_bonds: bool = True,
+    min_atoms: int = 1,
+    timeout_ms: Optional[int] = None,
+    ring_matches_ring_only: bool = False,
+    complete_rings_only: bool = False,
+    atom_compare: str = "elements",
+    bond_compare: str = "order_or_aromatic",
+    match_chiral_tag: bool = False,
+    match_charge: bool = False,
+    match_isotope: bool = False,
+    maximize_bonds: bool = True,
+) -> Optional[Mol]:
     """Find the Maximum Common Substructure (MCS) of a list of molecules.
 
     Returns the MCS as a :class:`Mol`, or ``None`` when there is no common substructure.
+    If ``timeout_ms`` is reached before the search finishes, returns the best result
+    found so far -- indistinguishable here from an exhaustive result; use
+    :func:`find_mcs_checked` when that distinction matters.
+
+    ``atom_compare`` is one of ``"elements"`` (default), ``"any_heavy_atom"``, or ``"any"``.
+    ``bond_compare`` is one of ``"order_or_aromatic"`` (default) or ``"any"``.
 
     Example::
 
         mcs = chematic.find_mcs([mol1, mol2])
         if mcs:
             print(mcs.smiles)
+
+        # Ring-aware scaffold extraction
+        scaffold = chematic.find_mcs(mols, ring_matches_ring_only=True, complete_rings_only=True)
+    """
+    ...
+
+def find_mcs_checked(
+    mols: list[Mol],
+    match_bonds: bool = True,
+    min_atoms: int = 1,
+    timeout_ms: Optional[int] = None,
+    ring_matches_ring_only: bool = False,
+    complete_rings_only: bool = False,
+    atom_compare: str = "elements",
+    bond_compare: str = "order_or_aromatic",
+    match_chiral_tag: bool = False,
+    match_charge: bool = False,
+    match_isotope: bool = False,
+    maximize_bonds: bool = True,
+) -> tuple[Optional[Mol], bool]:
+    """Like :func:`find_mcs`, but also reports whether ``timeout_ms`` was reached
+    before the search finished exhaustively.
+
+    Returns ``(mcs, was_timed_out)``: ``mcs`` is the MCS as a :class:`Mol` (or ``None``
+    if there is no common substructure), and ``was_timed_out`` is ``True`` if the search
+    was cut off before proving ``mcs`` optimal.
+
+    Example::
+
+        mcs, timed_out = chematic.find_mcs_checked(mols, timeout_ms=500)
+        if timed_out:
+            print("warning: MCS may not be optimal")
     """
     ...
 

--- a/crates/chematic-py/src/reactions.rs
+++ b/crates/chematic-py/src/reactions.rs
@@ -538,32 +538,66 @@ fn run_smirks_strict(smirks: &str, reactants: Vec<Mol>) -> PyResult<Vec<Vec<Mol>
         .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
-/// Find the Maximum Common Substructure (MCS) of a list of molecules.
-///
-/// Returns the MCS as a Mol, or ``None`` when there is no common substructure.
-///
-///     mcs = chematic.find_mcs([mol1, mol2])
-///     if mcs: print(mcs.smiles)
-///
-///     # Ring-aware scaffold extraction
-///     scaffold = chematic.find_mcs(mols, ring_matches_ring_only=True, complete_rings_only=True)
-#[pyfunction]
-#[pyo3(signature = (mols, ring_matches_ring_only=false, complete_rings_only=false))]
-fn find_mcs(
-    mols: Vec<Mol>,
+/// Build a full `McsConfig` from the individual keyword arguments shared by
+/// [`find_mcs`] and [`find_mcs_checked`] -- kept as one function so the two
+/// entry points can never silently drift apart on how a given argument set
+/// maps to `McsConfig`.
+#[allow(clippy::too_many_arguments)]
+fn build_mcs_config(
+    match_bonds: bool,
+    min_atoms: usize,
+    timeout_ms: Option<u64>,
     ring_matches_ring_only: bool,
     complete_rings_only: bool,
-) -> Option<Mol> {
-    use chematic_core::{Atom, AtomIdx, BondOrder, Element, MoleculeBuilder};
-    use chematic_smarts::{AtomPrimitive, AtomQuery, BondPrimitive, BondQuery, McsConfig};
+    atom_compare: &str,
+    bond_compare: &str,
+    match_chiral_tag: bool,
+    match_charge: bool,
+    match_isotope: bool,
+    maximize_bonds: bool,
+) -> PyResult<chematic_smarts::McsConfig> {
+    use chematic_smarts::{AtomCompare, BondCompare, McsConfig};
 
-    let refs: Vec<&chematic_core::Molecule> = mols.iter().map(|m| m.inner.as_ref()).collect();
-    let config = McsConfig {
+    let atom_compare = match atom_compare {
+        "elements" => AtomCompare::Elements,
+        "any_heavy_atom" => AtomCompare::AnyHeavyAtom,
+        "any" => AtomCompare::Any,
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "invalid atom_compare {other:?}: expected \"elements\", \"any_heavy_atom\", or \"any\""
+            )));
+        }
+    };
+    let bond_compare = match bond_compare {
+        "order_or_aromatic" => BondCompare::OrderOrAromatic,
+        "any" => BondCompare::Any,
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "invalid bond_compare {other:?}: expected \"order_or_aromatic\" or \"any\""
+            )));
+        }
+    };
+    Ok(McsConfig {
+        match_bonds,
+        min_atoms,
+        timeout_ms,
         ring_matches_ring_only,
         complete_rings_only,
-        ..McsConfig::default()
-    };
-    let qmol = chematic_smarts::find_mcs_with_config(&refs, &config);
+        atom_compare,
+        bond_compare,
+        match_chiral_tag,
+        match_charge,
+        match_isotope,
+        maximize_bonds,
+    })
+}
+
+/// Reconstruct a concrete `Mol` from a `QueryMolecule` produced by MCS search
+/// (atom queries are always `AtomicNum` primitives; bond queries are typed
+/// primitives) -- `None` when the query has no atoms (no common substructure).
+fn qmol_to_mol(qmol: &chematic_smarts::QueryMolecule) -> Option<Mol> {
+    use chematic_core::{Atom, AtomIdx, BondOrder, Element, MoleculeBuilder};
+    use chematic_smarts::{AtomPrimitive, AtomQuery, BondPrimitive, BondQuery};
 
     if qmol.atoms.is_empty() {
         return None;
@@ -607,6 +641,129 @@ fn find_mcs(
     })
 }
 
+/// Find the Maximum Common Substructure (MCS) of a list of molecules.
+///
+/// Returns the MCS as a Mol, or ``None`` when there is no common substructure.
+/// If ``timeout_ms`` is reached before the search finishes, returns the best
+/// result found so far -- indistinguishable here from an exhaustive result;
+/// use [`find_mcs_checked`] when that distinction matters.
+///
+///     mcs = chematic.find_mcs([mol1, mol2])
+///     if mcs: print(mcs.smiles)
+///
+///     # Ring-aware scaffold extraction
+///     scaffold = chematic.find_mcs(mols, ring_matches_ring_only=True, complete_rings_only=True)
+///
+///     # Ignore element identity, match any heavy atom (scaffold hopping)
+///     core = chematic.find_mcs(mols, atom_compare="any_heavy_atom")
+#[pyfunction]
+#[pyo3(signature = (
+    mols,
+    match_bonds=true,
+    min_atoms=1,
+    timeout_ms=None,
+    ring_matches_ring_only=false,
+    complete_rings_only=false,
+    atom_compare="elements",
+    bond_compare="order_or_aromatic",
+    match_chiral_tag=false,
+    match_charge=false,
+    match_isotope=false,
+    maximize_bonds=true,
+))]
+#[allow(clippy::too_many_arguments)]
+fn find_mcs(
+    mols: Vec<Mol>,
+    match_bonds: bool,
+    min_atoms: usize,
+    timeout_ms: Option<u64>,
+    ring_matches_ring_only: bool,
+    complete_rings_only: bool,
+    atom_compare: &str,
+    bond_compare: &str,
+    match_chiral_tag: bool,
+    match_charge: bool,
+    match_isotope: bool,
+    maximize_bonds: bool,
+) -> PyResult<Option<Mol>> {
+    let config = build_mcs_config(
+        match_bonds,
+        min_atoms,
+        timeout_ms,
+        ring_matches_ring_only,
+        complete_rings_only,
+        atom_compare,
+        bond_compare,
+        match_chiral_tag,
+        match_charge,
+        match_isotope,
+        maximize_bonds,
+    )?;
+    let refs: Vec<&chematic_core::Molecule> = mols.iter().map(|m| m.inner.as_ref()).collect();
+    let qmol = chematic_smarts::find_mcs_with_config(&refs, &config);
+    Ok(qmol_to_mol(&qmol))
+}
+
+/// Like [`find_mcs`], but also reports whether ``timeout_ms`` was reached
+/// before the search finished exhaustively.
+///
+/// Returns a tuple ``(mcs, was_timed_out)``: ``mcs`` is the MCS as a Mol (or
+/// ``None`` if there is no common substructure), and ``was_timed_out`` is
+/// ``True`` if the search was cut off before proving ``mcs`` optimal.
+///
+///     mcs, timed_out = chematic.find_mcs_checked(mols, timeout_ms=500)
+///     if timed_out:
+///         print("warning: MCS may not be optimal")
+#[pyfunction]
+#[pyo3(signature = (
+    mols,
+    match_bonds=true,
+    min_atoms=1,
+    timeout_ms=None,
+    ring_matches_ring_only=false,
+    complete_rings_only=false,
+    atom_compare="elements",
+    bond_compare="order_or_aromatic",
+    match_chiral_tag=false,
+    match_charge=false,
+    match_isotope=false,
+    maximize_bonds=true,
+))]
+#[allow(clippy::too_many_arguments)]
+fn find_mcs_checked(
+    mols: Vec<Mol>,
+    match_bonds: bool,
+    min_atoms: usize,
+    timeout_ms: Option<u64>,
+    ring_matches_ring_only: bool,
+    complete_rings_only: bool,
+    atom_compare: &str,
+    bond_compare: &str,
+    match_chiral_tag: bool,
+    match_charge: bool,
+    match_isotope: bool,
+    maximize_bonds: bool,
+) -> PyResult<(Option<Mol>, bool)> {
+    let config = build_mcs_config(
+        match_bonds,
+        min_atoms,
+        timeout_ms,
+        ring_matches_ring_only,
+        complete_rings_only,
+        atom_compare,
+        bond_compare,
+        match_chiral_tag,
+        match_charge,
+        match_isotope,
+        maximize_bonds,
+    )?;
+    let refs: Vec<&chematic_core::Molecule> = mols.iter().map(|m| m.inner.as_ref()).collect();
+    let outcome = chematic_smarts::find_mcs_with_config_checked(&refs, &config);
+    let was_timed_out = outcome.was_timed_out();
+    let qmol = outcome.into_query();
+    Ok((qmol_to_mol(&qmol), was_timed_out))
+}
+
 // ---------------------------------------------------------------------------
 // Module definition
 // ---------------------------------------------------------------------------
@@ -637,5 +794,6 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(run_smirks, m)?)?;
     m.add_function(wrap_pyfunction!(run_smirks_strict, m)?)?;
     m.add_function(wrap_pyfunction!(find_mcs, m)?)?;
+    m.add_function(wrap_pyfunction!(find_mcs_checked, m)?)?;
     Ok(())
 }

--- a/crates/chematic-py/tests/test_module_functions.py
+++ b/crates/chematic-py/tests/test_module_functions.py
@@ -198,6 +198,76 @@ def test_find_mcs_default_kwargs_unchanged():
     assert mcs is not None
 
 
+def test_find_mcs_match_charge_narrows_result():
+    # Acetate vs acetic acid: match_charge=False (default) matches the full
+    # core; match_charge=True must reject the charge-differing oxygen.
+    acetate = chematic.from_smiles("CC(=O)[O-]")
+    acetic = chematic.from_smiles("CC(=O)O")
+    without = chematic.find_mcs([acetate, acetic], match_charge=False)
+    with_charge = chematic.find_mcs([acetate, acetic], match_charge=True)
+    assert without.smiles != with_charge.smiles
+
+
+def test_find_mcs_match_isotope_narrows_result():
+    labeled = chematic.from_smiles("[13CH4]")
+    plain = chematic.from_smiles("C")
+    without = chematic.find_mcs([labeled, plain], match_isotope=False)
+    with_isotope = chematic.find_mcs([labeled, plain], match_isotope=True)
+    assert without is not None and without.heavy_atoms == 1
+    assert with_isotope is None or with_isotope.heavy_atoms == 0
+
+
+def test_find_mcs_atom_compare_any_heavy_atom_widens_match():
+    benzene = chematic.from_smiles("c1ccccc1")
+    pyridine = chematic.from_smiles("c1ccncc1")
+    elements = chematic.find_mcs([benzene, pyridine], atom_compare="elements")
+    any_heavy = chematic.find_mcs([benzene, pyridine], atom_compare="any_heavy_atom")
+    assert any_heavy is not None
+    assert any_heavy.heavy_atoms == 6
+    assert elements.heavy_atoms < any_heavy.heavy_atoms
+
+
+def test_find_mcs_invalid_atom_compare_raises():
+    m1 = chematic.from_smiles("CCO")
+    m2 = chematic.from_smiles("CCO")
+    with pytest.raises(ValueError):
+        chematic.find_mcs([m1, m2], atom_compare="not_a_real_mode")
+
+
+def test_find_mcs_invalid_bond_compare_raises():
+    m1 = chematic.from_smiles("CCO")
+    m2 = chematic.from_smiles("CCO")
+    with pytest.raises(ValueError):
+        chematic.find_mcs([m1, m2], bond_compare="not_a_real_mode")
+
+
+def test_find_mcs_checked_matches_find_mcs_when_not_timed_out():
+    m1 = chematic.from_smiles("c1ccccc1")
+    m2 = chematic.from_smiles("Cc1ccccc1")
+    mcs = chematic.find_mcs([m1, m2])
+    mcs_checked, was_timed_out = chematic.find_mcs_checked([m1, m2])
+    assert was_timed_out is False
+    assert mcs_checked is not None
+    assert mcs_checked.smiles == mcs.smiles
+
+
+def test_find_mcs_checked_reports_timeout():
+    m1 = chematic.from_smiles("CC(=O)Oc1ccccc1C(=O)O")
+    m2 = chematic.from_smiles("CC(=O)Nc1ccc(O)cc1")
+    mcs, was_timed_out = chematic.find_mcs_checked([m1, m2], timeout_ms=0)
+    assert was_timed_out is True
+
+
+def test_find_mcs_checked_none_result_shape():
+    m1 = chematic.from_smiles("C")
+    m2 = chematic.from_smiles("N")
+    result = chematic.find_mcs_checked([m1, m2])
+    assert isinstance(result, tuple) and len(result) == 2
+    mcs, was_timed_out = result
+    assert mcs is None or isinstance(mcs, chematic.Mol)
+    assert isinstance(was_timed_out, bool)
+
+
 # ---------------------------------------------------------------------------
 # B7: Reaction SMARTS matching
 # ---------------------------------------------------------------------------

--- a/crates/chematic-wasm/src/mol_reactions.rs
+++ b/crates/chematic-wasm/src/mol_reactions.rs
@@ -6,7 +6,105 @@ use crate::{
     escape_json_string, json_option_string_array, json_option_u8_array, parse_smiles_json_array,
     rgroup_fragment_smiles,
 };
+use serde::Deserialize;
 use wasm_bindgen::prelude::*;
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+enum AtomCompareJson {
+    #[serde(rename = "elements")]
+    Elements,
+    #[serde(rename = "any_heavy_atom")]
+    AnyHeavyAtom,
+    #[serde(rename = "any")]
+    Any,
+}
+
+impl From<AtomCompareJson> for chematic_smarts::AtomCompare {
+    fn from(v: AtomCompareJson) -> Self {
+        match v {
+            AtomCompareJson::Elements => chematic_smarts::AtomCompare::Elements,
+            AtomCompareJson::AnyHeavyAtom => chematic_smarts::AtomCompare::AnyHeavyAtom,
+            AtomCompareJson::Any => chematic_smarts::AtomCompare::Any,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+enum BondCompareJson {
+    #[serde(rename = "order_or_aromatic")]
+    OrderOrAromatic,
+    #[serde(rename = "any")]
+    Any,
+}
+
+impl From<BondCompareJson> for chematic_smarts::BondCompare {
+    fn from(v: BondCompareJson) -> Self {
+        match v {
+            BondCompareJson::OrderOrAromatic => chematic_smarts::BondCompare::OrderOrAromatic,
+            BondCompareJson::Any => chematic_smarts::BondCompare::Any,
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+fn default_min_atoms() -> usize {
+    1
+}
+fn default_atom_compare() -> AtomCompareJson {
+    AtomCompareJson::Elements
+}
+fn default_bond_compare() -> BondCompareJson {
+    BondCompareJson::OrderOrAromatic
+}
+
+/// JSON config for [`mcs_smiles_json_with_config`] -- every field optional,
+/// defaulting to exactly `McsConfig::default()`'s value.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct McsConfigJson {
+    #[serde(default = "default_true")]
+    match_bonds: bool,
+    #[serde(default = "default_min_atoms")]
+    min_atoms: usize,
+    #[serde(default)]
+    timeout_ms: Option<u64>,
+    #[serde(default)]
+    ring_matches_ring_only: bool,
+    #[serde(default)]
+    complete_rings_only: bool,
+    #[serde(default = "default_atom_compare")]
+    atom_compare: AtomCompareJson,
+    #[serde(default = "default_bond_compare")]
+    bond_compare: BondCompareJson,
+    #[serde(default)]
+    match_chiral_tag: bool,
+    #[serde(default)]
+    match_charge: bool,
+    #[serde(default)]
+    match_isotope: bool,
+    #[serde(default = "default_true")]
+    maximize_bonds: bool,
+}
+
+impl McsConfigJson {
+    fn into_mcs_config(self) -> chematic_smarts::McsConfig {
+        chematic_smarts::McsConfig {
+            match_bonds: self.match_bonds,
+            min_atoms: self.min_atoms,
+            timeout_ms: self.timeout_ms,
+            ring_matches_ring_only: self.ring_matches_ring_only,
+            complete_rings_only: self.complete_rings_only,
+            atom_compare: self.atom_compare.into(),
+            bond_compare: self.bond_compare.into(),
+            match_chiral_tag: self.match_chiral_tag,
+            match_charge: self.match_charge,
+            match_isotope: self.match_isotope,
+            maximize_bonds: self.maximize_bonds,
+        }
+    }
+}
 
 /// Parse CXSMILES and return preserved metadata as JSON.
 ///
@@ -435,36 +533,11 @@ pub fn neutralize_charges(mol: &MolHandle) -> MolHandle {
     }
 }
 
-/// Maximum Common Substructure of a set of molecules, returned as a canonical SMILES string.
-///
-/// `smiles_json` — a JSON array of at least 2 SMILES strings.
-/// Returns the MCS SMILES, or `"null"` when no common substructure was found.
-/// Returns a JS error on SMILES parse failure.
-#[wasm_bindgen]
-pub fn mcs_smiles_json(smiles_json: &str) -> Result<String, JsValue> {
-    let smiles_list = parse_smiles_json_array(smiles_json)?;
-    if smiles_list.len() < 2 {
-        return Err(JsValue::from_str(
-            "mcs_smiles_json requires at least 2 SMILES",
-        ));
-    }
-    let mols: Vec<chematic_core::Molecule> = smiles_list
-        .iter()
-        .map(|s| {
-            let mol = chematic_smiles::parse(s).map_err(|e| JsValue::from_str(&e.to_string()))?;
-            enforce_wasm_molecule_size(&mol)?;
-            Ok::<_, JsValue>(mol)
-        })
-        .collect::<Result<_, _>>()?;
-    let mol_refs: Vec<&chematic_core::Molecule> = mols.iter().collect();
-    let qmol = chematic_smarts::find_mcs(&mol_refs);
-
-    if qmol.atoms.is_empty() {
-        return Ok("null".to_string());
-    }
-
-    // Reconstruct a concrete Molecule from the QueryMolecule.
-    // MCS atom queries are AtomicNum primitives; bond queries are typed primitives.
+/// Reconstruct a concrete `Molecule` from a `QueryMolecule` produced by MCS
+/// search (atom queries are always `AtomicNum` primitives; bond queries are
+/// typed primitives) -- shared by every MCS binding below so they can't
+/// silently drift apart on how a query result is turned back into a molecule.
+fn qmol_to_molecule(qmol: &chematic_smarts::QueryMolecule) -> chematic_core::Molecule {
     use chematic_core::{Atom, AtomIdx, BondOrder, Element, MoleculeBuilder};
     use chematic_smarts::{AtomPrimitive, AtomQuery, BondPrimitive, BondQuery};
 
@@ -495,8 +568,44 @@ pub fn mcs_smiles_json(smiles_json: &str) -> Result<String, JsValue> {
             }
         }
     }
-    let mol = builder.build();
-    Ok(chematic_smiles::canonical_smiles(&mol))
+    builder.build()
+}
+
+fn parse_mcs_input(
+    smiles_json: &str,
+    fn_name: &str,
+) -> Result<Vec<chematic_core::Molecule>, JsValue> {
+    let smiles_list = parse_smiles_json_array(smiles_json)?;
+    if smiles_list.len() < 2 {
+        return Err(JsValue::from_str(&format!(
+            "{fn_name} requires at least 2 SMILES"
+        )));
+    }
+    smiles_list
+        .iter()
+        .map(|s| {
+            let mol = chematic_smiles::parse(s).map_err(|e| JsValue::from_str(&e.to_string()))?;
+            enforce_wasm_molecule_size(&mol)?;
+            Ok::<_, JsValue>(mol)
+        })
+        .collect()
+}
+
+/// Maximum Common Substructure of a set of molecules, returned as a canonical SMILES string.
+///
+/// `smiles_json` — a JSON array of at least 2 SMILES strings.
+/// Returns the MCS SMILES, or `"null"` when no common substructure was found.
+/// Returns a JS error on SMILES parse failure.
+#[wasm_bindgen]
+pub fn mcs_smiles_json(smiles_json: &str) -> Result<String, JsValue> {
+    let mols = parse_mcs_input(smiles_json, "mcs_smiles_json")?;
+    let mol_refs: Vec<&chematic_core::Molecule> = mols.iter().collect();
+    let qmol = chematic_smarts::find_mcs(&mol_refs);
+
+    if qmol.atoms.is_empty() {
+        return Ok("null".to_string());
+    }
+    Ok(chematic_smiles::canonical_smiles(&qmol_to_molecule(&qmol)))
 }
 
 /// MCS with ring-awareness constraints.
@@ -511,20 +620,7 @@ pub fn mcs_smiles_json_with_ring_config(
     ring_matches_ring_only: bool,
     complete_rings_only: bool,
 ) -> Result<String, JsValue> {
-    let smiles_list = parse_smiles_json_array(smiles_json)?;
-    if smiles_list.len() < 2 {
-        return Err(JsValue::from_str(
-            "mcs_smiles_json_with_ring_config requires at least 2 SMILES",
-        ));
-    }
-    let mols: Vec<chematic_core::Molecule> = smiles_list
-        .iter()
-        .map(|s| {
-            let mol = chematic_smiles::parse(s).map_err(|e| JsValue::from_str(&e.to_string()))?;
-            enforce_wasm_molecule_size(&mol)?;
-            Ok::<_, JsValue>(mol)
-        })
-        .collect::<Result<_, _>>()?;
+    let mols = parse_mcs_input(smiles_json, "mcs_smiles_json_with_ring_config")?;
     let mol_refs: Vec<&chematic_core::Molecule> = mols.iter().collect();
     let config = chematic_smarts::McsConfig {
         ring_matches_ring_only,
@@ -536,39 +632,50 @@ pub fn mcs_smiles_json_with_ring_config(
     if qmol.atoms.is_empty() {
         return Ok("null".to_string());
     }
+    Ok(chematic_smiles::canonical_smiles(&qmol_to_molecule(&qmol)))
+}
 
-    use chematic_core::{Atom, AtomIdx, BondOrder, Element, MoleculeBuilder};
-    use chematic_smarts::{AtomPrimitive, AtomQuery, BondPrimitive, BondQuery};
+/// Full `McsConfig` + `McsOutcome`-aware MCS search.
+///
+/// `smiles_json` — JSON array of at least 2 SMILES strings.
+/// `config_json` — a JSON object with any subset of `McsConfig`'s fields
+/// (camelCase keys, all optional, defaulting to `McsConfig::default()`):
+/// `matchBonds`, `minAtoms`, `timeoutMs`, `ringMatchesRingOnly`,
+/// `completeRingsOnly`, `atomCompare` (`"elements"` | `"any_heavy_atom"` |
+/// `"any"`), `bondCompare` (`"order_or_aromatic"` | `"any"`),
+/// `matchChiralTag`, `matchCharge`, `matchIsotope`, `maximizeBonds`.
+///
+/// Returns a JSON object `{"smiles": string|null, "wasTimedOut": bool}` --
+/// `smiles` is `null` when there is no common substructure; `wasTimedOut` is
+/// `true` if `timeoutMs` was reached before the search finished exhaustively
+/// (the returned `smiles`, if any, is then the best result found so far, not
+/// proven optimal).
+#[wasm_bindgen]
+pub fn mcs_smiles_json_with_config(
+    smiles_json: &str,
+    config_json: &str,
+) -> Result<String, JsValue> {
+    let mols = parse_mcs_input(smiles_json, "mcs_smiles_json_with_config")?;
+    let config: McsConfigJson =
+        serde_json::from_str(config_json).map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let config = config.into_mcs_config();
 
-    let mut builder = MoleculeBuilder::new();
-    for qa in &qmol.atoms {
-        let elem = match &qa.query {
-            AtomQuery::Primitive(AtomPrimitive::AtomicNum(n)) => {
-                Element::from_atomic_number(*n).unwrap_or(Element::C)
-            }
-            _ => Element::C,
-        };
-        builder.add_atom(Atom::new(elem));
-    }
-    for (atom_idx, neighbors) in qmol.adj.iter().enumerate() {
-        for (bond_idx, neighbor_idx) in neighbors {
-            if atom_idx < *neighbor_idx {
-                let order = match &qmol.bonds[*bond_idx].query {
-                    BondQuery::Primitive(BondPrimitive::Double) => BondOrder::Double,
-                    BondQuery::Primitive(BondPrimitive::Triple) => BondOrder::Triple,
-                    BondQuery::Primitive(BondPrimitive::Aromatic) => BondOrder::Aromatic,
-                    _ => BondOrder::Single,
-                };
-                let _ = builder.add_bond(
-                    AtomIdx(atom_idx as u32),
-                    AtomIdx(*neighbor_idx as u32),
-                    order,
-                );
-            }
-        }
-    }
-    let mol = builder.build();
-    Ok(chematic_smiles::canonical_smiles(&mol))
+    let mol_refs: Vec<&chematic_core::Molecule> = mols.iter().collect();
+    let outcome = chematic_smarts::find_mcs_with_config_checked(&mol_refs, &config);
+    let was_timed_out = outcome.was_timed_out();
+    let qmol = outcome.into_query();
+
+    let smiles_json_value = if qmol.atoms.is_empty() {
+        "null".to_string()
+    } else {
+        format!(
+            "\"{}\"",
+            escape_json_string(&chematic_smiles::canonical_smiles(&qmol_to_molecule(&qmol)))
+        )
+    };
+    Ok(format!(
+        r#"{{"smiles":{smiles_json_value},"wasTimedOut":{was_timed_out}}}"#
+    ))
 }
 
 /// Find matched molecular pairs in a set of molecules as JSON.
@@ -1119,3 +1226,84 @@ pub fn invert_stereocenter_at(mol: &MolHandle, atom_idx: u32) -> Result<MolHandl
 // ---------------------------------------------------------------------------
 // mol_transforms (3D geometry manipulation)
 // ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod mcs_config_tests {
+    use super::*;
+
+    #[test]
+    fn default_config_matches_bare_mcs_smiles_json() {
+        let smiles = r#"["CC(=O)Oc1ccccc1C(=O)O","CC(=O)Nc1ccc(O)cc1"]"#;
+        let full = mcs_smiles_json_with_config(smiles, "{}").unwrap();
+        let bare = mcs_smiles_json(smiles).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&full).unwrap();
+        assert_eq!(value["smiles"], serde_json::Value::String(bare));
+        assert_eq!(value["wasTimedOut"], false);
+    }
+
+    #[test]
+    fn no_common_substructure_returns_null_smiles() {
+        // Two disconnected, chemically unrelated single-heavy-atom molecules.
+        let smiles = r#"["[He]","[Ne]"]"#;
+        let result = mcs_smiles_json_with_config(smiles, "{}").unwrap();
+        let value: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(value["smiles"], serde_json::Value::Null);
+        assert_eq!(value["wasTimedOut"], false);
+    }
+
+    #[test]
+    fn match_charge_true_prevents_charged_neutral_match() {
+        // Acetate vs acetic acid: MCS with match_charge=false matches the
+        // full 4-heavy-atom core; match_charge=true must reject the
+        // charge-differing carboxylate oxygen, shrinking the MCS.
+        let smiles = r#"["CC(=O)[O-]","CC(=O)O"]"#;
+        let without = mcs_smiles_json_with_config(smiles, r#"{"matchCharge":false}"#).unwrap();
+        let with = mcs_smiles_json_with_config(smiles, r#"{"matchCharge":true}"#).unwrap();
+        assert_ne!(
+            without, with,
+            "match_charge=true must change the MCS result"
+        );
+    }
+
+    #[test]
+    fn atom_compare_any_heavy_atom_widens_match() {
+        // Benzene vs pyridine: default (element-exact) MCS excludes the N
+        // position; any_heavy_atom compare should include it (6-atom ring).
+        let smiles = r#"["c1ccccc1","c1ccncc1"]"#;
+        let elements =
+            mcs_smiles_json_with_config(smiles, r#"{"atomCompare":"elements"}"#).unwrap();
+        let any_heavy =
+            mcs_smiles_json_with_config(smiles, r#"{"atomCompare":"any_heavy_atom"}"#).unwrap();
+        assert_ne!(
+            elements, any_heavy,
+            "any_heavy_atom compare must change the MCS result vs elements"
+        );
+    }
+
+    #[test]
+    fn timeout_zero_is_reported_as_timed_out() {
+        let smiles = r#"["CC(=O)Oc1ccccc1C(=O)O","CC(=O)Nc1ccc(O)cc1"]"#;
+        let result = mcs_smiles_json_with_config(smiles, r#"{"timeoutMs":0}"#).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(value["wasTimedOut"], true);
+    }
+
+    // Error paths that surface as a real thrown `JsValue` are only safely
+    // constructible on the wasm32 target (constructing a `JsValue` natively
+    // aborts the process, per wasm-bindgen's own design) -- covered instead
+    // by `tests/mcs.test.mjs`, run under the actual wasm runtime via CI's
+    // `Test (WASM)` job. What's safe and worth testing natively here is the
+    // pure-serde config-parsing layer, which never touches `JsValue`.
+
+    #[test]
+    fn invalid_atom_compare_string_rejected_at_parse_time() {
+        let err = serde_json::from_str::<McsConfigJson>(r#"{"atomCompare":"bogus"}"#).unwrap_err();
+        assert!(err.to_string().contains("atomCompare") || err.to_string().contains("unknown"));
+    }
+
+    #[test]
+    fn unknown_config_field_rejected_at_parse_time() {
+        let err = serde_json::from_str::<McsConfigJson>(r#"{"notAField":true}"#).unwrap_err();
+        assert!(err.to_string().contains("notAField") || err.to_string().contains("unknown"));
+    }
+}

--- a/crates/chematic-wasm/tests/mcs.test.mjs
+++ b/crates/chematic-wasm/tests/mcs.test.mjs
@@ -1,0 +1,92 @@
+// Tests for mcs_smiles_json_with_config (Track A/99-point directive Phase 3):
+// full McsConfig + McsOutcome exposed to WASM, mirroring the Rust
+// chematic_smarts::find_mcs_with_config_checked API and the Python
+// find_mcs_checked() binding's (mol, was_timed_out) shape.
+//
+// Run manually after building the Node target:
+//
+//   wasm-pack build crates/chematic-wasm --target nodejs --out-dir pkg-node --release
+//   node crates/chematic-wasm/tests/mcs.test.mjs
+
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..", "..", "..");
+
+const wasm = await import(path.join(repoRoot, "crates/chematic-wasm/pkg-node/chematic_wasm.js"));
+const { mcs_smiles_json, mcs_smiles_json_with_config } = wasm;
+
+// Default config (`{}`) matches the bare mcs_smiles_json's own default.
+// (mcs_smiles_json returns a plain SMILES string, or the literal string
+// "null" -- not JSON -- so it's compared directly, not JSON.parse'd.)
+{
+  const smiles = JSON.stringify(["CC(=O)Oc1ccccc1C(=O)O", "CC(=O)Nc1ccc(O)cc1"]);
+  const full = JSON.parse(mcs_smiles_json_with_config(smiles, "{}"));
+  const bare = mcs_smiles_json(smiles);
+  assert.equal(full.smiles, bare);
+  assert.equal(full.wasTimedOut, false);
+}
+
+// No common substructure -> smiles: null, not an error.
+{
+  const smiles = JSON.stringify(["[He]", "[Ne]"]);
+  const result = JSON.parse(mcs_smiles_json_with_config(smiles, "{}"));
+  assert.equal(result.smiles, null);
+  assert.equal(result.wasTimedOut, false);
+}
+
+// matchCharge:true changes the result vs the false default.
+{
+  const smiles = JSON.stringify(["CC(=O)[O-]", "CC(=O)O"]);
+  const without = mcs_smiles_json_with_config(smiles, JSON.stringify({ matchCharge: false }));
+  const withCharge = mcs_smiles_json_with_config(smiles, JSON.stringify({ matchCharge: true }));
+  assert.notEqual(without, withCharge, "matchCharge:true must change the MCS result");
+}
+
+// atomCompare:"any_heavy_atom" widens the match vs the "elements" default.
+{
+  const smiles = JSON.stringify(["c1ccccc1", "c1ccncc1"]);
+  const elements = mcs_smiles_json_with_config(smiles, JSON.stringify({ atomCompare: "elements" }));
+  const anyHeavy = mcs_smiles_json_with_config(
+    smiles,
+    JSON.stringify({ atomCompare: "any_heavy_atom" })
+  );
+  assert.notEqual(elements, anyHeavy, "any_heavy_atom compare must change the MCS result");
+}
+
+// timeoutMs:0 is reported as timed out.
+{
+  const smiles = JSON.stringify(["CC(=O)Oc1ccccc1C(=O)O", "CC(=O)Nc1ccc(O)cc1"]);
+  const result = JSON.parse(mcs_smiles_json_with_config(smiles, JSON.stringify({ timeoutMs: 0 })));
+  assert.equal(result.wasTimedOut, true);
+}
+
+// Invalid atomCompare string is a real thrown error, not a silent default.
+{
+  const smiles = JSON.stringify(["CCO", "CCO"]);
+  assert.throws(
+    () => mcs_smiles_json_with_config(smiles, JSON.stringify({ atomCompare: "bogus" })),
+    "invalid atomCompare must throw"
+  );
+}
+
+// Unknown config field is rejected (deny_unknown_fields), not silently ignored.
+{
+  const smiles = JSON.stringify(["CCO", "CCO"]);
+  assert.throws(
+    () => mcs_smiles_json_with_config(smiles, JSON.stringify({ notAField: true })),
+    "unknown config field must throw"
+  );
+}
+
+// Fewer than 2 SMILES is rejected.
+{
+  assert.throws(
+    () => mcs_smiles_json_with_config(JSON.stringify(["CCO"]), "{}"),
+    "fewer than 2 SMILES must throw"
+  );
+}
+
+console.log("mcs.test.mjs: all assertions passed");


### PR DESCRIPTION
Track A / 99-point directive Phase 3: MCS full `McsConfig`/`McsOutcome` → Python/WASM.

**Before**: Python's `find_mcs` exposed only 2 of `McsConfig`'s 11 fields
(`ring_matches_ring_only`/`complete_rings_only`); WASM's two `mcs_smiles_json*`
functions exposed the same 2 fields (one didn't even take config at all).
Neither binding could reach `match_bonds`, `min_atoms`, `timeout_ms`,
`atom_compare`, `bond_compare`, `match_chiral_tag`, `match_charge`,
`match_isotope`, `maximize_bonds` -- and neither could tell
`McsOutcome::Exhaustive` apart from `TimedOut` (always silently discarded via
`find_mcs_with_config`, never the `_checked` variant).

**Python**: `find_mcs` extended to take all 11 `McsConfig` fields as keyword
arguments -- fully backward-compatible, every new argument defaults to
`McsConfig::default()`'s own value. New `find_mcs_checked` mirrors the Rust
`_checked` naming split, returns `(mcs, was_timed_out)`.

**WASM**: new `mcs_smiles_json_with_config(smiles_json, config_json)` takes a
camelCase JSON config (every field optional, `deny_unknown_fields`, mirrors
`pipeline_v2.rs`'s established conventions) and returns
`{"smiles": string|null, "wasTimedOut": bool}`. The two pre-existing bare
functions keep their exact signatures/behavior, refactored to share one
`QueryMolecule`-to-`Molecule` reconstruction helper (was duplicated 2-3x).

## Test plan
- [x] 7 native Rust tests (`chematic-wasm`, pure config-parsing + success paths)
- [x] 8 real wasm-runtime tests via `wasm-pack build --target nodejs` + `node tests/mcs.test.mjs`
      (`JsValue`-throwing error paths can only be safely tested here -- confirmed empirically
      that constructing a `JsValue` from a native `cargo test` aborts the process)
- [x] 8 new pytest cases + the full existing 769-test pytest suite green
- [x] Full existing 9-file Node integration suite green (no regressions from the shared-helper refactor)
- [x] `cargo fmt --all -- --check` / `cargo clippy -p chematic-wasm -p chematic-py --all-targets -- -D warnings` clean
- [x] `cargo check --workspace --exclude chematic-py --exclude chematic-wasm` clean