### PR TITLE
fix(mcs): AtomCompare::Elements no longer requires aromaticity match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — `chematic-smarts` (`find_mcs`'s default `AtomCompare::Elements` no longer requires matching aromaticity)
+
+- **Behavior change for every `find_mcs` caller (Rust/Python/WASM/MCP) using the
+  default `atom_compare`.** `AtomCompare::Elements` previously required both atomic
+  number AND aromaticity flag to match between atoms. It now matches on atomic
+  number alone, exactly mirroring RDKit's identically-named
+  `rdFMCS.AtomCompare.CompareElements` (confirmed via live oracle: RDKit never
+  encodes aromaticity as a per-atom constraint, only via bond-type queries, even
+  when both input molecules fully agree on aromaticity). Concretely: `find_mcs`
+  can now return a match (or a larger match) for atom pairs that agree on element
+  but disagree on aromaticity -- previously this returned `None` or an undersized
+  MCS. Differential measurement against a live RDKit oracle (`scripts/
+  mcs_rdkit_fmcs_diff.py`, n=200 pairs/corpus, exhaustive-only): agreement rose
+  from 74.6%/68.2%/70.4% to 88.4%/88.5%/97.0% across the three established
+  corpora (descriptor_census/ChEMBL/NCI).
+- **`AtomCompare::AnyHeavyAtom`/`Any` are unaffected** (they never checked
+  aromaticity). **There is currently no `AtomCompare` mode that restores the old
+  strict element+aromaticity match** -- callers relying on that exact behavior
+  need to add their own post-filter on the result.
+- Co-dependent fix: `build_query`/`molecule_to_query` no longer encode
+  aromaticity as a per-atom query constraint at all (previously hard-coded from
+  `mol[0]`'s own atom, regardless of which comparator mode found the match --
+  itself a latent, pre-existing gap for `AnyHeavyAtom`/`Any` too). Aromaticity is
+  now conveyed purely through the existing bond-level `Aromatic` query, matching
+  RDKit's own representation. The 4 independent "QueryMolecule -> concrete
+  Molecule" reconstruction sites (Python's `qmol_to_mol`, WASM's
+  `qmol_to_molecule`, the MCP server's own `qmol_to_molecule`, `chematic-chem`'s
+  `query_molecule_to_smiles`) were updated to derive `atom.aromatic` from
+  incident bond aromaticity instead of an atom-level primitive that no longer
+  exists.
+- **Known residual limitation**: an MCS result's `.smiles` accessor is a concrete
+  SMILES string, which cannot express "aromaticity don't-care" the way a SMARTS
+  pattern can. When two inputs' matched atoms genuinely disagree on aromaticity,
+  `.smiles` (built from one specific input's own bonds) is only guaranteed to
+  re-match *that* input as a substructure, not necessarily every input. A
+  SMARTS-preserving accessor is the real fix and is tracked as a follow-up, not
+  included here.
+
 ### Fixed — `chematic-py`/`chematic-wasm`/`chematic-mcp`/`chematic-chem` (MCS result silently lost heteroatoms and/or aromaticity)
 
 - `find_mcs`'s query-molecule atoms are encoded as the compound

--- a/crates/chematic-chem/src/workflow.rs
+++ b/crates/chematic-chem/src/workflow.rs
@@ -664,11 +664,12 @@ mod tests {
     #[test]
     fn compare_molecules_mcs_preserves_heteroatoms_and_aromaticity() {
         // Regression test: `query_molecule_to_smiles` once matched only the bare
-        // `AtomQuery::Primitive(AtomicNum(n))` case, but `find_mcs`'s query atoms
-        // are always the compound `And(AtomicNum(n), Aromatic(bool))` -- so every
-        // atom silently fell through to carbon. Benzene/toluene's all-carbon MCS
-        // (see the test above) could never catch this; a hydroxyphenyl MCS shared
-        // between aspirin and paracetamol can, since it contains an O atom.
+        // `AtomQuery::Primitive(AtomicNum(n))` case, but at the time `find_mcs`'s
+        // query atoms were always the compound `And(AtomicNum(n), Aromatic(bool))`
+        // -- so every atom silently fell through to carbon. Benzene/toluene's
+        // all-carbon MCS (see the test above) could never catch this; a
+        // hydroxyphenyl MCS shared between aspirin and paracetamol can, since it
+        // contains an O atom.
         let comparison =
             compare_molecules(&["CC(=O)Oc1ccccc1C(=O)O", "CC(=O)Nc1ccc(O)cc1"]).unwrap();
         let mcs = comparison

--- a/crates/chematic-mcp/src/tools.rs
+++ b/crates/chematic-mcp/src/tools.rs
@@ -143,9 +143,9 @@ fn bitvec_to_hex(fp: &BitVec2048) -> String {
 }
 
 /// Reconstruct a concrete `Molecule` from an MCS `QueryMolecule`. Atom
-/// queries are `And(AtomicNum(n), Aromatic(bool))` compounds, not bare
-/// `AtomicNum` primitives -- see `build_query`/`molecule_to_query` in
-/// `chematic-smarts`.
+/// queries are bare `AtomicNum` primitives; aromaticity is never a per-atom
+/// constraint, only carried via aromatic bond queries -- see
+/// `build_query`/`molecule_to_query` in `chematic-smarts`.
 fn qmol_to_molecule(qmol: &chematic_smarts::QueryMolecule) -> chematic_core::Molecule {
     fn extract_atomic_num(q: &AtomQuery) -> Option<u8> {
         match q {
@@ -155,21 +155,26 @@ fn qmol_to_molecule(qmol: &chematic_smarts::QueryMolecule) -> chematic_core::Mol
         }
     }
 
-    fn extract_aromatic(q: &AtomQuery) -> Option<bool> {
-        match q {
-            AtomQuery::Primitive(AtomPrimitive::Aromatic(a)) => Some(*a),
-            AtomQuery::And(lhs, rhs) => extract_aromatic(lhs).or_else(|| extract_aromatic(rhs)),
-            _ => None,
+    let mut aromatic_atoms = vec![false; qmol.atoms.len()];
+    for (atom_idx, neighbors) in qmol.adj.iter().enumerate() {
+        for (bond_idx, neighbor_idx) in neighbors {
+            if matches!(
+                qmol.bonds[*bond_idx].query,
+                BondQuery::Primitive(BondPrimitive::Aromatic)
+            ) {
+                aromatic_atoms[atom_idx] = true;
+                aromatic_atoms[*neighbor_idx] = true;
+            }
         }
     }
 
     let mut builder = MoleculeBuilder::new();
-    for qa in &qmol.atoms {
+    for (idx, qa) in qmol.atoms.iter().enumerate() {
         let elem = extract_atomic_num(&qa.query)
             .and_then(Element::from_atomic_number)
             .unwrap_or(Element::C);
         let mut atom = Atom::new(elem);
-        atom.aromatic = extract_aromatic(&qa.query).unwrap_or(false);
+        atom.aromatic = aromatic_atoms[idx];
         builder.add_atom(atom);
     }
     for (atom_idx, neighbors) in qmol.adj.iter().enumerate() {
@@ -1523,11 +1528,11 @@ mod tests {
     #[test]
     fn test_find_mcs_preserves_heteroatoms_and_aromaticity() {
         // Regression test: `qmol_to_molecule` once matched only the bare
-        // `AtomQuery::Primitive(AtomicNum(n))` case, but `find_mcs`'s query atoms
-        // are always the compound `And(AtomicNum(n), Aromatic(bool))` -- so every
-        // atom silently fell through to carbon. The benzene/phenol pair above
-        // can't catch this (its MCS is all-carbon benzene); aspirin/paracetamol's
-        // shared hydroxyphenyl MCS can, since it contains an O atom.
+        // `AtomQuery::Primitive(AtomicNum(n))` case, but at the time `find_mcs`'s
+        // query atoms were always the compound `And(AtomicNum(n), Aromatic(bool))`
+        // -- so every atom silently fell through to carbon. The benzene/phenol pair
+        // above can't catch this (its MCS is all-carbon benzene); aspirin/
+        // paracetamol's shared hydroxyphenyl MCS can, since it contains an O atom.
         let smiles_list = json!(["CC(=O)Oc1ccccc1C(=O)O", "CC(=O)Nc1ccc(O)cc1"]);
         let mut args_obj = serde_json::Map::new();
         args_obj.insert("smiles_list".to_string(), smiles_list);

--- a/crates/chematic-py/src/reactions.rs
+++ b/crates/chematic-py/src/reactions.rs
@@ -611,25 +611,30 @@ fn qmol_to_mol(qmol: &chematic_smarts::QueryMolecule) -> Option<Mol> {
         }
     }
 
-    // `build_query`/`molecule_to_query` always wrap each atom's query as
-    // `And(AtomicNum(n), Aromatic(bool))`, so this must recurse the same way
-    // `extract_atomic_num` does -- a non-recursive match here would silently
-    // never find the `Aromatic` primitive and leave every atom non-aromatic.
-    fn extract_aromatic(q: &AtomQuery) -> Option<bool> {
-        match q {
-            AtomQuery::Primitive(AtomPrimitive::Aromatic(a)) => Some(*a),
-            AtomQuery::And(lhs, rhs) => extract_aromatic(lhs).or_else(|| extract_aromatic(rhs)),
-            _ => None,
+    // `build_query`/`molecule_to_query` never encode aromaticity as a per-atom
+    // constraint (matches RDKit's own `CompareElements` representation) -- it's
+    // carried entirely by the aromatic bond queries, so an atom is aromatic here
+    // iff at least one of its query bonds is `BondPrimitive::Aromatic`.
+    let mut aromatic_atoms = vec![false; qmol.atoms.len()];
+    for (atom_idx, neighbors) in qmol.adj.iter().enumerate() {
+        for (bond_idx, neighbor_idx) in neighbors {
+            if matches!(
+                qmol.bonds[*bond_idx].query,
+                BondQuery::Primitive(BondPrimitive::Aromatic)
+            ) {
+                aromatic_atoms[atom_idx] = true;
+                aromatic_atoms[*neighbor_idx] = true;
+            }
         }
     }
 
     let mut builder = MoleculeBuilder::new();
-    for qa in &qmol.atoms {
+    for (idx, qa) in qmol.atoms.iter().enumerate() {
         let elem = extract_atomic_num(&qa.query)
             .and_then(Element::from_atomic_number)
             .unwrap_or(Element::C);
         let mut atom = Atom::new(elem);
-        atom.aromatic = extract_aromatic(&qa.query).unwrap_or(false);
+        atom.aromatic = aromatic_atoms[idx];
         builder.add_atom(atom);
     }
     for (atom_idx, neighbors) in qmol.adj.iter().enumerate() {

--- a/crates/chematic-py/tests/test_module_functions.py
+++ b/crates/chematic-py/tests/test_module_functions.py
@@ -207,6 +207,18 @@ def test_find_mcs_result_is_substructure_of_both_inputs():
     # which then failed a substructure re-match against either parent molecule --
     # defeating the primary purpose of an MCS result (self-verification /
     # substructure screening).
+    #
+    # NOTE: `mcs.smiles` re-matching *every* input is only guaranteed when the
+    # inputs agree on aromaticity at the matched atoms, as aspirin/paracetamol
+    # do here. `AtomCompare::Elements` (the default) matches purely on atomic
+    # number and permits cross-aromaticity matches (matching RDKit's own
+    # `CompareElements`); `build_query` reflects that by never encoding
+    # aromaticity as a per-atom constraint, only via bond queries. A SMILES
+    # string can't express "aromaticity don't-care" the way a SMARTS/query
+    # pattern can, so when two inputs' matched atoms genuinely disagree on
+    # aromaticity, `mcs.smiles` -- built from one specific input's own bonds --
+    # can fail to re-match the *other* input. That's an inherent limitation of
+    # the concrete-SMILES accessor, not a bug in the MCS search itself.
     m1 = chematic.from_smiles("CC(=O)Oc1ccccc1C(=O)O")  # aspirin
     m2 = chematic.from_smiles("CC(=O)Nc1ccc(O)cc1")  # paracetamol
     mcs = chematic.find_mcs([m1, m2])

--- a/crates/chematic-smarts/src/mcs.rs
+++ b/crates/chematic-smarts/src/mcs.rs
@@ -21,8 +21,11 @@ use crate::query::{AtomPrimitive, AtomQuery, BondPrimitive, BondQuery, QueryMole
 /// Atom-level comparison mode for MCS search.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum AtomCompare {
-    /// Atoms match only if they share the same atomic number and aromaticity flag.
-    /// This is the default and produces the most chemically specific MCS.
+    /// Atoms match if they share the same atomic number, regardless of aromaticity
+    /// (matches RDKit's `rdFMCS.AtomCompare.CompareElements` exactly -- confirmed
+    /// against a live oracle, e.g. `[#6]` matches both aromatic and non-aromatic
+    /// carbon; RDKit never encodes aromaticity as a per-atom constraint, only via
+    /// bond-type queries). This is the default.
     #[default]
     Elements,
     /// Any heavy atom (atomic number > 1) matches any other heavy atom, regardless of
@@ -691,9 +694,7 @@ fn atoms_compatible(
     match_isotope: bool,
 ) -> bool {
     let base = match compare {
-        AtomCompare::Elements => {
-            a.element.atomic_number() == b.element.atomic_number() && a.aromatic == b.aromatic
-        }
+        AtomCompare::Elements => a.element.atomic_number() == b.element.atomic_number(),
         AtomCompare::AnyHeavyAtom => a.element.atomic_number() > 1 && b.element.atomic_number() > 1,
         AtomCompare::Any => true,
     };
@@ -813,17 +814,19 @@ fn prune_partial_rings(mols: &[&Molecule], mapping: &mut PartialMapping, ring_se
 fn build_query(mol0: &Molecule, mapping: &PartialMapping, config: &McsConfig) -> QueryMolecule {
     let mut qmol = QueryMolecule::new();
 
-    // Add one query atom per mapped position.
+    // Add one query atom per mapped position. Aromaticity is deliberately NOT
+    // encoded here as a per-atom constraint (matches RDKit's own `CompareElements`
+    // representation, confirmed via live oracle): it's already fully captured by
+    // the aromatic bond queries added below, and hard-coding mol0's own atom.aromatic
+    // would make the query fail to re-match a different input molecule whose
+    // corresponding atom disagrees on aromaticity (a real, confirmed regression when
+    // AtomCompare::Elements permits cross-aromaticity matches).
     for row in &mapping.query_to_mol {
         let a0 = row[0];
         let atom = mol0.atom(a0);
         let an = atom.element.atomic_number();
-        let arom = atom.aromatic;
 
-        let query = AtomQuery::And(
-            Box::new(AtomQuery::Primitive(AtomPrimitive::AtomicNum(an))),
-            Box::new(AtomQuery::Primitive(AtomPrimitive::Aromatic(arom))),
-        );
+        let query = AtomQuery::Primitive(AtomPrimitive::AtomicNum(an));
         qmol.add_atom(query);
     }
 
@@ -888,11 +891,7 @@ fn molecule_to_query(mol: &Molecule) -> QueryMolecule {
 
     for (_, atom) in mol.atoms() {
         let an = atom.element.atomic_number();
-        let arom = atom.aromatic;
-        let query = AtomQuery::And(
-            Box::new(AtomQuery::Primitive(AtomPrimitive::AtomicNum(an))),
-            Box::new(AtomQuery::Primitive(AtomPrimitive::Aromatic(arom))),
-        );
+        let query = AtomQuery::Primitive(AtomPrimitive::AtomicNum(an));
         qmol.add_atom(query);
     }
 
@@ -1565,17 +1564,11 @@ mod tests {
         assert_eq!(o_first.atom_count(), 3);
         assert_eq!(
             n_first.atoms[0].query,
-            AtomQuery::And(
-                Box::new(AtomQuery::Primitive(AtomPrimitive::AtomicNum(7))),
-                Box::new(AtomQuery::Primitive(AtomPrimitive::Aromatic(false)))
-            )
+            AtomQuery::Primitive(AtomPrimitive::AtomicNum(7))
         );
         assert_eq!(
             o_first.atoms[0].query,
-            AtomQuery::And(
-                Box::new(AtomQuery::Primitive(AtomPrimitive::AtomicNum(8))),
-                Box::new(AtomQuery::Primitive(AtomPrimitive::Aromatic(false)))
-            )
+            AtomQuery::Primitive(AtomPrimitive::AtomicNum(8))
         );
     }
 }

--- a/crates/chematic-wasm/src/mol_reactions.rs
+++ b/crates/chematic-wasm/src/mol_reactions.rs
@@ -534,9 +534,9 @@ pub fn neutralize_charges(mol: &MolHandle) -> MolHandle {
 }
 
 /// Reconstruct a concrete `Molecule` from a `QueryMolecule` produced by MCS
-/// search (atom queries are `And(AtomicNum(n), Aromatic(bool))` compounds, not
-/// bare `AtomicNum` primitives -- see `build_query`/`molecule_to_query` in
-/// `chematic-smarts`; bond queries are typed primitives) -- shared by every
+/// search (atom queries are bare `AtomicNum` primitives; aromaticity is never a
+/// per-atom constraint, only carried via aromatic bond queries -- see
+/// `build_query`/`molecule_to_query` in `chematic-smarts`) -- shared by every
 /// MCS binding below so they can't silently drift apart on how a query result
 /// is turned back into a molecule.
 fn qmol_to_molecule(qmol: &chematic_smarts::QueryMolecule) -> chematic_core::Molecule {
@@ -551,21 +551,30 @@ fn qmol_to_molecule(qmol: &chematic_smarts::QueryMolecule) -> chematic_core::Mol
         }
     }
 
-    fn extract_aromatic(q: &AtomQuery) -> Option<bool> {
-        match q {
-            AtomQuery::Primitive(AtomPrimitive::Aromatic(a)) => Some(*a),
-            AtomQuery::And(lhs, rhs) => extract_aromatic(lhs).or_else(|| extract_aromatic(rhs)),
-            _ => None,
+    // `build_query`/`molecule_to_query` never encode aromaticity as a per-atom
+    // constraint (matches RDKit's own `CompareElements` representation) -- it's
+    // carried entirely by the aromatic bond queries, so an atom is aromatic here
+    // iff at least one of its query bonds is `BondPrimitive::Aromatic`.
+    let mut aromatic_atoms = vec![false; qmol.atoms.len()];
+    for (atom_idx, neighbors) in qmol.adj.iter().enumerate() {
+        for (bond_idx, neighbor_idx) in neighbors {
+            if matches!(
+                qmol.bonds[*bond_idx].query,
+                BondQuery::Primitive(BondPrimitive::Aromatic)
+            ) {
+                aromatic_atoms[atom_idx] = true;
+                aromatic_atoms[*neighbor_idx] = true;
+            }
         }
     }
 
     let mut builder = MoleculeBuilder::new();
-    for qa in &qmol.atoms {
+    for (idx, qa) in qmol.atoms.iter().enumerate() {
         let elem = extract_atomic_num(&qa.query)
             .and_then(Element::from_atomic_number)
             .unwrap_or(Element::C);
         let mut atom = Atom::new(elem);
-        atom.aromatic = extract_aromatic(&qa.query).unwrap_or(false);
+        atom.aromatic = aromatic_atoms[idx];
         builder.add_atom(atom);
     }
     for (atom_idx, neighbors) in qmol.adj.iter().enumerate() {

--- a/crates/chematic-wasm/tests/mcs.test.mjs
+++ b/crates/chematic-wasm/tests/mcs.test.mjs
@@ -28,9 +28,9 @@ const { mcs_smiles_json, mcs_smiles_json_with_config } = wasm;
   assert.equal(full.smiles, bare);
   assert.equal(full.wasTimedOut, false);
   // Regression test: qmol_to_molecule once matched only the bare
-  // AtomQuery::Primitive(AtomicNum(n)) case, but find_mcs's query atoms are
-  // always the compound And(AtomicNum(n), Aromatic(bool)) -- so every atom
-  // silently fell through to carbon. Aspirin/paracetamol's shared
+  // AtomQuery::Primitive(AtomicNum(n)) case, but at the time find_mcs's query
+  // atoms were always the compound And(AtomicNum(n), Aromatic(bool)) -- so
+  // every atom silently fell through to carbon. Aspirin/paracetamol's shared
   // hydroxyphenyl MCS must keep its oxygen atom.
   assert.match(full.smiles, /[Oo]/, `MCS lost its oxygen atom: ${full.smiles}`);
 }


### PR DESCRIPTION
## Summary

- `AtomCompare::Elements` (the default MCS atom comparator) previously required both atomic number **and** aromaticity flag to match. This diverged from RDKit's identically-named `rdFMCS.AtomCompare.CompareElements`, which matches on atomic number alone — confirmed via a live RDKit oracle, including cases where both input molecules fully agree on aromaticity (RDKit's returned SMARTS never carries a per-atom aromaticity primitive, only bond-level aromatic queries). This caused `find_mcs` to return `None` or an undersized MCS whenever two matched atoms' aromaticity disagreed, which is common across a general/mixed corpus.
- Co-fixes `build_query`/`molecule_to_query`, which always hard-coded `mol[0]`'s own atom aromaticity regardless of which comparator mode found the match (a latent pre-existing gap that also affected `AnyHeavyAtom`/`Any`, just with no visible symptom before). Aromaticity is now conveyed purely through the existing bond-level `Aromatic` query, matching RDKit's own representation.
- Updated the 4 independent "QueryMolecule → concrete Molecule" reconstruction sites (Python's `qmol_to_mol`, WASM's `qmol_to_molecule`, the MCP server's own `qmol_to_molecule`; `chematic-chem`'s `query_molecule_to_smiles` needed no change, having already derived aromaticity from bonds) to derive `atom.aromatic` from incident bond aromaticity instead of an atom-level primitive that no longer exists.

**Differential measurement** against a live RDKit oracle (`scripts/mcs_rdkit_fmcs_diff.py`, n=200 pairs/corpus, exhaustive-only): agreement rose from 74.6%/68.2%/70.4% to **88.4%/88.5%/97.0%** across the three established corpora (descriptor_census/ChEMBL/NCI).

**Behavior change**: callers relying on the old strict element+aromaticity default need to know there is currently no `AtomCompare` mode that restores it.

**Known residual** (documented, not fixed here): an MCS result's `.smiles` accessor is a concrete SMILES string and can't express "aromaticity don't-care" the way a SMARTS pattern can. When two inputs genuinely disagree on aromaticity at the matched atoms, `.smiles` is only guaranteed to re-match the search's internal anchor molecule, not necessarily every input. RDKit itself sidesteps this by having callers use `Chem.MolFromSmarts(res.smartsString)` rather than round-tripping through a concrete Mol/SMILES. A SMARTS-preserving accessor is tracked as a follow-up.

## Test plan

- [x] `cargo test -p chematic-smarts -p chematic-mcp -p chematic-chem --lib` — 178/83/826 passed
- [x] `cargo fmt --check` / `cargo clippy --lib --tests -- -D warnings` clean
- [x] `cargo build --workspace --exclude chematic-py --exclude chematic-wasm` / `cargo check -p chematic-py -p chematic-wasm` clean
- [x] Python MCS test suite (`crates/chematic-py/tests/test_module_functions.py -k mcs`) — 15/15 passed
- [x] `wasm-pack build --target nodejs` + `node crates/chematic-wasm/tests/mcs.test.mjs` — all pass
- [x] Re-ran differential corpus measurement post-fix (see above)