### PR TITLE
docs: classify local milestones in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,221 +196,197 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Consolidated resource-safety release
 
-- Consolidates the local-only v2.x development milestones into the next
-  release after v0.88.0.
+- Consolidates the local-only development milestones into the next release
+  after v0.88.0.
 - Adds bounded parser, reaction, CLI, WASM, MCP, and output paths, plus the
   repeatable unsafe-surface gate documented in `ROADMAP.md`.
-- The former `2.x` headings below are historical implementation details of
-  this consolidated v0.89.0 release, not separately published releases.
+- The internal milestones below are implementation details of this
+  consolidated v0.89.0 release, not separately published releases.
 
 - Earlier in the same release line, the 3D XYZ parser gained bounded input,
   atom-count, and physical-line limits through `XyzParseLimits`.
 
-## [2.32.0] - 2026-09-01
+### Internal development milestones
 
-### v2.32.0 — repeatable unsafe-surface gate
+#### repeatable unsafe-surface gate
 
 - Added a local unsafe-surface checker that rejects executable `unsafe` outside
   the reviewed optional native-InChI FFI module.
 - Wired the checker into `scripts/check.sh` and recorded the S2 audit gate.
 
-## [2.31.0] - 2026-09-01
 
-### v2.31.0 — native-InChI unsafe boundary audit
+#### native-InChI unsafe boundary audit
 
 - Documented the optional native-InChI C FFI as the sole executable unsafe
   boundary and reconciled security claims with the implementation.
 - Recorded pointer, count, layout, and output-ownership checks in the security
   surface inventory.
 
-## [2.30.0] - 2026-09-01
 
-### v2.30.0 — bounded WASM library inputs
+#### bounded WASM library inputs
 
 - `enumerate_library_2way` now bounds template and fragment input strings to
   1 MiB before parsing.
 - Scaffold and building-block molecules are checked against the 10,000-atom
   WASM boundary before combinatorial enumeration.
 
-## [2.29.0] - 2026-09-01
 
-### v2.29.0 — bounded WASM reaction products
+#### bounded WASM reaction products
 
 - `run_reactants` and `enumerate_library_2way` now reject products over 10,000
   atoms before canonicalization and JSON materialization.
 - Reaction output atom limits are aligned with the existing WASM molecule
   input boundary.
 
-## [2.28.0] - 2026-09-01
 
-### v2.28.0 — bounded WASM R-group queries
+#### bounded WASM R-group queries
 
 - `rgroup_decompose_json` now rejects SMARTS queries over 10,000 atoms after
   compilation.
 - Query complexity is bounded separately from the 1 MiB source-text limit.
 
-## [2.27.0] - 2026-09-01
 
-### v2.27.0 — bounded WASM MMP results
+#### bounded WASM MMP results
 
 - `mmp_pairs_json` now rejects more than 1,024 matched molecular pairs before
   constructing the JSON result.
 - Quadratic pair-result expansion no longer returns a partial payload.
 
-## [2.26.0] - 2026-09-01
 
-### v2.26.0 — bounded WASM SMARTS configuration
+#### bounded WASM SMARTS configuration
 
 - `rgroup_decompose_json` now bounds `core_smarts` before SMARTS compilation.
 - R-group query configuration follows the same 1 MiB WASM input contract as
   MCS configuration JSON and other query inputs.
 
-## [2.25.0] - 2026-09-01
 
-### v2.25.0 — bounded WASM MCS configuration
+#### bounded WASM MCS configuration
 
 - `mcs_smiles_json_with_config` now bounds `config_json` before deserialization.
 - Oversized MCS configuration input returns an explicit JS error.
 
-## [2.24.0] - 2026-09-01
 
-### v2.24.0 — bounded WASM reactant execution
+#### bounded WASM reactant execution
 
 - `run_reactants` now bounds reaction input bytes, reactant count, and atoms
   per reactant before execution.
 - Product sets are capped at 1,024 entries and reject rather than returning a
   partial JSON result.
 
-## [2.23.0] - 2026-09-01
 
-### v2.23.0 — bounded WASM tautomer enumeration
+#### bounded WASM tautomer enumeration
 
 - `enumerate_tautomers_json` now caps results at 1,024 entries.
 - Result-count exhaustion returns an explicit error object instead of a
   partial or unbounded JSON array.
 
-## [2.22.0] - 2026-09-01
 
-### v2.22.0 — bounded WASM Extended XYZ JSON output
+#### bounded WASM Extended XYZ JSON output
 
 - `extxyz_frame_json` now applies the shared 16 MiB serialized JSON output
   limit before returning data across the JS boundary.
 
-## [2.21.0] - 2026-09-01
 
-### v2.21.0 — bounded WASM format JSON output
+#### bounded WASM format JSON output
 
 - Format-oriented WASM JSON helpers now reject serialized output over 16 MiB.
 - The limit applies after serialization and before the result crosses the JS
   boundary, preventing oversized JSON payloads from being returned silently.
 
-## [2.20.0] - 2026-09-01
 
-### v2.20.0 — bounded MCP request framing
+#### bounded MCP request framing
 
 - MCP stdio reads JSON-RPC frames with a bounded buffer before parsing.
 - Oversized frames fail closed instead of allowing `BufRead::lines()` to
   allocate an unbounded line.
 
-## [2.19.0] - 2026-09-01
 
-### v2.19.0 — bounded MCP stdio framing
+#### bounded MCP stdio framing
 
 - MCP stdio now reads each JSON-RPC frame with a bounded buffer before JSON
   parsing, rather than allowing `BufRead::lines()` to allocate an unbounded
   input line.
 - Oversized frames fail closed and do not continue as a partial request.
 
-## [2.18.0] - 2026-09-01
 
-### v2.18.0 — bounded CLI output
+#### bounded CLI output
 
 - CLI output is now capped at 64 MiB for both stdout and file destinations.
 - Oversized conversion or report output fails explicitly before writing a
   partial result.
 
-## [2.17.0] - 2026-09-01
 
-### v2.17.0 — bounded MCP JSON-RPC responses
+#### bounded MCP JSON-RPC responses
 
 - MCP stdio responses are now capped at 1 MiB after envelope serialization.
 - Oversized responses are replaced with an explicit protocol error instead of
   being written as an unbounded JSON-RPC line.
 
-## [2.16.0] - 2026-09-01
 
-### v2.16.0 — bounded MCP SMARTS matching
+#### bounded MCP SMARTS matching
 
 - MCP `smarts_match` now caps returned embeddings at 10,000 and VF2 visits at
   1,000,000.
 - Match-budget or result-count exhaustion returns an explicit domain error
   instead of a partial match list.
 
-## [2.15.0] - 2026-09-01
 
-### v2.15.0 — bounded MCP MolJSON parsing
+#### bounded MCP MolJSON parsing
 
 - MCP `moljson_to_smiles` now uses explicit MolJSON limits instead of the
   much larger library defaults.
 - MolJSON input is bounded to 100,000 bytes, depth 64, 1,024 array items,
   10,000 atoms, and 20,000 bonds before molecule construction.
 
-## [2.14.0] - 2026-09-01
 
-### v2.14.0 — bounded MCP chemistry arguments
+#### bounded MCP chemistry arguments
 
 - MCP SMILES tools now reject inputs over 100,000 bytes and parsed molecules
   over 10,000 atoms before descriptor, fingerprint, reaction, or 3D work.
 - MCP SMARTS matching now applies the same string-size boundary before query
   compilation.
 
-## [2.13.0] - 2026-09-01
 
-### v2.13.0 — bounded MCP upstream responses
+#### bounded MCP upstream responses
 
 - MCP PubChem name lookup now caps the response body at 1 MiB while reading.
 - Oversized or invalid UTF-8 upstream responses fail explicitly without
   retaining an unbounded response string.
 
-## [2.12.0] - 2026-09-01
 
-### v2.12.0 — bounded WASM format conversion bridge
+#### bounded WASM format conversion bridge
 
 - WASM `convert_common_format` now rejects parsed molecules above the binding
   atom limit before any output-format expansion or serialization.
 - Common topology-format conversion now shares the same explicit atom-boundary
   contract as the format-specific APIs.
 
-## [2.11.0] - 2026-09-01
 
-### v2.11.0 — bounded WASM typed-array format paths
+#### bounded WASM typed-array format paths
 
 - Cube/OpenDX typed-array accessors now use the same explicit WASM parser
   limits as their JSON siblings.
 - Grid point and atom bounds therefore apply consistently before numeric data
   is moved into typed-array vectors.
 
-## [2.10.0] - 2026-09-01
 
-### v2.10.0 — uniform WASM format-parser limits
+#### uniform WASM format-parser limits
 
 - WASM Cube/OpenDX, mmCIF, PQR, LAMMPS data, and single-frame dump parsing
   now passes explicit binding-sized limits into the underlying parsers.
 - Volumetric grids, atom records, lines, sections, and frame columns are
   bounded before large format structures are materialized.
 
-## [2.9.0] - 2026-09-01
 
-### v2.9.0 — bounded WASM structured-format parsers
+#### bounded WASM structured-format parsers
 
 - WASM ORCA input parsing now passes explicit binding-sized limits for lines,
   keywords, blocks, block bytes, and atoms.
 - WASM QCSchema molecule/input/result parsing now uses explicit limits for
   JSON depth, array items, string bytes, and total input bytes.
 
-## [2.8.0] - 2026-09-01
 
-### v2.8.0 — bounded WASM output-log parsing
+#### bounded WASM output-log parsing
 
 - WASM ORCA output parsing now applies binding-sized input, line, geometry
   frame, and geometry atom limits before retaining parsed output.
@@ -418,71 +394,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reader, including input bytes, line size, atoms per frame, columns, and frame
   count.
 
-## [2.7.0] - 2026-09-01
 
-### v2.7.0 — bounded WASM trajectory and ORCA arrays
+#### bounded WASM trajectory and ORCA arrays
 
 - WASM LAMMPS trajectory parsing now caps retained frames at 1,024 and fails
   explicitly before appending another frame.
 - ORCA JSON comments, keywords, blocks, and nested coordinate atoms now share
   the 1,024-item array limit before conversion into Rust vectors.
 
-## [2.6.0] - 2026-09-01
 
-### v2.6.0 — bounded WASM format arrays
+#### bounded WASM format arrays
 
 - WASM mmCIF/PQR record writers and LAMMPS trajectory writers now reject JSON
   arrays larger than 1,024 items before conversion into Rust record vectors.
 - Nested format arrays use the same binding-level item limit, preventing
   oversized intermediate allocations at the JSON boundary.
 
-## [2.5.0] - 2026-09-01
 
-### v2.5.0 — bounded WASM workflow molecules
+#### bounded WASM workflow molecules
 
 - High-level WASM workflow APIs now enforce a 10,000-atom limit for single
   molecules, batch comparison, screening, and 3D generation.
 - Oversized molecules are rejected before descriptor, similarity, or geometry
   work begins, avoiding unbounded downstream allocation.
 
-## [2.4.0] - 2026-09-01
 
-### v2.4.0 — bounded WASM depiction batches
+#### bounded WASM depiction batches
 
 - WASM depiction grids and HTML reports now bound input size, record count, and
   per-molecule atom count before rendering.
 - Limit violations return explicit SVG/HTML errors instead of allowing
   unbounded intermediate molecule and output allocation.
 
-## [2.3.0] - 2026-09-01
 
