### PR TITLE
feat(fp,py): add rdkit_torsion_fp, RDKit-compatible Topological Torsion fingerprint (Track A Phase 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `chematic-fp`/`chematic-py` (`rdkit_torsion_fp`, RDKit-compatible Topological Torsion fingerprint)
+
+- New `chematic_fp::rdkit_torsion_fp` (Rust) / `Mol.rdkit_torsion_fp()` (Python): a
+  from-scratch Rust port of RDKit's
+  `GetHashedTopologicalTorsionFingerprintAsBitVect`, opt-in and fully separate from
+  the existing native `torsion_fp` (neither affects the other). First entry in the
+  fingerprint-parity series (Track A / 99-point directive Phase 6) — the closest of
+  six priority fingerprints measured against RDKit, chosen to establish the pattern.
+- Measured 87.2% bit-exact on a 1000-molecule general corpus sample against a live
+  RDKit oracle, up from 0% at the start of this round. Three real bugs found and
+  fixed along the way, each verified against the oracle: a missing `-2`
+  "topological torsion correction" on atom invariants, double-counted torsion paths
+  inflating RDKit's "count simulation" threshold bits, and missing 3-membered-ring
+  closure entries (a triangle's own closing bond forms an additional torsion that a
+  plain 4-distinct-atom path search can't find).
+- Two known, documented residuals remain (see `chematic_fp::rdkit_torsion`'s module
+  doc comment): RDKit's hybridization-gated pi-electron count for hypervalent atoms
+  (e.g. phosphorus/sulfur) isn't replicated, and asymmetrically-substituted
+  3-membered rings can need more than the one closure entry generated here.
+
 ### Added — `chematic-py`/`chematic-wasm` (full `McsConfig`/`McsOutcome` exposed to MCS bindings)
 
 - Python's `find_mcs` previously exposed only 2 of `McsConfig`'s 11 fields

--- a/crates/chematic-fp/src/lib.rs
+++ b/crates/chematic-fp/src/lib.rs
@@ -38,6 +38,7 @@ mod rdkit_isotope_delta_table;
 mod rdkit_morgan_config;
 mod rdkit_morgan_ecfp4;
 mod rdkit_morgan_hash;
+pub mod rdkit_torsion;
 pub mod reaction_fp;
 pub mod search;
 pub mod topo_path;
@@ -53,6 +54,7 @@ pub use ecfp::{
     ecfp6, ecfp6_rdkit_environment_experimental, ecfp6_rdkit_invariants, morgan_fp_counts,
     tanimoto_ecfp4,
 };
+pub use rdkit_torsion::rdkit_torsion_fp;
 /// Diagnostic-only APIs, not meant for production use — a per-`(atom,
 /// radius)` trace of chematic's real Morgan expansion, for the RDKit
 /// environment-parity oracle (see `scripts/ecfp_rdkit_environment_parity.py`),

--- a/crates/chematic-fp/src/rdkit_morgan_hash.rs
+++ b/crates/chematic-fp/src/rdkit_morgan_hash.rs
@@ -91,7 +91,7 @@ use crate::morgan_environment::BondSet;
 /// arithmetic, not UB) — `wrapping_add` is required, not cosmetic: plain `+`
 /// panics in a Rust debug build on the frequent overflow this formula
 /// produces.
-fn hash_combine(seed: u32, value: u32) -> u32 {
+pub(crate) fn hash_combine(seed: u32, value: u32) -> u32 {
     seed ^ value
         .wrapping_add(0x9e37_79b9)
         .wrapping_add(seed << 6)
@@ -113,7 +113,7 @@ fn hash_pair(a: u32, b: u32) -> u32 {
 /// invariant, whose component count is *not* fixed (see
 /// [`connectivity_invariant`]) — a shorter or longer vector changes the
 /// number of `hash_combine` calls, not just one component's value.
-fn hash_vec(values: &[u32]) -> u32 {
+pub(crate) fn hash_vec(values: &[u32]) -> u32 {
     values.iter().fold(0u32, |seed, &v| hash_combine(seed, v))
 }
 

--- a/crates/chematic-fp/src/rdkit_torsion.rs
+++ b/crates/chematic-fp/src/rdkit_torsion.rs
@@ -1,0 +1,480 @@
+//! RDKit-bit-exact Topological Torsion fingerprint (`GetHashedTopologicalTorsionFingerprintAsBitVect`).
+//!
+//! Opt-in `RdkitExact`-mode addition, kept fully separate from [`crate::atom_pair::torsion_fp`]
+//! (chematic's own native, similarity-preserving-but-not-RDKit-identical scheme) --
+//! neither function changes the other's behavior. First of the fingerprint-parity
+//! series (Track A / 99-point directive Phase 6): Topological Torsion measured
+//! closest to RDKit of the six priority fingerprints (avg. Hamming distance ~66/2048
+//! on a 100-molecule sample, vs. 300-600+ for the other five), so it's the pattern
+//! this module establishes for the rest.
+//!
+//! Derived from RDKit's C++ source (`Code/GraphMol/Fingerprints/FingerprintUtil.cpp`,
+//! `AtomPairs.cpp`, `TopologicalTorsionGenerator.cpp`, `Atom.cpp`), commit pinned at
+//! research time against `master` (RDKit 2026.03 series, matching this repo's
+//! currently-installed `rdkit` package). Every constant/formula below is a direct
+//! port, not a reinterpretation -- see each function's doc comment for the exact
+//! C++ source it mirrors.
+//!
+//! **Status**: 87.2% bit-exact on a 1000-molecule general corpus sample
+//! (`scripts/descriptor_census_corpus.smi`), verified against a live RDKit
+//! oracle (`rdkit.Chem.AllChem.GetHashedTopologicalTorsionFingerprintAsBitVect`).
+//! Two known, documented residual sources account for essentially all
+//! remaining misses -- see [`num_pi_electrons`]'s doc comment (RDKit's
+//! hybridization-gated pi-electron count for hypervalent atoms, e.g. P/S,
+//! not replicated) and [`triangle_closure_paths`]'s doc comment
+//! (asymmetrically-substituted 3-membered rings can need more than the one
+//! closure entry this module generates). Three real bugs were found and
+//! fixed reaching this point (0% -> 87.2%), each verified against the live
+//! oracle before moving to the next: a missing `-2` "topological torsion
+//! correction" on atom invariants, double-counted torsion paths inflating
+//! count-simulation thresholds, and missing 3-membered-ring closure
+//! entries entirely.
+
+use chematic_core::{AtomIdx, BondOrder, Molecule};
+
+use crate::bitvec::BitVec2048;
+use crate::rdkit_morgan_hash::hash_vec;
+
+// ---------------------------------------------------------------------------
+// AtomPairs.h / FingerprintUtil.cpp constants
+// ---------------------------------------------------------------------------
+
+const NUM_TYPE_BITS: u32 = 4;
+/// `AtomPairs::atomNumberTypes` -- a fixed, sorted 15-entry lookup table (16
+/// slots, index 15 also serves as the "everything else" bucket). Atomic
+/// numbers not in this list collapse to whichever bucket they'd sort into
+/// (see [`atom_type_index`]) -- faithfully replicated, including the
+/// surprising case where an atomic number below 5 (e.g. H, He) or above 53
+/// (e.g. most metals) both collapse toward the boundary buckets, not a
+/// dedicated "other" code.
+const ATOM_NUMBER_TYPES: [u8; 15] = [5, 6, 7, 8, 9, 14, 15, 16, 17, 33, 34, 35, 51, 52, 53];
+const NUM_PI_BITS: u32 = 2;
+const MAX_NUM_PI: u32 = (1 << NUM_PI_BITS) - 1;
+const NUM_BRANCH_BITS: u32 = 3;
+const MAX_NUM_BRANCHES: u32 = (1 << NUM_BRANCH_BITS) - 1;
+const CODE_SIZE: u32 = NUM_TYPE_BITS + NUM_PI_BITS + NUM_BRANCH_BITS;
+
+/// Count-simulation thresholds (`AtomPairs.cpp`'s `bounds[4] = {1, 2, 4, 8}`),
+/// used only when `nBitsPerEntry == 4` (the default, and the only mode this
+/// module implements).
+const COUNT_BOUNDS: [u32; 4] = [1, 2, 4, 8];
+const N_BITS_PER_ENTRY: usize = 4;
+
+/// `Atom.cpp`'s `numPiElectrons`: `1` for any aromatic atom (regardless of
+/// stored bond orders); otherwise the sum, over every real (non-dative,
+/// non-zero-order) bond, of `(bond_order_as_integer - 1)` -- i.e. 0 per
+/// single bond, 1 per double, 2 per triple, 3 per quadruple. Dative and
+/// zero-order bonds are excluded entirely (RDKit's `getValenceContrib(&atom)
+/// != 0.0` guard), not merely counted as order-1.
+///
+/// **Known residual, NOT implemented here**: the real C++ function's
+/// non-aromatic branch is additionally gated on `atom.getHybridization() !=
+/// Atom::SP3` -- for an atom RDKit's hybridization-perception classifies as
+/// SP3 despite carrying a formal double bond (confirmed via a live RDKit
+/// oracle: a phosphinic-acid `P` atom in `[PH](=O)O`, `GetHybridization()
+/// == SP3`, `GetNumPiElectrons() == 0` even though it has a `P=O` bond),
+/// the real function returns 0 unconditionally, skipping the bond-order sum
+/// entirely. This function has no hybridization gate at all, so it always
+/// takes the bond-order-sum path once an atom has any multiple bond,
+/// disagreeing with RDKit specifically for atoms RDKit perceives as SP3
+/// under formal-multiple-bond bookkeeping (observed for hypervalent P/S;
+/// not yet characterized exhaustively). Replicating this exactly requires
+/// porting RDKit's own hybridization-perception algorithm -- chematic's
+/// existing `chematic_chem::hybridization_per_atom` was checked and does
+/// NOT match RDKit for this same case (reports SP2, not SP3), so it isn't a
+/// drop-in fix either. Confirmed to be the dominant remaining source of
+/// non-bit-exact output after the 3-membered-ring fix
+/// ([`triangle_closure_paths`]) landed -- measured 87.2% bit-exact on a
+/// 1000-molecule general corpus sample, with essentially all remaining
+/// misses attributable to this gap or to asymmetrically-substituted
+/// 3-membered rings (see that function's own doc comment).
+fn num_pi_electrons(mol: &Molecule, idx: AtomIdx) -> u32 {
+    let atom = mol.atom(idx);
+    if atom.aromatic {
+        return 1;
+    }
+    let mut total: i32 = 0;
+    for (_, bidx) in mol.neighbors(idx) {
+        let contribution = match mol.bond(bidx).order {
+            BondOrder::Single | BondOrder::Up | BondOrder::Down | BondOrder::QueryAny => 1,
+            BondOrder::Double => 2,
+            BondOrder::Triple => 3,
+            BondOrder::Quadruple => 4,
+            BondOrder::Aromatic => 1,
+            // Query bond orders never occur on a concrete (non-SMARTS) Molecule,
+            // which is all this function is ever called on -- treated the same
+            // as QueryAny for exhaustiveness, never actually reached.
+            BondOrder::QuerySingleOrDouble
+            | BondOrder::QuerySingleOrAromatic
+            | BondOrder::QueryDoubleOrAromatic => 1,
+            BondOrder::Zero | BondOrder::Dative => continue,
+        };
+        total += contribution - 1;
+    }
+    total.max(0) as u32
+}
+
+/// `AtomPairs::getAtomCode`: packs `[type:4][pi:2][branch:3]` (LSB-first) into
+/// one `u32`, `branchSubtract` reducing the raw degree before the branch
+/// field is computed (clamped to 0, never underflows). `includeChirality` is
+/// not implemented here (this module targets `includeChirality=False`, the
+/// default `GetHashedTopologicalTorsionFingerprintAsBitVect` call and this
+/// crate's `mol.torsion_fp()`-equivalent scope) -- callers must not pass
+/// `true`.
+fn atom_code(mol: &Molecule, idx: AtomIdx, branch_subtract: u32) -> u32 {
+    let atom = mol.atom(idx);
+    let degree = mol.degree(idx) as u32;
+    let num_branches = degree.saturating_sub(branch_subtract);
+    let mut code = num_branches % MAX_NUM_BRANCHES;
+
+    let n_pi = num_pi_electrons(mol, idx) % MAX_NUM_PI;
+    code |= n_pi << NUM_BRANCH_BITS;
+
+    let type_idx = atom_type_index(atom.element.atomic_number());
+    code |= type_idx << (NUM_BRANCH_BITS + NUM_PI_BITS);
+
+    code
+}
+
+/// Linear scan matching `getAtomCode`'s lookup loop exactly. The C++ array is
+/// declared `atomNumberTypes[1 << numTypeBits]` (16 slots) but only 15 are
+/// explicitly initialized -- the 16th (index 15) is implicitly zero, and the
+/// loop bound is `nTypes = 1 << numTypeBits = 16`, not the initializer
+/// list's length. First exact match wins; the first table entry *greater*
+/// than `atomic_num` clamps `typeIdx` to `nTypes` then backs up to `nTypes -
+/// 1 = 15` (the phantom zero slot, NOT index 14) -- same clamp target if the
+/// scan runs off the end without a match. A literal port of the C++
+/// early-break/clamp logic, phantom slot included.
+fn atom_type_index(atomic_num: u8) -> u32 {
+    const N_TYPES: usize = 1 << NUM_TYPE_BITS as usize;
+    let table = |i: usize| -> u8 { ATOM_NUMBER_TYPES.get(i).copied().unwrap_or(0) };
+    let mut type_idx = 0usize;
+    while type_idx < N_TYPES {
+        if table(type_idx) == atomic_num {
+            break;
+        } else if table(type_idx) > atomic_num {
+            type_idx = N_TYPES;
+            break;
+        }
+        type_idx += 1;
+    }
+    if type_idx == N_TYPES {
+        type_idx -= 1;
+    }
+    type_idx as u32
+}
+
+// ---------------------------------------------------------------------------
+// Torsion path enumeration + hashing
+// ---------------------------------------------------------------------------
+
+/// Every simple (no repeated atom) path of exactly 4 atoms in the molecular
+/// graph, as `[a, b, c, d]` -- `findAllPathsOfLengthN(mol, 4, useBonds=false)`.
+/// `findAllPathsOfLengthN` returns each undirected path once, not once per
+/// direction (a path and its reverse walk are the same physical torsion) --
+/// deduplicated here by keeping only the `a.0 < d.0` orientation of each
+/// pair, matching that count exactly (confirmed empirically: without this,
+/// every torsion's count-simulation bucket count was inflated 2x, setting
+/// spurious extra threshold bits -- see this module's own investigation
+/// notes / git history for the methyl-serinate repro that caught it).
+fn four_atom_paths(mol: &Molecule) -> Vec<[AtomIdx; 4]> {
+    let n = mol.atom_count();
+    let mut paths = Vec::new();
+    for start in 0..n {
+        let a = AtomIdx(start as u32);
+        for (b, _) in mol.neighbors(a) {
+            for (c, _) in mol.neighbors(b) {
+                if c == a {
+                    continue;
+                }
+                for (d, _) in mol.neighbors(c) {
+                    if d == a || d == b || d.0 <= a.0 {
+                        continue;
+                    }
+                    paths.push([a, b, c, d]);
+                }
+            }
+        }
+    }
+    paths
+}
+
+/// A 3-membered ring's own closure bond makes the ring itself walkable as a
+/// 4-*position* torsion (`[a, b, c, a]`, revisiting `a`) using all 3 ring
+/// bonds -- not found by [`four_atom_paths`] (which requires 4 *distinct*
+/// atoms). Confirmed empirically against RDKit's own `SparseIntVect` output
+/// (`rdFingerprintGenerator.GetTopologicalTorsionGenerator().GetCountFingerprint`):
+/// a bare `C1CC1` (no substituent at all, only 3 heavy atoms -- no ordinary
+/// 4-atom path can even exist) still yields exactly one nonzero torsion
+/// entry, which can only come from this closed walk.
+///
+/// One entry per triangle, canonically starting from its lowest-`AtomIdx`
+/// member (found once, when iterating that member as `a`, by requiring
+/// `b.0 > a.0` and `c.0 > b.0`) -- [`torsion_hash`]'s own forward/reverse
+/// canonicalization handles the rest. This matches RDKit's observed output
+/// for a symmetric ring exactly; an *asymmetric* ring bearing different
+/// substituents on two or more ring atoms can add further closed-walk
+/// entries beyond this one (RDKit was observed emitting two for a
+/// 1,2-disubstituted cyclopropane) -- the exact rule for those additional
+/// entries is not yet reverse-engineered, so they are not generated here.
+/// This is a known, narrower residual: still not full bit-exact parity for
+/// molecules with an *asymmetrically substituted* 3-membered ring.
+fn triangle_closure_paths(mol: &Molecule) -> Vec<[AtomIdx; 4]> {
+    let n = mol.atom_count();
+    let mut paths = Vec::new();
+    for start in 0..n {
+        let a = AtomIdx(start as u32);
+        for (b, _) in mol.neighbors(a) {
+            if b.0 <= a.0 {
+                continue;
+            }
+            for (c, _) in mol.neighbors(a) {
+                if c.0 <= b.0 {
+                    continue;
+                }
+                if mol.bond_between(b, c).is_some() {
+                    paths.push([a, b, c, a]);
+                }
+            }
+        }
+    }
+    paths
+}
+
+/// `getTopologicalTorsionHash`: builds each path position's code via
+/// `invariant % (2^codeSize - 1) + 1`, then subtracts 1 more for the two
+/// *interior* positions (index 1 and 2) -- the two *endpoint* positions
+/// (index 0 and 3) keep the un-decremented value. Canonicalizes direction by
+/// comparing the path's code sequence against its own reverse (mirroring
+/// from both ends inward) and reading from whichever end yields the
+/// lexicographically smaller sequence, then folds via [`hash_vec`] (the same
+/// `gboost::hash_combine` sequential fold already verified for Morgan/ECFP4).
+fn torsion_hash(atom_invariants: &[u32], path: &[AtomIdx; 4]) -> u32 {
+    let modulus = (1u32 << CODE_SIZE) - 1;
+    let mut path_codes: Vec<u32> = path
+        .iter()
+        .enumerate()
+        .map(|(pos, &a)| {
+            let mut code = atom_invariants[a.0 as usize] % modulus + 1;
+            if pos != 0 && pos != path.len() - 1 {
+                code -= 1;
+            }
+            code
+        })
+        .collect();
+
+    let mut reverse_it = false;
+    let (mut i, mut j) = (0usize, path_codes.len() - 1);
+    while i < j {
+        if path_codes[i] > path_codes[j] {
+            reverse_it = true;
+            break;
+        } else if path_codes[i] < path_codes[j] {
+            break;
+        }
+        i += 1;
+        j -= 1;
+    }
+    if reverse_it {
+        path_codes.reverse();
+    }
+    hash_vec(&path_codes)
+}
+
+/// RDKit-bit-exact Topological Torsion fingerprint, matching
+/// `rdkit.Chem.AllChem.GetHashedTopologicalTorsionFingerprintAsBitVect(mol,
+/// nBits=2048)` (`includeChirality=False`, `nBitsPerEntry=4`, the Python
+/// API's own defaults) exactly. `torsionAtomCount` is fixed at 4 (RDKit's
+/// own default); `includeChirality` is not supported (see [`atom_code`]).
+///
+/// Every torsion path (both [`four_atom_paths`]'s ordinary 4-distinct-atom
+/// walks and [`triangle_closure_paths`]'s 3-membered-ring closures) folds
+/// (via [`torsion_hash`]) into one of 512 buckets (`2048 / 4`); each
+/// bucket's *count* of paths landing there is then expanded into 4
+/// threshold bits (`count >= 1, 2, 4, 8`) -- RDKit's "count simulation"
+/// scheme, not a plain one-bit-per-feature encoding. This is why chematic's
+/// own native [`crate::atom_pair::torsion_fp`] (a different, non-RDKit
+/// scheme) and this function produce structurally different bit patterns
+/// even before considering the atom-code/hashing differences.
+///
+/// Known residual (not yet bit-exact): an *asymmetrically substituted*
+/// 3-membered ring can require more than one closure entry per ring (see
+/// [`triangle_closure_paths`]'s doc comment) -- measured at ~87% bit-exact
+/// on a 200-molecule general corpus sample, with essentially all remaining
+/// misses confined to this one narrow structural class.
+pub fn rdkit_torsion_fp(mol: &Molecule) -> BitVec2048 {
+    let n = mol.atom_count();
+    // `AtomPairAtomInvGenerator::getAtomInvariants()`'s
+    // `topologicalTorsionCorrection`: every atom invariant used for torsion
+    // hashing is `getAtomCode(atom, 0, includeChirality) - 2` -- a raw
+    // `uint32_t` subtraction (wraps on underflow when the code is 0 or 1,
+    // matching C++'s well-defined unsigned modular arithmetic; `%
+    // (2^codeSize-1) + 1` in `torsion_hash` washes the wraparound back into
+    // range, but the wraparound itself must happen first to get the same
+    // washed-out value RDKit does).
+    let atom_invariants: Vec<u32> = (0..n)
+        .map(|i| atom_code(mol, AtomIdx(i as u32), 0).wrapping_sub(2))
+        .collect();
+
+    const BLOCK_LENGTH: u32 = 2048 / N_BITS_PER_ENTRY as u32;
+    let mut counts = vec![0u32; BLOCK_LENGTH as usize];
+    for path in four_atom_paths(mol)
+        .into_iter()
+        .chain(triangle_closure_paths(mol))
+    {
+        let h = torsion_hash(&atom_invariants, &path);
+        let bucket = (h % BLOCK_LENGTH) as usize;
+        counts[bucket] = counts[bucket].saturating_add(1);
+    }
+
+    let mut fp = BitVec2048::new();
+    for (bucket, &count) in counts.iter().enumerate() {
+        for (i, &bound) in COUNT_BOUNDS.iter().enumerate() {
+            if count >= bound {
+                fp.set(bucket * N_BITS_PER_ENTRY + i);
+            }
+        }
+    }
+    fp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chematic_smiles::parse;
+
+    fn mol(s: &str) -> Molecule {
+        parse(s).unwrap_or_else(|e| panic!("parse '{s}': {e}"))
+    }
+
+    #[test]
+    fn atom_type_index_exact_match() {
+        assert_eq!(atom_type_index(6), 1); // carbon, 2nd entry
+        assert_eq!(atom_type_index(5), 0); // boron, 1st entry
+        assert_eq!(atom_type_index(53), 14); // iodine, last entry
+    }
+
+    #[test]
+    fn atom_type_index_below_table_clamps_to_phantom_slot() {
+        // H (1) is smaller than every table entry -> clamps to the phantom
+        // 16th slot (index 15), matching the C++ array's implicit
+        // zero-initialized 16th element and nTypes=1<<numTypeBits=16 bound.
+        assert_eq!(atom_type_index(1), 15);
+    }
+
+    #[test]
+    fn atom_type_index_between_entries_clamps_to_phantom_slot_too() {
+        // 10 (Ne) falls between 9 and 14 in the table -- NOT "nearest below":
+        // any non-exact match clamps to the same phantom slot 15, verified
+        // by tracing the C++ loop by hand (the "greater" branch jumps
+        // straight to nTypes regardless of how far into the table it got).
+        assert_eq!(atom_type_index(10), 15);
+    }
+
+    #[test]
+    fn atom_type_index_above_table_clamps_to_phantom_slot() {
+        assert_eq!(atom_type_index(79), 15); // Au
+    }
+
+    #[test]
+    fn num_pi_electrons_aromatic_atom_is_always_one() {
+        let m = mol("c1ccccc1");
+        assert_eq!(num_pi_electrons(&m, AtomIdx(0)), 1);
+    }
+
+    #[test]
+    fn num_pi_electrons_single_bonds_only_is_zero() {
+        let m = mol("CCO");
+        assert_eq!(num_pi_electrons(&m, AtomIdx(0)), 0);
+    }
+
+    #[test]
+    fn num_pi_electrons_double_bond_is_one() {
+        let m = mol("C=O");
+        assert_eq!(num_pi_electrons(&m, AtomIdx(0)), 1);
+        assert_eq!(num_pi_electrons(&m, AtomIdx(1)), 1);
+    }
+
+    #[test]
+    fn num_pi_electrons_triple_bond_is_two() {
+        let m = mol("C#N");
+        assert_eq!(num_pi_electrons(&m, AtomIdx(0)), 2);
+        assert_eq!(num_pi_electrons(&m, AtomIdx(1)), 2);
+    }
+
+    #[test]
+    fn four_atom_paths_linear_butane_finds_one_undirected_path() {
+        let m = mol("CCCC");
+        let paths = four_atom_paths(&m);
+        assert_eq!(
+            paths.len(),
+            1,
+            "one physical path, one direction kept: {paths:?}"
+        );
+    }
+
+    #[test]
+    fn four_atom_paths_none_shorter_than_four_atoms() {
+        let m = mol("CCC");
+        assert!(four_atom_paths(&m).is_empty());
+    }
+
+    #[test]
+    fn triangle_closure_finds_one_entry_for_bare_cyclopropane() {
+        let m = mol("C1CC1");
+        // No ordinary 4-distinct-atom path can exist (only 3 heavy atoms
+        // total) -- the ring's own closure bond is the only source of any
+        // torsion contribution at all.
+        assert!(four_atom_paths(&m).is_empty());
+        let closures = triangle_closure_paths(&m);
+        assert_eq!(closures.len(), 1, "{closures:?}");
+        assert_eq!(closures[0][0], closures[0][3], "pivot atom must repeat");
+    }
+
+    #[test]
+    fn triangle_closure_pivot_is_lowest_index_ring_atom() {
+        let m = mol("CC1CC1"); // methyl on atom 1 -- ring is {1, 2, 3}
+        let closures = triangle_closure_paths(&m);
+        assert_eq!(closures.len(), 1, "{closures:?}");
+        assert_eq!(closures[0][0], AtomIdx(1));
+        assert_eq!(closures[0][3], AtomIdx(1));
+    }
+
+    #[test]
+    fn triangle_closure_empty_for_larger_rings() {
+        let m = mol("C1CCC1"); // 4-membered ring, no triangle
+        assert!(triangle_closure_paths(&m).is_empty());
+    }
+
+    #[test]
+    fn triangle_closure_empty_for_non_cyclic_molecules() {
+        let m = mol("CCCC");
+        assert!(triangle_closure_paths(&m).is_empty());
+    }
+
+    #[test]
+    fn rdkit_torsion_fp_nonempty_for_bare_cyclopropane() {
+        // Before triangle_closure_paths existed, this molecule had zero
+        // possible torsion contributions under the old (4-distinct-atom-only)
+        // enumeration -- RDKit's own real output is nonempty (one entry),
+        // so an empty fingerprint here would itself be a parity bug.
+        let m = mol("C1CC1");
+        assert!(rdkit_torsion_fp(&m).popcount() > 0);
+    }
+
+    #[test]
+    fn rdkit_torsion_fp_deterministic_and_nonempty_for_butane() {
+        let m = mol("CCCC");
+        let fp1 = rdkit_torsion_fp(&m);
+        let fp2 = rdkit_torsion_fp(&m);
+        assert_eq!(fp1.popcount(), fp2.popcount());
+        assert!(fp1.popcount() > 0);
+    }
+
+    #[test]
+    fn rdkit_torsion_fp_empty_for_short_molecules() {
+        let m = mol("CCC"); // only 3 heavy atoms, no 4-atom path exists
+        let fp = rdkit_torsion_fp(&m);
+        assert_eq!(fp.popcount(), 0);
+    }
+}

--- a/crates/chematic-py/src/mol_methods.rs
+++ b/crates/chematic-py/src/mol_methods.rs
@@ -1358,6 +1358,24 @@ impl Mol {
         bitvec2048_to_bytes(&chematic_fp::torsion_fp(&self.inner))
     }
 
+    /// RDKit-*compatible* (not yet fully bit-exact) Topological Torsion
+    /// fingerprint as bytes (256 bytes = 2048 bits).
+    ///
+    /// A from-scratch Rust port of RDKit's
+    /// ``rdkit.Chem.AllChem.GetHashedTopologicalTorsionFingerprintAsBitVect(mol, nBits=2048)``.
+    /// Measured 87.2% bit-exact on a 1000-molecule general corpus sample against a live
+    /// RDKit oracle. Two known, documented residual sources remain (see
+    /// ``chematic_fp::rdkit_torsion``'s own module doc comment for detail): RDKit's
+    /// hybridization-gated pi-electron count for hypervalent atoms (e.g. P/S) is not yet
+    /// replicated, and asymmetrically-substituted 3-membered rings can need more closure
+    /// entries than this implementation generates. A separate, opt-in function from
+    /// :meth:`torsion_fp` (chematic's own native, similarity-preserving scheme, unchanged);
+    /// neither affects the other's output. Does not support chirality (``includeChirality=True``
+    /// is not implemented).
+    fn rdkit_torsion_fp(&self) -> Vec<u8> {
+        bitvec2048_to_bytes(&chematic_fp::rdkit_torsion_fp(&self.inner))
+    }
+
     /// ECFP4 with chirality fingerprint as bytes.
     fn ecfp4_chiral(&self) -> Vec<u8> {
         let config = chematic_fp::EcfpConfig {

--- a/crates/chematic-py/tests/test_fp.py
+++ b/crates/chematic-py/tests/test_fp.py
@@ -78,6 +78,55 @@ def test_atom_pair_fp_different(aspirin, benzene):
     assert aspirin.atom_pair_fp() != benzene.atom_pair_fp()
 
 
+def test_rdkit_torsion_fp_length(aspirin):
+    assert len(aspirin.rdkit_torsion_fp()) == 256
+
+
+def test_rdkit_torsion_fp_different(aspirin, benzene):
+    assert aspirin.rdkit_torsion_fp() != benzene.rdkit_torsion_fp()
+
+
+def test_rdkit_torsion_fp_deterministic(aspirin):
+    assert aspirin.rdkit_torsion_fp() == aspirin.rdkit_torsion_fp()
+
+
+def test_rdkit_torsion_fp_independent_of_native_torsion_fp(aspirin):
+    # Separate opt-in function -- must not be the same bytes as the native
+    # (non-RDKit) scheme just because both happen to be 256-byte outputs.
+    assert aspirin.rdkit_torsion_fp() != aspirin.torsion_fp()
+
+
+def test_rdkit_torsion_fp_matches_rdkit_oracle_on_simple_molecules():
+    # Regression pin for the 3 real bugs found and fixed this round (missing
+    # -2 topological torsion correction, double-counted torsion paths,
+    # missing 3-membered-ring closure entries) -- these specific molecules
+    # were used to isolate each bug and must stay bit-exact.
+    import chematic
+
+    cases = [
+        "CCCC",  # linear butane, no ring
+        "C1CC1",  # bare cyclopropane -- only a ring-closure torsion exists
+        "CC1CC1",  # methylcyclopropane -- symmetric ring substitution
+        "COC1CC1",  # cyclopropyl ether
+    ]
+    try:
+        from rdkit import Chem
+        from rdkit.Chem import AllChem
+    except ImportError:
+        return  # rdkit not installed in this environment -- skip
+    for smi in cases:
+        m_chem = chematic.from_smiles(smi)
+        m_rd = Chem.MolFromSmiles(smi)
+        rd_bits = AllChem.GetHashedTopologicalTorsionFingerprintAsBitVect(
+            m_rd, nBits=2048
+        ).ToBitString()
+        chem_bytes = m_chem.rdkit_torsion_fp()
+        chem_bits = "".join(
+            format(byte, "08b")[::-1] for byte in chem_bytes
+        )[:2048]
+        assert chem_bits == rd_bits, f"{smi}: parity mismatch vs RDKit oracle"
+
+
 # ---------------------------------------------------------------------------
 # MACCS
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Track A / 99-point directive Phase 6 (fingerprint exact-parity half; the COSMolKit
comparison-harness half is explicitly out of scope for this PR -- deferred pending
a decision on how to actually reach COSMolKit, which isn't installable via pip/npm
under that name).

From-scratch Rust port of RDKit's `GetHashedTopologicalTorsionFingerprintAsBitVect`,
opt-in and fully separate from the existing native `torsion_fp` (neither affects the
other's output). Chosen as the closest of six priority fingerprints (Avalon, Pattern,
AtomPair, TopologicalTorsion, Layered, RDKit-path) measured against RDKit at the start
of this round, to establish the implementation pattern for the rest.

**Progress**: 0% -> 87.2% bit-exact on a 1000-molecule general corpus sample, verified
against a live RDKit oracle. Three real bugs found and fixed along the way, each
verified against the oracle before moving to the next:

1. Missing "-2 topological torsion correction" on atom invariants -- a raw wrapping
   `u32` subtraction (matches C++'s well-defined unsigned modular arithmetic), not a
   friendlier reinterpretation.
2. Double-counted torsion paths -- both directions of each physical path were being
   enumerated as separate entries, inflating RDKit's "count simulation" threshold bits.
3. Missing 3-membered-ring closure entries -- a triangle's own closing bond forms an
   additional torsion (walking `a-b-c-a`, revisiting the start atom) that a plain
   4-distinct-atom path search structurally cannot find. Confirmed via
   `rdFingerprintGenerator.GetTopologicalTorsionGenerator().GetCountFingerprint()`'s
   raw sparse counts on bare cyclopropane (`C1CC1`), which has no possible 4-distinct-atom
   path at all yet still produces one nonzero torsion entry.

**Two known, documented residuals remain** (see `crates/chematic-fp/src/rdkit_torsion.rs`'s
module doc comment for detail):
- RDKit's hybridization-gated pi-electron count for hypervalent atoms (e.g. phosphorus in
  phosphinic/phosphonic acids) isn't replicated -- confirmed via a live oracle that RDKit's
  `numPiElectrons` returns 0 for such atoms despite a formal double bond, gated on
  `GetHybridization() == SP3`. Chematic's existing `hybridization_per_atom` was checked and
  does NOT match RDKit for this case either, so it isn't a drop-in fix -- would require
  porting RDKit's own hybridization-perception algorithm, a separate, larger undertaking.
- Asymmetrically-substituted 3-membered rings can need more than the one closure entry this
  implementation generates (RDKit was observed emitting two for a 1,2-disubstituted
  cyclopropane); the exact selection rule for additional entries isn't yet reverse-engineered.

## Test plan
- [x] 17 native Rust tests (`chematic-fp`), covering atom-type lookup edge cases, pi-electron
      counting, path enumeration, and the triangle-closure fix specifically
- [x] Full existing `chematic-fp` suite (283 tests): green, no regressions
- [x] 5 new pytest cases (`test_fp.py`) + full existing 774-test pytest suite: green
- [x] `cargo fmt --all -- --check` / `cargo clippy -p chematic-fp -p chematic-py --all-targets -- -D warnings`: clean
- [x] Bit-exact parity measured directly against a live RDKit oracle at every stage (not just
      trusting the unit tests) -- this is how each of the 3 bugs above was actually found