### PR TITLE
docs: refresh canonical orbit performance evidence

### DIFF
--- a/docs/issue-triage-2026-09-08.md
+++ b/docs/issue-triage-2026-09-08.md
@@ -871,8 +871,8 @@ regression test.
 
 The exact twin/orbit path was re-run on 2026-09-11 with the checked-in Tier A/B
 harness and the canonical-search instrumentation feature. The run had zero
-old/new correctness mismatches, zero search-budget exhaustions, and an 8.19x
-Tier A geometric-mean speedup (Tier B negative control: 2.44x). Across Tier A
+old/new correctness mismatches, zero search-budget exhaustions, and an 8.26x
+Tier A geometric-mean speedup (Tier B negative control: 2.45x). Across Tier A
 the exhaustive engine visited 6,186 leaves while the orbit-pruned engine wrote
 13 leaves, visited 62 nodes, and performed 46 orbit tests; the repeated
 multi-Boc and multi-pivaloyl fixtures each collapsed to one leaf from 432

--- a/validation/results/canonical-orbit-perf-v1.0.12.json
+++ b/validation/results/canonical-orbit-perf-v1.0.12.json
@@ -12,7 +12,7 @@
     "new_leaves": 13,
     "new_nodes_visited": 62,
     "new_orbit_tests": 46,
-    "geomean_speedup": 8.19
+    "geomean_speedup": 8.26
   },
   "tier_b": {
     "fixtures": 6,
@@ -20,7 +20,7 @@
     "parse_failures": 0,
     "empty_outputs": 0,
     "budget_exhaustions": 0,
-    "geomean_speedup": 2.44
+    "geomean_speedup": 2.45
   },
   "scope": "Local Tier A/B proxy only. The exact RENKIN witness and downstream end-to-end throughput remain unmeasured and are required before closing issue #372."
 }


### PR DESCRIPTION
## Summary
- refresh the v1.0.12 canonical orbit benchmark from a release-mode run
- record Tier A 8.26x and Tier B 2.45x geomean speedups
- retain the explicit boundary that the exact RENKIN witness remains unmeasured

## Validation
- cargo run --release -p chematic-smiles --features canonical-search-instrumentation --example canonical_orbit_perf --offline
- git diff --check

No correctness mismatches or budget exhaustions were observed.