### PR TITLE
test(cml): cover multiple roots across bindings

### DIFF
--- a/validation/cross_binding_contract.json
+++ b/validation/cross_binding_contract.json
@@ -249,7 +249,7 @@
     "scope": "opt_in_structural_non_empty_cml",
     "valid_input": "<molecule><atomArray><atom id=\"a1\" elementType=\"C\"/></atomArray><bondArray/></molecule>",
     "expected_atom_count": 1,
-    "rejected_inputs": ["<cml/>", "<molecule><atomArray>", "<molecule><atomArray/></molecule>", "<molecule><atomArray></molecule></atomArray>"]
+    "rejected_inputs": ["<cml/>", "<molecule><atomArray>", "<molecule><atomArray/></molecule>", "<molecule><atomArray></molecule></atomArray>", "<molecule><atomArray><atom id=\"a1\" elementType=\"C\"/></atomArray></molecule><molecule><atomArray><atom id=\"a2\" elementType=\"N\"/></atomArray></molecule>"]
   },
   "cdxml_contract": {
     "schema_version": 1,


### PR DESCRIPTION
## Summary
- add a multiple-root strict CML rejection to the shared cross-binding fixture
- exercise the boundary through Python and Node/WASM contract loops

## Validation
- python3 scripts/check_cross_binding_manifest.py
- cargo test -p chematic-mol strict_cml --lib --offline
- source-built Python wheel: test_cross_binding_contract.py -k strict_cml