### PR TITLE
fix(ci): authenticate npm publication check

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -71,6 +71,8 @@ jobs:
       - name: Validate npm credentials and publication state
         id: npm_state
         working-directory: crates/chematic-wasm/pkg
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
           package_name=$(node -p "require('./package.json').name")


### PR DESCRIPTION
The v1.0.4 npm workflow built the WASM package successfully but `npm whoami` returned E401 because `NODE_AUTH_TOKEN` was only provided to the later publish step. Pass the existing `NPM_TOKEN` secret to the credential/state validation step as well.

Validated with actionlint, workflow pin checks, and git diff --check. After merge, rerun Publish to npm with ref `v1.0.4`.