### PR TITLE
fix: complete v1.0.6 CI diagnostics

### DIFF
--- a/crates/chematic-inchi/examples/dedup_stereo_guard_diagnosis.rs
+++ b/crates/chematic-inchi/examples/dedup_stereo_guard_diagnosis.rs
@@ -108,6 +108,7 @@ fn main() {
             let accurate_reason = accurate_unresolved.map(|r| match r {
                 CipUnresolvedReason::Tied => "Tied",
                 CipUnresolvedReason::BudgetExceeded => "BudgetExceeded",
+                CipUnresolvedReason::OracleUnstable => "OracleUnstable",
             });
 
             println!(

--- a/crates/chematic-perception/examples/issue337_all_root_cycle_probe.rs
+++ b/crates/chematic-perception/examples/issue337_all_root_cycle_probe.rs
@@ -156,10 +156,7 @@ fn gf2_rank(rows: &[BTreeSet<BondIdx>]) -> usize {
     let mut rank = 0;
     for row in rows {
         let mut current = row.clone();
-        loop {
-            let Some(&pivot) = current.iter().next_back() else {
-                break;
-            };
+        while let Some(&pivot) = current.iter().next_back() {
             if let Some(existing) = pivots.get(&pivot) {
                 let mut reduced = current;
                 for bond in existing {
@@ -202,6 +199,7 @@ fn enumerate_exact_cycles(
     target_len: usize,
     max_cycles: usize,
 ) -> (BTreeSet<Vec<u32>>, bool) {
+    #[allow(clippy::too_many_arguments)]
     fn dfs(
         mol: &chematic_core::Molecule,
         start: AtomIdx,


### PR DESCRIPTION
Fixes the post-release CI failures on v1.0.6: handle CipUnresolvedReason::OracleUnstable in the native-inchi example and satisfy Clippy in the perception probe example. Local format, focused clippy, and native-inchi example checks pass.