-### v2.3.0 — bounded WASM retro output
+#### bounded WASM retro output
 
 - WASM `retro_disconnect_json` now rejects requested result caps above 1,024.
 - `max_results = 0` now uses the WASM safety cap instead of meaning unlimited,
   preventing unbounded retro result and JSON growth at the binding boundary.
 
-## [2.2.0] - 2026-09-01
 
-### v2.2.0 — bounded WASM library inputs
+#### bounded WASM library inputs
 
 - WASM `enumerate_library_2way` now checks scaffold and building-block counts
   before parsing and collecting them.
 - Oversized pipe-delimited library inputs are rejected instead of creating
   unbounded intermediate vectors.
 
-## [2.1.0] - 2026-09-01
 
-### v2.1.0 — bounded WASM CDXML expansion
+#### bounded WASM CDXML expansion
 
 - WASM CDXML fragment conversion now passes its 1,024-fragment cap into the
   parser before fragment collection, avoiding oversized intermediate vectors.
 - The existing explicit error behavior for oversized fragment collections is
   preserved.
 
-## [2.0.0] - 2026-09-01
 
-### v2.0.0 — explicit WASM multi-record limits
+#### explicit WASM multi-record limits
 
 - WASM SDF JSON helpers now report record-count overflow instead of silently
   truncating after 1,024 records.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -457,104 +457,104 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WASM CDXML fragment conversion now rejects oversized fragment collections
   instead of returning a partial success result.
 
-## [1.9.0] - 2026-09-01
+### Internal development milestone
 
-### v1.9.0 — surfaced Python SMILES-file limits
+#### surfaced Python SMILES-file limits
 
 - Python `parse_smi_file` now propagates `.smi` resource-limit failures as
   `ValueError` instead of silently dropping them.
 - Ordinary malformed SMILES lines retain the existing skip behavior.
 
-## [1.8.0] - 2026-09-01
+### Internal development milestone
 
-### v1.8.0 — surfaced Python SDF resource limits
+#### surfaced Python SDF resource limits
 
 - Python `parse_sdf_with_coords` now propagates SDF resource-limit failures as
   `ValueError` instead of silently dropping them.
 - Ordinary malformed SDF records retain the existing skip behavior.
 
-## [1.7.0] - 2026-09-01
+### Internal development milestone
 
-### v1.7.0 — bounded Python coordinate writers
+#### bounded Python coordinate writers
 
 - Added a 100,000-atom input cap to Python `write_mmcif` and `write_pqr`.
 - Oversized atom collections are rejected before conversion into Rust record
   vectors, limiting binding-side allocation.
 
-## [1.6.0] - 2026-09-01
+### Internal development milestone
 
-### v1.6.0 — bounded Python SMILES writing
+#### bounded Python SMILES writing
 
 - Bounded Python `write_smi_file` to 100,000 records and 16 MiB of output.
 - Oversized output is rejected with `ValueError` before extending the output
   string beyond the configured limit.
 - Added checked output-size arithmetic.
 
-## [1.5.0] - 2026-09-01
+### Internal development milestone
 
-### v1.5.0 — bounded Python batch inputs
+#### bounded Python batch inputs
 
 - Added a 100,000-item cap to Python `from_smiles_list`, `descriptors_df`,
   and `screen` batch inputs.
 - Oversized batches are rejected before parallel parsing or descriptor work.
 - Added regression coverage for the batch boundary.
 
-## [1.4.0] - 2026-09-01
+### Internal development milestone
 
-### v1.4.0 — bounded Python format conversion
+#### bounded Python format conversion
 
 - Added a 16 MiB UTF-8 input cap to Python `convert_format` before dispatching
   to format parsers.
 - Added a regression test for oversized conversion input.
 
-## [1.3.0] - 2026-08-31
+### Internal development milestone
 
-### v1.3.0 — bounded reaction-pattern library queries
+#### bounded reaction-pattern library queries
 
 - Added `batch_query_with_library_with_limits`.
 - Pattern-library batch queries can now bound reaction and pattern counts
   before allocating result maps.
 - Added typed resource-limit handling through `ReactionQueryError`.
 
-## [1.2.0] - 2026-08-31
+### Internal development milestone
 
-### v1.2.0 — bounded reaction query embeddings
+#### bounded reaction query embeddings
 
 - Reaction SMARTS query reporting now asks the VF2 matcher for only the first
   embedding per molecule, matching the public result contract.
 - Avoided retaining all symmetric embeddings when only existence/one example
   is reported.
 
-## [1.1.0] - 2026-08-31
+### Internal development milestone
 
-### v1.1.0 — bounded batch reaction queries
+#### bounded batch reaction queries
 
 - Added `BatchQueryLimits` and `batch_query_reactions_with_limits`.
 - Batch reaction SMARTS queries now use a finite default reaction-count limit
   and return typed resource-limit errors before processing oversized input.
 - Added regression coverage for the batch boundary.
 
-## [1.0.0-pre.1] - 2026-08-31
+### Internal development milestone
 
-### Pre-release milestone — bounded retro-result retention
+#### bounded retro-result retention
 
 - Retrosynthesis enumeration now enforces `max_results` before retaining a
   new precursor set and its canonical strings.
 - Prevented oversized template result bursts from temporarily exceeding the
   caller's output cap.
 
-## [0.99.0] - 2026-08-31
+### Internal development milestone
 
-### v0.99.0 — bounded reaction-template matching
+#### bounded reaction-template matching
 
 - Added `ReactionTransformLimits` and explicit limited reaction matching APIs.
 - `run_reactants` and `find_reaction_matches` now use finite default match
   limits and reject oversized VF2 result sets before Cartesian expansion.
 - Added typed `TransformError::ResourceLimit` and regression coverage.
 
-## [0.98.0] - 2026-08-31
+### Internal development milestone
 
-### v0.98.0 — pre-allocation library output bounds
+#### pre-allocation library output bounds
 
 - Reaction-library enumeration now checks `max_size` before extending the
   accumulated product vector.
@@ -562,9 +562,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the configured output cap.
 - Added regression coverage for the pre-extension boundary.
 
-## [0.97.0] - 2026-08-31
+### Internal development milestone
 
-### v0.97.0 — checked reaction-library enumeration bounds
+#### checked reaction-library enumeration bounds
 
 - Empty fragment sets now return an empty library instead of entering an
   invalid indexing path.
@@ -572,9 +572,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a typed `CombinationCountOverflow` error on overflow.
 - Added regression coverage for the empty-set boundary.
 
-## [0.96.0] - 2026-08-31
+### Internal development milestone
 
-### v0.96.0 — bounded MDL RXN file parsing
+#### bounded MDL RXN file parsing
 
 - Added `RxnFileParseLimits` and `parse_rxn_file_with_limits`.
 - Bounded RXN input bytes, declared reactants/products, and retained MOL
@@ -582,54 +582,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Avoided materializing an unbounded intermediate `$MOL` block list and added
   regression coverage for input and component limits.
 
-## [0.95.0] - 2026-08-31
+### Internal development milestone
 
-### v0.95.0 — bounded streaming TDT reading
+#### bounded streaming TDT reading
 
 - Added record-count and per-record tag-count limits to `TdtReaderOptions`.
 - TDT streams now fail explicitly with typed resource-limit errors before
   retaining unbounded record state.
 - Added regression coverage for both limits.
 
-## [0.94.0] - 2026-08-31
+### Internal development milestone
 
-### v0.94.0 — bounded streaming SMILES tables
+#### bounded streaming SMILES tables
 
 - Added record-count and field-count limits to `SmilesRecordReader`.
 - Oversized streaming tables now return typed `TooManyRecords` or
   `TooManyFields` errors instead of growing unboundedly.
 - Added regression coverage for both streaming resource limits.
 
-## [0.93.0] - 2026-08-31
+### Internal development milestone
 
-### v0.93.0 — bounded InChI parsing
+#### bounded InChI parsing
 
 - Added `InchiParseLimits` and `parse_inchi_with_limits`.
 - Bounded pure-Rust InChI input bytes and heavy-atom construction before
   allocation with typed resource-limit errors.
 - Added regression coverage for input and atom limits.
 
-## [0.92.0] - 2026-08-31
+### Internal development milestone
 
-### v0.92.0 — bounded pure-Rust InChI parsing
+#### bounded pure-Rust InChI parsing
 
 - Added `InchiParseLimits` and `parse_inchi_with_limits`.
 - Bounded InChI input bytes and heavy-atom construction before allocation,
   returning typed `InchiParseError::ResourceLimit` failures.
 - Added regression coverage for input and atom limits.
 
-## [0.91.0] - 2026-08-31
+### Internal development milestone
 
-### v0.91.0 — bounded SMILES-table reading
+#### bounded SMILES-table reading
 
 - Added `SmiFileParseLimits` and `parse_smi_file_with_limits`.
 - Bounded `.smi` input bytes, physical line bytes, and yielded records with
   typed `SmilesError::ResourceLimit` outcomes.
 - Added regression coverage for file-level resource limits.
 
-## [0.90.0] - 2026-08-31
+### Internal development milestone
 
-### v0.90.0 — bounded KET parsing
+#### bounded KET parsing
 
 - Added `KetParseLimits` and explicit limited KET parsing APIs.
 - KET input bytes, atoms, and bonds are now bounded with typed resource-limit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,9 @@ No unreleased changes.
 - Rebuilt the checked-in demo WASM bundle at v1.0.0 so browser smoke tests use
   the same version as the workspace release.
 
-### v0.89.0 maintenance — bounded WASM geometry inputs
+## [0.89.0] - 2026-09-01
+
+### Maintenance — bounded WASM geometry inputs
 
 - Locally integrated and verified the Dependabot #444 `jsonschema` update
   (`0.50.1` → `0.52.1`); the workspace and all 85 MCP unit tests pass.
@@ -174,21 +176,17 @@ No unreleased changes.
 - WASM PDBQT conversion now reports malformed coordinate or charge JSON instead
   of silently defaulting to empty arrays.
 
-## [0.89.0] - 2026-09-01
-
-### v0.89.0 — consolidated resource-safety release
+### Consolidated resource-safety release
 
 - Consolidates the local-only v2.x development milestones into the next
   release after v0.88.0.
 - Adds bounded parser, reaction, CLI, WASM, MCP, and output paths, plus the
   repeatable unsafe-surface gate documented in `ROADMAP.md`.
-- This version was published from the verified main release commit; the
-  consolidated 2.x milestone headings below remain historical implementation
-  detail rather than additional published releases.
+- The former `2.x` headings below are historical implementation details of
+  this consolidated v0.89.0 release, not separately published releases.
 
-The former `2.x` headings below are local development milestone labels only;
-they were never published and are included as implementation detail for the
-consolidated v0.89.0 release.
+- Earlier in the same release line, the 3D XYZ parser gained bounded input,
+  atom-count, and physical-line limits through `XyzParseLimits`.
 
 ## [2.32.0] - 2026-09-01
 
@@ -550,9 +548,9 @@ consolidated v0.89.0 release.
   and return typed resource-limit errors before processing oversized input.
 - Added regression coverage for the batch boundary.
 
-## [1.0.0] - 2026-08-31
+## [1.0.0-pre.1] - 2026-08-31
 
-### v1.0.0 — bounded retro-result retention
+### Pre-release milestone — bounded retro-result retention
 
 - Retrosynthesis enumeration now enforces `max_results` before retaining a
   new precursor set and its canonical strings.
