### PR TITLE
feat(fp,py): add rdkit_pattern_fp, RDKit-compatible Pattern fingerprint (Track A Phase 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pi-electron count gap (shared via the reused atom-invariant), not a new gap in
   atom-pair enumeration or hashing.
 
+### Added — `chematic-fp`/`chematic-py` (`rdkit_pattern_fp`, RDKit-compatible Pattern fingerprint)
+
+- New `chematic_fp::rdkit_pattern_fp` (Rust) / `Mol.rdkit_pattern_fp()` (Python): a
+  from-scratch Rust port of RDKit's `PatternFingerprint`, opt-in and fully separate
+  from the existing native `pattern_fp` (neither affects the other). Third entry in
+  the fingerprint-parity series (Track A / 99-point directive Phase 6) — structurally
+  unrelated to the first two (SMARTS substructure matching against 13 fixed patterns,
+  not a path/pair enumeration), reusing chematic's existing `chematic-smarts` matcher
+  rather than a new one.
+- Measured against a live RDKit oracle on three corpora with different chemical
+  distributions: 100% bit-exact on a 1000-molecule general corpus sample, 99.6% on an
+  NCI sample, 94.1% on a ChEMBL sample. One real bug found and fixed along the way:
+  chematic's SMILES parser preserves a Kekule-notation input's literal single/double
+  bond orders even when the ring is perceived as aromatic, so a raw `bond.order ==
+  Aromatic` check silently missed every ring bond of a Kekule-written heteroaromatic —
+  fixed by using chematic's own aromaticity-perception model instead (found via a live
+  oracle repro, not source re-reading; caught the NCI corpus number at 30.4% before
+  the fix). The remaining residual traces entirely to chematic's own
+  aromaticity-perception model disagreeing with RDKit's on specific ring systems
+  (fused N/S-heterocycles, quinones, coordination complexes) — a pre-existing,
+  separate gap, not a defect in this fingerprint's own match-enumeration or hashing
+  logic (independently verified: per-pattern match counts identical to RDKit's own
+  `GetSubstructMatches(..., uniquify=False)` across all 13 patterns on a repro
+  molecule).
+
 ### Added — `chematic-py`/`chematic-wasm` (full `McsConfig`/`McsOutcome` exposed to MCS bindings)
 
 - Python's `find_mcs` previously exposed only 2 of `McsConfig`'s 11 fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,20 +54,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not a path/pair enumeration), reusing chematic's existing `chematic-smarts` matcher
   rather than a new one.
 - Measured against a live RDKit oracle on three corpora with different chemical
