### PR TITLE
revert(chematic-3d): un-ignore atorvastatin_fragment test (arch-specific, not CI-broken)

### DIFF
--- a/crates/chematic-3d/src/minimize.rs
+++ b/crates/chematic-3d/src/minimize.rs
@@ -3894,16 +3894,6 @@ mod policy_bridge_tests {
     /// member this measurement actually closes, not a stand-in for the
     /// others.
     #[test]
-    #[ignore = "confirmed broken (issue #438): now fails deterministically with \
-                MinimizationFailed/CatastrophicBondBlowup instead of the success \
-                this test asserts. Reproduces identically (same numeric residuals \
-                to 13 significant figures) on a clean rebuild of main AND on a \
-                clean v0.22.0 worktree checkout, so it predates v0.22.0's release \
-                and is not a regression from any change landing in v0.23.0 -- \
-                chematic-3d/ has zero diff since v0.22.0. Root-causing the UFF/ \
-                distance-geometry convergence regression is its own investigation, \
-                not done here; ignored so cargo test --workspace stays green while \
-                the bug stays tracked."]
     fn uff_only_rescue_now_preserves_stereo_for_atorvastatin_fragment() {
         let mol = parse(
             "CC(C)c1c(C(=O)Nc2ccccc2)c(-c2ccccc2)c(-c2ccc(F)cc2)n1CC[C@@H](O)C[C@@H](O)CC(=O)O",


### PR DESCRIPTION
## Summary

Corrects an overreach from the v0.23.0 release (PR #439): I added `#[ignore]` to `uff_only_rescue_now_preserves_stereo_for_atorvastatin_fragment` after confirming it fails deterministically on this machine (macOS arm64, Apple M4), including on a clean `v0.22.0` worktree checkout. I concluded it was "confirmed broken" and predates v0.22.0 -- but never checked whether it fails in this project's own CI.

It doesn't. PR #437's `Test` job (`ubuntu-latest`, the exact run watched go green before merging) shows `chematic-3d`'s suite passing this test: `597 passed; 0 failed; 4 ignored`. So the failure is an **architecture-dependent floating-point/numerical-convergence discrepancy** in the UFF/distance-geometry rescue path (arm64 vs. x86_64), not a cross-environment regression.

Un-ignoring restores real, currently-passing CI coverage that the previous commit silently removed for no benefit -- CI was never failing on this test, so ignoring it only reduced test coverage going forward without fixing anything CI-visible.

Issue #438 stays open with a corrected comment; root-causing the actual arm64-vs-x86_64 numerical discrepancy is unchanged scope, not done here.

## Test plan

- [x] `cargo fmt --check` / `cargo clippy -p chematic-3d --lib --tests -- -D warnings` clean
- [x] CI's own `Test` job will re-confirm this test passes on `ubuntu-latest` (as it already did on PR #437)