### PR TITLE
feat: extend polymer and loss-preserving CDXML edits

### DIFF
--- a/crates/chematic-mol/src/cdxml_document.rs
+++ b/crates/chematic-mol/src/cdxml_document.rs
@@ -62,6 +62,13 @@ pub enum CdxmlEdit {
         page_id: String,
         object_index: usize,
     },
+    /// Replace an object at a parent-to-child sibling path. `[0, 1]` means
+    /// the second child of the first page-level object.
+    ReplaceObjectPath {
+        page_id: String,
+        path: Vec<usize>,
+        raw_xml: String,
+    },
 }
 
 impl CdxmlDocument {
@@ -179,6 +186,58 @@ impl CdxmlDocument {
             .iter()
             .position(|p| p.id.as_deref() == Some(page_id))
             .ok_or_else(|| CdxmlError::UnknownAtomRef("unknown page id".into()))?;
+        if let CdxmlEdit::ReplaceObjectPath { path, raw_xml, .. } = edit {
+            if path.is_empty() {
+                return Err(CdxmlError::UnknownAtomRef("object path is empty".into()));
+            }
+            let mut current_page = 0usize;
+            let mut in_target = false;
+            let mut open_paths: Vec<Vec<usize>> = Vec::new();
+            let mut sibling_counts = vec![0usize];
+            for i in 0..lines.len() {
+                let trimmed = lines[i].trim().to_owned();
+                if trimmed.starts_with("<page") && !trimmed.starts_with("</page") {
+                    in_target = current_page == page;
+                    open_paths.clear();
+                    sibling_counts.clear();
+                    sibling_counts.push(0);
+                    continue;
+                }
+                if !in_target {
+                    if trimmed.starts_with("</page") {
+                        current_page += 1;
+                    }
+                    continue;
+                }
+                if trimmed.starts_with("</page") {
+                    in_target = false;
+                    current_page += 1;
+                    continue;
+                }
+                if trimmed.starts_with("</") {
+                    if !open_paths.is_empty() {
+                        open_paths.pop();
+                        sibling_counts.pop();
+                    }
+                    continue;
+                }
+                if !is_editable_object_line(&trimmed) {
+                    continue;
+                }
+                let mut object_path = open_paths.last().cloned().unwrap_or_default();
+                object_path.push(*sibling_counts.last().unwrap_or(&0));
+                *sibling_counts.last_mut().unwrap_or(&mut 0) += 1;
+                if object_path == *path {
+                    lines[i] = raw_xml.clone();
+                    return Self::parse(&format!("{}\n", lines.join("\n")));
+                }
+                if !trimmed.ends_with("/>") {
+                    open_paths.push(object_path);
+                    sibling_counts.push(0);
+                }
+            }
+            return Err(CdxmlError::UnknownAtomRef("object path not found".into()));
+        }
         let mut page_index = 0usize;
         let mut in_page = false;
         let mut object_index = 0usize;
@@ -324,8 +383,17 @@ fn page_id_for(edit: &CdxmlEdit) -> &str {
         | CdxmlEdit::ReplaceObject { page_id, .. }
         | CdxmlEdit::SetObjectAttribute { page_id, .. }
         | CdxmlEdit::InsertObject { page_id, .. }
-        | CdxmlEdit::RemoveObject { page_id, .. } => page_id,
+        | CdxmlEdit::RemoveObject { page_id, .. }
+        | CdxmlEdit::ReplaceObjectPath { page_id, .. } => page_id,
     }
+}
+
+fn is_editable_object_line(line: &str) -> bool {
+    line.starts_with('<')
+        && !line.starts_with("</")
+        && !line.starts_with("<?")
+        && !line.starts_with("<!")
+        && !line.starts_with("<page")
 }
 
 #[cfg(test)]
@@ -408,5 +476,22 @@ mod tests {
             })
             .unwrap();
         assert!(!doc.write().contains("<graphic id=\"g1\"/>"));
+    }
+
+    #[test]
+    fn replaces_nested_object_by_loss_preserving_path() {
+        let input = "<CDXML>\n<page id=\"p1\">\n<group id=\"g1\" unknown=\"keep\">\n<arrow id=\"a1\" Custom=\"keep\"/>\n</group>\n</page>\n</CDXML>";
+        let doc = CdxmlDocument::parse(input).unwrap();
+        let doc = doc
+            .apply(&CdxmlEdit::ReplaceObjectPath {
+                page_id: "p1".into(),
+                path: vec![0, 0],
+                raw_xml: "<text id=\"t1\" Custom=\"keep\"/>".into(),
+            })
+            .unwrap();
+        let output = doc.write();
+        assert!(output.contains("<group id=\"g1\" unknown=\"keep\">"));
+        assert!(output.contains("<text id=\"t1\" Custom=\"keep\"/>"));
+        assert!(!output.contains("<arrow id=\"a1\""));
     }
 }

