### PR TITLE
feat(fp,py): add rdkit_atom_pair_fp, RDKit-compatible Atom Pair fingerprint (Track A Phase 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (e.g. phosphorus/sulfur) isn't replicated, and asymmetrically-substituted
   3-membered rings can need more than the one closure entry generated here.
 
+### Added — `chematic-fp`/`chematic-py` (`rdkit_atom_pair_fp`, RDKit-compatible Atom Pair fingerprint)
+
+- New `chematic_fp::rdkit_atom_pair_fp` (Rust) / `Mol.rdkit_atom_pair_fp()` (Python): a
+  from-scratch Rust port of RDKit's `GetHashedAtomPairFingerprintAsBitVect`, opt-in
+  and fully separate from the existing native `atom_pair_fp` (neither affects the
+  other). Second entry in the fingerprint-parity series (Track A / 99-point
+  directive Phase 6), reusing `rdkit_torsion_fp`'s atom-invariant primitive since
+  RDKit's own `AtomPairAtomInvGenerator` is the shared generator for both.
+- Measured 87.2% bit-exact on a 1000-molecule general corpus sample against a live
+  RDKit oracle, with zero implementation bugs found this round — every mismatching
+  molecule in the sample contains a hypervalent phosphorus or sulfur atom, confirming
+  the entire residual is `rdkit_torsion_fp`'s already-documented hybridization-gated
+  pi-electron count gap (shared via the reused atom-invariant), not a new gap in
+  atom-pair enumeration or hashing.
+
 ### Added — `chematic-py`/`chematic-wasm` (full `McsConfig`/`McsOutcome` exposed to MCS bindings)
 
 - Python's `find_mcs` previously exposed only 2 of `McsConfig`'s 11 fields

--- a/crates/chematic-fp/src/lib.rs
+++ b/crates/chematic-fp/src/lib.rs
@@ -34,6 +34,7 @@ mod morgan_environment;
 pub mod path;
 pub mod pattern;
 pub mod pharmacophore_fp;
+pub mod rdkit_atom_pair;
 mod rdkit_isotope_delta_table;
 mod rdkit_morgan_config;
 mod rdkit_morgan_ecfp4;
@@ -54,6 +55,7 @@ pub use ecfp::{
     ecfp6, ecfp6_rdkit_environment_experimental, ecfp6_rdkit_invariants, morgan_fp_counts,
     tanimoto_ecfp4,
 };
+pub use rdkit_atom_pair::rdkit_atom_pair_fp;
 pub use rdkit_torsion::rdkit_torsion_fp;
 /// Diagnostic-only APIs, not meant for production use — a per-`(atom,
 /// radius)` trace of chematic's real Morgan expansion, for the RDKit

--- a/crates/chematic-fp/src/rdkit_atom_pair.rs
+++ b/crates/chematic-fp/src/rdkit_atom_pair.rs
@@ -1,0 +1,178 @@
+//! RDKit-bit-exact Atom Pair fingerprint (`GetHashedAtomPairFingerprintAsBitVect`).
+//!
+//! Opt-in `RdkitExact`-mode addition, kept fully separate from
+//! [`crate::atom_pair::atom_pair_fp`] (chematic's own native scheme). Second of
+//! the fingerprint-parity series (Track A / 99-point directive Phase 6), after
+//! [`crate::rdkit_torsion_fp`] -- reuses that module's atom-invariant primitive
+//! ([`crate::rdkit_torsion::atom_code`]) since RDKit's own `AtomPairAtomInvGenerator`
+//! is the shared invariant generator for both fingerprints, just constructed with
+//! its `topologicalTorsionCorrection` flag `false` here instead of `true`.
+//!
+//! Derived from RDKit's C++ source (`Code/GraphMol/Fingerprints/AtomPairGenerator.{h,cpp}`,
+//! `AtomPairGenerator.h`'s `AtomPairArguments` defaults, `FingerprintGenerator.cpp`'s
+//! `getFingerprintHelper`), fetched at research time against `master`. Every
+//! constant/formula below is a direct port -- see each function's doc comment for
+//! the exact C++ source it mirrors.
+//!
+//! Key differences from [`crate::rdkit_torsion_fp`], confirmed against source
+//! before implementing (not assumed from the superficial code-family similarity):
+//! - No `-2` torsion correction on atom invariants -- `getAtomCode(atom, 0, false)`,
+//!   unmodified.
+//! - Atom codes are reduced by a plain `% ((1 << codeSize) - 1)`, with no `+1`
+//!   offset and no interior-position decrement (that offset is
+//!   `getTopologicalTorsionHash`-specific, not shared).
+//! - The bit id is `hash_combine(hash_combine(hash_combine(0, min(codeI, codeJ)),
+//!   dist), max(codeI, codeJ))` (`AtomPairAtomEnv::getBitId`'s `hashResults` branch,
+//!   always taken here since `GetHashedAtomPairFingerprintAsBitVect` always sets a
+//!   nonzero `fpSize`) -- a 3-element [`hash_vec`] fold, not the path-direction-
+//!   canonicalizing scheme torsion uses.
+//! - Pairs range over topological distance `[1, 30]` (`AtomPairArguments`'s
+//!   `minDistance=1`, `maxDistance=maxPathLen-1=30`), each unordered pair counted
+//!   once -- there is no 3-membered-ring-closure analogue (that was a torsion-path
+//!   artifact of revisiting the pivot atom, not applicable to plain pairwise
+//!   distance).
+//!
+//! The final 512-bucket count-simulation encoding (`nBitsPerEntry=4`, bounds
+//! `[1,2,4,8]`, folded into a 2048-bit output) is identical in structure to
+//! [`crate::rdkit_torsion_fp`]'s.
+//!
+//! **Status**: 87.2% bit-exact on a 1000-molecule general corpus sample
+//! (`scripts/descriptor_census_corpus.smi`), verified against a live RDKit
+//! oracle (`rdkit.Chem.AllChem.GetHashedAtomPairFingerprintAsBitVect`) --
+//! zero implementation bugs found this round. Every single mismatching
+//! molecule in the sample contains a hypervalent S or P atom (confirmed: 0
+//! mismatches among non-S/P molecules), meaning the entire residual is
+//! [`crate::rdkit_torsion::num_pi_electrons`]'s already-documented
+//! hybridization-gate gap (shared via the reused `atom_code` invariant) --
+//! no new gap specific to atom-pair enumeration or hashing.
+
+use std::collections::VecDeque;
+
+use chematic_core::{AtomIdx, Molecule};
+
+use crate::bitvec::BitVec2048;
+use crate::rdkit_morgan_hash::hash_vec;
+use crate::rdkit_torsion::{CODE_SIZE, atom_code};
+
+/// `AtomPairArguments`: `minDistance = 1`, `maxDistance = maxPathLen - 1 = 30`
+/// (`numPathBits = 5` => `maxPathLen = (1 << 5) - 1 = 31`). Pairs outside this
+/// range are skipped entirely, not clamped.
+const MIN_DISTANCE: u32 = 1;
+const MAX_DISTANCE: u32 = 30;
+
+const COUNT_BOUNDS: [u32; 4] = [1, 2, 4, 8];
+const N_BITS_PER_ENTRY: usize = 4;
+
+/// BFS shortest-path distance between every atom pair, uncapped up to
+/// [`MAX_DISTANCE`] (unlike [`crate::atom_pair`]'s own native `all_pairs_dist`,
+/// which caps at a much smaller `MAX_DIST = 7` for its own unrelated scheme --
+/// reusing that helper here would silently drop the majority of real RDKit
+/// atom-pair entries). `None` for unreached atoms (disconnected fragments) or
+/// distances beyond `MAX_DISTANCE`.
+fn all_pairs_dist(mol: &Molecule) -> Vec<Vec<Option<u32>>> {
+    let n = mol.atom_count();
+    let mut dist = vec![vec![None; n]; n];
+    for (start, row) in dist.iter_mut().enumerate() {
+        row[start] = Some(0);
+        let mut queue = VecDeque::new();
+        queue.push_back(AtomIdx(start as u32));
+        while let Some(cur) = queue.pop_front() {
+            let d = row[cur.0 as usize].unwrap();
+            if d >= MAX_DISTANCE {
+                continue;
+            }
+            for (nb, _) in mol.neighbors(cur) {
+                let ni = nb.0 as usize;
+                if row[ni].is_none() {
+                    row[ni] = Some(d + 1);
+                    queue.push_back(nb);
+                }
+            }
+        }
+    }
+    dist
+}
+
+/// RDKit-bit-exact Atom Pair fingerprint, matching
+/// `rdkit.Chem.AllChem.GetHashedAtomPairFingerprintAsBitVect(mol, nBits=2048)`
+/// (`includeChirality=False`, `nBitsPerEntry=4`, the Python API's own defaults)
+/// exactly, except for [`crate::rdkit_torsion_fp`]'s own shared
+/// `num_pi_electrons` residual (hybridization-gate not replicated for
+/// hypervalent atoms) -- see that function's doc comment for the gap, and
+/// this module's own doc comment for the corpus measurement confirming it's
+/// the *only* remaining gap here.
+pub fn rdkit_atom_pair_fp(mol: &Molecule) -> BitVec2048 {
+    let n = mol.atom_count();
+    let code_limit = (1u32 << CODE_SIZE) - 1;
+    let codes: Vec<u32> = (0..n)
+        .map(|i| atom_code(mol, AtomIdx(i as u32), 0) % code_limit)
+        .collect();
+
+    let dist = all_pairs_dist(mol);
+    const BLOCK_LENGTH: u32 = 2048 / N_BITS_PER_ENTRY as u32;
+    let mut counts = vec![0u32; BLOCK_LENGTH as usize];
+    for i in 0..n {
+        for j in (i + 1)..n {
+            let Some(d) = dist[i][j] else { continue };
+            if !(MIN_DISTANCE..=MAX_DISTANCE).contains(&d) {
+                continue;
+            }
+            let (lo, hi) = if codes[i] <= codes[j] {
+                (codes[i], codes[j])
+            } else {
+                (codes[j], codes[i])
+            };
+            let h = hash_vec(&[lo, d, hi]);
+            let bucket = (h % BLOCK_LENGTH) as usize;
+            counts[bucket] = counts[bucket].saturating_add(1);
+        }
+    }
+
+    let mut fp = BitVec2048::new();
+    for (bucket, &count) in counts.iter().enumerate() {
+        for (i, &bound) in COUNT_BOUNDS.iter().enumerate() {
+            if count >= bound {
+                fp.set(bucket * N_BITS_PER_ENTRY + i);
+            }
+        }
+    }
+    fp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chematic_smiles::parse;
+
+    fn mol(s: &str) -> Molecule {
+        parse(s).unwrap_or_else(|e| panic!("parse '{s}': {e}"))
+    }
+
+    #[test]
+    fn deterministic() {
+        let m = mol("CCO");
+        assert_eq!(rdkit_atom_pair_fp(&m), rdkit_atom_pair_fp(&m));
+    }
+
+    #[test]
+    fn different_molecules_differ() {
+        assert_ne!(
+            rdkit_atom_pair_fp(&mol("CCO")),
+            rdkit_atom_pair_fp(&mol("CCN"))
+        );
+    }
+
+    #[test]
+    fn single_atom_has_no_pairs() {
+        assert_eq!(rdkit_atom_pair_fp(&mol("C")), BitVec2048::new());
+    }
+
+    #[test]
+    fn all_pairs_dist_uncapped_beyond_native_max_dist_7() {
+        // A 10-carbon chain has a pair at distance 9, well past the native
+        // `atom_pair.rs` MAX_DIST=7 cap -- must not be silently dropped here.
+        let m = mol("CCCCCCCCCC");
+        let dist = all_pairs_dist(&m);
+        assert_eq!(dist[0][9], Some(9));
+    }
+}

--- a/crates/chematic-fp/src/rdkit_torsion.rs
+++ b/crates/chematic-fp/src/rdkit_torsion.rs
@@ -52,7 +52,7 @@ const NUM_PI_BITS: u32 = 2;
 const MAX_NUM_PI: u32 = (1 << NUM_PI_BITS) - 1;
 const NUM_BRANCH_BITS: u32 = 3;
 const MAX_NUM_BRANCHES: u32 = (1 << NUM_BRANCH_BITS) - 1;
-const CODE_SIZE: u32 = NUM_TYPE_BITS + NUM_PI_BITS + NUM_BRANCH_BITS;
+pub(crate) const CODE_SIZE: u32 = NUM_TYPE_BITS + NUM_PI_BITS + NUM_BRANCH_BITS;
 
 /// Count-simulation thresholds (`AtomPairs.cpp`'s `bounds[4] = {1, 2, 4, 8}`),
 /// used only when `nBitsPerEntry == 4` (the default, and the only mode this
@@ -88,7 +88,7 @@ const N_BITS_PER_ENTRY: usize = 4;
 /// 1000-molecule general corpus sample, with essentially all remaining
 /// misses attributable to this gap or to asymmetrically-substituted
 /// 3-membered rings (see that function's own doc comment).
-fn num_pi_electrons(mol: &Molecule, idx: AtomIdx) -> u32 {
+pub(crate) fn num_pi_electrons(mol: &Molecule, idx: AtomIdx) -> u32 {
     let atom = mol.atom(idx);
     if atom.aromatic {
         return 1;
@@ -121,7 +121,7 @@ fn num_pi_electrons(mol: &Molecule, idx: AtomIdx) -> u32 {
 /// default `GetHashedTopologicalTorsionFingerprintAsBitVect` call and this
 /// crate's `mol.torsion_fp()`-equivalent scope) -- callers must not pass
 /// `true`.
-fn atom_code(mol: &Molecule, idx: AtomIdx, branch_subtract: u32) -> u32 {
+pub(crate) fn atom_code(mol: &Molecule, idx: AtomIdx, branch_subtract: u32) -> u32 {
     let atom = mol.atom(idx);
     let degree = mol.degree(idx) as u32;
     let num_branches = degree.saturating_sub(branch_subtract);

--- a/crates/chematic-py/src/mol_methods.rs
+++ b/crates/chematic-py/src/mol_methods.rs
@@ -1376,6 +1376,23 @@ impl Mol {
         bitvec2048_to_bytes(&chematic_fp::rdkit_torsion_fp(&self.inner))
     }
 
+    /// RDKit-*compatible* (not yet fully bit-exact) Atom Pair fingerprint as
+    /// bytes (256 bytes = 2048 bits).
+    ///
+    /// A from-scratch Rust port of RDKit's
+    /// ``rdkit.Chem.AllChem.GetHashedAtomPairFingerprintAsBitVect(mol, nBits=2048)``.
+    /// Measured 87.2% bit-exact on a 1000-molecule general corpus sample against a live
+    /// RDKit oracle -- every mismatching molecule in that sample contains a hypervalent
+    /// S or P atom, confirming the *only* residual is the one already documented for
+    /// :meth:`rdkit_torsion_fp` (RDKit's hybridization-gated pi-electron count for
+    /// hypervalent atoms is not yet replicated; see ``chematic_fp::rdkit_torsion``'s
+    /// module doc comment). A separate, opt-in function from :meth:`atom_pair_fp`
+    /// (chematic's own native scheme, unchanged); neither affects the other's output.
+    /// Does not support chirality (``includeChirality=True`` is not implemented).
+    fn rdkit_atom_pair_fp(&self) -> Vec<u8> {
+        bitvec2048_to_bytes(&chematic_fp::rdkit_atom_pair_fp(&self.inner))
+    }
+
     /// ECFP4 with chirality fingerprint as bytes.
     fn ecfp4_chiral(&self) -> Vec<u8> {
         let config = chematic_fp::EcfpConfig {

--- a/crates/chematic-py/tests/test_fp.py
+++ b/crates/chematic-py/tests/test_fp.py
@@ -127,6 +127,55 @@ def test_rdkit_torsion_fp_matches_rdkit_oracle_on_simple_molecules():
         assert chem_bits == rd_bits, f"{smi}: parity mismatch vs RDKit oracle"
 
 
+def test_rdkit_atom_pair_fp_length(aspirin):
+    assert len(aspirin.rdkit_atom_pair_fp()) == 256
+
+
+def test_rdkit_atom_pair_fp_different(aspirin, benzene):
+    assert aspirin.rdkit_atom_pair_fp() != benzene.rdkit_atom_pair_fp()
+
+
+def test_rdkit_atom_pair_fp_deterministic(aspirin):
+    assert aspirin.rdkit_atom_pair_fp() == aspirin.rdkit_atom_pair_fp()
+
+
+def test_rdkit_atom_pair_fp_independent_of_native_atom_pair_fp(aspirin):
+    # Separate opt-in function -- must not be the same bytes as the native
+    # (non-RDKit) scheme just because both happen to be 256-byte outputs.
+    assert aspirin.rdkit_atom_pair_fp() != aspirin.atom_pair_fp()
+
+
+def test_rdkit_atom_pair_fp_matches_rdkit_oracle_on_simple_molecules():
+    # Regression pin: these were the molecules used to verify the atom-pair
+    # port (shares its atom-invariant scheme with rdkit_torsion_fp, so these
+    # overlap that fingerprint's own repro set) -- must stay bit-exact.
+    import chematic
+
+    cases = [
+        "CCO",
+        "CCCC",
+        "C1CC1",
+        "CC1CC1",
+        "COC1CC1",
+    ]
+    try:
+        from rdkit import Chem
+        from rdkit.Chem import rdMolDescriptors
+    except ImportError:
+        return  # rdkit not installed in this environment -- skip
+    for smi in cases:
+        m_chem = chematic.from_smiles(smi)
+        m_rd = Chem.MolFromSmiles(smi)
+        rd_bits = rdMolDescriptors.GetHashedAtomPairFingerprintAsBitVect(
+            m_rd, nBits=2048
+        ).ToBitString()
+        chem_bytes = m_chem.rdkit_atom_pair_fp()
+        chem_bits = "".join(
+            format(byte, "08b")[::-1] for byte in chem_bytes
+        )[:2048]
+        assert chem_bits == rd_bits, f"{smi}: parity mismatch vs RDKit oracle"
+
+
 # ---------------------------------------------------------------------------
 # MACCS
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Second entry in the fingerprint-parity series (Track A / 99-point directive Phase 6), after `rdkit_torsion_fp` (#431). Adds `chematic_fp::rdkit_atom_pair_fp` (Rust) / `Mol.rdkit_atom_pair_fp()` (Python): a from-scratch Rust port of RDKit's `GetHashedAtomPairFingerprintAsBitVect`, opt-in and fully separate from the existing native `atom_pair_fp`.
- Reuses `rdkit_torsion_fp`'s `atom_code`/`CODE_SIZE` (widened to `pub(crate)`) since RDKit's own `AtomPairAtomInvGenerator` is the shared invariant generator for both fingerprints — confirmed against RDKit's C++ source (`AtomPairGenerator.{h,cpp}`, `FingerprintUtil.cpp`) that AtomPair passes `topologicalTorsionCorrection=false` (no `-2`) and reduces atom codes by a plain `% ((1<<9)-1)` with no `+1` offset, unlike torsion's own hash.
- New code: an uncapped BFS distance helper over `[1, 30]` (chematic's existing native `atom_pair.rs` caps its own unrelated scheme at `MAX_DIST=7`, which would silently drop most real RDKit entries if reused) and RDKit's hashed bit-id (`hash_combine` fold of `min(codeI,codeJ)`, `dist`, `max(codeI,codeJ)`, confirmed via source rather than assumed from the code-family resemblance to torsion).

## Result

Measured against a live RDKit oracle:
- 5/5 small hand-picked molecules (including all 4 of `rdkit_torsion_fp`'s own bug-repro molecules) bit-exact.
- **87.2% bit-exact on the same 1000-molecule general corpus sample used for `rdkit_torsion_fp`**, with **zero implementation bugs found this round**.
- Every single mismatching molecule in the sample contains a hypervalent P or S atom; confirmed 0 mismatches among non-P/S molecules. This means 100% of the residual is `rdkit_torsion_fp`'s already-documented `num_pi_electrons` hybridization-gate gap (shared via the reused atom invariant) — not a new gap in atom-pair enumeration or hashing.

## Test plan

- [x] `cargo test -p chematic-fp --lib` — 287/287 (283 existing + 4 new)
- [x] `cargo fmt --check` / `cargo clippy -p chematic-fp -p chematic-py --lib --tests -- -D warnings` — clean
- [x] `cargo check -p chematic-py -p chematic-wasm` — clean
- [x] `maturin develop` + `pytest crates/chematic-py/tests/test_fp.py` — 34/34 (5 new tests, mirroring `rdkit_torsion_fp`'s own test pattern, incl. a live-RDKit-oracle regression pin)
- [x] Full `pytest` suite — 779/779 (774 existing + 5 new)

Not merging per standing session directive — opened for review only.