### PR TITLE
release: v1.0.13

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -3,7 +3,7 @@
   "description": "A bounded, typed cheminformatics runtime with SMILES/SMARTS parsing, molecular descriptors, fingerprints, substructure search, selected chemical formats, Python and WebAssembly bindings, and MCP integration.",
   "upload_type": "software",
   "license": "MIT",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "publication_date": "2026-09-10",
   "keywords": [
     "cheminformatics",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and public releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+No unreleased changes.
+
+## [1.0.13] - 2026-09-11
+
 - Rejected multiple top-level elements in the opt-in strict CML parser while
   preserving the historical lenient parser behavior.
 - Added the multiple-root rejection to the shared Rust/Python/Node/WASM CML
@@ -440,7 +444,8 @@ The authoritative list of published tags and release artifacts is the
 historical implementation notes remain available in the archived detailed
 history and Git history.
 
-[Unreleased]: https://github.com/kent-tokyo/chematic/compare/v1.0.12...HEAD
+[Unreleased]: https://github.com/kent-tokyo/chematic/compare/v1.0.13...HEAD
+[1.0.13]: https://github.com/kent-tokyo/chematic/compare/v1.0.12...v1.0.13
 [1.0.12]: https://github.com/kent-tokyo/chematic/compare/v1.0.11...v1.0.12
 [1.0.11]: https://github.com/kent-tokyo/chematic/compare/v1.0.10...v1.0.11
 [1.0.10]: https://github.com/kent-tokyo/chematic/compare/v1.0.9...v1.0.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and public releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Rejected multiple top-level elements in the opt-in strict CML parser while
+  preserving the historical lenient parser behavior.
+- Added the multiple-root rejection to the shared Rust/Python/Node/WASM CML
+  contract so all supported bindings exercise the same fail-closed boundary.
 - Added typed CDXML text/caption style access for font, size, and alignment,
   with non-finite numeric values rejected and unknown presentation attributes
   preserved.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,5 +25,5 @@ keywords:
 license:
   - MIT
   - Apache-2.0
-version: 1.0.12
+version: 1.0.13
 date-released: "2026-09-10"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chematic"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "chematic-3d",
  "chematic-chem",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-3d"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "chematic-chem",
  "chematic-core",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-chem"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "chematic-cip",
  "chematic-core",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-cip"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "chematic-chem",
  "chematic-core",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-cli"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "chematic-chem",
  "chematic-core",
@@ -324,11 +324,11 @@ dependencies = [
 
 [[package]]
 name = "chematic-core"
-version = "1.0.12"
+version = "1.0.13"
 
 [[package]]
 name = "chematic-crystal"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "chematic-core",
  "criterion",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-depict"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "chematic-core",
  "chematic-perception",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-ewald"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "chematic-3d",
  "chematic-core",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-ff"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "chematic-core",
  "chematic-perception",
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-fp"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "chematic-cip",
  "chematic-core",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-inchi"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "cc",
  "chematic-chem",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-iupac"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "chematic-core",
  "chematic-perception",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-mcp"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "chematic-3d",
  "chematic-chem",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-mol"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "chematic-3d",
  "chematic-chem",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-perception"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "chematic-core",
  "chematic-smiles",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-py"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "chematic-3d",
  "chematic-chem",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-rxn"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "chematic-chem",
  "chematic-core",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-smarts"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "chematic-core",
  "chematic-perception",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-smiles"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "chematic-core",
  "chematic-fp",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "chematic-wasm"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "chematic-3d",
  "chematic-chem",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ lto = true           # whole-program link-time optimization
 codegen-units = 1    # required for LTO; also enables more cross-crate inlining
 
 [workspace.package]
-version = "1.0.12"
+version = "1.0.13"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Kentaro Tanabe (kent-tokyo) <kent-tokyo@users.noreply.github.com>"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install @kent-tokyo/chematic
 
 Python needs no C/C++ compiler. Rust and WebAssembly builds use the same core.
 
-### v1.0.12 release boundary
+### v1.0.13 release boundary
 
 This release records expanded reaction, V3000, parser-safety, CIP, and
 cross-binding validation. RDKit-compatible fingerprints, Markush/polymer

--- a/README_ja.md
+++ b/README_ja.md
@@ -23,7 +23,7 @@ npm install @kent-tokyo/chematic
 
 Python版はC/C++コンパイラなしで導入できます。
 
-### v1.0.12 の対応範囲
+### v1.0.13 の対応範囲
 
 反応、V3000、入力安全性、CIP、各バインディングの検証を拡張しました。
 RDKit互換フィンガープリント、Markush/polymer意味論、ブラウザartifactの

--- a/README_zh.md
+++ b/README_zh.md
@@ -23,7 +23,7 @@ npm install @kent-tokyo/chematic
 
 Python 版本无需 C/C++ 编译器。
 
-### v1.0.12 范围
+### v1.0.13 范围
 
 本版本扩展了反应、V3000、输入安全、CIP 和各绑定的验证。RDKit 兼容指纹、
 Markush/polymer 语义以及浏览器 artifact 的完全一致性仍属于 bounded scope。

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # chematic roadmap
 
-> Revised 2026-09-11. The current release is v1.0.12. The workspace version is
-> 1.0.12; checked-in benchmark artifacts retain their measured version.
+> Revised 2026-09-11. The current release is v1.0.13. The workspace version is
+> 1.0.13; checked-in benchmark artifacts retain their measured version.
 
 The detailed roadmap and completed gate-by-gate evidence through 2026-09-05 is
 retained in

--- a/crates/chematic-3d/Cargo.toml
+++ b/crates/chematic-3d/Cargo.toml
@@ -17,12 +17,12 @@ documentation = "https://docs.rs/chematic-3d"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "1.0.12" }
-chematic-perception = { path = "../chematic-perception", version = "1.0.12" }
-chematic-ff         = { path = "../chematic-ff",         version = "1.0.12" }
-chematic-chem       = { path = "../chematic-chem",       version = "1.0.12" }
-chematic-fp         = { path = "../chematic-fp",         version = "1.0.12" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.12" }
+chematic-core       = { path = "../chematic-core",       version = "1.0.13" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.13" }
+chematic-ff         = { path = "../chematic-ff",         version = "1.0.13" }
+chematic-chem       = { path = "../chematic-chem",       version = "1.0.13" }
+chematic-fp         = { path = "../chematic-fp",         version = "1.0.13" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.13" }
 serde_json          = "1.0"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #219); web-time

--- a/crates/chematic-3d/README.md
+++ b/crates/chematic-3d/README.md
@@ -137,8 +137,8 @@ All functions compile to `wasm32-unknown-unknown` without modification.
 wasm-pack build --target web --release
 ```
 
-The published-size baseline for the optimized `chematic-wasm` artifact is 3.73 MB raw / 1.36 MB gzip,
-measured from the v1.0.10 release line; see the dated artifact record rather than treating this as a
+The current measured optimized `chematic-wasm` artifact is 3.93 MB raw / 1.43 MB gzip,
+measured in the v1.0.12 Node/WASM gate; see the dated artifact record rather than treating this as a
 permanent size guarantee.
 
 ## Crate Dependencies

--- a/crates/chematic-chem/Cargo.toml
+++ b/crates/chematic-chem/Cargo.toml
@@ -17,14 +17,14 @@ documentation = "https://docs.rs/chematic-chem"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "1.0.12" }
+chematic-core       = { path = "../chematic-core",       version = "1.0.13" }
 rustc-hash          = "2"
-chematic-perception = { path = "../chematic-perception", version = "1.0.12" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.12" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.12" }
-chematic-fp         = { path = "../chematic-fp",         version = "1.0.12" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "1.0.12" }
-chematic-cip        = { path = "../chematic-cip",        version = "1.0.12" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.13" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.13" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.13" }
+chematic-fp         = { path = "../chematic-fp",         version = "1.0.13" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "1.0.13" }
+chematic-cip        = { path = "../chematic-cip",        version = "1.0.13" }
 serde               = { version = "1.0", features = ["derive"], optional = true }
 serde_json          = { version = "1.0", optional = true }
 miniz_oxide         = { version = "0.9", optional = true, default-features = false, features = ["with-alloc"] }

--- a/crates/chematic-cip/Cargo.toml
+++ b/crates/chematic-cip/Cargo.toml
@@ -18,8 +18,8 @@ publish = ["crates-io"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "1.0.12" }
-chematic-perception = { path = "../chematic-perception", version = "1.0.12" }
+chematic-core       = { path = "../chematic-core",       version = "1.0.13" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.13" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-cli/Cargo.toml
+++ b/crates/chematic-cli/Cargo.toml
@@ -18,10 +18,10 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 serde_json = "1.0"
-chematic-smarts = { path = "../chematic-smarts", version = "1.0.12" }
-chematic-core = { path = "../chematic-core", version = "1.0.12" }
-chematic-fp = { path = "../chematic-fp", version = "1.0.12" }
-chematic-chem = { path = "../chematic-chem", version = "1.0.12", features = ["serde"] }
-chematic-rxn = { path = "../chematic-rxn", version = "1.0.12" }
-chematic-mol = { path = "../chematic-mol", version = "1.0.12" }
-chematic-smiles = { path = "../chematic-smiles", version = "1.0.12" }
+chematic-smarts = { path = "../chematic-smarts", version = "1.0.13" }
+chematic-core = { path = "../chematic-core", version = "1.0.13" }
+chematic-fp = { path = "../chematic-fp", version = "1.0.13" }
+chematic-chem = { path = "../chematic-chem", version = "1.0.13", features = ["serde"] }
+chematic-rxn = { path = "../chematic-rxn", version = "1.0.13" }
+chematic-mol = { path = "../chematic-mol", version = "1.0.13" }
+chematic-smiles = { path = "../chematic-smiles", version = "1.0.13" }

--- a/crates/chematic-crystal/Cargo.toml
+++ b/crates/chematic-crystal/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 serde = ["dep:serde", "dep:serde_json"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "1.0.12" }
+chematic-core = { path = "../chematic-core", version = "1.0.13" }
 serde         = { version = "1.0", features = ["derive"], optional = true }
 serde_json    = { version = "1.0", optional = true }
 

--- a/crates/chematic-depict/Cargo.toml
+++ b/crates/chematic-depict/Cargo.toml
@@ -23,10 +23,10 @@ png = ["dep:tiny-skia"]
 pdf = ["dep:svg2pdf"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "1.0.12" }
-chematic-perception = { path = "../chematic-perception", version = "1.0.12" }
-chematic-rxn = { path = "../chematic-rxn", version = "1.0.12" }
-chematic-smiles = { path = "../chematic-smiles", version = "1.0.12" }
+chematic-core = { path = "../chematic-core", version = "1.0.13" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.13" }
+chematic-rxn = { path = "../chematic-rxn", version = "1.0.13" }
+chematic-smiles = { path = "../chematic-smiles", version = "1.0.13" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tiny-skia = { version = "0.12", optional = true }

--- a/crates/chematic-ewald/Cargo.toml
+++ b/crates/chematic-ewald/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/chematic-ewald"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "1.0.12" }
+chematic-core = { path = "../chematic-core", version = "1.0.13" }
 rustfft = "6.4"
 
 [dev-dependencies]

--- a/crates/chematic-ff/Cargo.toml
+++ b/crates/chematic-ff/Cargo.toml
@@ -17,9 +17,9 @@ documentation = "https://docs.rs/chematic-ff"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "1.0.12" }
+chematic-core       = { path = "../chematic-core",       version = "1.0.13" }
 rayon                = "1"
-chematic-perception = { path = "../chematic-perception", version = "1.0.12" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.13" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-fp/Cargo.toml
+++ b/crates/chematic-fp/Cargo.toml
@@ -24,14 +24,14 @@ diagnostics = []
 
 [dependencies]
 rayon = "1"
-chematic-core = { path = "../chematic-core", version = "1.0.12" }
-chematic-cip = { path = "../chematic-cip", version = "1.0.12" }
+chematic-core = { path = "../chematic-core", version = "1.0.13" }
+chematic-cip = { path = "../chematic-cip", version = "1.0.13" }
 rustc-hash = "2"
 smallvec = "1"
-chematic-perception = { path = "../chematic-perception", version = "1.0.12" }
-chematic-rxn = { path = "../chematic-rxn", version = "1.0.12" }
-chematic-smarts = { path = "../chematic-smarts", version = "1.0.12" }
-chematic-smiles = { path = "../chematic-smiles", version = "1.0.12" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.13" }
+chematic-rxn = { path = "../chematic-rxn", version = "1.0.13" }
+chematic-smarts = { path = "../chematic-smarts", version = "1.0.13" }
+chematic-smiles = { path = "../chematic-smiles", version = "1.0.13" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/chematic-inchi/Cargo.toml
+++ b/crates/chematic-inchi/Cargo.toml
@@ -19,10 +19,10 @@ readme = "README.md"
 native-inchi = ["dep:cc"]
 
 [dependencies]
-chematic-core = { version = "1.0.12", path = "../chematic-core" }
-chematic-smiles = { version = "1.0.12", path = "../chematic-smiles" }
-chematic-chem = { version = "1.0.12", path = "../chematic-chem" }
-chematic-rxn = { version = "1.0.12", path = "../chematic-rxn" }
+chematic-core = { version = "1.0.13", path = "../chematic-core" }
+chematic-smiles = { version = "1.0.13", path = "../chematic-smiles" }
+chematic-chem = { version = "1.0.13", path = "../chematic-chem" }
+chematic-rxn = { version = "1.0.13", path = "../chematic-rxn" }
 
 [build-dependencies]
 cc = { version = "1", optional = true }

--- a/crates/chematic-inchi/README.md
+++ b/crates/chematic-inchi/README.md
@@ -14,7 +14,7 @@ Output is **bit-exact** with the reference implementation.
 
 ```toml
 [dependencies]
-chematic-inchi = { version = "1.0.12", features = ["native-inchi"] }
+chematic-inchi = { version = "1.0.13", features = ["native-inchi"] }
 ```
 
 ```rust

--- a/crates/chematic-iupac/Cargo.toml
+++ b/crates/chematic-iupac/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-iupac"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "1.0.12" }
-chematic-perception = { path = "../chematic-perception", version = "1.0.12" }
+chematic-core       = { path = "../chematic-core",       version = "1.0.13" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.13" }
 
 [dev-dependencies]
 # Path-only (no `version`): see chematic-smiles/Cargo.toml's dev-dependencies

--- a/crates/chematic-mcp/Cargo.toml
+++ b/crates/chematic-mcp/Cargo.toml
@@ -18,15 +18,15 @@ path = "src/main.rs"
 [dependencies]
 serde_json = "1.0"
 ureq = "3"
-chematic-core       = { path = "../chematic-core",       version = "1.0.12" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.12" }
-chematic-chem       = { path = "../chematic-chem",       version = "1.0.12", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "1.0.12" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.12" }
-chematic-3d         = { path = "../chematic-3d",         version = "1.0.12" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "1.0.12" }
-chematic-mol        = { path = "../chematic-mol",        version = "1.0.12" }
-chematic-perception = { path = "../chematic-perception", version = "1.0.12" }
+chematic-core       = { path = "../chematic-core",       version = "1.0.13" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.13" }
+chematic-chem       = { path = "../chematic-chem",       version = "1.0.13", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "1.0.13" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.13" }
+chematic-3d         = { path = "../chematic-3d",         version = "1.0.13" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "1.0.13" }
+chematic-mol        = { path = "../chematic-mol",        version = "1.0.13" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.13" }
 
 [dev-dependencies]
 # Real JSON Schema 2020-12 validator, used only in tests to independently

--- a/crates/chematic-mcp/README.md
+++ b/crates/chematic-mcp/README.md
@@ -33,7 +33,7 @@ registry in `src/tools.rs` is the source of truth for the available tools.
 
 ```toml
 [dependencies]
-chematic-mcp = { version = "1.0.12", path = "../chematic-mcp" }
+chematic-mcp = { version = "1.0.13", path = "../chematic-mcp" }
 ```
 
 ## Running the server

--- a/crates/chematic-mol/Cargo.toml
+++ b/crates/chematic-mol/Cargo.toml
@@ -25,12 +25,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 crystal = ["dep:chematic-crystal"]
 
 [dependencies]
-chematic-core        = { path = "../chematic-core",        version = "1.0.12" }
-chematic-3d           = { path = "../chematic-3d",           version = "1.0.12" }
-chematic-rxn         = { path = "../chematic-rxn",         version = "1.0.12" }
-chematic-perception  = { path = "../chematic-perception",  version = "1.0.12" }
-chematic-smiles      = { path = "../chematic-smiles",      version = "1.0.12" }
-chematic-crystal     = { path = "../chematic-crystal",     version = "1.0.12", optional = true }
+chematic-core        = { path = "../chematic-core",        version = "1.0.13" }
+chematic-3d           = { path = "../chematic-3d",           version = "1.0.13" }
+chematic-rxn         = { path = "../chematic-rxn",         version = "1.0.13" }
+chematic-perception  = { path = "../chematic-perception",  version = "1.0.13" }
+chematic-smiles      = { path = "../chematic-smiles",      version = "1.0.13" }
+chematic-crystal     = { path = "../chematic-crystal",     version = "1.0.13", optional = true }
 serde_json           = "1.0"
 serde                = { version = "1.0", features = ["derive"] }
 

--- a/crates/chematic-mol/README.md
+++ b/crates/chematic-mol/README.md
@@ -19,6 +19,9 @@ Pure Rust molecular file format reader/writer — **SDF, MOL V2000/V3000, CML, C
 
 ### CML (Chemical Markup Language)
 - **Parse/Write**: XML-based molecular format
+- **Strict parsing**: `parse_cml_strict` is opt-in and rejects empty molecules,
+  unbalanced/multiple-root documents, and unterminated lexical sections;
+  `parse_cml` retains its historical lenient behavior.
 - **Y-Coordinate System** (DOCUMENTED in v0.1.32):
   - CML uses **chemical Y-up** (Y increases upward)
   - SVG rendering requires Y-negation: `svg_y = -cml_y`

--- a/crates/chematic-perception/Cargo.toml
+++ b/crates/chematic-perception/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 diagnostics = []
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "1.0.12" }
+chematic-core = { path = "../chematic-core", version = "1.0.13" }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/chematic-py/Cargo.toml
+++ b/crates/chematic-py/Cargo.toml
@@ -26,17 +26,17 @@ numpy = "0.29"
 serde_json = "1.0"
 rayon = "1"
 ndarray = { version = "0.17", default-features = false }
-chematic-core       = { path = "../chematic-core",       version = "1.0.12" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.12" }
-chematic-perception = { path = "../chematic-perception", version = "1.0.12" }
-chematic-chem       = { path = "../chematic-chem",       version = "1.0.12" }
-chematic-fp         = { path = "../chematic-fp",         version = "1.0.12" }
-chematic-depict     = { path = "../chematic-depict",     version = "1.0.12", features = ["pdf"] }
-chematic-mol        = { path = "../chematic-mol",        version = "1.0.12", features = ["crystal"] }
-chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.12" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "1.0.12" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "1.0.12" }
-chematic-rxn        = { path = "../chematic-rxn",        version = "1.0.12" }
-chematic-3d         = { path = "../chematic-3d",         version = "1.0.12" }
-chematic-ff         = { path = "../chematic-ff",         version = "1.0.12" }
-chematic-crystal    = { path = "../chematic-crystal",    version = "1.0.12" }
+chematic-core       = { path = "../chematic-core",       version = "1.0.13" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.13" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.13" }
+chematic-chem       = { path = "../chematic-chem",       version = "1.0.13" }
+chematic-fp         = { path = "../chematic-fp",         version = "1.0.13" }
+chematic-depict     = { path = "../chematic-depict",     version = "1.0.13", features = ["pdf"] }
+chematic-mol        = { path = "../chematic-mol",        version = "1.0.13", features = ["crystal"] }
+chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.13" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "1.0.13" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "1.0.13" }
+chematic-rxn        = { path = "../chematic-rxn",        version = "1.0.13" }
+chematic-3d         = { path = "../chematic-3d",         version = "1.0.13" }
+chematic-ff         = { path = "../chematic-ff",         version = "1.0.13" }
+chematic-crystal    = { path = "../chematic-crystal",    version = "1.0.13" }

--- a/crates/chematic-rxn/Cargo.toml
+++ b/crates/chematic-rxn/Cargo.toml
@@ -23,10 +23,10 @@ rustdoc-args = ["--cfg", "docsrs"]
 perf-instrumentation = []
 
 [dependencies]
-chematic-core   = { path = "../chematic-core",   version = "1.0.12" }
-chematic-perception = { path = "../chematic-perception", version = "1.0.12" }
-chematic-smiles = { path = "../chematic-smiles", version = "1.0.12" }
-chematic-smarts = { path = "../chematic-smarts", version = "1.0.12" }
+chematic-core   = { path = "../chematic-core",   version = "1.0.13" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.13" }
+chematic-smiles = { path = "../chematic-smiles", version = "1.0.13" }
+chematic-smarts = { path = "../chematic-smarts", version = "1.0.13" }
 rustc-hash = "2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/chematic-smarts/Cargo.toml
+++ b/crates/chematic-smarts/Cargo.toml
@@ -17,8 +17,8 @@ documentation = "https://docs.rs/chematic-smarts"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "1.0.12" }
-chematic-perception = { path = "../chematic-perception", version = "1.0.12" }
+chematic-core = { path = "../chematic-core", version = "1.0.13" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.13" }
 rustc-hash = "2"
 
 # std::time::Instant panics on wasm32-unknown-unknown (issue #221); web-time

--- a/crates/chematic-smiles/Cargo.toml
+++ b/crates/chematic-smiles/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://docs.rs/chematic-smiles"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-chematic-core = { path = "../chematic-core", version = "1.0.12" }
+chematic-core = { path = "../chematic-core", version = "1.0.13" }
 # Production use: `compute_stereo_alkene_ends` (canonical.rs) needs SSSR ring
 # membership to exclude endocyclic small-ring double bonds from marker-carrier
 # candidacy (issue #149's ring-constrained residual, see
@@ -27,7 +27,7 @@ chematic-core = { path = "../chematic-core", version = "1.0.12" }
 # graph, only test binaries. Was previously a dev-only dependency of this
 # crate for a different reason (re-aromatizing test fixtures); now also a
 # real one.
-chematic-perception = { path = "../chematic-perception", version = "1.0.12" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.13" }
 smallvec = "1"
 
 [features]

--- a/crates/chematic-wasm/Cargo.toml
+++ b/crates/chematic-wasm/Cargo.toml
@@ -32,20 +32,20 @@ web-sys = { version = "0.3", features = ["console"] }
 js-sys = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chematic-core       = { path = "../chematic-core",       version = "1.0.12" }
-chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.12" }
-chematic-perception = { path = "../chematic-perception", version = "1.0.12" }
-chematic-chem       = { path = "../chematic-chem",       version = "1.0.12", features = ["serde"] }
-chematic-crystal    = { path = "../chematic-crystal",    version = "1.0.12", features = ["serde"] }
-chematic-fp         = { path = "../chematic-fp",         version = "1.0.12" }
-chematic-depict     = { path = "../chematic-depict",     version = "1.0.12", default-features = false, features = [] }
-chematic-rxn        = { path = "../chematic-rxn",        version = "1.0.12" }
-chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.12" }
-chematic-3d         = { path = "../chematic-3d",         version = "1.0.12" }
-chematic-mol        = { path = "../chematic-mol",        version = "1.0.12" }
-chematic-inchi      = { path = "../chematic-inchi",      version = "1.0.12" }
-chematic-iupac      = { path = "../chematic-iupac",      version = "1.0.12" }
-chematic-ff         = { path = "../chematic-ff",         version = "1.0.12" }
+chematic-core       = { path = "../chematic-core",       version = "1.0.13" }
+chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.13" }
+chematic-perception = { path = "../chematic-perception", version = "1.0.13" }
+chematic-chem       = { path = "../chematic-chem",       version = "1.0.13", features = ["serde"] }
+chematic-crystal    = { path = "../chematic-crystal",    version = "1.0.13", features = ["serde"] }
+chematic-fp         = { path = "../chematic-fp",         version = "1.0.13" }
+chematic-depict     = { path = "../chematic-depict",     version = "1.0.13", default-features = false, features = [] }
+chematic-rxn        = { path = "../chematic-rxn",        version = "1.0.13" }
+chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.13" }
+chematic-3d         = { path = "../chematic-3d",         version = "1.0.13" }
+chematic-mol        = { path = "../chematic-mol",        version = "1.0.13" }
+chematic-inchi      = { path = "../chematic-inchi",      version = "1.0.13" }
+chematic-iupac      = { path = "../chematic-iupac",      version = "1.0.13" }
+chematic-ff         = { path = "../chematic-ff",         version = "1.0.13" }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/chematic-wasm/README.md
+++ b/crates/chematic-wasm/README.md
@@ -29,7 +29,8 @@ npm install @kent-tokyo/chematic
   deterministic input indices and partial/complete status; bounded malformed
   XYZ frames are grouped inline as rejected records when a later count-line
   boundary is recoverable (core file-backed readers remain fail-stop)
-- Bounded topology parsing for CML, ChemicalJSON (`mol_from_cjson`), MolJSON,
+- Bounded topology parsing for CML (`mol_from_cml_strict` provides the opt-in
+  non-empty, balanced, single-root boundary), ChemicalJSON (`mol_from_cjson`), MolJSON,
   CDXML, MOL2, and PDB/mmCIF
 - PDBx/mmCIF, PQR, QCSchema JSON, ORCA input/output, Gaussian Cube, OpenDX,
   and LAMMPS data/dump I/O (JSON-based bindings; see `format_io.rs`)
@@ -185,7 +186,7 @@ interpretation, or cross-engine semantic compatibility.
 
 ## Bundle Size
 
-The optimized v1.0.12 artifact was measured at **3.73 MB raw / 1.36 MB gzip**. Bundle size depends on features and toolchain; see [`benchmarks/2026-09-09-wasm-size-v1.0.10.md`](../../benchmarks/2026-09-09-wasm-size-v1.0.10.md) for exact tools, digest, and reproduction steps.
+The optimized v1.0.12 artifact was measured at **3.93 MB raw / 1.43 MB gzip**. Bundle size depends on features and toolchain; see [`benchmarks/2026-09-11-official-rdkit-js-v1.0.12.md`](../../benchmarks/2026-09-11-official-rdkit-js-v1.0.12.md) for exact tools, digest, and reproduction steps.
 
 PNG rasterization (`tiny_skia`) is excluded from the WASM build — use SVG output instead. All SVG depiction APIs remain fully available.
 

--- a/crates/chematic/Cargo.toml
+++ b/crates/chematic/Cargo.toml
@@ -54,16 +54,16 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
-chematic-core       = { path = "../chematic-core",       version = "1.0.12", optional = true }
-chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.12", optional = true }
-chematic-perception = { path = "../chematic-perception", version = "1.0.12", optional = true }
-chematic-mol        = { path = "../chematic-mol",        version = "1.0.12", optional = true }
-chematic-depict     = { path = "../chematic-depict",     version = "1.0.12", optional = true }
-chematic-chem       = { path = "../chematic-chem",       version = "1.0.12", optional = true }
-chematic-fp         = { path = "../chematic-fp",         version = "1.0.12", optional = true }
-chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.12", optional = true }
-chematic-rxn        = { path = "../chematic-rxn",        version = "1.0.12", optional = true }
-chematic-3d         = { path = "../chematic-3d",         version = "1.0.12", optional = true }
-chematic-inchi      = { path = "../chematic-inchi",      version = "1.0.12", optional = true }
-chematic-iupac      = { path = "../chematic-iupac",      version = "1.0.12", optional = true }
-chematic-crystal    = { path = "../chematic-crystal",    version = "1.0.12", optional = true }
+chematic-core       = { path = "../chematic-core",       version = "1.0.13", optional = true }
+chematic-smiles     = { path = "../chematic-smiles",     version = "1.0.13", optional = true }
+chematic-perception = { path = "../chematic-perception", version = "1.0.13", optional = true }
+chematic-mol        = { path = "../chematic-mol",        version = "1.0.13", optional = true }
+chematic-depict     = { path = "../chematic-depict",     version = "1.0.13", optional = true }
+chematic-chem       = { path = "../chematic-chem",       version = "1.0.13", optional = true }
+chematic-fp         = { path = "../chematic-fp",         version = "1.0.13", optional = true }
+chematic-smarts     = { path = "../chematic-smarts",     version = "1.0.13", optional = true }
+chematic-rxn        = { path = "../chematic-rxn",        version = "1.0.13", optional = true }
+chematic-3d         = { path = "../chematic-3d",         version = "1.0.13", optional = true }
+chematic-inchi      = { path = "../chematic-inchi",      version = "1.0.13", optional = true }
+chematic-iupac      = { path = "../chematic-iupac",      version = "1.0.13", optional = true }
+chematic-crystal    = { path = "../chematic-crystal",    version = "1.0.13", optional = true }

--- a/demo/pkg/package.json
+++ b/demo/pkg/package.json
@@ -5,7 +5,7 @@
     "Kentaro Tanabe (kent-tokyo) <kent-tokyo@users.noreply.github.com>"
   ],
   "description": "WebAssembly bindings for chematic — use chematic from JavaScript/TypeScript",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -7,7 +7,7 @@ counted as wins. Dated raw records are indexed in
 
 ## Current status
 
-The current release line is **v1.0.12**. The newest checked-in performance
+The current release line is **v1.0.13**. The newest checked-in performance
 records include the v1.0.12 three-lane similarity-search gate; older operation
 timing and published-size rows remain explicitly pinned to their recorded
 source/release-line versions.

--- a/docs/compatibility-dashboard.md
+++ b/docs/compatibility-dashboard.md
@@ -10,7 +10,7 @@ This is a compatibility-contract dashboard, not a universal RDKit parity or spee
 
 ## Shared binding contract
 
-Operation inventory: `56` currently shared operations; validate with `python3 scripts/check_cross_binding_manifest.py`.
+Operation inventory: `57` currently shared operations; validate with `python3 scripts/check_cross_binding_manifest.py`.
 
 | Area | Checked-in assertions | Status |
 |---|---:|---|

--- a/docs/format-capabilities.md
+++ b/docs/format-capabilities.md
@@ -155,7 +155,12 @@ Notes on the cells above that need qualification:
 
 ### CML
 
-- **Rust**: `chematic_mol::{parse_cml, parse_cml_with_limits, write_cml, CmlError, CmlParseLimits}`.
+- **Rust**: `chematic_mol::{parse_cml, parse_cml_strict, parse_cml_with_limits, parse_cml_strict_with_limits, write_cml, CmlError, CmlParseLimits}`.
+- **Strict boundary**: `parse_cml_strict` is opt-in; it requires a non-empty
+  molecule, balanced XML-ish elements, exactly one root element, and rejects
+  unterminated quoted attributes, comments, CDATA sections, and processing
+  instructions. The historical `parse_cml` path remains lenient for
+  compatibility.
 - **Coordinate units**: Ångström in returned 2D coordinates.
 - **Connectivity**: native CML bond elements.
 - **Parse limits**: `CmlParseLimits` bounds input bytes, physical line

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,9 +38,9 @@ no backend of their own. (This describes chematic's own browser tools; if you bu
 on top of chematic-wasm that calls other network APIs, that's your own code's choice, not
 something chematic does on your behalf.)
 
-**Lightweight deployment.** The latest measured release-line WASM bundle is **3.73 MB raw / 1.36 MB gzip**, measured
-2026-09-09 with `wasm-pack 0.13.1` + `wasm-opt 130` — see the
-[artifact record](https://github.com/kent-tokyo/chematic/blob/main/benchmarks/2026-09-09-wasm-size-v1.0.10.md)
+**Lightweight deployment.** The current v1.0.12 Node/WASM bundle is **3.93 MB raw / 1.43 MB gzip**, measured
+2026-09-11 with `wasm-pack 0.13.1`, `wasm-bindgen 0.2.121`, and `wasm-opt 130` — see the
+[official RDKit.js comparison](https://github.com/kent-tokyo/chematic/blob/main/benchmarks/2026-09-11-official-rdkit-js-v1.0.12.md)
 for the digest and reproduction commands.
 
 **One Rust core, multiple interfaces.** The same `chematic-*` Rust crates back the native Rust
@@ -146,7 +146,7 @@ Full worked examples → [Use cases](use-cases/)
 |---|---|---|---|
 | Install | `pip install chematic` | `pip install rdkit` (official prebuilt wheels) or conda | `npm install @rdkit/rdkit`, no Python bindings |
 | C/C++ toolchain | Not required, even building from source | Not required for the prebuilt wheel; required building from source | Not required by consumers of the published package |
-| Browser / WASM | Yes — 3.73 MB raw / 1.36 MB gzip | Not applicable (Python/C++ library) | Yes — 6.91 MB raw (`RDKit_minimal.wasm`; pinned historical measurement) |
+| Browser / WASM | Yes — 3.93 MB raw / 1.43 MB gzip (v1.0.12 Node gate) | Not applicable (Python/C++ library) | Yes — 6.91 MB raw / 2.05 MB gzip (same-condition Node gate) |
 | pKa / ADMET prediction | Built-in, rule-based screening — not for clinical use | External tool required | External tool required |
 | AI agent / MCP integration | Built-in, 20 tools (stdio only) | — | — |
 | Ecosystem maturity | Growing (2024–) | Established (2006–) | Established; official JavaScript/WASM distribution path |

--- a/docs/rdkit-comparison.md
+++ b/docs/rdkit-comparison.md
@@ -79,11 +79,11 @@ states parity. See [`validation.md`](validation.md).
 
 ## WASM artifact size
 
-The optimized chematic v1.0.10 release-line artifact was **3.73 MB raw / 1.36 MB gzip**. The
-pinned RDKit.js comparator was **6.91 MB raw**; its gzip size was
-not independently measured. These builds have different feature surfaces, so
-size is a deployment observation rather than a feature-normalized benchmark.
-See the [artifact record](../benchmarks/2026-09-09-wasm-size-v1.0.10.md).
+The current v1.0.12 Node/WASM gate measured chematic at **3.93 MB raw / 1.43 MB gzip**
+and the pinned official RDKit.js comparator at **6.91 MB raw / 2.05 MB gzip**.
+These builds have different feature surfaces, so size is a deployment observation
+rather than a feature-normalized benchmark. See the
+[official comparison record](../benchmarks/2026-09-11-official-rdkit-js-v1.0.12.md).
 
 ## Interpretation rule
 

--- a/docs/rdkit-migration.md
+++ b/docs/rdkit-migration.md
@@ -334,11 +334,11 @@ formats" claim.
 **Not applicable to RDKit's core Python package** — browser consumers use
 RDKit's official JavaScript/WASM distribution path, `@rdkit/rdkit`.
 chematic ships `chematic-wasm` directly from the same Rust source as the
-Python bindings. Measured 2026-09-09 from the v1.0.10 release candidate (see the
-[artifact record](../benchmarks/2026-09-09-wasm-size-v1.0.10.md)): chematic's WASM bundle is
-**3.73 MB raw / 1.36 MB gzip**, versus RDKit.js's `RDKit_minimal.wasm` at
-**6.91 MB raw** (gzip not independently measured) — about 2.0× smaller on a
-raw-to-raw basis. See [`format-capabilities.md`](format-capabilities.md)
+Python bindings. Measured 2026-09-11 in the v1.0.12 Node/WASM gate (see the
+[artifact record](../benchmarks/2026-09-11-official-rdkit-js-v1.0.12.md)): chematic's WASM bundle is
+**3.93 MB raw / 1.43 MB gzip**, versus RDKit.js at
+**6.91 MB raw / 2.05 MB gzip** — about 1.8× smaller raw and 1.4× smaller gzip.
+See [`format-capabilities.md`](format-capabilities.md)
 for exactly which formats are and are not exposed at the WASM layer (plain
 CIF, notably, is not).
 

--- a/docs/rdkit_cheatsheet.md
+++ b/docs/rdkit_cheatsheet.md
@@ -301,7 +301,7 @@ df = pd.DataFrame(chematic.bulk.descriptors(smiles_list))
 
 - **pKa prediction** — built-in rule-based screening, no external tools (not for clinical use)
 - **ADMET profile** — built-in rule-based screening, BBB/Caco-2/hERG/CYP3A4 in a single call (not for clinical use)
-- **WASM support** — runs in the browser (3.73 MB raw / 1.36 MB gzip bundle, v1.0.10 candidate measured 2026-09-09)
+- **WASM support** — runs in the browser (3.93 MB raw / 1.43 MB gzip bundle, v1.0.12 measured 2026-09-11)
 - **MCP server** — direct integration with AI agents
 - **Pure Rust** — no conda, works in Docker / serverless / CI without extra setup
 - **Atropisomer detection** — `mol.atropisomers()` detects biaryl and allene axes

--- a/docs/release-metadata.md
+++ b/docs/release-metadata.md
@@ -34,8 +34,8 @@ tag):
 
 ```bash
 python3 scripts/generate_release_metadata.py \
-  --version 1.0.12 \
-  --commit "$(git rev-list -1 v1.0.12)" \
-  --released-at "$(git show -s --format=%cI v1.0.12)" \
+  --version 1.0.13 \
+  --commit "$(git rev-list -1 v1.0.13)" \
+  --released-at "$(git show -s --format=%cI v1.0.13)" \
   --output /tmp/chematic-release-metadata.json
 ```

--- a/docs/roadmap-open-work.md
+++ b/docs/roadmap-open-work.md
@@ -10,7 +10,7 @@ The opt-in analytic L-BFGS objective now switches the cutoff energy and gradient
 together; the production-default minimizer remains unchanged.
 
 This document is the current disposition of unchecked roadmap items for the
-v1.0.12 release tree. An item
+v1.0.13 release tree. An item
 is not complete merely because a narrower local slice has evidence.
 
 | Roadmap area | Open work | Disposition |

--- a/docs/roadmap-open-work.md
+++ b/docs/roadmap-open-work.md
@@ -69,20 +69,12 @@ passed. The default advisory `deny` step cannot acquire its lock because the
 Cargo advisory database is under a read-only path, but a writable-copy rerun
 against advisory-db revision `5a0ebedfe8bdd2e295b171f4162f8c977bcad9a5`
 passes advisories, bans, licenses, and sources; see
-`validation/results/cargo-deny-v1.0.10.json`. Python pytest remains
-toolchain-skipped because the local virtualenv does not contain the package and
-test dependencies. With the system extension and plugin autoload disabled, the
-six current shared-format binding checks (PDB, MOL2, CML, CDXML, mmCIF,
-MolJSON) pass. The interpreter used for that probe imported the installed
-`chematic` v1.0.3 from the user site-packages directory rather than the
-workspace v1.0.10 extension; the broader Python contract file therefore still
-has stale-install API-surface failures outside those format checks. A clean
-workspace extension install is now locally reproducible: a v1.0.10 wheel was
-built offline into a temporary environment and all 945 Python tests passed with
-zero failures or skips. The same freshly built wheel also passes the 38-case
-reaction SMARTS contract directly. The wheel is a local candidate only and is
-not published or installed into the normal user environment. Neither condition
-is promoted to a completed roadmap item.
+`validation/results/cargo-deny-v1.0.10.json`. A source-built v1.0.12 wheel is
+also reproducible offline in the project virtual environment; the strict CML
+shared contract passes after rebuilding the wheel, while the system Python
+installation is not treated as workspace evidence. The wheel is a local
+candidate only and is not published or installed into the normal user
+environment. Neither condition is promoted to a completed roadmap item.
 
 The P1 streaming safety runner was also rerun against the current v1.0.12 workspace:
 800 malformed-input attempts (800 unique payloads; 80 per format), 10

--- a/docs/use-cases/browser-app.md
+++ b/docs/use-cases/browser-app.md
@@ -6,10 +6,10 @@ You want to ship a chemistry tool to users who won't install anything — a web 
 
 ## Solution
 
-chematic compiles to WebAssembly at **3.73 MB raw / 1.36 MB gzip** (latest measured v1.0.10 release-line artifact,
-measured 2026-09-09 with `wasm-pack 0.13.1` + `wasm-opt 130`; see the
-[artifact record](../../benchmarks/2026-09-09-wasm-size-v1.0.10.md)) — roughly 2.0× smaller than the
-pinned RDKit.js raw-size comparator. No server required: descriptor calculation, fingerprint
+chematic compiles to WebAssembly at **3.93 MB raw / 1.43 MB gzip** (v1.0.12 Node/WASM gate,
+measured 2026-09-11 with `wasm-pack 0.13.1`, `wasm-bindgen 0.2.121`, and `wasm-opt 130`; see the
+[comparison record](../../benchmarks/2026-09-11-official-rdkit-js-v1.0.12.md)) — roughly 1.8× smaller raw and 1.4× smaller gzip than the
+pinned RDKit.js comparator. No server required: descriptor calculation, fingerprint
 generation, and similarity search run entirely in the browser, offline-capable after first load.
 
 ## Output / What you get
@@ -135,11 +135,10 @@ document.getElementById("file-input").addEventListener("change", async (e) => {
 
 | Task | chematic WASM | RDKit.js |
 |------|--------------|----------|
-| Bundle size | 3.54 MB raw / 1.29 MB gzip | 6.91 MB raw (`RDKit_minimal.wasm`; gzip not independently measured) |
+| Bundle size | 3.93 MB raw / 1.43 MB gzip | 6.91 MB raw / 2.05 MB gzip |
 
-The chematic bundle was measured 2026-09-09 from the v1.0.10 release line; v1.0.11 retains this
-historical artifact record (see the
-[artifact record](../../benchmarks/2026-09-09-wasm-size-v1.0.10.md)). Per-operation, in-browser timings
+The current chematic bundle measurement is from the v1.0.12 Node/WASM gate (see the
+[artifact record](../../benchmarks/2026-09-11-official-rdkit-js-v1.0.12.md)). Per-operation, in-browser timings
 (SMILES parse, ECFP4, Tanimoto)
 previously listed here were never independently reconfirmed and have been removed rather than
 repeated as fact — see [`benchmarks/2026-07-17.md`](https://github.com/kent-tokyo/chematic/blob/main/benchmarks/2026-07-17.md)'s own notes,

--- a/docs/use-cases/rust-server.md
+++ b/docs/use-cases/rust-server.md
@@ -23,7 +23,7 @@ $ curl -s -X POST http://localhost:3000/descriptors \
 ```toml
 # Cargo.toml
 [dependencies]
-chematic = { version = "1.0.12", features = ["chem", "fp", "smarts"] }
+chematic = { version = "1.0.13", features = ["chem", "fp", "smarts"] }
 axum      = "0.7"
 serde     = { version = "1", features = ["derive"] }
 tokio     = { version = "1", features = ["full"] }
@@ -140,4 +140,4 @@ fn process_sdf(path: &str) -> Vec<DescriptorOutput> {
 - `chematic_chem::{molecular_weight, logp_and_mr, tpsa, hbd_count, ring_bundle}` — descriptor functions
 - `chematic_fp::ecfp4(&mol)` / `tanimoto_bitvec(&fp1, &fp2)` — fingerprints + similarity
 - `chematic_mol::SdfReader` — streaming SDF parser
-- `chematic = { version = "1.0.12", features = ["chem", "fp", "smarts"] }` — minimal feature set for a descriptor API
+- `chematic = { version = "1.0.13", features = ["chem", "fp", "smarts"] }` — minimal feature set for a descriptor API

--- a/release-metadata/v1.0.13.json
+++ b/release-metadata/v1.0.13.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "product": "chematic",
+  "release": {
+    "version": "1.0.13",
+    "tag": "v1.0.13",
+    "commit": null,
+    "commit_source": "The attached GitHub Release asset is generated from the exact v1.0.13 tag commit.",
+    "released_at": "2026-09-11T00:00:00+09:00"
+  },
+  "packages": {
+    "rust": {"name": "chematic", "version": "1.0.13", "registry_url": "https://crates.io/crates/chematic/1.0.13"},
+    "python": {"name": "chematic", "version": "1.0.13", "registry_url": "https://pypi.org/project/chematic/1.0.13/"},
+    "npm": {"name": "@kent-tokyo/chematic", "version": "1.0.13", "registry_url": "https://www.npmjs.com/package/@kent-tokyo/chematic/v/1.0.13"}
+  },
+  "wasm": {
+    "artifact": "demo/pkg/chematic_wasm_bg.wasm",
+    "measurements": [{
+      "status": "historical",
+      "release_or_snapshot": "v1.0.10 release-line measurement retained for v1.0.13",
+      "raw_bytes": 3577593,
+      "compressed_bytes": 1306377,
+      "command": "wasm-pack 0.13.1; wasm-opt 130; gzip -9",
+      "runtime": "macOS arm64",
+      "source": "benchmarks/2026-09-09-wasm-size-v1.0.10.md"
+    }]
+  },
+  "mcp": {"tool_count": 20, "transport": ["stdio"], "network_enabled_tools": ["pubchem_lookup"]},
+  "benchmarks": {"historical": [
+    {"path": "benchmarks/2026-09-05-hotpath-110.md", "status": "historical", "versions": ["v1.0.6 source", "v1.0.7 source"], "commit": "local source A/B; tag commit not applicable to baseline", "corpus": "5,000 SMILES and 365-record SDF fixtures", "hardware": "Apple M4 macOS 26.5.2"}
+  ]},
+  "generated_at": "2026-09-11T00:00:00+09:00"
+}


### PR DESCRIPTION
## Summary\n- bump workspace and publishable crates to v1.0.13\n- synchronize README, roadmap, changelog, citation, Zenodo, and release metadata\n- retain prior benchmark artifacts as historical evidence\n\n## Validation\n- cargo check --workspace --offline\n- cargo test --workspace --lib --offline\n- release/documentation/publish-graph/benchmark/roadmap/cross-binding gates\n\nThe v1.0.13 tag has been pushed and its release publication workflows are running.