--- a/crates/chematic-mol/src/semantic.rs
+++ b/crates/chematic-mol/src/semantic.rs
@@ -254,7 +254,8 @@ impl SemanticModel {
                     })? as u32,
             );
             let mut unit_atoms = Vec::new();
-            for _ in 0..repeats {
+            let mut previous_right: Option<AtomIdx> = None;
+            for repeat_index in 0..repeats {
                 let fragment = chematic_smiles::parse(pattern).map_err(|e| {
                     SemanticError::InvalidExpansion {
                         id: unit.id.clone(),
@@ -308,23 +309,28 @@ impl SemanticModel {
                             })?;
                     }
                 }
+                let chain_left = previous_right.unwrap_or(left);
                 molecule
                     .add_bond(
-                        left,
+                        chain_left,
                         remap[&endpoint_left],
                         chematic_core::BondOrder::Single,
                     )
-                    .and_then(|_| {
-                        molecule.add_bond(
-                            right,
-                            remap[&endpoint_right],
-                            chematic_core::BondOrder::Single,
-                        )
-                    })
                     .map_err(|e| SemanticError::InvalidExpansion {
                         id: unit.id.clone(),
                         reason: e.to_string(),
                     })?;
+                let current_right = remap[&endpoint_right];
+                if repeat_index + 1 == repeats {
+                    molecule
+                        .add_bond(right, current_right, chematic_core::BondOrder::Single)
+                        .map_err(|e| SemanticError::InvalidExpansion {
+                            id: unit.id.clone(),
+                            reason: e.to_string(),
+                        })?;
+                } else {
+                    previous_right = Some(current_right);
+                }
             }
             mapping.insert(unit.id.clone(), unit_atoms);
         }
@@ -536,15 +542,15 @@ mod tests {
                     },
                 ],
                 end_groups: vec![],
-                repeat_count: Some(1),
+                repeat_count: Some(2),
                 repeat_smiles: Some("[*]CC[*]".into()),
                 repeat_endpoint_atoms: None,
             }],
             ..Default::default()
         };
         let expanded = model.expand(&base).unwrap();
-        assert_eq!(expanded.molecule.atom_count(), 4);
-        assert_eq!(expanded.source_to_expanded["p1"].len(), 2);
+        assert_eq!(expanded.molecule.atom_count(), 6);
+        assert_eq!(expanded.source_to_expanded["p1"].len(), 4);
     }
 
     #[test]
@@ -563,14 +569,14 @@ mod tests {
                     },
                 ],
                 end_groups: vec![],
-                repeat_count: Some(1),
+                repeat_count: Some(2),
                 repeat_smiles: Some("CCO".into()),
                 repeat_endpoint_atoms: Some([0, 2]),
             }],
             ..Default::default()
         };
         let expanded = model.expand(&base).unwrap();
-        assert_eq!(expanded.molecule.atom_count(), 5);
-        assert_eq!(expanded.source_to_expanded["p1"].len(), 3);
+        assert_eq!(expanded.molecule.atom_count(), 8);
+        assert_eq!(expanded.source_to_expanded["p1"].len(), 6);
     }
 }

--- a/docs/semantic-model.md
+++ b/docs/semantic-model.md
@@ -20,6 +20,8 @@ typed `SemanticError`; callers must not treat it as a best-effort molecule.
 
 `CdxmlDocument` preserves the original XML and exposes page/object summaries.
 `CdxmlEdit` applies bounded page-attribute or opaque-object replacements and
-re-parses the result before returning it. Unknown attributes and objects remain
-in `write()` output. The binding JSON marker is
+re-parses the result before returning it. `ReplaceObjectPath` addresses a
+multiline nested object by its parent-to-child sibling path (for example,
+`[0, 1]` is the second child of the first page-level object), while retaining
+unknown attributes and all untouched objects in `write()` output. The binding JSON marker is
 `chematic.cdxml-document.v1`.


### PR DESCRIPTION
## Summary
- support explicit non-placeholder polymer endpoints
- chain repeated units from left attachment through each repeat to the right attachment
- preserve source-to-expanded mapping for added repeat atoms
- add `CdxmlEdit::ReplaceObjectPath` for bounded nested/group object replacement
- preserve unknown attributes and untouched XML while reparsing edited documents

## Validation
- cargo fmt --all -- --check
- cargo test -p chematic-mol cdxml_document --offline
- cargo test -p chematic-mol semantic --offline
- cargo clippy -p chematic-mol --all-targets --offline -- -D warnings

Version remains unchanged.