-  distributions: 100% bit-exact on a 1000-molecule general corpus sample, 99.6% on an
-  NCI sample, 94.1% on a ChEMBL sample. One real bug found and fixed along the way:
-  chematic's SMILES parser preserves a Kekule-notation input's literal single/double
-  bond orders even when the ring is perceived as aromatic, so a raw `bond.order ==
-  Aromatic` check silently missed every ring bond of a Kekule-written heteroaromatic —
-  fixed by using chematic's own aromaticity-perception model instead (found via a live
-  oracle repro, not source re-reading; caught the NCI corpus number at 30.4% before
-  the fix). The remaining residual traces entirely to chematic's own
-  aromaticity-perception model disagreeing with RDKit's on specific ring systems
-  (fused N/S-heterocycles, quinones, coordination complexes) — a pre-existing,
-  separate gap, not a defect in this fingerprint's own match-enumeration or hashing
-  logic (independently verified: per-pattern match counts identical to RDKit's own
-  `GetSubstructMatches(..., uniquify=False)` across all 13 patterns on a repro
-  molecule).
+  distributions: 100% bit-exact on a 1000-molecule general corpus sample, 100% on a
+  ChEMBL sample, 99.6% on an NCI sample. Two real bugs found and fixed along the way:
+  (1) chematic's SMILES parser preserves a Kekule-notation input's literal
+  single/double bond orders even when the ring is perceived as aromatic, so a raw
+  `bond.order == Aromatic` check silently missed every ring bond of a Kekule-written
+  heteroaromatic — caught the NCI corpus number at 30.4% before switching to
+  chematic's own aromaticity-perception model; (2) naively re-perceiving *every*
+  non-literally-aromatic bond then regressed the ChEMBL corpus from 100% to 94.1% —
+  for a molecule with both lowercase-aromatic and Kekule-written rings, re-perceiving
+  the whole molecule wrongly classified a genuinely non-aromatic Kekule ring as
+  aromatic too. Fixed by only re-perceiving molecules with *zero* literal `Aromatic`
+  bonds anywhere; molecules that already carry any literal `Aromatic` bond trust every
+  bond's own stored order throughout instead. The remaining NCI residual traces
+  entirely to chematic's own aromaticity-perception model disagreeing with RDKit's on
+  specific wholly-Kekule-written ring systems (a brominated anthraquinone/xanthone
+  core, an S/N-containing bicyclic heterocycle, a ketone-fused tetralone-like system,
+  a Zn coordination complex) — a pre-existing, separate gap, not a defect in this
+  fingerprint's own match-enumeration or hashing logic (independently verified:
+  per-pattern match counts identical to RDKit's own `GetSubstructMatches(...,
+  uniquify=False)` across all 13 patterns on a repro molecule before either bug was
+  even found).
 
 ### Added — `chematic-py`/`chematic-wasm` (full `McsConfig`/`McsOutcome` exposed to MCS bindings)
 

--- a/crates/chematic-fp/src/lib.rs
+++ b/crates/chematic-fp/src/lib.rs
@@ -39,6 +39,7 @@ mod rdkit_isotope_delta_table;
 mod rdkit_morgan_config;
 mod rdkit_morgan_ecfp4;
 mod rdkit_morgan_hash;
+pub mod rdkit_pattern;
 pub mod rdkit_torsion;
 pub mod reaction_fp;
 pub mod search;
@@ -56,6 +57,7 @@ pub use ecfp::{
     tanimoto_ecfp4,
 };
 pub use rdkit_atom_pair::rdkit_atom_pair_fp;
+pub use rdkit_pattern::rdkit_pattern_fp;
 pub use rdkit_torsion::rdkit_torsion_fp;
 /// Diagnostic-only APIs, not meant for production use — a per-`(atom,
 /// radius)` trace of chematic's real Morgan expansion, for the RDKit

--- a/crates/chematic-fp/src/rdkit_pattern.rs
+++ b/crates/chematic-fp/src/rdkit_pattern.rs
@@ -39,18 +39,11 @@
 //!   in the pattern's own bond order (query bonds and atoms are `QueryMolecule`
 //!   `Vec`s, i.e. already in SMARTS-text parse order -- the same order RDKit's
 //!   own query mol exposes). Aromatic bonds always hash RDKit's `AROMATIC`
-//!   code (`12`) regardless of Kekule order -- determined via
-//!   [`chematic_perception::aromaticity::assign_aromaticity_ex`]
-//!   (`AromaticityAlgorithm::RdkitLike`), **not** a raw `bond.order ==
-//!   BondOrder::Aromatic` check: chematic's parser preserves a Kekulized
-//!   *input*'s literal single/double bond orders verbatim even when the ring
-//!   is perceived as aromatic, while RDKit always normalizes such bonds to
-//!   `AROMATIC` type regardless of input notation. An earlier version of this
-//!   module used the raw-order check and was 100% bit-exact on two corpora
-//!   but only 30.4% on a third (NCI) before this was caught -- every
-//!   Kekule-notation heteroaromatic (e.g. `S1C2=CC3=CC=CC=C3C=C2N=C1...`)
-//!   silently hashed the wrong bond code. See [`matched_bond_code`]'s own doc
-//!   comment for the confirmed repro.
+//!   code (`12`) regardless of Kekule order. See [`matched_bond_code`]'s own
+//!   doc comment for exactly how "is this bond aromatic" is determined --
+//!   chematic's own bond model needed two real fixes here before it matched
+//!   RDKit's, neither of them guessable from source alone (both found via
+//!   corpus-scale, not small-molecule, testing).
 //! - `fpSize` buckets directly (`bitId % fpSize`) -- **no** count-simulation
 //!   tail (unlike torsion/atom-pair): `PatternFingerprintMol`'s signature has
 //!   no `nBitsPerEntry` parameter at all, confirmed from source before
@@ -67,27 +60,27 @@
 //!
 //! **Status, measured against a live RDKit oracle (1000-molecule samples,
 //! three corpora with different chemical distributions)**: 100% bit-exact on
-//! `scripts/descriptor_census_corpus.smi`, 99.6% on
-//! `scripts/nci_first_5k_smiles_only.smi`, 94.1% on
-//! `scripts/chembl_accuracy_corpus_4999.smi`. Every mismatch traces to
-//! chematic's [`chematic_perception::aromaticity::assign_aromaticity_ex`]
-//! disagreeing with RDKit's own aromaticity perception on a specific ring
-//! system -- confirmed by direct atom/bond-level comparison against a live
-//! RDKit oracle for representative failures on each corpus (a benzothiazole
-//! fused to a naphtho ring; a benzo-fused tetrahydropyrimidine with two
-//! pendant, non-fused phenyl substituents that chematic perceives as part of
-//! one aromatic system while RDKit does not; brominated anthraquinone/xanthone
-//! cores; S/N-containing bicyclic heterocycles; a Zn coordination complex).
-//! This is a pre-existing, already partially-tracked gap in chematic's own
-//! aromaticity model (see `AromaticityAlgorithm::RdkitLike`'s own doc comment
-//! for its known P/keto-lactam gaps) surfacing through this fingerprint's
-//! sensitivity to bond-level aromaticity -- not a defect in this module's own
-//! match-enumeration or hashing logic, both independently confirmed correct
-//! (per-pattern match *counts* were verified identical to RDKit's own
+//! `scripts/descriptor_census_corpus.smi`, 100% on
+//! `scripts/chembl_accuracy_corpus_4999.smi`, 99.6% on
+//! `scripts/nci_first_5k_smiles_only.smi`. The 4 remaining NCI mismatches all
+//! come from molecules with *zero* literal `Aromatic`-order bonds anywhere
+//! (pure Kekule-notation input), where [`matched_bond_code`]'s fallback to
+//! [`chematic_perception::aromaticity::assign_aromaticity_ex`] is the only
+//! available aromaticity signal and that model itself disagrees with RDKit's
+//! own perception for these specific ring systems (a brominated
+//! anthraquinone/xanthone core, an S/N-containing bicyclic heterocycle, a
+//! ketone-fused tetralone-like system, a Zn coordination complex) -- a
+//! pre-existing, already partially-tracked gap in chematic's own aromaticity
+//! model (see `AromaticityAlgorithm::RdkitLike`'s own doc comment for its
+//! known P/keto-lactam gaps), not a defect in this module's own
+//! match-enumeration or hashing logic (independently confirmed correct:
+//! per-pattern match *counts* were verified identical to RDKit's own
 //! `GetSubstructMatches(..., uniquify=False)` across all 13 patterns on a
-//! repro molecule before the aromaticity gap was even found). Full
+//! repro molecule before either bond-aromaticity bug was even found). Full
 //! aromaticity-perception parity with RDKit is a separate, much larger
 //! undertaking, out of scope for this round.
+
+use std::sync::LazyLock;
 
 use rustc_hash::FxHashMap;
 
@@ -118,6 +111,16 @@ const PATTERNS: [&str; 13] = [
     "[*]",
 ];
 
+/// [`PATTERNS`], pre-compiled once. `chematic-smarts`'s own docs note that
+/// re-parsing a SMARTS string is the dominant overhead in repeated matching --
+/// these 13 patterns are fixed and reused for every molecule.
+static COMPILED_PATTERNS: LazyLock<Vec<QueryMolecule>> = LazyLock::new(|| {
+    PATTERNS
+        .iter()
+        .map(|s| parse_smarts(s).unwrap_or_else(|e| panic!("built-in pattern '{s}': {e}")))
+        .collect()
+});
+
 /// RDKit's raw `Bond::BondType` enum integer, for the bond types that can
 /// occur on a concrete (non-query) `Molecule`'s own bonds. `Aromatic` is
 /// handled by the caller (always `12`, regardless of Kekule order -- see
@@ -142,21 +145,41 @@ fn rdkit_bond_type_code(order: BondOrder) -> u32 {
     }
 }
 
