### PR TITLE
docs: refresh README release boundary for v1.0.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         run: python3 scripts/check_cross_binding_manifest.py
       - name: Static binding surface inventory
         run: python3 scripts/check_binding_surface.py > /dev/null
+      - name: Release documentation consistency
+        run: python3 scripts/check_release_docs_consistency.py
 
   test-integration:
     name: Integration tests (${{ matrix.package }} / ${{ matrix.target }})

--- a/README_ja.md
+++ b/README_ja.md
@@ -46,13 +46,13 @@ Spectrophores は patent/FTO 状態が独立に確認されるまで Rust/Python
 
 canonical/SDF の行は 2026-09-04 macOS arm64 の中央値であり、記録した corpus と
 処理境界に限定されます。[ベンチマーク詳細](https://kent-tokyo.github.io/chematic/benchmark/)を参照。
-chematic の WASM サイズは v1.0.9 release candidate を `wasm-pack 0.13.1` +
-`wasm-opt 130` でビルドして 2026-09-07 に計測: **3.58 MB raw**(**1.31 MB gzip**)。
+chematic の WASM サイズは v1.0.10 release candidate を `wasm-pack 0.13.1` +
+`wasm-opt 130` でビルドして 2026-09-09 に計測: **3.73 MB raw**（**1.36 MB gzip**）。
 比較対象は履歴として固定した RDKit.js **6.91 MB**
 (`@rdkit/rdkit@2025.3.4-1.0.0`の`RDKit_minimal.wasm`、unpkg.com で確認) · Indigo(Ketcher向けビルド)
 **11.24 MB**(`indigo-ketcher@1.45.1`のメイン`.wasm`、jsDelivr で確認) — chematic の raw WASM
-バイナリは現在、RDKit.js よりおよそ2.1倍、Indigo の Ketcher向けビルドよりおよそ3.8倍小さい
-(raw同士の比較)。詳細は[v1.0.9 artifact 記録](benchmarks/2026-09-07-wasm-size-v1.0.9.md)を参照。
+バイナリは現在、RDKit.js よりおよそ1.9倍、Indigo の Ketcher向けビルドよりおよそ3.0倍小さい
+(raw同士の比較)。詳細は[v1.0.10 artifact 記録](benchmarks/2026-09-09-wasm-size-v1.0.10.md)を参照。
 
 **機能の成熟度（早見表）：**
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -41,13 +41,13 @@ Spectrophores 在 patent/FTO 状态得到独立确认前已从 Rust/Python API �
 
 canonical/SDF 行是 2026-09-04 macOS arm64 的中位数，仅适用于所记录的语料和
 操作边界。参阅[基准测试详情](https://kent-tokyo.github.io/chematic/benchmark/)。
-chematic WASM 包体积于 2026-09-07 使用 `wasm-pack 0.13.1` + `wasm-opt 130`
-从 v1.0.9 release candidate 构建并测量：**raw 3.58 MB**（**gzip 1.31 MB**）。固定的历史比较项为
+chematic WASM 包体积于 2026-09-09 使用 `wasm-pack 0.13.1` + `wasm-opt 130`
+从 v1.0.10 release candidate 构建并测量：**raw 3.73 MB**（**gzip 1.36 MB**）。固定的历史比较项为
 RDKit.js **6.91 MB**
 （`@rdkit/rdkit@2025.3.4-1.0.0` 的 `RDKit_minimal.wasm`，经 unpkg.com 确认）· Indigo（Ketcher
 构建版）**11.24 MB**（`indigo-ketcher@1.45.1` 的主 `.wasm`，经 jsDelivr 确认）—— 以 raw 对 raw
-比较，chematic 目前比 RDKit.js 小约 2.1 倍，比 Indigo 的 Ketcher 构建版小约 3.8 倍。
-详见 [v1.0.9 artifact 记录](benchmarks/2026-09-07-wasm-size-v1.0.9.md)。
+比较，chematic 目前比 RDKit.js 小约 1.9 倍，比 Indigo 的 Ketcher 构建版小约 3.0 倍。
+详见 [v1.0.10 artifact 记录](benchmarks/2026-09-09-wasm-size-v1.0.10.md)。
 
 **v1.0.11（2026-09-10）：** 延续 v1.0.10 的 descriptor provenance、共享契约与 streaming safety gate，加入 V3000 parser 与 3D pipeline 责任分离，以及 CIP 异常状态的 fail-closed 处理，同时保持既有搜索结果与排序契约。#149/#337 残差仍保持 fail-closed 或诊断专用。
 

--- a/scripts/check_release_docs_consistency.py
+++ b/scripts/check_release_docs_consistency.py
@@ -33,6 +33,12 @@ def main() -> int:
         return 1
     release_version = version_match.group(1)
 
+    release_headings = {
+        Path("README.md"): f"### v{release_version} release boundary",
+        Path("README_ja.md"): f"### v{release_version} の対応範囲",
+        Path("README_zh.md"): f"### v{release_version} 范围",
+    }
+
     for path in DOCS:
         try:
             text = path.read_text(encoding="utf-8")
@@ -44,6 +50,9 @@ def main() -> int:
             errors.append(f"{relative}: stale SCHEMATIC release-key secret name")
         if relative != Path("README_ja.md") and "chematic" not in text:
             errors.append(f"{relative}: missing chematic product name")
+        expected_heading = release_headings.get(relative)
+        if expected_heading is not None and expected_heading not in text:
+            errors.append(f"{relative}: missing current release boundary heading {expected_heading}")
 
     custody = (ROOT / "docs" / "release-key-custody.md").read_text(encoding="utf-8")
     if "CHEMATIC_RELEASE_PRIVATE_KEY" not in custody:


### PR DESCRIPTION
Closes #512\n\nSummary:\n- align Japanese and Chinese WASM artifact references with the measured v1.0.10 release-candidate record\n- add locale-specific current-release boundary heading checks derived from Cargo.toml\n- run release documentation consistency in CI\n\nVerification:\n- python3 scripts/check_release_docs_consistency.py\n- git diff --check