@@ -651,15 +649,6 @@ consolidated v0.89.0 release.
 - KET input bytes, atoms, and bonds are now bounded with typed resource-limit
   errors, including through the existing Python and WASM parser paths.
 - Added regression coverage for all KET resource limits.
-
-## [0.89.0] - 2026-08-31
-
-### v0.89.0 — bounded 3D XYZ parsing
-
-- Added `XyzParseLimits` and `parse_xyz_with_limits` to `chematic-3d`.
-- Bounded input bytes, declared atom count, and physical line length for the
-  bond-inferring XYZ parser used by Python and WASM bindings.
-- Added regression coverage for each resource-limit error.
 
 ## [0.88.0] - 2026-08-31
 
@@ -8778,7 +8767,9 @@ Initial release covering Phase 1 (foundation) and Phase 2 (molecular perception 
 - `#![forbid(unsafe_code)]` on all crates.
 - FNV-1a hashing for reproducible, deterministic canonical SMILES across platforms.
 
-[Unreleased]: https://github.com/kent-tokyo/chematic/compare/v0.31.0...HEAD
+[Unreleased]: https://github.com/kent-tokyo/chematic/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/kent-tokyo/chematic/releases/tag/v1.0.0
+[0.89.0]: https://github.com/kent-tokyo/chematic/releases/tag/v0.89.0
 [0.36.0]: https://github.com/kent-tokyo/chematic/compare/v0.35.0...v0.36.0
 [0.37.0]: https://github.com/kent-tokyo/chematic/compare/v0.36.0...v0.37.0
 [0.38.0]: https://github.com/kent-tokyo/chematic/compare/v0.37.0...v0.38.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No unreleased changes.
+### Improved — `chematic-3d` UFF stereo rescue (#210)
+
+- The bounded UFF rescue now tries up to three deterministic distance-geometry
+  starts when an earlier stereo-preserving start is unsound or cannot converge.
+  The original default seed remains first and successful candidates are accepted
+  immediately, preserving existing successful results while covering additional
+  stochastic embedding basins.
+- Each candidate still requires finite coordinates, sane bond lengths, sound
+  minimization, and fully satisfied declared stereo; if all candidates fail, the
+  original typed failure is returned unchanged apart from the retry marker.
+
+## [1.0.1] - 2026-09-03
+
+### Release status
+
+- Patch release containing the bounded, deterministic UFF stereo-rescue retry
+  improvement and its regression evidence.
+- The v1.0.0 compatibility boundary and known Experimental/non-parity scope are
+  unchanged.
 
 ## [1.0.0] - 2026-09-03
 
@@ -8768,6 +8786,7 @@ Initial release covering Phase 1 (foundation) and Phase 2 (molecular perception 
 - FNV-1a hashing for reproducible, deterministic canonical SMILES across platforms.
 
 [Unreleased]: https://github.com/kent-tokyo/chematic/compare/v1.0.0...HEAD
+[1.0.1]: https://github.com/kent-tokyo/chematic/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/kent-tokyo/chematic/releases/tag/v1.0.0
 [0.89.0]: https://github.com/kent-tokyo/chematic/releases/tag/v0.89.0
 [0.36.0]: https://github.com/kent-tokyo/chematic/compare/v0.35.0...v0.36.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chematic"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chematic-3d",
  "chematic-chem",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-3d"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chematic-chem",
  "chematic-core",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-chem"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chematic-cip",
  "chematic-core",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-cip"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chematic-chem",
  "chematic-core",
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chematic-chem",
  "chematic-core",
@@ -317,11 +317,11 @@ dependencies = [
 
 [[package]]
 name = "chematic-core"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 name = "chematic-crystal"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chematic-core",
  "criterion",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-depict"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chematic-core",
  "chematic-perception",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-ewald"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chematic-3d",
  "chematic-core",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-ff"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chematic-core",
  "chematic-perception",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-fp"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chematic-cip",
  "chematic-core",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-inchi"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cc",
  "chematic-chem",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-iupac"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chematic-core",
  "chematic-perception",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-mcp"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chematic-3d",
  "chematic-chem",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-mol"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chematic-chem",
  "chematic-core",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-perception"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chematic-core",
  "chematic-smiles",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-py"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chematic-3d",
  "chematic-chem",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-rxn"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chematic-chem",
  "chematic-core",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-smarts"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chematic-core",
  "chematic-perception",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-smiles"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chematic-core",
  "chematic-perception",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-wasm"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chematic-3d",
  "chematic-chem",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Kentaro Tanabe (kent-tokyo) <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ can vary slightly by toolchain and build environment.
 | IUPAC name generation | Partial (25+ classes) |
 | Pure-Rust InChI | Approximate (enable `native-inchi` feature for exact) |
 
-### v1.0.0 release boundary
+### v1.0.1 release boundary
 
-The v1.0 release candidate is intended to ship with the documented bounded
+The v1.0.1 patch release retains the v1.0.0 documented bounded
 CDXML/polymer API, partial Python `RWMol` compatibility, fail-closed canonical
 identity, explicit aromaticity/CIP modes, and Experimental 3D/MMFF94. The
 complete compatibility contract and reproducible local release gate are in
@@ -213,7 +213,7 @@ differential-validation results vs RDKit, and runnable examples.
 ```python
 import chematic
 chematic.doctor()
-# chematic v1.0.0 candidate
+# chematic v1.0.1
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-07-17, v0.4.29 vs RDKit 2026.03.3 --
@@ -609,7 +609,7 @@ Full benchmark methodology → [validation/](validation/) · History → [benchm
 
 ```
 chematic/
-├── Cargo.toml                    workspace root (v1.0.0 candidate)
+├── Cargo.toml                    workspace root (v1.0.1)
 ├── CHANGELOG.md
 ├── crates/
 │   ├── chematic-core/            Atom, Bond, Molecule, Element, kekulization (4-pass + blossom)

--- a/README_ja.md
+++ b/README_ja.md
@@ -16,9 +16,9 @@ Python・Rust・ブラウザ向けケモインフォマティクスライブラ�
 **デフォルトで速く、設計で安全なケモインフォマティクス。**  
 Pure Rust · C/C++ ゼロ · Python · WebAssembly · [公式サイト](https://chematic.io/) · [ライブデモ](https://kent-tokyo.github.io/chematic/playground/)
 
-### v1.0.0 の対応範囲
+### v1.0.1 の対応範囲
 
-v1.0.0 は、bounded な CDXML/polymer API、部分的な Python `RWMol`
+v1.0.1 は、v1.0.0 の対応範囲を維持し、bounded な CDXML/polymer API、部分的な Python `RWMol`
 互換、fail-closed canonical identity、明示的な aromaticity/CIP モード、
 Experimental の 3D/MMFF94 を公開契約とします。完全な任意構造 CDXML 編集、
 複雑な Markush/polymer 展開、完全な RDKit `RWMol` 互換、3D の完全な
@@ -134,7 +134,7 @@ Rust・JavaScript の詳細な使用例は [ドキュメント](https://kent-tok
 ```python
 import chematic
 chematic.doctor()
-# chematic v1.0.0 candidate
+# chematic v1.0.1
 # Python 3.12.x  |  darwin arm64
 #
 # Descriptor accuracy (benchmark 2026-06, v0.4.22 vs RDKit 2026.03.3 --

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,12 +4,13 @@
 
 | Version | Supported | Status |
 |---------|-----------|--------|
+| v1.0.1 | Yes (partial registries) | Current patch release; GitHub Release, crates.io, and PyPI publication follows the v1.0.0 boundary |
 | v1.0.0 | Yes (partial registries) | GitHub Release, crates.io, and PyPI published; npm publication is blocked by registry scope/token permissions |
 | v0.89.0 | Yes | Previous published release; release evidence verified |
 | v0.88.0 | Limited | Previous stable release — security fixes only |
 | < v0.88.0 | Limited | Security fixes only (limited) |
 
-**Active Support**: v1.0.0 is the latest published release. The npm package
+**Active Support**: v1.0.1 is the latest release. The npm package
 publication remains an external registry configuration follow-up.
 **Release evidence**: v0.89.0 was built from main commit `344e9dc2`; the
 release-key evidence workflow passed in run `33699428867`, including clean
@@ -138,6 +139,12 @@ Subscribe to GitHub notifications for this repository to receive alerts about se
 ---
 
 ## Security Fix History
+
+### v1.0.1 verification status
+
+- This patch release preserves the v1.0.0 security boundary and adds no new
+  input or privilege boundary. The local release checks cover the bounded UFF
+  rescue change, documentation consistency, and the existing workspace gates.
 
 ### v1.0.0 verification status
 

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -17,12 +17,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "1.0.0" }
-chematic-perception = { path = "../chematic-perception", version = "1.0.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "1.0.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "1.0.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "1.0.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.0" }
+chematic-core       = { path = "../chematic-core",       version = "1.0.1" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.1" }
+chematic-ff         = { path = "../chematic-ff",         version = "1.0.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "1.0.1" }
+chematic-fp         = { path = "../chematic-fp",         version = "1.0.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.1" }
 serde_json          = "1.0"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #219); web-time

--- a/crates/chematic-3d/src/minimize.rs
+++ b/crates/chematic-3d/src/minimize.rs
@@ -2116,8 +2116,9 @@ fn run_uff_bridge(
 /// `pipeline_v2.rs` stage 11 exists to catch and retry; this simpler
 /// embed→minimize→verify bridge just falls through to the original failure
 /// instead, which is correct/safe, not a bug) — closing that residual would
-/// need adding an equivalent repair step here, a separate, larger change not
-/// attempted by this measurement.
+/// need adding an equivalent repair step here. The rescue now makes a bounded,
+/// deterministic three-seed search, but that is a robustness retry and not a
+/// claim of complete stereochemical convergence for every topology.
 ///
 /// If `embed_distance_geometry_v2` itself fails, or the retry is unsound or
 /// stereo-violating, the ORIGINAL failure is returned unchanged except for
@@ -2138,12 +2139,23 @@ fn rescue_with_distance_geometry_v2(
     // See this function's own doc comment ("Revised, issue #210") for why
     // these are set instead of `EmbedParameters::default()`.
     let has_stereo = mol_has_declared_stereo(mol);
-    let embed_params = EmbedParameters {
+    // Try a small fixed set of independent starts. This is deterministic and
+    // keeps the rescue cost bounded while avoiding dependence on one unlucky
+    // stereo-preserving embedding basin.
+    const RESCUE_SEED_OFFSETS: [u64; 3] = [0, 0x9E37_79B9_7F4A_7C15, 0xD1B5_4A32_D192_ED03];
+    let base_params = EmbedParameters {
         enforce_chirality: has_stereo,
         materialize_implicit_h_for_chirality: has_stereo,
         ..EmbedParameters::default()
     };
-    if let Ok(v2_coords) = embed_distance_geometry_v2(mol, &embed_params) {
+    for offset in RESCUE_SEED_OFFSETS {
+        let embed_params = EmbedParameters {
+            random_seed: base_params.random_seed.wrapping_add(offset),
+            ..base_params.clone()
+        };
+        let Ok(v2_coords) = embed_distance_geometry_v2(mol, &embed_params) else {
+            continue;
+        };
         let retry_coord_vec = coords_to_vec(&v2_coords, n);
         // `energy_before`/`energy_after` on a successful rescue must both describe
         // the SAME trajectory (the DG v2 geometry, before and after minimizing it) --

--- a/crates/chematic-3d/src/minimize.rs
+++ b/crates/chematic-3d/src/minimize.rs
@@ -2005,11 +2005,14 @@ struct UffBridgeRun {
 /// Issues #185/#188 (UFF minimizer catastrophic bond-length blowup on some
 /// starting geometries, sound convergence on others, at the shared default
 /// 200-iteration budget): tries the caller-provided `coords` first, exactly
-/// as before. Only if that specific attempt fails soundness with
-/// `CatastrophicBondBlowup`/`NonFiniteCoordinates` does this retry once from
-/// `embed_distance_geometry_v2`'s geometry instead (see
+/// as before. A retry occurs for a catastrophic/non-finite result, or when
+/// chematic-ff reports that it rejected an energy-decreasing but unsound
+/// proposal during line search. The latter preserves the distinction between
+/// an ordinary residual-force failure and a failure caused by the bounded
+/// blowup guard. The retry uses `embed_distance_geometry_v2`'s geometry (see
 /// [`rescue_with_distance_geometry_v2`] for why this is a post-hoc retry on
 /// the actual outcome, not a pre-minimization heuristic guess) — every other
+/// caller
 /// caller (including every molecule that already passes today) sees zero
 /// behavior change, and this never silently substitutes: which geometry
 /// actually produced the returned result is always visible on
@@ -2049,11 +2052,12 @@ fn run_uff_bridge(
             starting_geometry: UffStartingGeometry::AsProvided,
         }),
         Err(ForceFieldBridgeError::MinimizationFailed(detail))
-            if matches!(
-                detail.reason,
-                MinimizationFailureReason::CatastrophicBondBlowup
-                    | MinimizationFailureReason::NonFiniteCoordinates
-            ) =>
+            if result.rejected_unsound_step
+                || matches!(
+                    detail.reason,
+                    MinimizationFailureReason::CatastrophicBondBlowup
+                        | MinimizationFailureReason::NonFiniteCoordinates
+                ) =>
         {
             rescue_with_distance_geometry_v2(mol, &types, max_iter, detail)
         }
@@ -3297,21 +3301,13 @@ mod policy_bridge_tests {
     /// it reproduces inside chematic-ff's own UFF minimizer. Confirmed: the
     /// vdW 1-3 exclusion bug (chematic-ff #176) is already fixed (verified
     /// by reading `uff.rs`'s graph-based exclusion set), so this is a
-    /// distinct, still-open chematic-ff robustness gap (candidate cause,
-    /// unproven: `minimize_uff`'s naive steepest-descent-with-step-halving
-    /// line search on a larger, more constrained fused-ring system) — not
-    /// something this PR fixes (chematic-ff is out of this PR's
-    /// file-ownership scope) or definitively diagnoses. Not specific to
-    /// ring count either way: anthracene (3 fused rings) blows up under the
-    /// same isolated path too, and worse than naphthalene (2 fused
-    /// rings) — it never recovers a sound geometry even at 200,000 steps,
-    /// vs. naphthalene's ~10,000 (see issue #185's investigation notes; an
-    /// earlier reading of anthracene as "immune" was itself an artifact of
-    /// a since-fixed `dg::generate_coords` ring-placement bug that
-    /// silently superimposed two of its rings, corrupting that
-    /// measurement).
+    /// Regression for issue #185: chematic-ff's incomplete UFF potential must
+    /// not be allowed to accept an energy-decreasing proposal with a
+    /// catastrophically stretched fused-aromatic bond. The minimizer now
+    /// rejects that proposal in its line search and returns a bounded,
+    /// explicitly unsound result only if no sound descent step remains.
     #[test]
-    fn chematic_ff_own_uff_minimizer_blows_up_naphthalene_independent_of_this_bridge() {
+    fn chematic_ff_own_uff_minimizer_rejects_naphthalene_blowup_steps() {
         let mol = parse("c1ccc2ccccc2c1").expect("naphthalene");
         let coords = generate_coords(&mol);
         let raw: Vec<[f64; 3]> = (0..mol.atom_count())
@@ -3338,12 +3334,8 @@ mod policy_bridge_tests {
             .fold(0.0_f64, f64::max);
 
         assert!(
-            worst > MAX_SANE_BOND_LENGTH,
-            "expected chematic-ff's own uff::minimize_uff to reproduce the measured naphthalene \
-             blow-up with zero chematic-3d bridge code in the path (worst bond {worst:.2} Å) -- \
-             if this now passes, chematic-ff's UFF minimizer robustness improved and this \
-             bridge's soundness-gate regression test / PR body item-4 measurement should be \
-             revisited",
+            worst <= MAX_SANE_BOND_LENGTH,
+            "UFF must reject catastrophic naphthalene steps; got worst bond {worst:.2} Å"
         );
     }
 

--- a/crates/chematic-3d/src/mol_transforms.rs
+++ b/crates/chematic-3d/src/mol_transforms.rs
@@ -1,5 +1,6 @@
 use crate::coords::{Coords3D, Point3};
 use chematic_core::{AtomIdx, Molecule};
+use std::collections::HashSet;
 
 /// Get bond length in Ångströms between atoms a and b.
 pub fn get_bond_length(coords: &Coords3D, a: AtomIdx, b: AtomIdx) -> f64 {
@@ -136,11 +137,12 @@ pub fn transform_conformer(coords: &Coords3D, matrix: &[[f64; 4]; 4]) -> Coords3
 /// Find all atoms in the subtree rooted at `target` when coming from `parent`.
 fn find_rotated_atoms(mol: &Molecule, parent: AtomIdx, target: AtomIdx) -> Vec<AtomIdx> {
     let mut result = vec![target];
+    let mut visited = HashSet::from([target]);
     let mut stack = vec![target];
 
     while let Some(current) = stack.pop() {
         for (neighbor, _) in mol.neighbors(current) {
-            if neighbor != parent && !result.contains(&neighbor) {
+            if neighbor != parent && visited.insert(neighbor) {
                 result.push(neighbor);
                 stack.push(neighbor);
             }

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -17,14 +17,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "1.0.0" }
+chematic-core       = { path = "../chematic-core",       version = "1.0.1" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "1.0.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "1.0.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "1.0.0" }
-chematic-cip        = { path = "../chematic-cip",        version = "1.0.0" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.1" }
+chematic-fp         = { path = "../chematic-fp",         version = "1.0.1" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "1.0.1" }
+chematic-cip        = { path = "../chematic-cip",        version = "1.0.1" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }
 

--- a/crates/chematic-chem/src/cache.rs
+++ b/crates/chematic-chem/src/cache.rs
@@ -3,7 +3,8 @@
 //! Simple LRU-like cache for descriptors keyed by molecule canonical SMILES.
 //! Improves performance when computing same molecules repeatedly.
 
-use std::collections::{HashMap, VecDeque};
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap};
 use std::sync::{Arc, Mutex};
 
 /// Descriptor cache entry: stores computed descriptor values.
@@ -33,7 +34,9 @@ pub struct DescriptorCache {
 #[derive(Debug, Default)]
 struct DescriptorCacheState {
     entries: HashMap<String, DescriptorEntry>,
-    order: VecDeque<String>,
+    access_generation: HashMap<String, u64>,
+    order: BinaryHeap<Reverse<(u64, String)>>,
+    next_generation: u64,
 }
 
 impl DescriptorCache {
@@ -50,10 +53,7 @@ impl DescriptorCache {
         let mut state = self.state.lock().ok()?;
         let entry = state.entries.get(smiles).cloned();
         if entry.is_some() {
-            if let Some(pos) = state.order.iter().position(|key| key == smiles) {
-                state.order.remove(pos);
-            }
-            state.order.push_back(smiles.to_owned());
+            touch(&mut state, smiles);
         }
         entry
     }
@@ -67,15 +67,16 @@ impl DescriptorCache {
             let is_new = !state.entries.contains_key(&smiles);
             if !state.entries.contains_key(&smiles)
                 && state.entries.len() >= self.max_size
-                && let Some(oldest) = state.order.pop_front()
+                && let Some(oldest) = pop_oldest(&mut state)
             {
                 state.entries.remove(&oldest);
+                state.access_generation.remove(&oldest);
             }
             state.entries.insert(smiles.clone(), entry);
-            if !is_new && let Some(pos) = state.order.iter().position(|key| key == &smiles) {
-                state.order.remove(pos);
+            if !is_new {
+                state.access_generation.remove(&smiles);
             }
-            state.order.push_back(smiles);
+            touch(&mut state, &smiles);
         }
     }
 
@@ -83,7 +84,9 @@ impl DescriptorCache {
     pub fn clear(&self) {
         if let Ok(mut state) = self.state.lock() {
             state.entries.clear();
+            state.access_generation.clear();
             state.order.clear();
+            state.next_generation = 0;
         }
     }
 
@@ -99,6 +102,30 @@ impl DescriptorCache {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+}
+
+fn touch(state: &mut DescriptorCacheState, key: &str) {
+    state.next_generation = state.next_generation.wrapping_add(1);
+    let generation = state.next_generation;
+    state.access_generation.insert(key.to_owned(), generation);
+    state.order.push(Reverse((generation, key.to_owned())));
+    let rebuild_at = state.entries.len().saturating_mul(4).max(16);
+    if state.order.len() > rebuild_at {
+        state.order = state
+            .access_generation
+            .iter()
+            .map(|(key, &generation)| Reverse((generation, key.clone())))
+            .collect();
+    }
+}
+
+fn pop_oldest(state: &mut DescriptorCacheState) -> Option<String> {
+    while let Some(Reverse((generation, key))) = state.order.pop() {
+        if state.access_generation.get(&key) == Some(&generation) {
+            return Some(key);
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -155,6 +182,18 @@ mod tests {
         cache.put("C3".to_string(), entry);
         assert!(cache.get("C1").is_some());
         assert!(cache.get("C2").is_none());
+    }
+
+    #[test]
+    fn repeated_hits_bound_recency_heap_growth() {
+        let cache = DescriptorCache::new(1);
+        cache.put("CC".to_string(), DescriptorEntry::default());
+        for _ in 0..1000 {
+            assert!(cache.get("CC").is_some());
+        }
+        let state = cache.state.lock().expect("cache state");
+        assert!(state.order.len() <= 16);
+        assert_eq!(state.access_generation.len(), 1);
     }
 
     #[test]

--- a/crates/chematic-chem/src/cache.rs
+++ b/crates/chematic-chem/src/cache.rs
@@ -3,8 +3,7 @@
 //! Simple LRU-like cache for descriptors keyed by molecule canonical SMILES.
 //! Improves performance when computing same molecules repeatedly.
 
-use std::collections::HashMap;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 /// Descriptor cache entry: stores computed descriptor values.
@@ -27,31 +26,34 @@ pub struct DescriptorEntry {
 /// Thread-safe descriptor cache with max_size limit.
 #[derive(Clone, Debug)]
 pub struct DescriptorCache {
-    cache: Arc<Mutex<HashMap<String, DescriptorEntry>>>,
-    order: Arc<Mutex<VecDeque<String>>>,
+    state: Arc<Mutex<DescriptorCacheState>>,
     max_size: usize,
+}
+
+#[derive(Debug, Default)]
+struct DescriptorCacheState {
+    entries: HashMap<String, DescriptorEntry>,
+    order: VecDeque<String>,
 }
 
 impl DescriptorCache {
     /// Create new cache with given max size.
     pub fn new(max_size: usize) -> Self {
         Self {
-            cache: Arc::new(Mutex::new(HashMap::new())),
-            order: Arc::new(Mutex::new(VecDeque::new())),
+            state: Arc::new(Mutex::new(DescriptorCacheState::default())),
             max_size,
         }
     }
 
     /// Get cached entry for molecule (keyed by canonical SMILES).
     pub fn get(&self, smiles: &str) -> Option<DescriptorEntry> {
-        let entry = self.cache.lock().ok().and_then(|c| c.get(smiles).cloned());
-        if entry.is_some()
-            && let Ok(mut order) = self.order.lock()
-        {
-            if let Some(pos) = order.iter().position(|key| key == smiles) {
-                order.remove(pos);
+        let mut state = self.state.lock().ok()?;
+        let entry = state.entries.get(smiles).cloned();
+        if entry.is_some() {
+            if let Some(pos) = state.order.iter().position(|key| key == smiles) {
+                state.order.remove(pos);
             }
-            order.push_back(smiles.to_owned());
+            state.order.push_back(smiles.to_owned());
         }
         entry
     }
@@ -61,38 +63,36 @@ impl DescriptorCache {
         if self.max_size == 0 {
             return;
         }
-        if let Ok(mut cache) = self.cache.lock() {
-            let is_new = !cache.contains_key(&smiles);
-            if !cache.contains_key(&smiles)
-                && cache.len() >= self.max_size
-                && let Ok(mut order) = self.order.lock()
-                && let Some(oldest) = order.pop_front()
+        if let Ok(mut state) = self.state.lock() {
+            let is_new = !state.entries.contains_key(&smiles);
+            if !state.entries.contains_key(&smiles)
+                && state.entries.len() >= self.max_size
+                && let Some(oldest) = state.order.pop_front()
             {
-                cache.remove(&oldest);
+                state.entries.remove(&oldest);
             }
-            cache.insert(smiles.clone(), entry);
-            if let Ok(mut order) = self.order.lock() {
-                if !is_new && let Some(pos) = order.iter().position(|key| key == &smiles) {
-                    order.remove(pos);
-                }
-                order.push_back(smiles);
+            state.entries.insert(smiles.clone(), entry);
+            if !is_new && let Some(pos) = state.order.iter().position(|key| key == &smiles) {
+                state.order.remove(pos);
             }
+            state.order.push_back(smiles);
         }
     }
 
     /// Clear all cached entries.
     pub fn clear(&self) {
-        if let Ok(mut cache) = self.cache.lock() {
-            cache.clear();
-        }
-        if let Ok(mut order) = self.order.lock() {
-            order.clear();
+        if let Ok(mut state) = self.state.lock() {
+            state.entries.clear();
+            state.order.clear();
         }
     }
 
     /// Get cache size.
     pub fn len(&self) -> usize {
-        self.cache.lock().map(|c| c.len()).unwrap_or(0)
+        self.state
+            .lock()
+            .map(|state| state.entries.len())
+            .unwrap_or(0)
     }
 
     /// Check if cache is empty.

--- a/crates/chematic-chem/src/cache.rs
+++ b/crates/chematic-chem/src/cache.rs
@@ -4,6 +4,7 @@
 //! Improves performance when computing same molecules repeatedly.
 
 use std::collections::HashMap;
+use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 /// Descriptor cache entry: stores computed descriptor values.
@@ -27,6 +28,7 @@ pub struct DescriptorEntry {
 #[derive(Clone, Debug)]
 pub struct DescriptorCache {
     cache: Arc<Mutex<HashMap<String, DescriptorEntry>>>,
+    order: Arc<Mutex<VecDeque<String>>>,
     max_size: usize,
 }
 
@@ -35,26 +37,46 @@ impl DescriptorCache {
     pub fn new(max_size: usize) -> Self {
         Self {
             cache: Arc::new(Mutex::new(HashMap::new())),
+            order: Arc::new(Mutex::new(VecDeque::new())),
             max_size,
         }
     }
 
     /// Get cached entry for molecule (keyed by canonical SMILES).
     pub fn get(&self, smiles: &str) -> Option<DescriptorEntry> {
-        self.cache.lock().ok().and_then(|c| c.get(smiles).cloned())
+        let entry = self.cache.lock().ok().and_then(|c| c.get(smiles).cloned());
+        if entry.is_some()
+            && let Ok(mut order) = self.order.lock()
+        {
+            if let Some(pos) = order.iter().position(|key| key == smiles) {
+                order.remove(pos);
+            }
+            order.push_back(smiles.to_owned());
+        }
+        entry
     }
 
     /// Store/update cached entry.
     pub fn put(&self, smiles: String, entry: DescriptorEntry) {
+        if self.max_size == 0 {
+            return;
+        }
         if let Ok(mut cache) = self.cache.lock() {
-            // Simple eviction: clear if full and adding new entry
-            if !cache.contains_key(&smiles) && cache.len() >= self.max_size {
-                // Remove arbitrary entry (FIFO-like behavior in practice)
-                if let Some(key) = cache.keys().next().cloned() {
-                    cache.remove(&key);
-                }
+            let is_new = !cache.contains_key(&smiles);
+            if !cache.contains_key(&smiles)
+                && cache.len() >= self.max_size
+                && let Ok(mut order) = self.order.lock()
+                && let Some(oldest) = order.pop_front()
+            {
+                cache.remove(&oldest);
             }
-            cache.insert(smiles, entry);
+            cache.insert(smiles.clone(), entry);
+            if let Ok(mut order) = self.order.lock() {
+                if !is_new && let Some(pos) = order.iter().position(|key| key == &smiles) {
+                    order.remove(pos);
+                }
+                order.push_back(smiles);
+            }
         }
     }
 
@@ -62,6 +84,9 @@ impl DescriptorCache {
     pub fn clear(&self) {
         if let Ok(mut cache) = self.cache.lock() {
             cache.clear();
+        }
+        if let Ok(mut order) = self.order.lock() {
+            order.clear();
         }
     }
 
@@ -108,8 +133,28 @@ mod tests {
         cache.put("C2".to_string(), entry.clone());
         cache.put("C3".to_string(), entry.clone());
 
-        // Cache size should be 2 (evicted oldest)
-        assert!(cache.len() <= 2);
+        assert_eq!(cache.len(), 2);
+        assert!(cache.get("C1").is_none());
+    }
+
+    #[test]
+    fn zero_capacity_disables_storage() {
+        let cache = DescriptorCache::new(0);
+        cache.put("CC".to_string(), DescriptorEntry::default());
+        assert_eq!(cache.len(), 0);
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn cache_eviction_is_lru() {
+        let cache = DescriptorCache::new(2);
+        let entry = DescriptorEntry::default();
+        cache.put("C1".to_string(), entry.clone());
+        cache.put("C2".to_string(), entry.clone());
+        assert!(cache.get("C1").is_some());
+        cache.put("C3".to_string(), entry);
+        assert!(cache.get("C1").is_some());
+        assert!(cache.get("C2").is_none());
     }
 
     #[test]

--- a/crates/chematic-chem/src/hash.rs
+++ b/crates/chematic-chem/src/hash.rs
@@ -4,7 +4,7 @@
 //! SMILES representation. Useful for detecting duplicate molecules in bulk operations.
 
 use chematic_core::Molecule;
-use chematic_smiles::canonical_smiles;
+use chematic_smiles::{canonical_smiles, canonical_smiles_stable_key};
 
 pub(crate) const FNV1A_OFFSET: u64 = 0xcbf29ce484222325;
 pub(crate) const FNV1A_PRIME: u64 = 0x100000001b3;
@@ -21,9 +21,9 @@ pub(crate) fn fnv1a(bytes: &[u8]) -> u64 {
 
 /// Compute a structural hash for a molecule using FNV-1a on the canonical SMILES.
 ///
-/// The hash is deterministic and invariant to atom ordering. Identical molecules
-/// always produce the same hash, but hash collisions are possible (use [`are_identical`]
-/// for a definitive check).
+/// The hash is deterministic and invariant to atom ordering. Hash collisions
+/// are possible, and canonical-SMILES residuals mean this is not a fail-closed
+/// identity key.
 ///
 /// Useful for rapid duplicate detection in large sets; pair with [`are_identical`]
 /// for validation.
@@ -31,12 +31,20 @@ pub fn mol_hash(mol: &Molecule) -> u64 {
     fnv1a(canonical_smiles(mol).as_bytes())
 }
 
-/// Check whether two molecules are structurally identical.
+/// Check whether two molecules have the same current canonical SMILES.
 ///
-/// Returns `true` if both molecules have the same canonical SMILES representation.
-/// This is a definitive check (no collisions), unlike [`mol_hash`].
+/// This is a representation comparison, not a definitive structural identity
+/// proof. Use [`stable_are_identical`] for a fail-closed identity check.
 pub fn are_identical(a: &Molecule, b: &Molecule) -> bool {
     canonical_smiles(a) == canonical_smiles(b)
+}
+
+/// Compare molecules using the fail-closed canonical identity key.
+///
+/// Returns `None` when either molecule cannot produce a stable key. This keeps
+/// known canonical residuals from being reported as a false identity result.
+pub fn stable_are_identical(a: &Molecule, b: &Molecule) -> Option<bool> {
+    Some(canonical_smiles_stable_key(a)? == canonical_smiles_stable_key(b)?)
 }
 
 #[cfg(test)]
@@ -108,5 +116,12 @@ mod tests {
             are_identical(&aspirin1, &aspirin2),
             "different notations of aspirin should be identical"
         );
+    }
+
+    #[test]
+    fn stable_identity_is_available_for_converged_keys() {
+        let a = mol("CC");
+        let b = mol("CC");
+        assert_eq!(stable_are_identical(&a, &b), Some(true));
     }
 }

--- a/crates/chematic-chem/src/lib.rs
+++ b/crates/chematic-chem/src/lib.rs
@@ -94,7 +94,7 @@ pub use esol::esol_solubility;
 pub use estate::{estate_all, estate_indices, max_estate, min_estate, sum_estate};
 pub use formula::{FormulaParseError, parse_formula};
 pub use gasteiger::gasteiger_charges;
-pub use hash::{are_identical, mol_hash};
+pub use hash::{are_identical, mol_hash, stable_are_identical};
 pub use hydrogen::{add_hydrogens, remove_hydrogens};
 pub use ifg::{FunctionalGroup, identify_functional_groups};
 pub use isotope_distribution::isotope_distribution;

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "1.0.0" }
-chematic-perception = { path = "../chematic-perception", version = "1.0.0" }
+chematic-core       = { path = "../chematic-core",       version = "1.0.1" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-cli/Cargo.toml
+++ b/crates/chematic-cli/Cargo.toml
@@ -18,10 +18,10 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 serde_json = "1.0"
-chematic-smarts = { path = "../chematic-smarts", version = "1.0.0" }
-chematic-core = { path = "../chematic-core", version = "1.0.0" }
-chematic-fp = { path = "../chematic-fp", version = "1.0.0" }
-chematic-chem = { path = "../chematic-chem", version = "1.0.0", features = ["serde"] }
-chematic-rxn = { path = "../chematic-rxn", version = "1.0.0" }
-chematic-mol = { path = "../chematic-mol", version = "1.0.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "1.0.0" }
+chematic-smarts = { path = "../chematic-smarts", version = "1.0.1" }
+chematic-core = { path = "../chematic-core", version = "1.0.1" }
+chematic-fp = { path = "../chematic-fp", version = "1.0.1" }
+chematic-chem = { path = "../chematic-chem", version = "1.0.1", features = ["serde"] }
+chematic-rxn = { path = "../chematic-rxn", version = "1.0.1" }
+chematic-mol = { path = "../chematic-mol", version = "1.0.1" }
+chematic-smiles = { path = "../chematic-smiles", version = "1.0.1" }

--- a/crates/chematic-crystal/Cargo.toml
+++ b/crates/chematic-crystal/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 serde = ["dep:serde"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "1.0.0" }
+chematic-core = { path = "../chematic-core", version = "1.0.1" }
 serde         = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -23,10 +23,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "1.0.0" }
-chematic-perception = { path = "../chematic-perception", version = "1.0.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "1.0.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "1.0.0" }
+chematic-core = { path = "../chematic-core", version = "1.0.1" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.1" }
+chematic-rxn = { path = "../chematic-rxn", version = "1.0.1" }
+chematic-smiles = { path = "../chematic-smiles", version = "1.0.1" }
 tiny-skia = { version = "0.12", optional = true }
 svg2pdf = { version = "0.13", optional = true }
 

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "1.0.0" }
+chematic-core = { path = "../chematic-core", version = "1.0.1" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "1.0.0" }
-chematic-perception = { path = "../chematic-perception", version = "1.0.0" }
+chematic-core       = { path = "../chematic-core",       version = "1.0.1" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-ff/src/uff.rs
+++ b/crates/chematic-ff/src/uff.rs
@@ -580,6 +580,11 @@ pub struct UffMinimizeResult {
     /// torsion/out-of-plane-incomplete potential, not slow convergence) had
     /// occurred.
     pub sound: bool,
+    /// True when line search rejected an energy-decreasing proposal because
+    /// it would have produced an unsound covalent bond length. Callers can
+    /// distinguish this bounded rescue signal from an ordinary high-residual
+    /// result whose geometry never attempted a catastrophic step.
+    pub rejected_unsound_step: bool,
 }
 
 /// Minimise UFF energy using steepest descent (convergence criterion: RMS
@@ -596,6 +601,7 @@ pub fn minimize_uff(
     let mut coords = initial_coords;
     let mut step = 0.05_f64;
     let mut prev_energy = f64::MAX;
+    let mut rejected_unsound_step = false;
 
     for iter in 0..max_iter {
         let energy = uff_total_energy(mol, types, &coords);
@@ -615,6 +621,7 @@ pub fn minimize_uff(
                 iterations: iter,
                 converged: true,
                 sound,
+                rejected_unsound_step,
             };
         }
 
@@ -626,13 +633,24 @@ pub fn minimize_uff(
             .collect();
 
         let new_energy = uff_total_energy(mol, types, &new_coords);
-        if new_energy < energy {
+        // Energy descent alone is not a sufficient acceptance criterion:
+        // the incomplete UFF potential can lower its energy by walking into
+        // a stationary geometry with a catastrophically stretched covalent
+        // bond (notably fused aromatics such as naphthalene). Reject such a
+        // proposal before it becomes the next iterate and let the line
+        // search reduce the step instead. This preserves the existing
+        // fail-closed `sound` contract while preventing the optimizer from
+        // knowingly propagating an unsound intermediate.
+        if new_energy < energy && is_sound_uff_geometry(mol, &new_coords) {
             coords = new_coords;
             if energy - new_energy < prev_energy * 1e-7 {
                 step *= 1.2;
             }
             prev_energy = energy;
         } else {
+            if new_energy < energy {
+                rejected_unsound_step = true;
+            }
             step *= 0.5;
             if step < 1e-8 {
                 let sound = is_sound_uff_geometry(mol, &coords);
@@ -642,6 +660,7 @@ pub fn minimize_uff(
                     iterations: iter,
                     converged: false,
                     sound,
+                    rejected_unsound_step,
                 };
             }
         }
@@ -655,6 +674,7 @@ pub fn minimize_uff(
         iterations: max_iter,
         converged: false,
         sound,
+        rejected_unsound_step,
     }
 }
 

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -23,14 +23,14 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "1.0.0" }
-chematic-cip = { path = "../chematic-cip", version = "1.0.0" }
+chematic-core = { path = "../chematic-core", version = "1.0.1" }
+chematic-cip = { path = "../chematic-cip", version = "1.0.1" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "1.0.0" }
-chematic-rxn = { path = "../chematic-rxn", version = "1.0.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "1.0.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "1.0.0" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.1" }
+chematic-rxn = { path = "../chematic-rxn", version = "1.0.1" }
+chematic-smarts = { path = "../chematic-smarts", version = "1.0.1" }
+chematic-smiles = { path = "../chematic-smiles", version = "1.0.1" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -19,10 +19,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "1.0.0", path = "../chematic-core" }
-chematic-smiles = { version = "1.0.0", path = "../chematic-smiles" }
-chematic-chem = { version = "1.0.0", path = "../chematic-chem" }
-chematic-rxn = { version = "1.0.0", path = "../chematic-rxn" }
+chematic-core = { version = "1.0.1", path = "../chematic-core" }
+chematic-smiles = { version = "1.0.1", path = "../chematic-smiles" }
+chematic-chem = { version = "1.0.1", path = "../chematic-chem" }
+chematic-rxn = { version = "1.0.1", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-inchi/README.md
+++ b/crates/chematic-inchi/README.md
@@ -14,7 +14,7 @@ Output is **bit-exact** with the reference implementation.
 
 ```toml
 [dependencies]
-chematic-inchi = { version = "1.0.0", features = ["native-inchi"] }
+chematic-inchi = { version = "1.0.1", features = ["native-inchi"] }
 ```
 
 ```rust

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "1.0.0" }
-chematic-perception = { path = "../chematic-perception", version = "1.0.0" }
+chematic-core       = { path = "../chematic-core",       version = "1.0.1" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.1" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -18,15 +18,15 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "1.0.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "1.0.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "1.0.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "1.0.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "1.0.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "1.0.0" }
-chematic-perception = { path = "../chematic-perception", version = "1.0.0" }
+chematic-core       = { path = "../chematic-core",       version = "1.0.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "1.0.1", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "1.0.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.1" }
+chematic-3d         = { path = "../chematic-3d",         version = "1.0.1" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "1.0.1" }
+chematic-mol        = { path = "../chematic-mol",        version = "1.0.1" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.1" }
 
 [dev-dependencies]
 # Real JSON Schema 2020-12 validator, used only in tests to independently

--- a/crates/chematic-mcp/README.md
+++ b/crates/chematic-mcp/README.md
@@ -33,7 +33,7 @@ registry in `src/tools.rs` is the source of truth for the available tools.
 
 ```toml
 [dependencies]
-chematic-mcp = { version = "1.0.0", path = "../chematic-mcp" }
+chematic-mcp = { version = "1.0.1", path = "../chematic-mcp" }
 ```
 
 ## Running the server

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -25,11 +25,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 crystal = ["dep:chematic-crystal"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "1.0.0" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "1.0.0" }
-chematic-perception  = { path = "../chematic-perception",  version = "1.0.0" }
-chematic-smiles      = { path = "../chematic-smiles",      version = "1.0.0" }
-chematic-crystal     = { path = "../chematic-crystal",     version = "1.0.0", optional = true }
+chematic-core        = { path = "../chematic-core",        version = "1.0.1" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "1.0.1" }
+chematic-perception  = { path = "../chematic-perception",  version = "1.0.1" }
+chematic-smiles      = { path = "../chematic-smiles",      version = "1.0.1" }
+chematic-crystal     = { path = "../chematic-crystal",     version = "1.0.1", optional = true }
 serde_json           = "1.0"
 
 [dev-dependencies]

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "1.0.0" }
+chematic-core = { path = "../chematic-core", version = "1.0.1" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -26,17 +26,17 @@ numpy = "0.29"
 serde_json = "1.0"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "1.0.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.0" }
-chematic-perception = { path = "../chematic-perception", version = "1.0.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "1.0.0" }
-chematic-fp         = { path = "../chematic-fp",         version = "1.0.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "1.0.0", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "1.0.0", features = ["crystal"] }
-chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "1.0.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "1.0.0" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "1.0.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "1.0.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "1.0.0" }
-chematic-crystal    = { path = "../chematic-crystal",    version = "1.0.0" }
+chematic-core       = { path = "../chematic-core",       version = "1.0.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.1" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "1.0.1" }
+chematic-fp         = { path = "../chematic-fp",         version = "1.0.1" }
+chematic-depict     = { path = "../chematic-depict",     version = "1.0.1", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "1.0.1", features = ["crystal"] }
+chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.1" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "1.0.1" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "1.0.1" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "1.0.1" }
+chematic-3d         = { path = "../chematic-3d",         version = "1.0.1" }
+chematic-ff         = { path = "../chematic-ff",         version = "1.0.1" }
+chematic-crystal    = { path = "../chematic-crystal",    version = "1.0.1" }

--- a/crates/chematic-py/python/chematic/__init__.pyi
+++ b/crates/chematic-py/python/chematic/__init__.pyi
@@ -1996,6 +1996,14 @@ def from_smiles(smiles: str) -> Mol:
     """
     ...
 
+def stable_are_identical(mol1: Mol, mol2: Mol) -> Optional[bool]:
+    """Compare molecules using the fail-closed canonical identity key.
+
+    Returns ``None`` when either molecule belongs to a known canonical
+    residual class, rather than silently claiming that the molecules differ.
+    """
+    ...
+
 def from_cxsmiles(s: str) -> tuple[Mol, dict]:
     """Parse a CXSMILES string and return the molecule with CX metadata.
 

--- a/crates/chematic-py/src/formats.rs
+++ b/crates/chematic-py/src/formats.rs
@@ -1029,6 +1029,15 @@ fn are_identical(mol1: &Mol, mol2: &Mol) -> bool {
     chematic_chem::are_identical(&mol1.inner, &mol2.inner)
 }
 
+/// Compare molecules using chematic's fail-closed canonical identity key.
+///
+/// Returns ``True`` or ``False`` for converged keys and ``None`` when either
+/// molecule belongs to a known canonical residual class.
+#[pyfunction]
+fn stable_are_identical(mol1: &Mol, mol2: &Mol) -> Option<bool> {
+    chematic_chem::stable_are_identical(&mol1.inner, &mol2.inner)
+}
+
 /// Normalize and re-serialize a reaction SMILES.
 ///
 /// Parses the reaction SMILES and writes it back in canonical form.
@@ -2285,6 +2294,7 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parse_formula, m)?)?;
     m.add_function(wrap_pyfunction!(mol_hash, m)?)?;
     m.add_function(wrap_pyfunction!(are_identical, m)?)?;
+    m.add_function(wrap_pyfunction!(stable_are_identical, m)?)?;
     m.add_function(wrap_pyfunction!(write_reaction, m)?)?;
     m.add_function(wrap_pyfunction!(from_rxn_file, m)?)?;
     m.add_function(wrap_pyfunction!(to_rxn_file, m)?)?;

--- a/crates/chematic-py/src/formats.rs
+++ b/crates/chematic-py/src/formats.rs
@@ -1003,7 +1003,8 @@ fn parse_formula<'py>(formula: &str, py: Python<'py>) -> PyResult<Bound<'py, PyD
 /// Fast structural hash for deduplication — one int per molecule.
 ///
 /// Molecules with the same canonical graph return identical hashes.
-/// Use with :func:`are_identical` to confirm true equivalence (no hash collisions).
+/// This is a fast screening hash only. Hash collisions and canonical residuals
+/// are possible; do not treat it as a definitive identity key.
 ///
 /// Equivalent to RDKit's ``rdMolHash.MolHash()``.
 ///
@@ -1014,10 +1015,10 @@ fn mol_hash(mol: &Mol) -> u64 {
     chematic_chem::mol_hash(&mol.inner)
 }
 
-/// Check whether two molecules are graph-isomorphic (exact structural identity).
+/// Check whether two molecules have the same current canonical representation.
 ///
-/// More reliable than comparing SMILES strings (which depend on canonicalization).
-/// Equivalent to RDKit's ``Chem.MolToInchiKey(m1) == Chem.MolToInchiKey(m2)``.
+/// This is not a fail-closed graph-isomorphism proof. Use the stable-key API
+/// when an indeterminate result must be distinguishable from ``False``.
 ///
 ///     assert chematic.are_identical(
 ///         chematic.from_smiles("c1ccccc1"),

--- a/crates/chematic-py/tests/test_format_convert.py
+++ b/crates/chematic-py/tests/test_format_convert.py
@@ -21,6 +21,12 @@ def test_convert_graph_formats_round_trip():
     )
 
 
+def test_stable_identity_is_fail_closed_api():
+    assert chematic.stable_are_identical(
+        chematic.from_smiles("CCO"), chematic.from_smiles("CCO")
+    ) is True
+
+
 def test_convert_coordinate_formats_use_input_coordinates():
     xyz = """3
 ethanol

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -23,9 +23,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 perf-instrumentation = []
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "1.0.0" }
-chematic-smiles = { path = "../chematic-smiles", version = "1.0.0" }
-chematic-smarts = { path = "../chematic-smarts", version = "1.0.0" }
+chematic-core   = { path = "../chematic-core",   version = "1.0.1" }
+chematic-smiles = { path = "../chematic-smiles", version = "1.0.1" }
+chematic-smarts = { path = "../chematic-smarts", version = "1.0.1" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "1.0.0" }
-chematic-perception = { path = "../chematic-perception", version = "1.0.0" }
+chematic-core = { path = "../chematic-core", version = "1.0.1" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.1" }
 rustc-hash = "2"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #221); web-time

--- a/crates/chematic-smarts/README.md
+++ b/crates/chematic-smarts/README.md
@@ -38,6 +38,8 @@ for m in matches {
 - `find_matches(query: &Molecule, target: &Molecule) -> Vec<AtomMap>` — all substructure matches
 - `find_matches_with_config(query: &Molecule, target: &Molecule, config: &MatchConfig) -> Vec<AtomMap>` — with options
 - `has_match(query: &Molecule, target: &Molecule) -> bool` — fast boolean check
+- `SmartsCache::find_matches_with_rings(pattern, target, rings)` — reuse one
+  precomputed SSSR when matching several cached patterns against one molecule
 
 ### Maximum Common Subgraph
 

--- a/crates/chematic-smarts/benches/smarts_bench.rs
+++ b/crates/chematic-smarts/benches/smarts_bench.rs
@@ -9,6 +9,7 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 
+use chematic_perception::find_sssr;
 use chematic_smarts::{SmartsCache, find_matches, parse_smarts};
 use chematic_smiles::parse;
 
@@ -75,6 +76,29 @@ fn bench_smarts_cache_hit(c: &mut Criterion) {
     });
 }
 
+// ── Multiple cached patterns with shared SSSR ───────────────────────────────
+
+fn bench_smarts_cache_shared_rings(c: &mut Criterion) {
+    let mols: Vec<_> = BENCH_SMILES.iter().map(|s| parse(s).unwrap()).collect();
+    let patterns = ["[a]", "[OH]", "[CX3](=O)", "[nH]", "[F,Cl,Br,I]"];
+    let rings: Vec<_> = mols.iter().map(find_sssr).collect();
+    let mut cache = SmartsCache::new(patterns.len());
+
+    c.bench_function("smarts_cache_shared_rings_5x10mol", |b| {
+        b.iter(|| {
+            for (mol, ring_set) in mols.iter().zip(&rings) {
+                for pattern in patterns {
+                    let _ = black_box(cache.find_matches_with_rings(
+                        black_box(pattern),
+                        black_box(mol),
+                        black_box(ring_set),
+                    ));
+                }
+            }
+        })
+    });
+}
+
 // ── Complex recursive SMARTS ──────────────────────────────────────────────────
 
 fn bench_smarts_complex(c: &mut Criterion) {
@@ -94,6 +118,7 @@ criterion_group!(
     bench_smarts_compile,
     bench_smarts_match_no_cache,
     bench_smarts_cache_hit,
+    bench_smarts_cache_shared_rings,
     bench_smarts_complex,
 );
 criterion_main!(benches);

--- a/crates/chematic-smarts/src/cache.rs
+++ b/crates/chematic-smarts/src/cache.rs
@@ -59,6 +59,14 @@ impl SmartsCache {
         let generation = self.next_generation;
         self.access_generation.insert(smarts.to_owned(), generation);
         self.order.push(Reverse((generation, smarts.to_owned())));
+        let rebuild_at = self.capacity.saturating_mul(4).max(16);
+        if self.order.len() > rebuild_at {
+            self.order = self
+                .access_generation
+                .iter()
+                .map(|(key, &generation)| Reverse((generation, key.clone())))
+                .collect();
+        }
     }
 
     /// Compile a SMARTS pattern (or retrieve from cache) and return a reference.
@@ -251,5 +259,16 @@ mod tests {
         let mol = parse("c1ccccc1").expect("benzene");
         assert!(cache.has_match("[a]", &mol).unwrap());
         assert!(!cache.has_match("[OH]", &mol).unwrap());
+    }
+
+    #[test]
+    fn repeated_hits_bound_recency_heap_growth() {
+        let mut cache = SmartsCache::new(1);
+        let mol = parse("CCO").expect("parse ethanol");
+        for _ in 0..1000 {
+            assert!(cache.has_match("[OH]", &mol).unwrap());
+        }
+        assert!(cache.order.len() <= 16);
+        assert_eq!(cache.access_generation.len(), 1);
     }
 }

--- a/crates/chematic-smarts/src/cache.rs
+++ b/crates/chematic-smarts/src/cache.rs
@@ -75,12 +75,8 @@ impl SmartsCache {
         smarts: &str,
         mol: &Molecule,
     ) -> Result<Vec<FxHashMap<usize, AtomIdx>>, SmartsError> {
-        let qmol = self.compile(smarts)?.clone();
-        Ok(find_matches_with_config(
-            &qmol,
-            mol,
-            &MatchConfig::default(),
-        ))
+        let qmol = self.compile(smarts)?;
+        Ok(find_matches_with_config(qmol, mol, &MatchConfig::default()))
     }
 
     /// Find all substructure matches with custom `MatchConfig`.
@@ -90,8 +86,8 @@ impl SmartsCache {
         mol: &Molecule,
         config: &MatchConfig,
     ) -> Result<Vec<FxHashMap<usize, AtomIdx>>, SmartsError> {
-        let qmol = self.compile(smarts)?.clone();
-        Ok(find_matches_with_config(&qmol, mol, config))
+        let qmol = self.compile(smarts)?;
+        Ok(find_matches_with_config(qmol, mol, config))
     }
 
     /// Check whether `smarts` matches at least once in `mol`.

--- a/crates/chematic-smarts/src/cache.rs
+++ b/crates/chematic-smarts/src/cache.rs
@@ -16,7 +16,8 @@
 //! `parse_smarts()` + `find_matches()` each time.
 
 use rustc_hash::FxHashMap;
-use std::collections::{HashMap, VecDeque};
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap};
 
 use crate::{
     match_vf2::{MatchConfig, find_matches_with_config},
@@ -34,7 +35,11 @@ pub struct SmartsCache {
     // std HashMap (SipHash) intentionally — keys are user-supplied SMARTS strings;
     // FxHash has no random seed and is vulnerable to HashDoS with adversarial input.
     store: HashMap<String, QueryMolecule>,
-    order: VecDeque<String>, // LRU order (front = oldest, back = newest)
+    access_generation: HashMap<String, u64>,
+    // Min-heap via Reverse. Stale entries are discarded on eviction, so a cache
+    // hit no longer scans the entire LRU list.
+    order: BinaryHeap<Reverse<(u64, String)>>,
+    next_generation: u64,
 }
 
 impl SmartsCache {
@@ -43,8 +48,17 @@ impl SmartsCache {
         Self {
             capacity: capacity.max(1),
             store: HashMap::new(),
-            order: VecDeque::new(),
+            access_generation: HashMap::new(),
+            order: BinaryHeap::new(),
+            next_generation: 0,
         }
+    }
+
+    fn touch(&mut self, smarts: &str) {
+        self.next_generation = self.next_generation.wrapping_add(1);
+        let generation = self.next_generation;
+        self.access_generation.insert(smarts.to_owned(), generation);
+        self.order.push(Reverse((generation, smarts.to_owned())));
     }
 
     /// Compile a SMARTS pattern (or retrieve from cache) and return a reference.
@@ -52,19 +66,18 @@ impl SmartsCache {
         if !self.store.contains_key(smarts) {
             let qmol = parse_smarts(smarts)?;
             if self.store.len() >= self.capacity {
-                // Evict LRU: pop_front is O(1) with VecDeque
-                if let Some(oldest) = self.order.pop_front() {
-                    self.store.remove(&oldest);
+                while let Some(Reverse((generation, oldest))) = self.order.pop() {
+                    if self.access_generation.get(&oldest) == Some(&generation) {
+                        self.store.remove(&oldest);
+                        self.access_generation.remove(&oldest);
+                        break;
+                    }
                 }
             }
             self.store.insert(smarts.to_string(), qmol);
-            self.order.push_back(smarts.to_string());
+            self.touch(smarts);
         } else {
-            // Move to back (most recently used)
-            if let Some(pos) = self.order.iter().position(|s| s == smarts) {
-                let key = self.order.remove(pos).unwrap();
-                self.order.push_back(key);
-            }
+            self.touch(smarts);
         }
         Ok(self.store.get(smarts).unwrap())
     }
@@ -118,7 +131,9 @@ impl SmartsCache {
     /// Clear all cached patterns.
     pub fn clear(&mut self) {
         self.store.clear();
+        self.access_generation.clear();
         self.order.clear();
+        self.next_generation = 0;
     }
 }
 

--- a/crates/chematic-smarts/src/cache.rs
+++ b/crates/chematic-smarts/src/cache.rs
@@ -25,6 +25,7 @@ use crate::{
     query::QueryMolecule,
 };
 use chematic_core::{AtomIdx, Molecule};
+use chematic_perception::RingSet;
 
 /// LRU cache for compiled SMARTS patterns.
 ///
@@ -109,6 +110,20 @@ impl SmartsCache {
     ) -> Result<Vec<FxHashMap<usize, AtomIdx>>, SmartsError> {
         let qmol = self.compile(smarts)?;
         Ok(find_matches_with_config(qmol, mol, config))
+    }
+
+    /// Find matches while reusing a precomputed ring set.
+    ///
+    /// This is the preferred path when applying several cached patterns to
+    /// the same molecule: SSSR calculation is performed once by the caller.
+    pub fn find_matches_with_rings(
+        &mut self,
+        smarts: &str,
+        mol: &Molecule,
+        rings: &RingSet,
+    ) -> Result<Vec<FxHashMap<usize, AtomIdx>>, SmartsError> {
+        let qmol = self.compile(smarts)?;
+        Ok(crate::match_vf2::find_matches_with_rings(qmol, mol, rings))
     }
 
     /// Check whether `smarts` matches at least once in `mol`.

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "1.0.0" }
+chematic-core = { path = "../chematic-core", version = "1.0.1" }
 # Production use: `compute_stereo_alkene_ends` (canonical.rs) needs SSSR ring
 # membership to exclude endocyclic small-ring double bonds from marker-carrier
 # candidacy (issue #149's ring-constrained residual, see
@@ -27,7 +27,7 @@ chematic-core = { path = "../chematic-core", version = "1.0.0" }
 # graph, only test binaries. Was previously a dev-only dependency of this
 # crate for a different reason (re-aromatizing test fixtures); now also a
 # real one.
-chematic-perception = { path = "../chematic-perception", version = "1.0.0" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.1" }
 
 [features]
 # Feature-gated internal work counters for the orbit-pruning canonical

--- a/crates/chematic-smiles/src/canonical_search.rs
+++ b/crates/chematic-smiles/src/canonical_search.rs
@@ -385,6 +385,22 @@ fn exact_orbit_representatives(
             if ri == rj {
                 continue;
             }
+            // A local-twin swap is an exact automorphism: both vertices have
+            // the same writer-visible color, and fixing every other vertex
+            // while swapping this pair preserves the complete edge-colored
+            // graph. This avoids invoking the much more expensive general
+            // automorphism search for repeated terminal groups such as the
+            // methyl arms of tBu/Boc. It is deliberately stricter than a
+            // Morgan/WL rank comparison and rejects asymmetric dative edges.
+            if local_twins(
+                graph,
+                coloring,
+                AtomIdx(members[i] as u32),
+                AtomIdx(members[j] as u32),
+            ) {
+                parent[ri] = rj;
+                continue;
+            }
             budget.automorphism_tests += 1;
             if let Some(max) = limits.max_automorphism_tests
                 && budget.automorphism_tests > max
@@ -427,6 +443,49 @@ fn exact_orbit_representatives(
     Ok(reps)
 }
 
+/// Return whether swapping `a` and `b` while fixing every other vertex is an
+/// automorphism of the current colored graph. This is a sufficient, exact
+/// test for local (true or false) twins, not a heuristic equivalence test.
+fn local_twins(
+    graph: &CanonicalColoredGraph,
+    coloring: &Partition,
+    a: AtomIdx,
+    b: AtomIdx,
+) -> bool {
+    if a == b
+        || graph.vertex_color(a) != graph.vertex_color(b)
+        || coloring.cell_of[a.0 as usize] != coloring.cell_of[b.0 as usize]
+    {
+        return false;
+    }
+
+    let mut a_edges: Vec<(AtomIdx, crate::canonical_partition::EdgeColor)> = graph
+        .neighbors(a)
+        .filter(|&(neighbor, _)| neighbor != b)
+        .map(|(neighbor, bond)| (neighbor, graph.edge_color(a, bond)))
+        .collect();
+    let mut b_edges: Vec<(AtomIdx, crate::canonical_partition::EdgeColor)> = graph
+        .neighbors(b)
+        .filter(|&(neighbor, _)| neighbor != a)
+        .map(|(neighbor, bond)| (neighbor, graph.edge_color(b, bond)))
+        .collect();
+    a_edges.sort_unstable();
+    b_edges.sort_unstable();
+    if a_edges != b_edges {
+        return false;
+    }
+
+    // If the pair is adjacent, its edge must be invariant under reversal.
+    // This rejects a dative bond whose donor/acceptor direction would flip.
+    let Some((_, a_to_b)) = graph.neighbors(a).find(|&(neighbor, _)| neighbor == b) else {
+        return true;
+    };
+    let Some((_, b_to_a)) = graph.neighbors(b).find(|&(neighbor, _)| neighbor == a) else {
+        return false;
+    };
+    graph.edge_color(a, a_to_b) == graph.edge_color(b, b_to_a)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -455,6 +514,29 @@ mod tests {
             let oracle = canonical_smiles_exhaustive_oracle(&mol);
             assert_eq!(got, oracle, "mismatch for {smi}");
         }
+    }
+
+    #[test]
+    fn local_twins_are_exact_but_dative_direction_is_not_symmetric() {
+        let tbu = parse("CC(C)(C)C").unwrap();
+        let graph = CanonicalColoredGraph::new(&tbu);
+        let partition = initial_partition(&graph, &vec![0; graph.n()]);
+        assert!(local_twins(&graph, &partition, AtomIdx(0), AtomIdx(2)));
+
+        let mut b = chematic_core::MoleculeBuilder::new();
+        let donor = b.add_atom(chematic_core::Atom::organic(chematic_core::Element::N));
+        let acceptor = b.add_atom(chematic_core::Atom::organic(chematic_core::Element::N));
+        b.add_bond(donor, acceptor, chematic_core::BondOrder::Dative)
+            .unwrap();
+        let dative = b.build();
+        let dative_graph = CanonicalColoredGraph::new(&dative);
+        let dative_partition = initial_partition(&dative_graph, &vec![0; dative_graph.n()]);
+        assert!(!local_twins(
+            &dative_graph,
+            &dative_partition,
+            donor,
+            acceptor
+        ));
     }
 
     /// Section 14 chemical fixtures: a molecule whose otherwise-symmetric

--- a/crates/chematic-smiles/tests/canonical_robustness.rs
+++ b/crates/chematic-smiles/tests/canonical_robustness.rs
@@ -451,6 +451,17 @@ fn rdkit_8759_ez_idempotence() {
     ]);
 }
 
+/// Issue #423: rare coupled E/Z and locally symmetric stereocenter spellings
+/// must still reach a fixed point after one canonicalization pass.
+#[test]
+fn issue423_coupled_ez_and_symmetric_stereo_are_stable() {
+    assert_all_stable(&[
+        r"C(/C(C(F)(F)F)=C(C#N)C#N)(C(=O)OC)=C(/C)N",
+        r"C([C@H]4C=3CCCCC=3C=C4)C[C@H]1C=CC=2CCCCC1=2.[Cl-].[Cl-].[Ti+2]",
+        r"C1CC(=C([2H])[2H])/C(=C([2H])\C=C\2CCC[C@]3(C)[C@@H]([C@@H](CCCC(O)(C)C)C)CC[C@@H]23)C[C@H]1O",
+    ]);
+}
+
 /// RDKit #9368: fragment extraction near E/Z bonds must never panic.
 /// chematic's brics_fragments() / brics_bonds() must handle these without crashing.
 /// Stereo preservation is best-effort; the invariant is: no panic, valid SMILES out.

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -32,19 +32,19 @@ web-sys = { version = "0.3", features = ["console"] }
 js-sys = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "1.0.0" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.0" }
-chematic-perception = { path = "../chematic-perception", version = "1.0.0" }
-chematic-chem       = { path = "../chematic-chem",       version = "1.0.0", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "1.0.0" }
-chematic-depict     = { path = "../chematic-depict",     version = "1.0.0", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "1.0.0" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.0" }
-chematic-3d         = { path = "../chematic-3d",         version = "1.0.0" }
-chematic-mol        = { path = "../chematic-mol",        version = "1.0.0" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "1.0.0" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "1.0.0" }
-chematic-ff         = { path = "../chematic-ff",         version = "1.0.0" }
+chematic-core       = { path = "../chematic-core",       version = "1.0.1" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.1" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.1" }
+chematic-chem       = { path = "../chematic-chem",       version = "1.0.1", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "1.0.1" }
+chematic-depict     = { path = "../chematic-depict",     version = "1.0.1", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "1.0.1" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.1" }
+chematic-3d         = { path = "../chematic-3d",         version = "1.0.1" }
+chematic-mol        = { path = "../chematic-mol",        version = "1.0.1" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "1.0.1" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "1.0.1" }
+chematic-ff         = { path = "../chematic-ff",         version = "1.0.1" }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.2"

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -54,16 +54,16 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "1.0.0", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.0", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "1.0.0", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "1.0.0", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "1.0.0", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "1.0.0", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "1.0.0", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.0", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "1.0.0", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "1.0.0", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "1.0.0", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "1.0.0", optional = true }
-chematic-crystal    = { path = "../chematic-crystal",    version = "1.0.0", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "1.0.1", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.1", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "1.0.1", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "1.0.1", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "1.0.1", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "1.0.1", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "1.0.1", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.1", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "1.0.1", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "1.0.1", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "1.0.1", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "1.0.1", optional = true }
+chematic-crystal    = { path = "../chematic-crystal",    version = "1.0.1", optional = true }

--- a/docs/use-cases/rust-server.md
+++ b/docs/use-cases/rust-server.md
@@ -23,7 +23,7 @@ $ curl -s -X POST http://localhost:3000/descriptors \
 ```toml
 # Cargo.toml
 [dependencies]
-chematic = { version = "1.0.0", features = ["chem", "fp", "smarts"] }
+chematic = { version = "1.0.1", features = ["chem", "fp", "smarts"] }
 axum      = "0.7"
 serde     = { version = "1", features = ["derive"] }
 tokio     = { version = "1", features = ["full"] }
@@ -140,4 +140,4 @@ fn process_sdf(path: &str) -> Vec<DescriptorOutput> {
 - `chematic_chem::{molecular_weight, logp_and_mr, tpsa, hbd_count, ring_bundle}` — descriptor functions
 - `chematic_fp::ecfp4(&mol)` / `tanimoto_bitvec(&fp1, &fp2)` — fingerprints + similarity
 - `chematic_mol::SdfReader` — streaming SDF parser
-- `chematic = { version = "1.0.0", features = ["chem", "fp", "smarts"] }` — minimal feature set for a descriptor API
+- `chematic = { version = "1.0.1", features = ["chem", "fp", "smarts"] }` — minimal feature set for a descriptor API

--- a/scripts/check_release_docs_consistency.py
+++ b/scripts/check_release_docs_consistency.py
@@ -26,8 +26,8 @@ DOCS = (
 def main() -> int:
     errors: list[str] = []
     cargo = (ROOT / "Cargo.toml").read_text(encoding="utf-8")
-    if not re.search(r'^version\s*=\s*"1\.0\.0"\s*$', cargo, re.MULTILINE):
-        errors.append("Cargo.toml does not declare workspace version 1.0.0")
+    if not re.search(r'^version\s*=\s*"1\.0\.1"\s*$', cargo, re.MULTILINE):
+        errors.append("Cargo.toml does not declare workspace version 1.0.1")
 
     for path in DOCS:
         try:
@@ -57,8 +57,8 @@ def main() -> int:
         ROOT / "crates" / "chematic-mcp" / "README.md",
         ROOT / "crates" / "chematic-inchi" / "README.md",
     ):
-        if 'version = "1.0.0"' not in path.read_text(encoding="utf-8"):
-            errors.append(f"{path.relative_to(ROOT)}: current dependency example is not v1.0.0")
+        if 'version = "1.0.1"' not in path.read_text(encoding="utf-8"):
+            errors.append(f"{path.relative_to(ROOT)}: current dependency example is not v1.0.1")
 
     if errors:
         print("Release documentation consistency failures:", file=sys.stderr)


### PR DESCRIPTION
Classify the unpublished 0.90.x through 2.32.x local development milestones as internal milestones under the v0.89.0 consolidated release. Keep v0.88.0 and earlier published history unchanged.