-/// Uses [`AromaticityModel::is_bond_aromatic`] rather than checking
-/// `bond.order == BondOrder::Aromatic` directly: chematic's SMILES parser
-/// preserves a Kekulized *input*'s literal alternating single/double bond
-/// orders verbatim (round-trip fidelity), even for a ring the atoms
-/// themselves are perceived as aromatic -- unlike RDKit, which always
-/// normalizes a perceived-aromatic bond's type to `AROMATIC` regardless of
-/// how the input SMILES wrote it. A bond-order check alone therefore misses
-/// every aromatic ring bond in Kekule-notation input (confirmed via a live
-/// oracle repro: a benzothiazole-fused system parsed from explicit `C1=CC=..`
-/// notation kept `Single`/`Double` bond orders in chematic while RDKit
-/// reported `AROMATIC` for the same bonds) -- re-perceiving aromaticity here
-/// is the fix, not a Kekulized-order-only check.
+/// Two real bugs were found and fixed here, both via corpus-scale testing
+/// (small hand-picked molecules missed both):
+///
+/// 1. **Missing re-perception on wholly-Kekulized input.** chematic's SMILES
+///    parser preserves a Kekulized *input*'s literal alternating
+///    single/double bond orders verbatim (round-trip fidelity), even for a
+///    ring the atoms themselves are perceived as aromatic -- unlike RDKit,
+///    which always normalizes a perceived-aromatic bond's type to `AROMATIC`
+///    regardless of how the input SMILES wrote it. A raw `bond.order ==
+///    Aromatic` check alone therefore missed every aromatic ring bond in
+///    Kekule-notation input (repro: `S1C2=CC3=CC=CC=C3C=C2N=C1C4=CC=CC=C4`,
+///    a benzothiazole fused to a naphtho ring, kept `Single`/`Double` bond
+///    orders in chematic while RDKit reported `AROMATIC` for the same bonds
+///    -- caught an NCI-corpus sample at 30.4% bit-exact).
+/// 2. **Over-eager re-perception on partially-aromatic-marked input.**
+///    Naively falling back to [`AromaticityModel::is_bond_aromatic`] for
+///    *every* non-literally-aromatic bond regressed a ChEMBL-corpus sample
+///    from 100% to 94.1%: for a molecule like
+///    `C1=C(c2ccccc2)N2CCCN=C2c2ccccc21` (two lowercase, literally-aromatic
+///    pendant phenyls attached to a Kekule-written, genuinely non-aromatic
+///    central ring), re-perceiving the whole molecule wrongly classified the
+///    central ring as aromatic too -- a real disagreement between
+///    chematic's own aromaticity model and RDKit's for that ring shape, not
+///    fixable by tweaking this function further. The caller
+///    ([`rdkit_pattern_fp`]) now only invokes `assign_aromaticity_ex` at all
+///    for molecules with *zero* literal `Aromatic` bonds anywhere (pure
+///    Kekule input, where it's the only available signal); molecules that
+///    already carry any literal `Aromatic` bond trust every bond's own
+///    stored order throughout instead of re-perceiving, since such
+///    molecules already went through *some* aromaticity-aware writer. This
+///    fixed the ChEMBL regression back to 100% without reintroducing the
+///    NCI failure (verified together, not just individually).
 fn matched_bond_code(
     mol: &Molecule,
-    model: &AromaticityModel,
+    model: Option<&AromaticityModel>,
     m: &FxHashMap<usize, AtomIdx>,
     a1: usize,
     a2: usize,
@@ -164,10 +187,12 @@ fn matched_bond_code(
     let (bidx, bond) = mol
         .bond_between(m[&a1], m[&a2])
         .expect("a matched pattern bond must exist between its mapped target atoms");
-    if model.is_bond_aromatic(bidx) {
-        12
-    } else {
-        rdkit_bond_type_code(bond.order)
+    if bond.order == BondOrder::Aromatic {
+        return 12;
+    }
+    match model {
+        Some(model) if model.is_bond_aromatic(bidx) => 12,
+        _ => rdkit_bond_type_code(bond.order),
     }
 }
 
@@ -181,13 +206,25 @@ pub fn rdkit_pattern_fp(mol: &Molecule) -> BitVec2048 {
         uniquify: false,
         ..MatchConfig::default()
     };
-    let aromaticity = assign_aromaticity_ex(mol, AromaticityAlgorithm::RdkitLike);
+    // Molecules that already carry any literal `BondOrder::Aromatic` bond went
+    // through *some* aromaticity-aware writer at some point -- trust every
+    // bond's own stored order throughout such a molecule rather than
+    // re-perceiving, since re-perception on a partially-Kekulized,
+    // partially-aromatic-marked molecule is where chematic's own model most
+    // often disagrees with RDKit's (see module doc comment). Only invoke
+    // [`assign_aromaticity_ex`] for molecules with zero literal `Aromatic`
+    // bonds anywhere (i.e. wholly Kekule-notation input), where it's the only
+    // available aromaticity signal at all.
+    let has_literal_aromatic_bond = mol.bonds().any(|(_, b)| b.order == BondOrder::Aromatic);
+    let aromaticity = if has_literal_aromatic_bond {
+        None
+    } else {
+        Some(assign_aromaticity_ex(mol, AromaticityAlgorithm::RdkitLike))
+    };
 
-    for (i, smarts) in PATTERNS.iter().enumerate() {
+    for (i, query) in COMPILED_PATTERNS.iter().enumerate() {
         let p_idx = (i + 1) as u32;
-        let query: QueryMolecule =
-            parse_smarts(smarts).unwrap_or_else(|e| panic!("built-in pattern '{smarts}': {e}"));
-        let matches = find_matches_with_config(&query, mol, &cfg);
+        let matches = find_matches_with_config(query, mol, &cfg);
 
         let mut m_idx = p_idx
             .wrapping_add(query.atoms.len() as u32)
@@ -204,7 +241,7 @@ pub fn rdkit_pattern_fp(mol: &Molecule) -> BitVec2048 {
                 bit_id = hash_combine(bit_id, an);
             }
             for qb in &query.bonds {
-                let code = matched_bond_code(mol, &aromaticity, m, qb.atom1, qb.atom2);
+                let code = matched_bond_code(mol, aromaticity.as_ref(), m, qb.atom1, qb.atom2);
                 bit_id = hash_combine(bit_id, code);
             }
             fp.set((bit_id % FP_SIZE) as usize);

--- a/crates/chematic-fp/src/rdkit_pattern.rs
+++ b/crates/chematic-fp/src/rdkit_pattern.rs
@@ -1,0 +1,242 @@
+//! RDKit-bit-exact Pattern fingerprint (`Chem.PatternFingerprint`).
+//!
+//! Opt-in `RdkitExact`-mode addition, kept fully separate from
+//! [`crate::pattern::pattern_fp`] (chematic's own native scheme). Third of the
+//! fingerprint-parity series (Track A / 99-point directive Phase 6), after
+//! [`crate::rdkit_torsion_fp`]/[`crate::rdkit_atom_pair_fp`]. Structurally
+//! unrelated to those two -- Pattern uses SMARTS substructure matching against
+//! 13 fixed patterns, not a path/pair enumeration + shared atom invariant.
+//!
+//! Derived from RDKit's C++ source
+//! (`Code/GraphMol/Fingerprints/PatternFingerprints.cpp`, function
+//! `updatePatternFingerprint` / `PatternFingerprintMol`), fetched at research
+//! time against `master`. Every constant/formula below is a direct port.
+//!
+//! Algorithm, confirmed against source before implementing:
+//! - [`PATTERNS`] is RDKit's own `pqs[]` array verbatim (13 SMARTS strings,
+//!   1-based index `pIdx` used as a hash seed component).
+//! - For each pattern, find every match via chematic's own
+//!   `chematic_smarts::find_matches_with_config` with `uniquify: false` --
+//!   this already reproduces RDKit's own `SubstructMatch(..., uniquify=false)`
+//!   semantics exactly, *including* returning one entry per automorphism
+//!   (e.g. a 6-membered-ring pattern on benzene yields 12 matches, not 1) --
+//!   verified directly against a live RDKit oracle on 9 pattern/molecule pairs
+//!   before writing this module, not assumed from the API's docstring.
+//! - **Occurrence-count bits**: RDKit's C++ mutates a single seed variable
+//!   `mIdx` (initialized to `pIdx + numPatternAtoms + numPatternBonds`) via
+//!   one `hash_combine(mIdx, 0xBEEF)` step *per match*, carrying the updated
+//!   value forward to the next match of the *same* pattern (not reset per
+//!   match) -- a running accumulator, not a fresh hash per match. Since the
+//!   combined value (`0xBEEF`) never depends on which atoms matched, this
+//!   produces a sequence of `k` distinct bits purely as a function of the
+//!   pattern's own seed and the match *count* `k` -- independent of match
+//!   *order*, so this module doesn't need to replicate RDKit's own match
+//!   enumeration order for this part (confirmed by construction, not by
+//!   trial and error).
+//! - **Content bits**: `bitId` starts fresh at `pIdx` per match, then folds in
+//!   (via [`hash_combine`]) each matched atom's atomic number in *query-atom-
+//!   index* order (0..n), followed by each pattern bond's *matched* bond type
+//!   in the pattern's own bond order (query bonds and atoms are `QueryMolecule`
+//!   `Vec`s, i.e. already in SMARTS-text parse order -- the same order RDKit's
+//!   own query mol exposes). Aromatic bonds always hash RDKit's `AROMATIC`
+//!   code (`12`) regardless of Kekule order -- determined via
+//!   [`chematic_perception::aromaticity::assign_aromaticity_ex`]
+//!   (`AromaticityAlgorithm::RdkitLike`), **not** a raw `bond.order ==
+//!   BondOrder::Aromatic` check: chematic's parser preserves a Kekulized
+//!   *input*'s literal single/double bond orders verbatim even when the ring
+//!   is perceived as aromatic, while RDKit always normalizes such bonds to
+//!   `AROMATIC` type regardless of input notation. An earlier version of this
+//!   module used the raw-order check and was 100% bit-exact on two corpora
+//!   but only 30.4% on a third (NCI) before this was caught -- every
+//!   Kekule-notation heteroaromatic (e.g. `S1C2=CC3=CC=CC=C3C=C2N=C1...`)
+//!   silently hashed the wrong bond code. See [`matched_bond_code`]'s own doc
+//!   comment for the confirmed repro.
+//! - `fpSize` buckets directly (`bitId % fpSize`) -- **no** count-simulation
+//!   tail (unlike torsion/atom-pair): `PatternFingerprintMol`'s signature has
+//!   no `nBitsPerEntry` parameter at all, confirmed from source before
+//!   assuming the torsion/atom-pair tail would apply here too.
+//!
+//! **Not implemented** (mirrors this series' established chirality/query
+//! carve-outs): `tautomericFingerprint=True` (a second, alternate bond-hash
+//! path for tautomer-invariant fingerprinting), and the `isQueryAtom`/
+//! `isQueryBond` skip logic (only reachable when fingerprinting a
+//! `QueryMolecule`/SMARTS pattern itself -- this module, like
+//! `rdkit_torsion_fp`/`rdkit_atom_pair_fp`, targets fingerprinting concrete
+//! molecules parsed from SMILES, which never carry query atoms/bonds, so that
+//! branch is unreachable dead code for this scope, not a gap).
+//!
+//! **Status, measured against a live RDKit oracle (1000-molecule samples,
+//! three corpora with different chemical distributions)**: 100% bit-exact on
+//! `scripts/descriptor_census_corpus.smi`, 99.6% on
+//! `scripts/nci_first_5k_smiles_only.smi`, 94.1% on
+//! `scripts/chembl_accuracy_corpus_4999.smi`. Every mismatch traces to
+//! chematic's [`chematic_perception::aromaticity::assign_aromaticity_ex`]
+//! disagreeing with RDKit's own aromaticity perception on a specific ring
+//! system -- confirmed by direct atom/bond-level comparison against a live
+//! RDKit oracle for representative failures on each corpus (a benzothiazole
+//! fused to a naphtho ring; a benzo-fused tetrahydropyrimidine with two
+//! pendant, non-fused phenyl substituents that chematic perceives as part of
+//! one aromatic system while RDKit does not; brominated anthraquinone/xanthone
+//! cores; S/N-containing bicyclic heterocycles; a Zn coordination complex).
+//! This is a pre-existing, already partially-tracked gap in chematic's own
+//! aromaticity model (see `AromaticityAlgorithm::RdkitLike`'s own doc comment
+//! for its known P/keto-lactam gaps) surfacing through this fingerprint's
+//! sensitivity to bond-level aromaticity -- not a defect in this module's own
+//! match-enumeration or hashing logic, both independently confirmed correct
+//! (per-pattern match *counts* were verified identical to RDKit's own
+//! `GetSubstructMatches(..., uniquify=False)` across all 13 patterns on a
+//! repro molecule before the aromaticity gap was even found). Full
+//! aromaticity-perception parity with RDKit is a separate, much larger
+//! undertaking, out of scope for this round.
+
+use rustc_hash::FxHashMap;
+
+use chematic_core::{AtomIdx, BondOrder, Molecule};
+use chematic_perception::aromaticity::{
+    AromaticityAlgorithm, AromaticityModel, assign_aromaticity_ex,
+};
+use chematic_smarts::{MatchConfig, QueryMolecule, find_matches_with_config, parse_smarts};
+
+use crate::bitvec::BitVec2048;
+use crate::rdkit_morgan_hash::hash_combine;
+
+/// RDKit's `pqs[]` (`PatternFingerprints.cpp`), verbatim and in order --
+/// 1-based position feeds directly into each pattern's hash seed.
+const PATTERNS: [&str; 13] = [
+    "[*]~[*]",
+    "[*]~[*]~[*]",
+    "[R]~1~[R]~[R]~1",
+    "[*]~[*](~[*])~[*]",
+    "[R]~1[R]~[R]~[R]~1",
+    "[*]~[*]~[*](~[*])~[*]",
+    "[R]~1~[R]~[R]~[R]~[R]~1",
+    "[R]~1~[R]~[R]~[R]~[R]~[R]~1",
+    "[R](@[R])(@[R])~[R]~[R](@[R])(@[R])",
+    "[R](@[R])(@[R])~[R]@[R]~[R](@[R])(@[R])",
+    "[*]~[R](@[R])@[R](@[R])~[*]",
+    "[*]~[R](@[R])@[R]@[R](@[R])~[*]",
+    "[*]",
+];
+
+/// RDKit's raw `Bond::BondType` enum integer, for the bond types that can
+/// occur on a concrete (non-query) `Molecule`'s own bonds. `Aromatic` is
+/// handled by the caller (always `12`, regardless of Kekule order -- see
+/// module doc comment); `Up`/`Down` are chematic's own stereo-annotated
+/// single bonds, hashed as plain `SINGLE` like every other single-bond
+/// context in this crate (matching [`crate::rdkit_torsion::num_pi_electrons`]'s
+/// own treatment).
+fn rdkit_bond_type_code(order: BondOrder) -> u32 {
+    match order {
+        BondOrder::Single | BondOrder::Up | BondOrder::Down | BondOrder::QueryAny => 1,
+        BondOrder::Double => 2,
+        BondOrder::Triple => 3,
+        BondOrder::Quadruple => 4,
+        BondOrder::Aromatic => 12,
+        BondOrder::Dative => 17,
+        BondOrder::Zero => 21,
+        // Query-only bond orders never occur on a concrete Molecule's own
+        // bonds (only on QueryMolecule bonds, which are never hashed here).
+        BondOrder::QuerySingleOrDouble
+        | BondOrder::QuerySingleOrAromatic
+        | BondOrder::QueryDoubleOrAromatic => 1,
+    }
+}
+
+/// Uses [`AromaticityModel::is_bond_aromatic`] rather than checking
+/// `bond.order == BondOrder::Aromatic` directly: chematic's SMILES parser
+/// preserves a Kekulized *input*'s literal alternating single/double bond
+/// orders verbatim (round-trip fidelity), even for a ring the atoms
+/// themselves are perceived as aromatic -- unlike RDKit, which always
+/// normalizes a perceived-aromatic bond's type to `AROMATIC` regardless of
+/// how the input SMILES wrote it. A bond-order check alone therefore misses
+/// every aromatic ring bond in Kekule-notation input (confirmed via a live
+/// oracle repro: a benzothiazole-fused system parsed from explicit `C1=CC=..`
+/// notation kept `Single`/`Double` bond orders in chematic while RDKit
+/// reported `AROMATIC` for the same bonds) -- re-perceiving aromaticity here
+/// is the fix, not a Kekulized-order-only check.
+fn matched_bond_code(
+    mol: &Molecule,
+    model: &AromaticityModel,
+    m: &FxHashMap<usize, AtomIdx>,
+    a1: usize,
+    a2: usize,
+) -> u32 {
+    let (bidx, bond) = mol
+        .bond_between(m[&a1], m[&a2])
+        .expect("a matched pattern bond must exist between its mapped target atoms");
+    if model.is_bond_aromatic(bidx) {
+        12
+    } else {
+        rdkit_bond_type_code(bond.order)
+    }
+}
+
+/// RDKit-bit-exact Pattern fingerprint, matching
+/// `rdkit.Chem.PatternFingerprint(mol, fpSize=2048)` (the Python API's own
+/// default, `tautomericFingerprint=False`).
+pub fn rdkit_pattern_fp(mol: &Molecule) -> BitVec2048 {
+    const FP_SIZE: u32 = 2048;
+    let mut fp = BitVec2048::new();
+    let cfg = MatchConfig {
+        uniquify: false,
+        ..MatchConfig::default()
+    };
+    let aromaticity = assign_aromaticity_ex(mol, AromaticityAlgorithm::RdkitLike);
+
+    for (i, smarts) in PATTERNS.iter().enumerate() {
+        let p_idx = (i + 1) as u32;
+        let query: QueryMolecule =
+            parse_smarts(smarts).unwrap_or_else(|e| panic!("built-in pattern '{smarts}': {e}"));
+        let matches = find_matches_with_config(&query, mol, &cfg);
+
+        let mut m_idx = p_idx
+            .wrapping_add(query.atoms.len() as u32)
+            .wrapping_add(query.bonds.len() as u32);
+        for _ in &matches {
+            m_idx = hash_combine(m_idx, 0xBEEF);
+            fp.set((m_idx % FP_SIZE) as usize);
+        }
+
+        for m in &matches {
+            let mut bit_id = p_idx;
+            for qi in 0..query.atoms.len() {
+                let an = mol.atom(m[&qi]).element.atomic_number() as u32;
+                bit_id = hash_combine(bit_id, an);
+            }
+            for qb in &query.bonds {
+                let code = matched_bond_code(mol, &aromaticity, m, qb.atom1, qb.atom2);
+                bit_id = hash_combine(bit_id, code);
+            }
+            fp.set((bit_id % FP_SIZE) as usize);
+        }
+    }
+    fp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chematic_smiles::parse;
+
+    fn mol(s: &str) -> Molecule {
+        parse(s).unwrap_or_else(|e| panic!("parse '{s}': {e}"))
+    }
+
+    #[test]
+    fn deterministic() {
+        let m = mol("CCO");
+        assert_eq!(rdkit_pattern_fp(&m), rdkit_pattern_fp(&m));
+    }
+
+    #[test]
+    fn different_molecules_differ() {
+        assert_ne!(rdkit_pattern_fp(&mol("CCO")), rdkit_pattern_fp(&mol("CCN")));
+    }
+
+    #[test]
+    fn single_atom_sets_at_least_one_bit() {
+        // The "[*]" fragment pattern alone guarantees a nonzero fingerprint
+        // for any non-empty molecule.
+        assert_ne!(rdkit_pattern_fp(&mol("C")), BitVec2048::new());
+    }
+}

--- a/crates/chematic-py/src/mol_methods.rs
+++ b/crates/chematic-py/src/mol_methods.rs
@@ -1400,9 +1400,15 @@ impl Mol {
     /// ``rdkit.Chem.PatternFingerprint(mol, fpSize=2048)``. Unlike
     /// :meth:`rdkit_torsion_fp`/:meth:`rdkit_atom_pair_fp`, this uses SMARTS
     /// substructure matching against 13 fixed patterns rather than a path/pair
-    /// enumeration. A separate, opt-in function from :meth:`pattern_fp`
-    /// (chematic's own native scheme, unchanged); neither affects the other's
-    /// output. Does not support ``tautomericFingerprint=True``.
+    /// enumeration. Measured against a live RDKit oracle on three corpora with
+    /// different chemical distributions: 100% bit-exact on a general and a
+    /// ChEMBL sample, 99.6% on an NCI sample -- the residual traces entirely to
+    /// chematic's own aromaticity-perception model disagreeing with RDKit's on
+    /// specific ring systems (see ``chematic_fp::rdkit_pattern``'s module doc
+    /// comment for detail), not a defect in this port's own logic. A separate,
+    /// opt-in function from :meth:`pattern_fp` (chematic's own native scheme,
+    /// unchanged); neither affects the other's output. Does not support
+    /// ``tautomericFingerprint=True``.
     fn rdkit_pattern_fp(&self) -> Vec<u8> {
         bitvec2048_to_bytes(&chematic_fp::rdkit_pattern_fp(&self.inner))
     }

--- a/crates/chematic-py/src/mol_methods.rs
+++ b/crates/chematic-py/src/mol_methods.rs
@@ -1393,6 +1393,20 @@ impl Mol {
         bitvec2048_to_bytes(&chematic_fp::rdkit_atom_pair_fp(&self.inner))
     }
 
+    /// RDKit-*compatible* (not yet fully bit-exact) Pattern fingerprint as
+    /// bytes (256 bytes = 2048 bits).
+    ///
+    /// A from-scratch Rust port of RDKit's
+    /// ``rdkit.Chem.PatternFingerprint(mol, fpSize=2048)``. Unlike
+    /// :meth:`rdkit_torsion_fp`/:meth:`rdkit_atom_pair_fp`, this uses SMARTS
+    /// substructure matching against 13 fixed patterns rather than a path/pair
+    /// enumeration. A separate, opt-in function from :meth:`pattern_fp`
+    /// (chematic's own native scheme, unchanged); neither affects the other's
+    /// output. Does not support ``tautomericFingerprint=True``.
+    fn rdkit_pattern_fp(&self) -> Vec<u8> {
+        bitvec2048_to_bytes(&chematic_fp::rdkit_pattern_fp(&self.inner))
+    }
+
     /// ECFP4 with chirality fingerprint as bytes.
     fn ecfp4_chiral(&self) -> Vec<u8> {
         let config = chematic_fp::EcfpConfig {

--- a/crates/chematic-py/tests/test_fp.py
+++ b/crates/chematic-py/tests/test_fp.py
@@ -176,6 +176,78 @@ def test_rdkit_atom_pair_fp_matches_rdkit_oracle_on_simple_molecules():
         assert chem_bits == rd_bits, f"{smi}: parity mismatch vs RDKit oracle"
 
 
+def _bits(fp_bytes):
+    return set(i for i in range(2048) if (fp_bytes[i // 8] >> (i % 8)) & 1)
+
+
+def test_rdkit_pattern_fp_substructure_bits_are_a_subset():
+    # Pattern fingerprints exist for substructure screening: a substructure's
+    # own bits must be a subset of its parent molecule's bits, or screening
+    # would produce false negatives. Checked on whole *concrete* molecules
+    # (this port doesn't support fingerprinting a SMARTS query molecule
+    # itself -- see the module's own doc comment) where one is a literal
+    # substructure of the other.
+    import chematic
+
+    pairs = [
+        ("c1ccccc1", "c1ccc2ccccc2c1"),
+        ("CCO", "CCOC"),
+        ("c1ccccc1", "CC(=O)Oc1ccccc1C(=O)O"),
+    ]
+    for sub, full in pairs:
+        b_sub = _bits(chematic.from_smiles(sub).rdkit_pattern_fp())
+        b_full = _bits(chematic.from_smiles(full).rdkit_pattern_fp())
+        assert b_sub <= b_full, f"{sub} bits not a subset of {full} bits"
+
+
+def test_rdkit_pattern_fp_length(aspirin):
+    assert len(aspirin.rdkit_pattern_fp()) == 256
+
+
+def test_rdkit_pattern_fp_different(aspirin, benzene):
+    assert aspirin.rdkit_pattern_fp() != benzene.rdkit_pattern_fp()
+
+
+def test_rdkit_pattern_fp_deterministic(aspirin):
+    assert aspirin.rdkit_pattern_fp() == aspirin.rdkit_pattern_fp()
+
+
+def test_rdkit_pattern_fp_independent_of_native_pattern_fp(aspirin):
+    # Separate opt-in function -- must not be the same bytes as the native
+    # (non-RDKit) scheme just because both happen to be 256-byte outputs.
+    assert aspirin.rdkit_pattern_fp() != aspirin.pattern_fp()
+
+
+def test_rdkit_pattern_fp_matches_rdkit_oracle_on_simple_molecules():
+    # Regression pin, including the Kekule-notation heteroaromatic that
+    # exposed the aromaticity-perception bug this port originally had (a raw
+    # bond.order == Aromatic check silently missed every ring bond of a
+    # Kekule-written aromatic ring) -- must stay bit-exact.
+    import chematic
+
+    cases = [
+        "CCO",
+        "CCCC",
+        "C1CC1",
+        "c1ccccc1",
+        "c1ccc2ccccc2c1",
+        "S1C2=CC3=CC=CC=C3C=C2N=C1C4=CC=CC=C4",
+    ]
+    try:
+        from rdkit import Chem
+    except ImportError:
+        return  # rdkit not installed in this environment -- skip
+    for smi in cases:
+        m_chem = chematic.from_smiles(smi)
+        m_rd = Chem.MolFromSmiles(smi)
+        rd_bits = Chem.PatternFingerprint(m_rd, fpSize=2048).ToBitString()
+        chem_bytes = m_chem.rdkit_pattern_fp()
+        chem_bits = "".join(
+            format(byte, "08b")[::-1] for byte in chem_bytes
+        )[:2048]
+        assert chem_bits == rd_bits, f"{smi}: parity mismatch vs RDKit oracle"
+
+
 # ---------------------------------------------------------------------------
 # MACCS
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Third entry in the fingerprint-parity series (Track A / 99-point directive Phase 6), after `rdkit_torsion_fp` (#431) and `rdkit_atom_pair_fp` (#432). Adds `chematic_fp::rdkit_pattern_fp` (Rust) / `Mol.rdkit_pattern_fp()` (Python): a from-scratch Rust port of RDKit's `PatternFingerprint`, opt-in and fully separate from the existing native `pattern_fp`.
- Structurally unrelated to the first two — Pattern uses SMARTS substructure matching against RDKit's own 13 fixed `pqs[]` patterns (`Code/GraphMol/Fingerprints/PatternFingerprints.cpp`), not a path/pair enumeration + shared atom invariant. Reuses chematic's existing `chematic-smarts` VF2 matcher (`uniquify: false`) rather than writing a new one — empirically confirmed (before any implementation was written) that it already reproduces RDKit's own `SubstructMatch(..., uniquify=False)` semantics exactly, including returning one match per automorphism (e.g. 12 matches for a 6-membered-ring pattern on benzene, not 1).
- Replicates RDKit's subtle "occurrence-count" mechanism exactly: a single hash seed per pattern gets folded with a constant once per match, carried forward across matches (not reset) — since the folded value never depends on which atoms matched, the resulting bit set is a pure function of match *count*, so this port doesn't need to replicate RDKit's own match enumeration *order*.
- The 13 fixed SMARTS patterns are pre-compiled once via `LazyLock` rather than re-parsed per molecule (`chematic-smarts`'s own docs flag re-parsing as the dominant overhead in repeated matching).

## Two bugs found and fixed

1. chematic's SMILES parser preserves a Kekule-notation input's literal single/double bond orders even when the ring is perceived as aromatic (round-trip fidelity), unlike RDKit, which always normalizes a perceived-aromatic bond's type to `AROMATIC` regardless of input notation. A first version checked `bond.order == BondOrder::Aromatic` directly and was 100% bit-exact on 2 of 3 corpora but only 30.4% on NCI — every Kekule-notation heteroaromatic (e.g. `S1C2=CC3=CC=CC=C3C=C2N=C1C4=CC=CC=C4`) silently hashed the wrong bond code. Fixed by using `chematic_perception::aromaticity::assign_aromaticity_ex` instead of the raw stored bond order.
2. That fix then regressed a ChEMBL sample 100% → 94.1%: naively re-perceiving *every* non-literally-aromatic bond wrongly classified a genuinely non-aromatic Kekule-written ring as aromatic when it coexisted with a lowercase-aromatic ring in the same molecule (e.g. `C1=C(c2ccccc2)N2CCCN=C2c2ccccc21` — two lowercase pendant phenyls plus a Kekule-written, genuinely non-aromatic central ring). Caught by an independent advisor review before merge, which predicted the exact fix and outcome. Fixed by only invoking re-perception for molecules with **zero** literal `Aromatic` bonds anywhere (pure Kekule input); molecules that already carry any literal `Aromatic` bond now trust every bond's own stored order throughout instead of re-perceiving.

## Result

Measured against a live RDKit oracle on three corpora with different chemical distributions:
- **100% bit-exact** on a 1000-molecule general corpus sample (`descriptor_census_corpus.smi`)
- **100% bit-exact** on a ChEMBL sample
- **99.6% bit-exact** on an NCI sample

The 4 remaining NCI mismatches are all wholly-Kekule-written molecules where re-perception is the only available aromaticity signal and chematic's own aromaticity-perception model disagrees with RDKit's for those specific ring systems (a brominated anthraquinone/xanthone core, an S/N-containing bicyclic heterocycle, a ketone-fused tetralone-like system, a Zn coordination complex) — a pre-existing, separate gap, independently confirmed **not** a defect in this fingerprint's own match-enumeration or hashing logic: per-pattern match *counts* were verified identical to RDKit's own `GetSubstructMatches(..., uniquify=False)` across all 13 patterns on a repro molecule before either bug was even found. Full aromaticity-perception parity with RDKit is a separate, much larger undertaking, out of scope here.

**Avalon deliberately parked, not attempted**: researched its real algorithm before committing any time — it lives in a vendored external C library (`reaccslib`/`struchk`/`canonizer`, a decades-old toolkit with its own mol representation), a toolkit port rather than a fingerprint port. Out of scope for this series' effort level, despite ranking numerically "closest" by raw hamming distance — that metric doesn't reflect porting difficulty.

## Test plan

- [x] `cargo test -p chematic-fp --lib` — 290/290
- [x] `cargo fmt --check` / `cargo clippy -p chematic-fp -p chematic-py --lib --tests -- -D warnings` — clean
- [x] `cargo check -p chematic-py -p chematic-wasm` — clean
- [x] `maturin develop` + `pytest crates/chematic-py/tests/test_fp.py` — 40/40 (6 new tests: standard length/determinism/independence checks, a live-RDKit-oracle regression pin including the Kekule-notation bug repro, and a substructure-screening subset-property check: `Q.bits ⊆ M.bits` for a substructure `Q` of molecule `M`)
- [x] Full `pytest` suite — 785/785 (779 existing + 6 new)

Not merging per standing session directive — opened for review only.